### PR TITLE
fixtureutil: buildBinary runs with GOWORK=off

### DIFF
--- a/e2e/parity/fixtureutil/fixtureutil.go
+++ b/e2e/parity/fixtureutil/fixtureutil.go
@@ -77,6 +77,11 @@ func buildBinary(moduleRoot, pkg, name string) (string, error) {
 	outPath := filepath.Join(tmpDir, name)
 	cmd := exec.Command("go", "build", "-o", outPath, pkg)
 	cmd.Dir = moduleRoot
+	// GOWORK=off: out-of-tree callers (cyoda-go-cassandra's e2e suite)
+	// resolve moduleRoot to cyoda-go's copy in the Go module cache, which
+	// may carry a go.work referencing sibling directories that don't exist
+	// in the cache. Force module-mode so the build uses go.mod alone.
+	cmd.Env = append(os.Environ(), "GOWORK=off")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
One-line fix. Out-of-tree callers hit go.work in the mod-cache copy of cyoda-go referencing sibling paths that don't exist there. In-tree callers unaffected.