### PR TITLE
feat: postgres SI + row-granular first-committer-wins (#18)

### DIFF
--- a/docs/superpowers/plans/2026-04-15-postgres-si-first-committer-wins.md
+++ b/docs/superpowers/plans/2026-04-15-postgres-si-first-committer-wins.md
@@ -1,0 +1,2429 @@
+# Postgres SI + Row-Granular First-Committer-Wins — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the postgres plugin's `SERIALIZABLE` isolation (page-granular SSI, source of #17 flakes and cross-page false positives) with `REPEATABLE READ` + application-layer row-granular first-committer-wins that matches the cassandra plugin's semantics exactly.
+
+**Architecture:** Per-transaction read/write-set bookkeeping inside the postgres plugin. Store methods on `entityStore` record `(entity_id → version)` into a `*txState` parallel to the existing `txRegistry`. `TransactionManager.Commit` issues one batched `SELECT id, version FROM entities WHERE tenant_id=$1 AND id=ANY($2) FOR SHARE` (sorted, chunked) over the union of read+write sets, compares captured versions to current, and maps mismatches and postgres-raised `40001` to `spi.ErrConflict`. No SPI changes. Non-entity stores (Model, KV, Message, Workflow, SMAudit) operate at plain SI — coverage gap tracked as #35.
+
+**Tech Stack:** Go 1.26, `jackc/pgx/v5`, postgres 15+, testcontainers-go (existing test harness), `go test` + `spi.ErrConflict` semantics.
+
+**Spec:** [`docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md`](../specs/2026-04-15-postgres-si-first-committer-wins-design.md)
+
+**Related issues:** [#18](https://github.com/Cyoda-platform/cyoda-go/issues/18) (this work), [#17](https://github.com/Cyoda-platform/cyoda-go/issues/17) (flake closed by this), [#35](https://github.com/Cyoda-platform/cyoda-go/issues/35) (non-entity-store coverage follow-up), [cyoda-go-cassandra#22](https://github.com/Cyoda-platform/cyoda-go-cassandra/issues/22) (sibling).
+
+---
+
+## File structure
+
+**New files:**
+- `plugins/postgres/txstate.go` — `txState` type + helpers (RecordRead/Write, SortedUnionIDs, ValidateReadSet, ValidateWriteSet, PushSavepoint, RestoreSavepoint, ReleaseSavepoint).
+- `plugins/postgres/txstate_test.go` — unit tests for the above; no DB needed.
+- `plugins/postgres/commit_validator.go` — `validateInChunks` helper (isolated so tests can override `validateChunkSize`).
+- `plugins/postgres/commit_validator_test.go` — unit-integration tests with real postgres.
+
+**Modified files:**
+- `plugins/postgres/transaction_manager.go` — add `txStates` map; switch `Begin` to `RepeatableRead`; wire validation into `Commit`; hook savepoints through txState.
+- `plugins/postgres/transaction_manager_test.go` — new tests for RR behavior + validation.
+- `plugins/postgres/entity_store.go` — add `recordRead`/`recordWrite` calls in `Get`, `GetAll`, `Save`, `SaveAll`, `CompareAndSave`, `Delete`, `DeleteAll`.
+- `plugins/postgres/entity_store_test.go` — verify bookkeeping hooks populate txState correctly.
+- `plugins/postgres/conformance_test.go` — drop any `SkipIfFlaky` guards around the concurrent-different-entities scenario; add a same-entity concurrency test if not already present.
+- `internal/spitest/` — add savepoint-divergence conformance comment; strengthen concurrency tests to assert `spi.ErrConflict` semantics consistently across plugins.
+
+The existing `txRegistry` stays untouched — its only job remains txID→pgx.Tx lookup. `txState` is a **parallel map** on `TransactionManager`, keyed by the same txID.
+
+---
+
+## Design notes the implementer must carry into code
+
+**Idempotency rule for bookkeeping** (subtle but load-bearing):
+
+1. An entity is ever in at most one of `readSet` / `writeSet`, never both.
+2. `recordRead(id, version)` is a no-op if `id ∈ writeSet` (we wrote it ourselves; no cross-tx read-validation needed for our own writes) OR if `id ∈ readSet` (first-read-wins).
+3. `recordWrite(id, preWriteVersion)` is a no-op if `id ∈ writeSet` (first-write-wins — the original pre-write version is the load-bearing one). If `id ∈ readSet`, move to `writeSet` at the read's captured version and drop from `readSet`.
+
+Rationale: within our tx, reads after our own writes return our own writes — if we recorded those as readSet entries, commit-time validation would compare them to committed-by-others state (which is what our tx *replaced* upstream) and spuriously fail. Writing once before validation avoids this; the helpers enforce the rule.
+
+**Pre-write version from `entity_store.go`** comes from the existing UPSERT's `RETURNING version, (xmax = 0)` clause: `isNew=true` → `preWriteVersion = 0`; `isNew=false` → `preWriteVersion = returnedVersion - 1`.
+
+**Chunking preserves sort order.** IDs are sorted once at the top of `validateInChunks`; chunks are taken in order; lock acquisition stays deterministic across chunks and across concurrent committers.
+
+**FOR SHARE (not FOR UPDATE).** See spec rationale. Implementation carries a one-line code comment pointing to the spec.
+
+**GetAsAt / GetVersionHistory / Count** are NOT tracked — implementation carries a one-line code comment stating this intentional omission, pointing at the spec's "Known limitation: phantom reads on range/list queries" section.
+
+---
+
+## Task list
+
+### Task 1: Create `txState` skeleton + constructor
+
+**Files:**
+- Create: `plugins/postgres/txstate.go`
+- Create: `plugins/postgres/txstate_test.go`
+
+- [ ] **Step 1: Write failing test for `newTxState`**
+
+```go
+// plugins/postgres/txstate_test.go
+package postgres
+
+import (
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+func TestNewTxState_ZeroValue(t *testing.T) {
+	s := newTxState(spi.TenantID("t1"))
+	if s == nil {
+		t.Fatal("expected non-nil txState")
+	}
+	if s.tenantID != "t1" {
+		t.Errorf("tenantID: want t1, got %s", s.tenantID)
+	}
+	if len(s.readSet) != 0 {
+		t.Errorf("readSet: want empty, got %d entries", len(s.readSet))
+	}
+	if len(s.writeSet) != 0 {
+		t.Errorf("writeSet: want empty, got %d entries", len(s.writeSet))
+	}
+	if len(s.savepoints) != 0 {
+		t.Errorf("savepoints: want empty, got %d entries", len(s.savepoints))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./plugins/postgres/ -run TestNewTxState_ZeroValue -v`
+Expected: FAIL with `undefined: newTxState`
+
+- [ ] **Step 3: Implement minimal `txState`**
+
+```go
+// plugins/postgres/txstate.go
+package postgres
+
+import (
+	"sync"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// txState holds per-transaction bookkeeping for first-committer-wins
+// validation. One instance per active tx, indexed by txID on the
+// TransactionManager.
+//
+// Invariants:
+//   - An entity ID appears in at most one of readSet/writeSet at any time.
+//   - readSet[id] = the version as first observed by a Get within this tx.
+//   - writeSet[id] = the pre-write version for an entity we wrote; 0 for
+//     a fresh insert.
+//
+// See docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md
+// for the full semantic model.
+type txState struct {
+	mu         sync.Mutex
+	tenantID   spi.TenantID
+	readSet    map[string]int64
+	writeSet   map[string]int64
+	savepoints []savepointEntry
+}
+
+type savepointEntry struct {
+	id       string
+	readSet  map[string]int64
+	writeSet map[string]int64
+}
+
+func newTxState(tenantID spi.TenantID) *txState {
+	return &txState{
+		tenantID: tenantID,
+		readSet:  make(map[string]int64),
+		writeSet: make(map[string]int64),
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./plugins/postgres/ -run TestNewTxState_ZeroValue -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/txstate.go plugins/postgres/txstate_test.go
+git commit -m "feat(postgres): add txState skeleton for first-committer-wins bookkeeping"
+```
+
+---
+
+### Task 2: `RecordRead` — first-read-wins + writeSet exclusion
+
+**Files:**
+- Modify: `plugins/postgres/txstate.go`
+- Modify: `plugins/postgres/txstate_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `plugins/postgres/txstate_test.go`:
+
+```go
+func TestRecordRead_FirstReadWins(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.RecordRead("e1", 7) // should be ignored
+	if got := s.readSet["e1"]; got != 5 {
+		t.Errorf("readSet[e1]: want 5, got %d", got)
+	}
+}
+
+func TestRecordRead_SkipIfWritten(t *testing.T) {
+	s := newTxState("t1")
+	s.writeSet["e1"] = 3
+	s.RecordRead("e1", 7) // should be ignored — we already wrote it
+	if _, exists := s.readSet["e1"]; exists {
+		t.Error("readSet[e1]: should not record when entity is in writeSet")
+	}
+	if got := s.writeSet["e1"]; got != 3 {
+		t.Errorf("writeSet[e1]: want unchanged 3, got %d", got)
+	}
+}
+
+func TestRecordRead_MultipleEntities(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.RecordRead("e2", 9)
+	if got := s.readSet["e1"]; got != 5 {
+		t.Errorf("readSet[e1]: want 5, got %d", got)
+	}
+	if got := s.readSet["e2"]; got != 9 {
+		t.Errorf("readSet[e2]: want 9, got %d", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./plugins/postgres/ -run TestRecordRead -v`
+Expected: FAIL with `s.RecordRead undefined`
+
+- [ ] **Step 3: Implement `RecordRead`**
+
+Append to `plugins/postgres/txstate.go`:
+
+```go
+// RecordRead captures a read's observed version for commit-time validation.
+// No-op if the entity is already in writeSet (our own write; not cross-tx
+// validated) or already in readSet (first-read-wins — a later read returns
+// either our own writes or a consistent snapshot; we only care about the
+// first observation for conflict detection).
+func (s *txState) RecordRead(entityID string, version int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, written := s.writeSet[entityID]; written {
+		return
+	}
+	if _, already := s.readSet[entityID]; already {
+		return
+	}
+	s.readSet[entityID] = version
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./plugins/postgres/ -run TestRecordRead -v`
+Expected: PASS (all three tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/txstate.go plugins/postgres/txstate_test.go
+git commit -m "feat(postgres): txState.RecordRead with first-read-wins + writeSet exclusion"
+```
+
+---
+
+### Task 3: `RecordWrite` — first-write-wins + readSet promotion
+
+**Files:**
+- Modify: `plugins/postgres/txstate.go`
+- Modify: `plugins/postgres/txstate_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `plugins/postgres/txstate_test.go`:
+
+```go
+func TestRecordWrite_FirstWriteWins(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 5)
+	s.RecordWrite("e1", 7) // should be ignored — pre-write version is load-bearing
+	if got := s.writeSet["e1"]; got != 5 {
+		t.Errorf("writeSet[e1]: want 5, got %d", got)
+	}
+}
+
+func TestRecordWrite_PromotesFromReadSet(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5) // first: read at v=5
+	s.RecordWrite("e1", 5) // then: write at pre-write v=5
+	if _, stillRead := s.readSet["e1"]; stillRead {
+		t.Error("readSet[e1]: should have been promoted out on write")
+	}
+	if got := s.writeSet["e1"]; got != 5 {
+		t.Errorf("writeSet[e1]: want 5, got %d", got)
+	}
+}
+
+func TestRecordWrite_FreshInsertZero(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 0) // convention: 0 = "did not exist before this tx"
+	if got := s.writeSet["e1"]; got != 0 {
+		t.Errorf("writeSet[e1]: want 0 (fresh insert), got %d", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./plugins/postgres/ -run TestRecordWrite -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `RecordWrite`**
+
+Append to `plugins/postgres/txstate.go`:
+
+```go
+// RecordWrite captures a write's pre-write version for commit-time validation.
+// Pre-write version 0 is the convention for "entity did not exist when this
+// tx first wrote it" (fresh insert).
+//
+// No-op if the entity is already in writeSet (first-write-wins — we captured
+// the pre-write version on the first write; subsequent writes by us don't
+// change that load-bearing value).
+//
+// If the entity is in readSet, we promote it to writeSet using the read's
+// captured version (which equals the pre-write version we just observed)
+// and drop from readSet — an entity must be in at most one set.
+func (s *txState) RecordWrite(entityID string, preWriteVersion int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, written := s.writeSet[entityID]; written {
+		return
+	}
+	if readVersion, inRead := s.readSet[entityID]; inRead {
+		s.writeSet[entityID] = readVersion
+		delete(s.readSet, entityID)
+		return
+	}
+	s.writeSet[entityID] = preWriteVersion
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./plugins/postgres/ -run TestRecordWrite -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/txstate.go plugins/postgres/txstate_test.go
+git commit -m "feat(postgres): txState.RecordWrite with first-write-wins + readSet promotion"
+```
+
+---
+
+### Task 4: `SortedUnionIDs` — deterministic lock-acquisition order
+
+**Files:**
+- Modify: `plugins/postgres/txstate.go`
+- Modify: `plugins/postgres/txstate_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `plugins/postgres/txstate_test.go`:
+
+```go
+func TestSortedUnionIDs_EmptyState(t *testing.T) {
+	s := newTxState("t1")
+	ids := s.SortedUnionIDs()
+	if len(ids) != 0 {
+		t.Errorf("want empty slice, got %v", ids)
+	}
+}
+
+func TestSortedUnionIDs_MixedReadAndWrite(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("c", 1)
+	s.RecordRead("a", 2)
+	s.RecordWrite("d", 0)
+	s.RecordWrite("b", 3)
+	ids := s.SortedUnionIDs()
+	want := []string{"a", "b", "c", "d"}
+	if len(ids) != len(want) {
+		t.Fatalf("want %d ids, got %d: %v", len(want), len(ids), ids)
+	}
+	for i, id := range want {
+		if ids[i] != id {
+			t.Errorf("ids[%d]: want %q, got %q", i, id, ids[i])
+		}
+	}
+}
+
+func TestSortedUnionIDs_Disjoint(t *testing.T) {
+	// Invariant: readSet and writeSet are disjoint by construction.
+	s := newTxState("t1")
+	s.RecordRead("a", 1)
+	s.RecordWrite("a", 1) // promotes to writeSet
+	ids := s.SortedUnionIDs()
+	if len(ids) != 1 || ids[0] != "a" {
+		t.Errorf("want [a], got %v", ids)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./plugins/postgres/ -run TestSortedUnionIDs -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `SortedUnionIDs`**
+
+Append to `plugins/postgres/txstate.go`:
+
+```go
+import "sort"
+
+// (add "sort" to the existing import block)
+
+// SortedUnionIDs returns the sorted union of readSet and writeSet entity IDs.
+// Sorting makes FOR SHARE lock acquisition deterministic across concurrent
+// committers, preventing a class of 40P01 deadlocks that would otherwise
+// surface as ErrConflict under contention.
+func (s *txState) SortedUnionIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ids := make([]string, 0, len(s.readSet)+len(s.writeSet))
+	for id := range s.readSet {
+		ids = append(ids, id)
+	}
+	for id := range s.writeSet {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+```
+
+Note: the invariant of readSet/writeSet being disjoint is enforced by `RecordRead` / `RecordWrite`, so no dedup pass is needed.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./plugins/postgres/ -run TestSortedUnionIDs -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/txstate.go plugins/postgres/txstate_test.go
+git commit -m "feat(postgres): txState.SortedUnionIDs for deterministic lock order"
+```
+
+---
+
+### Task 5: `ValidateReadSet` and `ValidateWriteSet`
+
+**Files:**
+- Modify: `plugins/postgres/txstate.go`
+- Modify: `plugins/postgres/txstate_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `plugins/postgres/txstate_test.go`:
+
+```go
+func TestValidateReadSet_AllMatch(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.RecordRead("e2", 7)
+	current := map[string]int64{"e1": 5, "e2": 7}
+	if err := s.ValidateReadSet(current); err != nil {
+		t.Errorf("want nil, got %v", err)
+	}
+}
+
+func TestValidateReadSet_VersionMismatch(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	current := map[string]int64{"e1": 6}
+	err := s.ValidateReadSet(current)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	// Error message should identify the entity and versions.
+	if !strings.Contains(err.Error(), "e1") {
+		t.Errorf("error should mention entity ID, got: %v", err)
+	}
+}
+
+func TestValidateReadSet_MissingEntity(t *testing.T) {
+	// Concurrent committer deleted the row (hard delete case).
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	current := map[string]int64{} // e1 absent
+	err := s.ValidateReadSet(current)
+	if err == nil {
+		t.Fatal("want error for missing entity, got nil")
+	}
+}
+
+func TestValidateWriteSet_UpdateMatch(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 5) // expected pre-write version 5
+	current := map[string]int64{"e1": 5}
+	if err := s.ValidateWriteSet(current); err != nil {
+		t.Errorf("want nil, got %v", err)
+	}
+}
+
+func TestValidateWriteSet_FreshInsertAbsent(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 0) // fresh insert
+	current := map[string]int64{} // e1 absent in committed view — correct
+	if err := s.ValidateWriteSet(current); err != nil {
+		t.Errorf("want nil, got %v", err)
+	}
+}
+
+func TestValidateWriteSet_FreshInsertRaceLost(t *testing.T) {
+	// Two txs tried to insert e1; the other committed first.
+	s := newTxState("t1")
+	s.RecordWrite("e1", 0)
+	current := map[string]int64{"e1": 1}
+	err := s.ValidateWriteSet(current)
+	if err == nil {
+		t.Fatal("want error for lost insert race, got nil")
+	}
+}
+
+func TestValidateWriteSet_UpdateVersionMismatch(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 5)
+	current := map[string]int64{"e1": 6} // concurrent committer bumped
+	err := s.ValidateWriteSet(current)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+}
+```
+
+Add `"strings"` to the test file's imports.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./plugins/postgres/ -run TestValidate -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `ValidateReadSet` and `ValidateWriteSet`**
+
+Append to `plugins/postgres/txstate.go` (add `"fmt"` to imports):
+
+```go
+// ValidateReadSet checks that every entity in readSet still exists in
+// the DB at the captured version. Returns an error describing the first
+// mismatch; nil if all match.
+func (s *txState) ValidateReadSet(current map[string]int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, expected := range s.readSet {
+		got, ok := current[id]
+		if !ok {
+			return fmt.Errorf("read-set validation: entity %s deleted by concurrent committer (expected version %d)", id, expected)
+		}
+		if got != expected {
+			return fmt.Errorf("read-set validation: entity %s version changed: expected %d, current %d", id, expected, got)
+		}
+	}
+	return nil
+}
+
+// ValidateWriteSet checks that every entity in writeSet is still at its
+// captured pre-write version (for updates/deletes) or absent from the DB
+// (for fresh inserts, pre-write version 0).
+func (s *txState) ValidateWriteSet(current map[string]int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, expected := range s.writeSet {
+		got, ok := current[id]
+		if expected == 0 {
+			// Fresh insert: row must be absent in the committed view.
+			if ok {
+				return fmt.Errorf("write-set validation: entity %s lost insert race — concurrent committer created it at version %d", id, got)
+			}
+			continue
+		}
+		if !ok {
+			return fmt.Errorf("write-set validation: entity %s deleted by concurrent committer (expected pre-write version %d)", id, expected)
+		}
+		if got != expected {
+			return fmt.Errorf("write-set validation: entity %s pre-write version changed: expected %d, current %d", id, expected, got)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./plugins/postgres/ -run TestValidate -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/txstate.go plugins/postgres/txstate_test.go
+git commit -m "feat(postgres): txState.Validate{Read,Write}Set with precise error messages"
+```
+
+---
+
+### Task 6: Savepoint snapshot / restore / release on txState
+
+**Files:**
+- Modify: `plugins/postgres/txstate.go`
+- Modify: `plugins/postgres/txstate_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `plugins/postgres/txstate_test.go`:
+
+```go
+func TestPushSavepoint_DeepCopiesSets(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.PushSavepoint("sp1")
+	s.RecordRead("e2", 7) // added after savepoint
+	if len(s.savepoints) != 1 {
+		t.Fatalf("want 1 savepoint, got %d", len(s.savepoints))
+	}
+	snap := s.savepoints[0]
+	if snap.id != "sp1" {
+		t.Errorf("savepoint id: want sp1, got %s", snap.id)
+	}
+	// Snapshot captured {e1} only; later read of e2 didn't leak into it.
+	if _, ok := snap.readSet["e1"]; !ok {
+		t.Error("savepoint readSet should contain e1")
+	}
+	if _, ok := snap.readSet["e2"]; ok {
+		t.Error("savepoint readSet should NOT contain e2 (added after push)")
+	}
+}
+
+func TestRestoreSavepoint_RestoresSets(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.PushSavepoint("sp1")
+	s.RecordRead("e2", 7)
+	s.RecordWrite("e3", 0)
+	if err := s.RestoreSavepoint("sp1"); err != nil {
+		t.Fatalf("RestoreSavepoint: %v", err)
+	}
+	// Reads/writes added after sp1 must be gone.
+	if _, ok := s.readSet["e2"]; ok {
+		t.Error("readSet[e2] should have been restored away")
+	}
+	if _, ok := s.writeSet["e3"]; ok {
+		t.Error("writeSet[e3] should have been restored away")
+	}
+	// Pre-savepoint state preserved.
+	if got := s.readSet["e1"]; got != 5 {
+		t.Errorf("readSet[e1]: want 5, got %d", got)
+	}
+	// Savepoint itself remains (postgres semantics: ROLLBACK TO SAVEPOINT
+	// keeps the savepoint for future use).
+	if len(s.savepoints) != 1 {
+		t.Errorf("want savepoint preserved after rollback-to, got %d", len(s.savepoints))
+	}
+}
+
+func TestRestoreSavepoint_TrimsLaterSavepoints(t *testing.T) {
+	s := newTxState("t1")
+	s.PushSavepoint("sp1")
+	s.PushSavepoint("sp2") // nested
+	if err := s.RestoreSavepoint("sp1"); err != nil {
+		t.Fatalf("RestoreSavepoint: %v", err)
+	}
+	if len(s.savepoints) != 1 {
+		t.Errorf("want 1 savepoint (sp2 trimmed), got %d", len(s.savepoints))
+	}
+	if s.savepoints[0].id != "sp1" {
+		t.Errorf("remaining savepoint: want sp1, got %s", s.savepoints[0].id)
+	}
+}
+
+func TestReleaseSavepoint_DropsEntryKeepsWork(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.PushSavepoint("sp1")
+	s.RecordRead("e2", 7)
+	if err := s.ReleaseSavepoint("sp1"); err != nil {
+		t.Fatalf("ReleaseSavepoint: %v", err)
+	}
+	if len(s.savepoints) != 0 {
+		t.Errorf("want 0 savepoints, got %d", len(s.savepoints))
+	}
+	// Work done after push is KEPT on release.
+	if got := s.readSet["e2"]; got != 7 {
+		t.Errorf("readSet[e2]: want 7 (kept), got %d", got)
+	}
+}
+
+func TestRestoreSavepoint_Unknown(t *testing.T) {
+	s := newTxState("t1")
+	err := s.RestoreSavepoint("bogus")
+	if err == nil {
+		t.Fatal("want error for unknown savepoint, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./plugins/postgres/ -run "TestPushSavepoint|TestRestoreSavepoint|TestReleaseSavepoint" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement savepoint methods**
+
+Append to `plugins/postgres/txstate.go`:
+
+```go
+// PushSavepoint stores a deep copy of the current readSet/writeSet under
+// the given savepoint ID. Subsequent RestoreSavepoint(id) restores both
+// sets to this snapshot and trims later savepoints (postgres nested
+// savepoint semantics).
+func (s *txState) PushSavepoint(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snap := savepointEntry{
+		id:       id,
+		readSet:  make(map[string]int64, len(s.readSet)),
+		writeSet: make(map[string]int64, len(s.writeSet)),
+	}
+	for k, v := range s.readSet {
+		snap.readSet[k] = v
+	}
+	for k, v := range s.writeSet {
+		snap.writeSet[k] = v
+	}
+	s.savepoints = append(s.savepoints, snap)
+}
+
+// RestoreSavepoint restores readSet/writeSet to the snapshot captured at
+// PushSavepoint(id) and trims any savepoints pushed after id. The named
+// savepoint itself remains (mirroring postgres ROLLBACK TO SAVEPOINT).
+func (s *txState) RestoreSavepoint(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := -1
+	for i, sp := range s.savepoints {
+		if sp.id == id {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("unknown savepoint %q", id)
+	}
+	snap := s.savepoints[idx]
+	s.readSet = make(map[string]int64, len(snap.readSet))
+	s.writeSet = make(map[string]int64, len(snap.writeSet))
+	for k, v := range snap.readSet {
+		s.readSet[k] = v
+	}
+	for k, v := range snap.writeSet {
+		s.writeSet[k] = v
+	}
+	s.savepoints = s.savepoints[:idx+1] // trim later, keep idx (savepoint preserved)
+	return nil
+}
+
+// ReleaseSavepoint drops the savepoint entry without touching the current
+// readSet/writeSet — work done after the push is kept. Mirrors postgres
+// RELEASE SAVEPOINT semantics.
+func (s *txState) ReleaseSavepoint(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := -1
+	for i, sp := range s.savepoints {
+		if sp.id == id {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("unknown savepoint %q", id)
+	}
+	s.savepoints = append(s.savepoints[:idx], s.savepoints[idx+1:]...)
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./plugins/postgres/ -run "TestPushSavepoint|TestRestoreSavepoint|TestReleaseSavepoint" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/txstate.go plugins/postgres/txstate_test.go
+git commit -m "feat(postgres): txState savepoint snapshot/restore/release"
+```
+
+---
+
+### Task 7: Integrate `*txState` into `TransactionManager`
+
+**Files:**
+- Modify: `plugins/postgres/transaction_manager.go`
+- Modify: `plugins/postgres/transaction_manager_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `plugins/postgres/transaction_manager_test.go`:
+
+```go
+func TestTxManager_BeginAllocatesTxState(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+
+	txID, _, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+
+	// Internal inspection via export_test.go accessor.
+	if !postgres.HasTxState(tm, txID) {
+		t.Errorf("expected txState registered for %s", txID)
+	}
+
+	if err := tm.Commit(ctx, txID); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	if postgres.HasTxState(tm, txID) {
+		t.Errorf("expected txState removed after Commit for %s", txID)
+	}
+}
+
+func TestTxManager_RollbackCleansTxState(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+	txID, _, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if err := tm.Rollback(ctx, txID); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if postgres.HasTxState(tm, txID) {
+		t.Errorf("expected txState removed after Rollback for %s", txID)
+	}
+}
+```
+
+- [ ] **Step 2: Add the `HasTxState` export helper and run — expect compile error first, then test fail**
+
+In `plugins/postgres/export_test.go` append:
+
+```go
+// HasTxState reports whether the given txID has an active txState entry.
+// Test-only accessor.
+func HasTxState(tm *TransactionManager, txID string) bool {
+	tm.txStatesMu.Lock()
+	defer tm.txStatesMu.Unlock()
+	_, ok := tm.txStates[txID]
+	return ok
+}
+```
+
+Run: `go test ./plugins/postgres/ -run TestTxManager_BeginAllocatesTxState -v`
+Expected: compile error (`tm.txStatesMu undefined`)
+
+- [ ] **Step 3: Wire `txStates` into `TransactionManager`**
+
+In `plugins/postgres/transaction_manager.go`, modify the struct and constructor:
+
+```go
+type TransactionManager struct {
+	pool     *pgxpool.Pool
+	registry *txRegistry
+	uuids    spi.UUIDGenerator
+	mu       sync.Mutex
+	submitTimes map[string]time.Time
+	tenants     map[string]spi.TenantID
+	// txStates holds per-transaction bookkeeping for first-committer-wins
+	// validation at commit. Populated on Begin; validated and removed on
+	// Commit; removed on Rollback.
+	txStatesMu sync.Mutex
+	txStates   map[string]*txState
+}
+
+func NewTransactionManager(pool *pgxpool.Pool, uuids spi.UUIDGenerator) *TransactionManager {
+	return &TransactionManager{
+		pool:        pool,
+		registry:    newTxRegistry(),
+		uuids:       uuids,
+		submitTimes: make(map[string]time.Time),
+		tenants:     make(map[string]spi.TenantID),
+		txStates:    make(map[string]*txState),
+	}
+}
+```
+
+Modify `Begin` to register the txState (place the insertion after the existing `tm.tenants[txID] = tenantID` line):
+
+```go
+	tm.txStatesMu.Lock()
+	tm.txStates[txID] = newTxState(tenantID)
+	tm.txStatesMu.Unlock()
+```
+
+Add a helper near `removeTenant`:
+
+```go
+// removeTxState drops the txState entry for a completed transaction.
+func (tm *TransactionManager) removeTxState(txID string) {
+	tm.txStatesMu.Lock()
+	delete(tm.txStates, txID)
+	tm.txStatesMu.Unlock()
+}
+
+// lookupTxState returns the txState for the given txID.
+func (tm *TransactionManager) lookupTxState(txID string) (*txState, bool) {
+	tm.txStatesMu.Lock()
+	defer tm.txStatesMu.Unlock()
+	s, ok := tm.txStates[txID]
+	return s, ok
+}
+```
+
+Update `Commit` and `Rollback` to call `tm.removeTxState(txID)` alongside the existing `tm.removeTenant(txID)` (on every completion path — success and error). Do not add the validation logic yet; that's Task 10.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./plugins/postgres/ -run "TestTxManager_BeginAllocatesTxState|TestTxManager_RollbackCleansTxState" -v`
+Expected: PASS
+
+Also run the existing TxManager tests to ensure no regression:
+
+Run: `go test ./plugins/postgres/ -run TestTxManager -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/transaction_manager.go plugins/postgres/transaction_manager_test.go plugins/postgres/export_test.go
+git commit -m "feat(postgres): wire txState lifecycle into TransactionManager"
+```
+
+---
+
+### Task 8: Switch isolation level to `RepeatableRead`
+
+**Files:**
+- Modify: `plugins/postgres/transaction_manager.go`
+- Modify: `plugins/postgres/transaction_manager_test.go`
+
+- [ ] **Step 1: Write regression test proving RR still gives snapshot + read-your-own-writes**
+
+Append to `plugins/postgres/transaction_manager_test.go`:
+
+```go
+func TestTxManager_RepeatableRead_SnapshotAndReadYourOwnWrites(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+
+	// Tx1 inserts a row.
+	txID1, txCtx1, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin 1: %v", err)
+	}
+	tx1, _ := tm.LookupTx(txID1)
+	if _, err := tx1.Exec(txCtx1,
+		`INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		 VALUES ('t1', 'e1', 'M', '1', 1, false, '{}'::jsonb)`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	// Read-your-own-writes within tx1.
+	var v int64
+	if err := tx1.QueryRow(txCtx1,
+		`SELECT version FROM entities WHERE tenant_id='t1' AND entity_id='e1'`).Scan(&v); err != nil {
+		t.Fatalf("read own write: %v", err)
+	}
+	if v != 1 {
+		t.Errorf("read-your-own-writes: want version=1, got %d", v)
+	}
+	if err := tm.Commit(ctx, txID1); err != nil {
+		t.Fatalf("Commit 1: %v", err)
+	}
+
+	// Tx2 begins, takes snapshot.
+	txID2, txCtx2, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin 2: %v", err)
+	}
+	tx2, _ := tm.LookupTx(txID2)
+	// Confirm tx2 sees e1 at version 1.
+	var v2 int64
+	if err := tx2.QueryRow(txCtx2,
+		`SELECT version FROM entities WHERE tenant_id='t1' AND entity_id='e1'`).Scan(&v2); err != nil {
+		t.Fatalf("tx2 read: %v", err)
+	}
+	if v2 != 1 {
+		t.Errorf("tx2 snapshot: want 1, got %d", v2)
+	}
+
+	// Tx3 (outside tx2) commits a version bump.
+	txID3, txCtx3, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin 3: %v", err)
+	}
+	tx3, _ := tm.LookupTx(txID3)
+	if _, err := tx3.Exec(txCtx3,
+		`UPDATE entities SET version=2 WHERE tenant_id='t1' AND entity_id='e1'`); err != nil {
+		t.Fatalf("tx3 update: %v", err)
+	}
+	if err := tm.Commit(ctx, txID3); err != nil {
+		t.Fatalf("Commit 3: %v", err)
+	}
+
+	// Tx2 should STILL see version 1 (snapshot isolation preserved).
+	if err := tx2.QueryRow(txCtx2,
+		`SELECT version FROM entities WHERE tenant_id='t1' AND entity_id='e1'`).Scan(&v2); err != nil {
+		t.Fatalf("tx2 re-read: %v", err)
+	}
+	if v2 != 1 {
+		t.Errorf("snapshot preserved after concurrent commit: want 1, got %d", v2)
+	}
+
+	_ = pool // keep available
+	_ = tm.Rollback(ctx, txID2)
+}
+```
+
+- [ ] **Step 2: Run test — should pass under current SERIALIZABLE (both provide snapshot)**
+
+Run: `go test ./plugins/postgres/ -run TestTxManager_RepeatableRead_SnapshotAndReadYourOwnWrites -v`
+Expected: PASS (this confirms the test is valid for both isolation levels)
+
+- [ ] **Step 3: Flip to `RepeatableRead`**
+
+In `plugins/postgres/transaction_manager.go`, change the `Begin` isolation:
+
+```go
+	pgxTx, err := tm.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
+```
+
+Also update the doc comment on `Begin`:
+
+```go
+// Begin starts a new REPEATABLE READ transaction (snapshot isolation) and
+// returns the transaction ID and a context carrying the TransactionState.
+//
+// Row-granular first-committer-wins is enforced in application code via
+// txState bookkeeping (readSet/writeSet) and commit-time validation — see
+// Commit() and docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md.
+```
+
+Also update the doc comment at the top of the struct:
+
+```go
+// TransactionManager implements spi.TransactionManager backed by PostgreSQL
+// with REPEATABLE READ isolation plus application-layer row-granular
+// first-committer-wins validation. Each Begin() acquires a real pgx.Tx,
+// registers it in the txRegistry, and allocates a *txState for read/write
+// bookkeeping used by Commit.
+```
+
+- [ ] **Step 4: Run full postgres test suite to verify no regression**
+
+Run: `go test ./plugins/postgres/ -v`
+Expected: all PASS (including the new RR regression test). If any test fails, diagnose before proceeding — this flip should be a pure substitution since SSI ⊃ SI.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/transaction_manager.go plugins/postgres/transaction_manager_test.go
+git commit -m "feat(postgres): switch isolation to REPEATABLE READ
+
+First-committer-wins is now enforced in application code via the
+txState bookkeeping machinery; the SERIALIZABLE page-level SSI layer
+is no longer needed and was the source of #17 false positives."
+```
+
+---
+
+### Task 9: `validateInChunks` helper with real postgres
+
+**Files:**
+- Create: `plugins/postgres/commit_validator.go`
+- Create: `plugins/postgres/commit_validator_test.go`
+- Modify: `plugins/postgres/export_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// plugins/postgres/commit_validator_test.go
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/plugins/postgres"
+)
+
+func TestValidateInChunks_EmptyIDs(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(ctx, txID)
+	tx, _ := tm.LookupTx(txID)
+	current, err := postgres.ValidateInChunksForTest(txCtx, tx, "t1", nil, 100)
+	if err != nil {
+		t.Fatalf("validateInChunks(nil): %v", err)
+	}
+	if len(current) != 0 {
+		t.Errorf("want empty map, got %v", current)
+	}
+}
+
+func TestValidateInChunks_SingleChunkReturnsVersions(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+
+	// Pre-populate two rows.
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'e1', 'M', '1', 3, false, '{}'::jsonb),
+		       ('t1', 'e2', 'M', '1', 7, false, '{}'::jsonb)
+	`)
+
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(ctx, txID)
+	tx, _ := tm.LookupTx(txID)
+	current, err := postgres.ValidateInChunksForTest(txCtx, tx, "t1", []string{"e1", "e2"}, 100)
+	if err != nil {
+		t.Fatalf("validateInChunks: %v", err)
+	}
+	if current["e1"] != 3 || current["e2"] != 7 {
+		t.Errorf("versions: want {e1:3,e2:7}, got %v", current)
+	}
+}
+
+func TestValidateInChunks_MultipleChunks(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+
+	// Insert 5 rows.
+	for i, id := range []string{"a", "b", "c", "d", "e"} {
+		_, _ = pool.Exec(ctx, `
+			INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+			VALUES ('t1', $1, 'M', '1', $2, false, '{}'::jsonb)
+		`, id, int64(i+1))
+	}
+
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(ctx, txID)
+	tx, _ := tm.LookupTx(txID)
+	// chunk size 2 forces 3 chunks (5 IDs).
+	current, err := postgres.ValidateInChunksForTest(txCtx, tx, "t1",
+		[]string{"a", "b", "c", "d", "e"}, 2)
+	if err != nil {
+		t.Fatalf("validateInChunks: %v", err)
+	}
+	if len(current) != 5 {
+		t.Errorf("want 5 rows, got %d: %v", len(current), current)
+	}
+}
+
+func TestValidateInChunks_TenantScoped(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+
+	// Same entity_id in two tenants.
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'e1', 'M', '1', 1, false, '{}'::jsonb),
+		       ('t2', 'e1', 'M', '1', 99, false, '{}'::jsonb)
+	`)
+
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(ctx, txID)
+	tx, _ := tm.LookupTx(txID)
+	current, err := postgres.ValidateInChunksForTest(txCtx, tx, "t1", []string{"e1"}, 100)
+	if err != nil {
+		t.Fatalf("validateInChunks: %v", err)
+	}
+	if current["e1"] != 1 {
+		t.Errorf("tenant scoping: want t1's e1=1, got %d", current["e1"])
+	}
+}
+```
+
+- [ ] **Step 2: Implement `validateInChunks` + add test-only export**
+
+Create `plugins/postgres/commit_validator.go`:
+
+```go
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// defaultValidateChunkSize is the batching threshold for the commit-time
+// FOR SHARE query. Conservative — well under postgres planner thresholds
+// for ANY($1::text[]) arrays. See design doc § "Batch size guard".
+const defaultValidateChunkSize = 1000
+
+// validateInChunks issues SELECT id, version FROM entities WHERE tenant_id=$1
+// AND id = ANY($2) FOR SHARE over sortedIDs, chunked to stay within planner
+// bounds. Returns a map of entity_id → current version covering every row
+// that currently exists for the tenant. Entities absent from the DB are
+// absent from the map — the caller distinguishes "not present = concurrent
+// deletion / expected-absent for fresh insert" in the validate calls.
+//
+// Sort order is preserved across chunks: lock acquisition remains
+// deterministic across concurrent committers.
+//
+// FOR SHARE (not FOR UPDATE) is the right mode: two committing txs both
+// locking the same unchanged row succeed compatibly; any write-write
+// overlap was already caught by tuple-level locks on the DML upstream.
+// Read-set staleness is caught by the subsequent ValidateReadSet compare;
+// concurrent-committer-after-snapshot on the locked rows is caught by
+// postgres itself raising 40001 on the FOR SHARE.
+func (tm *TransactionManager) validateInChunks(
+	ctx context.Context, tx pgx.Tx, tenantID spi.TenantID, sortedIDs []string, chunkSize int,
+) (map[string]int64, error) {
+	if chunkSize <= 0 {
+		chunkSize = defaultValidateChunkSize
+	}
+	current := make(map[string]int64, len(sortedIDs))
+	for i := 0; i < len(sortedIDs); i += chunkSize {
+		end := i + chunkSize
+		if end > len(sortedIDs) {
+			end = len(sortedIDs)
+		}
+		chunk := sortedIDs[i:end]
+		rows, err := tx.Query(ctx, `
+			SELECT entity_id, version
+			  FROM entities
+			 WHERE tenant_id = $1
+			   AND entity_id = ANY($2::text[])
+			 FOR SHARE
+		`, string(tenantID), chunk)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var id string
+			var v int64
+			if err := rows.Scan(&id, &v); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			current[id] = v
+		}
+		rows.Close()
+	}
+	return current, nil
+}
+```
+
+Append to `plugins/postgres/export_test.go`:
+
+```go
+// ValidateInChunksForTest exposes validateInChunks for unit testing.
+func ValidateInChunksForTest(
+	ctx context.Context, tx pgx.Tx, tenantID spi.TenantID, sortedIDs []string, chunkSize int,
+) (map[string]int64, error) {
+	var tm *TransactionManager // method needs a receiver but doesn't use fields in this helper
+	return tm.validateInChunks(ctx, tx, tenantID, sortedIDs, chunkSize)
+}
+```
+
+Ensure `export_test.go` imports `context`, `github.com/jackc/pgx/v5`, and `spi`.
+
+- [ ] **Step 3: Run tests**
+
+Run: `go test ./plugins/postgres/ -run TestValidateInChunks -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/postgres/commit_validator.go plugins/postgres/commit_validator_test.go plugins/postgres/export_test.go
+git commit -m "feat(postgres): validateInChunks helper with sorted FOR SHARE batching"
+```
+
+---
+
+### Task 10: Wire validation into `Commit`
+
+**Files:**
+- Modify: `plugins/postgres/transaction_manager.go`
+- Modify: `plugins/postgres/transaction_manager_test.go`
+
+- [ ] **Step 1: Write failing test — read-set conflict aborts commit**
+
+Append to `plugins/postgres/transaction_manager_test.go`:
+
+```go
+func TestTxManager_Commit_ReadSetConflict(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+
+	// Seed.
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'e1', 'M', '1', 5, false, '{}'::jsonb)
+	`)
+
+	// Tx A: begin, record a read at version 5, delay commit.
+	txA, _, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin A: %v", err)
+	}
+	stateA, _ := postgres.LookupTxStateForTest(tm, txA)
+	stateA.RecordRead("e1", 5)
+
+	// Tx B: bumps e1 to version 6 and commits.
+	txB, txCtxB, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin B: %v", err)
+	}
+	tx, _ := tm.LookupTx(txB)
+	if _, err := tx.Exec(txCtxB,
+		`UPDATE entities SET version=6 WHERE tenant_id='t1' AND entity_id='e1'`); err != nil {
+		t.Fatalf("B update: %v", err)
+	}
+	if err := tm.Commit(ctx, txB); err != nil {
+		t.Fatalf("B commit: %v", err)
+	}
+
+	// Tx A: commit must fail with ErrConflict.
+	err = tm.Commit(ctx, txA)
+	if err == nil {
+		t.Fatal("want ErrConflict on A.Commit, got nil")
+	}
+	if !errors.Is(err, spi.ErrConflict) {
+		t.Errorf("want ErrConflict, got %v", err)
+	}
+}
+```
+
+Add the `LookupTxStateForTest` accessor in `plugins/postgres/export_test.go`:
+
+```go
+func LookupTxStateForTest(tm *TransactionManager, txID string) (*txState, bool) {
+	return tm.lookupTxState(txID)
+}
+```
+
+And export the `RecordRead` / `RecordWrite` methods for test callers — they are already uppercase, so the accessor above suffices. (`*txState` itself is unexported; the returned interface is used as an opaque handle via the exported methods.)
+
+Actually since `*txState` is unexported, the test file (in package `postgres_test`) cannot reference the type. Fix: define an interface alias in `export_test.go`:
+
+```go
+// TxStateForTest exposes the recording methods needed by tests.
+type TxStateForTest interface {
+	RecordRead(id string, version int64)
+	RecordWrite(id string, preWriteVersion int64)
+	PushSavepoint(id string)
+	RestoreSavepoint(id string) error
+	ReleaseSavepoint(id string) error
+}
+
+func LookupTxStateForTest(tm *TransactionManager, txID string) (TxStateForTest, bool) {
+	return tm.lookupTxState(txID)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./plugins/postgres/ -run TestTxManager_Commit_ReadSetConflict -v`
+Expected: FAIL — Tx A commits successfully because validation is not yet wired.
+
+- [ ] **Step 3: Wire validation into `Commit`**
+
+Modify the `Commit` method in `plugins/postgres/transaction_manager.go`. Insert the validation block **before** the existing `SELECT CURRENT_TIMESTAMP` submit-time capture:
+
+```go
+func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
+	pgxTx, ok := tm.registry.Lookup(txID)
+	if !ok {
+		return fmt.Errorf("Commit: transaction %s not found", txID)
+	}
+	state, ok := tm.lookupTxState(txID)
+	if !ok {
+		return fmt.Errorf("Commit: tx state for %s not found", txID)
+	}
+
+	// Row-granular first-committer-wins validation. See design doc
+	// "Why this preserves the published semantic" for the dual-mechanism
+	// argument (tuple locks + FOR SHARE).
+	ids := state.SortedUnionIDs()
+	if len(ids) > 0 {
+		current, err := tm.validateInChunks(ctx, pgxTx, state.tenantID, ids, 0)
+		if err != nil {
+			// 40001 from FOR SHARE under RR = a concurrent committer
+			// modified one of our locked rows since our snapshot.
+			// classifyError maps it to spi.ErrConflict.
+			tm.registry.Remove(txID)
+			tm.removeTenant(txID)
+			tm.removeTxState(txID)
+			_ = pgxTx.Rollback(context.Background())
+			return classifyError(fmt.Errorf("Commit: validate: %w", err))
+		}
+		if verr := state.ValidateReadSet(current); verr != nil {
+			tm.registry.Remove(txID)
+			tm.removeTenant(txID)
+			tm.removeTxState(txID)
+			_ = pgxTx.Rollback(context.Background())
+			return fmt.Errorf("%w: Commit: %w", spi.ErrConflict, verr)
+		}
+		if verr := state.ValidateWriteSet(current); verr != nil {
+			tm.registry.Remove(txID)
+			tm.removeTenant(txID)
+			tm.removeTxState(txID)
+			_ = pgxTx.Rollback(context.Background())
+			return fmt.Errorf("%w: Commit: %w", spi.ErrConflict, verr)
+		}
+	}
+
+	// ... existing commit logic (submit time capture, pgxTx.Commit) ...
+}
+```
+
+Ensure `tm.removeTxState(txID)` is also called on the existing success and error paths of `Commit` and on `Rollback` (added in Task 7 should already cover these; verify all exit paths).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./plugins/postgres/ -run TestTxManager_Commit_ReadSetConflict -v`
+Expected: PASS
+
+Run full postgres test suite:
+
+Run: `go test ./plugins/postgres/ -v`
+Expected: all PASS (no regressions)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/transaction_manager.go plugins/postgres/transaction_manager_test.go plugins/postgres/export_test.go
+git commit -m "feat(postgres): wire first-committer-wins validation into Commit"
+```
+
+---
+
+### Task 11: Hook `recordRead` into `entityStore.Get`
+
+**Files:**
+- Modify: `plugins/postgres/entity_store.go`
+- Modify: `plugins/postgres/entity_store_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `plugins/postgres/entity_store_test.go`:
+
+```go
+func TestEntityStore_Get_PopulatesReadSet(t *testing.T) {
+	pool := newTestPool(t)
+	if err := postgres.DropSchemaForTest(pool); err != nil { t.Fatalf("reset: %v", err) }
+	if err := postgres.Migrate(pool); err != nil { t.Fatalf("migrate: %v", err) }
+	t.Cleanup(func() { _ = postgres.DropSchemaForTest(pool) })
+	uuids := newTestUUIDGenerator()
+	tm := postgres.NewTransactionManager(pool, uuids)
+	factory, _ := postgres.NewStoreFactoryForTest(pool, uuids, tm)
+
+	ctx := ctxWithTenant("t1")
+	// Seed.
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'e1', 'M', '1', 3, false, '{"hello":"world"}'::jsonb)
+	`)
+
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(ctx, txID)
+
+	es, _ := factory.EntityStore(txCtx)
+	if _, err := es.Get(txCtx, "e1"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	state, ok := postgres.LookupTxStateForTest(tm, txID)
+	if !ok {
+		t.Fatal("expected txState")
+	}
+	if v := postgres.ReadSetVersionForTest(state, "e1"); v != 3 {
+		t.Errorf("readSet[e1]: want 3, got %d", v)
+	}
+}
+
+func TestEntityStore_Get_NoTxContext_DoesNotRecord(t *testing.T) {
+	// A Get outside any transaction (no txCtx) must not panic and
+	// must not attempt any bookkeeping.
+	pool := newTestPool(t)
+	if err := postgres.DropSchemaForTest(pool); err != nil { t.Fatalf("reset: %v", err) }
+	if err := postgres.Migrate(pool); err != nil { t.Fatalf("migrate: %v", err) }
+	t.Cleanup(func() { _ = postgres.DropSchemaForTest(pool) })
+	uuids := newTestUUIDGenerator()
+	tm := postgres.NewTransactionManager(pool, uuids)
+	factory, _ := postgres.NewStoreFactoryForTest(pool, uuids, tm)
+
+	ctx := ctxWithTenant("t1")
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'e1', 'M', '1', 3, false, '{}'::jsonb)
+	`)
+	es, _ := factory.EntityStore(ctx)
+	if _, err := es.Get(ctx, "e1"); err != nil {
+		t.Fatalf("Get(no tx): %v", err)
+	}
+}
+```
+
+Add `ReadSetVersionForTest` to `export_test.go`:
+
+```go
+// ReadSetVersionForTest returns the captured readSet version for the
+// given entity, or 0 if not present.
+func ReadSetVersionForTest(s TxStateForTest, entityID string) int64 {
+	inner, ok := s.(*txState)
+	if !ok {
+		return 0
+	}
+	inner.mu.Lock()
+	defer inner.mu.Unlock()
+	return inner.readSet[entityID]
+}
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+Run: `go test ./plugins/postgres/ -run "TestEntityStore_Get_PopulatesReadSet|TestEntityStore_Get_NoTxContext_DoesNotRecord" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Add `recordRead` helper and hook it into `Get`**
+
+Append to `plugins/postgres/txstate.go`:
+
+```go
+// recordReadIfInTx records a read into the tx's state, if the context
+// carries a transaction. No-op for non-tx reads.
+func (tm *TransactionManager) recordReadIfInTx(ctx context.Context, entityID string, version int64) {
+	txState := spi.GetTransaction(ctx)
+	if txState == nil {
+		return
+	}
+	s, ok := tm.lookupTxState(txState.ID)
+	if !ok {
+		return
+	}
+	s.RecordRead(entityID, version)
+}
+
+// recordWriteIfInTx records a write into the tx's state, if the context
+// carries a transaction. No-op for non-tx writes.
+func (tm *TransactionManager) recordWriteIfInTx(ctx context.Context, entityID string, preWriteVersion int64) {
+	txState := spi.GetTransaction(ctx)
+	if txState == nil {
+		return
+	}
+	s, ok := tm.lookupTxState(txState.ID)
+	if !ok {
+		return
+	}
+	s.RecordWrite(entityID, preWriteVersion)
+}
+```
+
+Add `"context"` to imports.
+
+Now the entity store needs access to the TransactionManager. Look at how `entityStore` is constructed — it currently holds `q Querier` and `tenantID`. We need either a reference to the TM or a functional handle. Check `plugins/postgres/store_factory.go` to see how `entityStore` is assembled and thread the TM through.
+
+If the factory already holds a `*TransactionManager`, add a field to `entityStore`:
+
+```go
+type entityStore struct {
+	q        Querier
+	tenantID spi.TenantID
+	tm       *TransactionManager
+}
+```
+
+And update the factory constructor to pass `tm`.
+
+Hook into `Get`. At the end of `Get`, just before `return entity, nil`, add:
+
+```go
+	s.tm.recordReadIfInTx(ctx, entity.Meta.ID, entity.Meta.Version)
+```
+
+(Placement: after the entity has been fully populated from the DB rows, before return.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./plugins/postgres/ -run "TestEntityStore_Get_PopulatesReadSet|TestEntityStore_Get_NoTxContext_DoesNotRecord" -v`
+Expected: PASS
+
+Run full postgres test suite:
+
+Run: `go test ./plugins/postgres/ -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/
+git commit -m "feat(postgres): hook recordRead into entityStore.Get"
+```
+
+---
+
+### Task 12: Hook `recordWrite` into `entityStore.Save`
+
+**Files:**
+- Modify: `plugins/postgres/entity_store.go`
+- Modify: `plugins/postgres/entity_store_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `plugins/postgres/entity_store_test.go`:
+
+```go
+func TestEntityStore_Save_FreshInsertRecordsZero(t *testing.T) {
+	// ... boilerplate (see Task 11 test) ...
+	// Seed: nothing. Save a new entity.
+	txID, txCtx, _ := tm.Begin(ctx)
+	defer tm.Rollback(ctx, txID)
+	es, _ := factory.EntityStore(txCtx)
+	entity := &spi.Entity{
+		Meta: spi.EntityMeta{
+			ID:       "new-e1",
+			TenantID: "t1",
+			ModelRef: spi.ModelRef{EntityName: "M", ModelVersion: "1"},
+		},
+		Data: []byte(`{"x":1}`),
+	}
+	if _, err := es.Save(txCtx, entity); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	state, _ := postgres.LookupTxStateForTest(tm, txID)
+	if v, present := postgres.WriteSetVersionForTest(state, "new-e1"); !present {
+		t.Fatal("writeSet should contain new-e1")
+	} else if v != 0 {
+		t.Errorf("writeSet[new-e1]: want 0 (fresh insert), got %d", v)
+	}
+}
+
+func TestEntityStore_Save_UpdateRecordsPreWriteVersion(t *testing.T) {
+	// ... boilerplate ...
+	// Seed an existing entity at version 4.
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'existing', 'M', '1', 4, false, '{}'::jsonb)
+	`)
+	txID, txCtx, _ := tm.Begin(ctx)
+	defer tm.Rollback(ctx, txID)
+	es, _ := factory.EntityStore(txCtx)
+	entity := &spi.Entity{
+		Meta: spi.EntityMeta{
+			ID:       "existing",
+			TenantID: "t1",
+			ModelRef: spi.ModelRef{EntityName: "M", ModelVersion: "1"},
+		},
+		Data: []byte(`{"updated":true}`),
+	}
+	if _, err := es.Save(txCtx, entity); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	state, _ := postgres.LookupTxStateForTest(tm, txID)
+	if v, present := postgres.WriteSetVersionForTest(state, "existing"); !present {
+		t.Fatal("writeSet should contain existing")
+	} else if v != 4 {
+		t.Errorf("writeSet[existing]: want 4 (pre-write), got %d", v)
+	}
+}
+```
+
+Add `WriteSetVersionForTest` to `export_test.go`:
+
+```go
+func WriteSetVersionForTest(s TxStateForTest, entityID string) (int64, bool) {
+	inner, ok := s.(*txState)
+	if !ok {
+		return 0, false
+	}
+	inner.mu.Lock()
+	defer inner.mu.Unlock()
+	v, present := inner.writeSet[entityID]
+	return v, present
+}
+```
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `go test ./plugins/postgres/ -run "TestEntityStore_Save_FreshInsertRecordsZero|TestEntityStore_Save_UpdateRecordsPreWriteVersion" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Hook `recordWrite` into `Save`**
+
+In `plugins/postgres/entity_store.go`, at the end of `Save` (after `RETURNING version, (xmax = 0)` has populated `nextVersion` and `isNew`, and after all the bookkeeping inserts into `entity_versions` are complete), add:
+
+```go
+	// Pre-write version: 0 for fresh insert (isNew), else nextVersion-1.
+	var preWriteVersion int64
+	if !isNew {
+		preWriteVersion = nextVersion - 1
+	}
+	s.tm.recordWriteIfInTx(ctx, eid, preWriteVersion)
+```
+
+Place this **immediately before** the final `return nextVersion, nil`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./plugins/postgres/ -run "TestEntityStore_Save_FreshInsertRecordsZero|TestEntityStore_Save_UpdateRecordsPreWriteVersion" -v`
+Expected: PASS
+
+Run full postgres test suite:
+
+Run: `go test ./plugins/postgres/ -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/entity_store.go plugins/postgres/entity_store_test.go plugins/postgres/export_test.go
+git commit -m "feat(postgres): hook recordWrite into entityStore.Save"
+```
+
+---
+
+### Task 13: Hook `recordWrite` into `CompareAndSave` and `Delete`
+
+**Files:**
+- Modify: `plugins/postgres/entity_store.go`
+- Modify: `plugins/postgres/entity_store_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `plugins/postgres/entity_store_test.go`:
+
+```go
+func TestEntityStore_CompareAndSave_RecordsWriteSet(t *testing.T) {
+	// ... boilerplate ...
+	// Seed existing entity with a known transaction_id.
+	// The existing CAS semantics expect an expectedTxID argument; set
+	// seed to match.
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'cas-e', 'M', '1', 2, false, '{}'::jsonb)
+	`)
+	// (Seed entity_versions row too if CompareAndSave requires it — mirror
+	// existing CAS tests in entity_store_test.go for the setup.)
+	txID, txCtx, _ := tm.Begin(ctx)
+	defer tm.Rollback(ctx, txID)
+	es, _ := factory.EntityStore(txCtx)
+	entity := &spi.Entity{
+		Meta: spi.EntityMeta{
+			ID:       "cas-e",
+			TenantID: "t1",
+			ModelRef: spi.ModelRef{EntityName: "M", ModelVersion: "1"},
+		},
+		Data: []byte(`{"after-cas":true}`),
+	}
+	expectedTxID := "seed-tx" // match seed row's transaction_id
+	if _, err := es.CompareAndSave(txCtx, entity, expectedTxID); err != nil {
+		t.Fatalf("CompareAndSave: %v", err)
+	}
+	state, _ := postgres.LookupTxStateForTest(tm, txID)
+	if v, present := postgres.WriteSetVersionForTest(state, "cas-e"); !present || v != 2 {
+		t.Errorf("writeSet[cas-e]: want 2, got (v=%d, present=%v)", v, present)
+	}
+}
+
+func TestEntityStore_Delete_RecordsWriteSet(t *testing.T) {
+	// ... boilerplate ...
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'del-e', 'M', '1', 6, false, '{}'::jsonb)
+	`)
+	txID, txCtx, _ := tm.Begin(ctx)
+	defer tm.Rollback(ctx, txID)
+	es, _ := factory.EntityStore(txCtx)
+	if err := es.Delete(txCtx, "del-e"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	state, _ := postgres.LookupTxStateForTest(tm, txID)
+	if v, present := postgres.WriteSetVersionForTest(state, "del-e"); !present || v != 6 {
+		t.Errorf("writeSet[del-e]: want 6, got (v=%d, present=%v)", v, present)
+	}
+}
+```
+
+Review existing `CompareAndSave` / `Delete` tests to confirm the exact seed setup (transaction_id / entity_versions rows) required.
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+Run: `go test ./plugins/postgres/ -run "TestEntityStore_CompareAndSave_RecordsWriteSet|TestEntityStore_Delete_RecordsWriteSet" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Hook into both methods**
+
+In `plugins/postgres/entity_store.go`:
+
+- `CompareAndSave`: after the UPSERT/UPDATE succeeds and the post-write version is known, compute `preWriteVersion = postVersion - 1` (CAS always modifies an existing row; never a fresh insert). Call `s.tm.recordWriteIfInTx(ctx, eid, preWriteVersion)` just before return.
+
+- `Delete`: `Delete` reads the current version before soft-deleting (the existing implementation already does so for history). Use that version as `preWriteVersion` and call `s.tm.recordWriteIfInTx(ctx, eid, preDeleteVersion)` just before return.
+
+Inspect the existing bodies and place each call adjacent to the successful-exit path only (don't record on the error paths).
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./plugins/postgres/ -run "TestEntityStore_CompareAndSave_RecordsWriteSet|TestEntityStore_Delete_RecordsWriteSet" -v`
+Expected: PASS
+
+Run full suite:
+
+Run: `go test ./plugins/postgres/ -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/entity_store.go plugins/postgres/entity_store_test.go
+git commit -m "feat(postgres): hook recordWrite into CompareAndSave and Delete"
+```
+
+---
+
+### Task 14: Hook `GetAll` / `SaveAll` / `DeleteAll`; annotate non-tracked methods
+
+**Files:**
+- Modify: `plugins/postgres/entity_store.go`
+- Modify: `plugins/postgres/entity_store_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `plugins/postgres/entity_store_test.go`:
+
+```go
+func TestEntityStore_GetAll_RecordsEachReadSet(t *testing.T) {
+	// ... boilerplate ...
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES
+		  ('t1', 'a', 'M', '1', 1, false, '{}'::jsonb),
+		  ('t1', 'b', 'M', '1', 2, false, '{}'::jsonb),
+		  ('t1', 'c', 'M', '1', 3, false, '{}'::jsonb)
+	`)
+	txID, txCtx, _ := tm.Begin(ctx)
+	defer tm.Rollback(ctx, txID)
+	es, _ := factory.EntityStore(txCtx)
+	entities, err := es.GetAll(txCtx, spi.ModelRef{EntityName: "M", ModelVersion: "1"})
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if len(entities) != 3 {
+		t.Fatalf("want 3, got %d", len(entities))
+	}
+	state, _ := postgres.LookupTxStateForTest(tm, txID)
+	for _, id := range []string{"a", "b", "c"} {
+		if v := postgres.ReadSetVersionForTest(state, id); v == 0 {
+			t.Errorf("readSet[%s]: expected populated, was 0", id)
+		}
+	}
+}
+
+func TestEntityStore_DeleteAll_RecordsEachWriteSet(t *testing.T) {
+	// similar: seed N rows, DeleteAll, verify each in writeSet with pre-delete version.
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `go test ./plugins/postgres/ -run "TestEntityStore_GetAll_RecordsEachReadSet|TestEntityStore_DeleteAll_RecordsEachWriteSet" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Hook into `GetAll` and `DeleteAll`; leave `SaveAll` — which is already `spi.DefaultSaveAll(s, ctx, entities)` looping over `Save` — automatically covered since each `Save` records.**
+
+In `GetAll`, after the slice is fully populated, loop:
+
+```go
+	for _, e := range entities {
+		s.tm.recordReadIfInTx(ctx, e.Meta.ID, e.Meta.Version)
+	}
+```
+
+In `DeleteAll`, the existing implementation either does a bulk UPDATE ... SET deleted=true or iterates per-entity — inspect to determine how to capture pre-delete versions. If bulk, add a prior `SELECT entity_id, version FROM entities WHERE ...` to capture versions before the UPDATE, then record each. If it already iterates, record inline.
+
+**Annotate the untracked methods** (spec "Known limitation: phantom reads"). In `entity_store.go`, add a one-line code comment above each of:
+
+- `GetAsAt` — `// Deliberately not tracked: historical reads target immutable versions, not the live row. See design spec §Known limitation.`
+- `GetAllAsAt` — same comment.
+- `GetVersionHistory` — `// Deliberately not tracked: observational, not a live-row read.`
+- `Count` — `// Deliberately not tracked: aggregate with no per-row identity. See design spec §Known limitation (phantom reads on range queries).`
+- `Exists` — decide: if used in read-decide-write patterns, track (like `Get`); if purely a probe, don't. Default: **do track** by capturing the version when the entity exists; add comment accordingly.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./plugins/postgres/ -run "TestEntityStore_GetAll|TestEntityStore_DeleteAll|TestEntityStore_SaveAll" -v`
+Expected: PASS
+
+Run full suite:
+
+Run: `go test ./plugins/postgres/ -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/entity_store.go plugins/postgres/entity_store_test.go
+git commit -m "feat(postgres): hook recordRead/Write for GetAll/DeleteAll; annotate untracked methods"
+```
+
+---
+
+### Task 15: Wire `Savepoint` / `RollbackToSavepoint` / `ReleaseSavepoint` through `txState`
+
+**Files:**
+- Modify: `plugins/postgres/transaction_manager.go`
+- Modify: `plugins/postgres/transaction_manager_test.go`
+
+- [ ] **Step 1: Write failing test — savepoint rollback drops post-savepoint read-set**
+
+Append to `plugins/postgres/transaction_manager_test.go`:
+
+```go
+func TestTxManager_Savepoint_RollsBackTxStateEntries(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'x', 'M', '1', 1, false, '{}'::jsonb),
+		       ('t1', 'y', 'M', '1', 1, false, '{}'::jsonb)
+	`)
+
+	txID, txCtx, _ := tm.Begin(ctx)
+	defer tm.Rollback(ctx, txID)
+
+	state, _ := postgres.LookupTxStateForTest(tm, txID)
+	state.RecordRead("x", 1)
+
+	spID, err := tm.Savepoint(txCtx, txID)
+	if err != nil {
+		t.Fatalf("Savepoint: %v", err)
+	}
+
+	state.RecordRead("y", 1)
+
+	if err := tm.RollbackToSavepoint(txCtx, txID, spID); err != nil {
+		t.Fatalf("RollbackToSavepoint: %v", err)
+	}
+
+	// y should be gone; x preserved.
+	if postgres.ReadSetVersionForTest(state, "y") != 0 {
+		t.Error("readSet[y] should have been restored away")
+	}
+	if postgres.ReadSetVersionForTest(state, "x") != 1 {
+		t.Error("readSet[x] should have been preserved")
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `go test ./plugins/postgres/ -run TestTxManager_Savepoint_RollsBackTxStateEntries -v`
+Expected: FAIL
+
+- [ ] **Step 3: Wire the savepoint methods**
+
+In `plugins/postgres/transaction_manager.go`, modify `Savepoint` / `RollbackToSavepoint` / `ReleaseSavepoint`. Example for `Savepoint`:
+
+```go
+func (tm *TransactionManager) Savepoint(ctx context.Context, txID string) (string, error) {
+	pgxTx, ok := tm.registry.Lookup(txID)
+	if !ok {
+		return "", fmt.Errorf("Savepoint: transaction %s not found", txID)
+	}
+	state, ok := tm.lookupTxState(txID)
+	if !ok {
+		return "", fmt.Errorf("Savepoint: tx state for %s not found", txID)
+	}
+	spID := uuid.UUID(tm.uuids.NewTimeUUID()).String()
+	spName := "sp_" + spID
+	if _, err := pgxTx.Exec(ctx, "SAVEPOINT "+pgx.Identifier{spName}.Sanitize()); err != nil {
+		return "", fmt.Errorf("Savepoint: %w", err)
+	}
+	state.PushSavepoint(spID)
+	return spID, nil
+}
+```
+
+Analogously:
+- `RollbackToSavepoint` — execute `ROLLBACK TO SAVEPOINT` first, then call `state.RestoreSavepoint(spID)`.
+- `ReleaseSavepoint` — execute `RELEASE SAVEPOINT` first, then `state.ReleaseSavepoint(spID)`.
+
+Order matters: the pgx side is the source of truth for durable SQL state; the txState mirror is bookkeeping. Execute SQL first, then mirror.
+
+- [ ] **Step 4: Run test**
+
+Run: `go test ./plugins/postgres/ -run TestTxManager_Savepoint -v`
+Expected: PASS
+
+Run full suite:
+
+Run: `go test ./plugins/postgres/ -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/postgres/transaction_manager.go plugins/postgres/transaction_manager_test.go
+git commit -m "feat(postgres): wire savepoints through txState snapshot/restore"
+```
+
+---
+
+### Task 16: End-to-end test — #17 regression (disjoint entities concurrent)
+
+**Files:**
+- Modify: `plugins/postgres/conformance_test.go` (or `entity_store_test.go` if a more focused home exists)
+
+- [ ] **Step 1: Write the regression test**
+
+If `TestConformance/Entity/Concurrent/DifferentEntities` already exists in the spitest suite, re-enable it and remove any postgres-specific skip annotations. If a focused postgres-only test doesn't exist, add:
+
+```go
+func TestEntityStore_ConcurrentDisjointInserts_NoFalseConflicts(t *testing.T) {
+	// Regression for #17: under SSI this was flaky (page-level SIReadLocks
+	// caused 40001 on concurrent inserts of distinct UUIDs within the same
+	// tenant). Under SI + FCW, disjoint inserts must all commit.
+	pool := newTestPool(t)
+	if err := postgres.DropSchemaForTest(pool); err != nil { t.Fatalf("reset: %v", err) }
+	if err := postgres.Migrate(pool); err != nil { t.Fatalf("migrate: %v", err) }
+	t.Cleanup(func() { _ = postgres.DropSchemaForTest(pool) })
+	uuids := newTestUUIDGenerator()
+	tm := postgres.NewTransactionManager(pool, uuids)
+	factory, _ := postgres.NewStoreFactoryForTest(pool, uuids, tm)
+
+	ctx := ctxWithTenant("t1")
+
+	// First, populate the tree so the b-tree has enough pages that disjoint
+	// inserts would have collided under SSI (mirrors the #17 repro).
+	for i := 0; i < 200; i++ {
+		id := fmt.Sprintf("seed-%04d", i)
+		_, _ = pool.Exec(ctx, `
+			INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+			VALUES ('t1', $1, 'M', '1', 1, false, '{}'::jsonb)
+		`, id)
+	}
+
+	// Now 8 concurrent inserts of distinct UUIDs.
+	const N = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			txID, txCtx, err := tm.Begin(ctx)
+			if err != nil {
+				errs <- err
+				return
+			}
+			es, _ := factory.EntityStore(txCtx)
+			entity := &spi.Entity{
+				Meta: spi.EntityMeta{
+					ID:       fmt.Sprintf("concurrent-%d-%s", i, uuid.NewString()),
+					TenantID: "t1",
+					ModelRef: spi.ModelRef{EntityName: "M", ModelVersion: "1"},
+				},
+				Data: []byte(`{}`),
+			}
+			if _, err := es.Save(txCtx, entity); err != nil {
+				errs <- err
+				_ = tm.Rollback(ctx, txID)
+				return
+			}
+			errs <- tm.Commit(ctx, txID)
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Errorf("disjoint concurrent insert should never conflict: %v", err)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test — should pass under new SI+FCW**
+
+Run: `go test ./plugins/postgres/ -run TestEntityStore_ConcurrentDisjointInserts_NoFalseConflicts -v`
+Expected: PASS. If it flakes, run 20× via `-count=20` to confirm stability.
+
+- [ ] **Step 3: Loop-stability check**
+
+Run: `go test ./plugins/postgres/ -run TestEntityStore_ConcurrentDisjointInserts_NoFalseConflicts -count=20 -v`
+Expected: PASS (all 20 iterations). The #17 flake is gone.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/postgres/
+git commit -m "test(postgres): regression guard for #17 — disjoint concurrent inserts"
+```
+
+---
+
+### Task 17: End-to-end — same-entity race + deleted-entity conflict
+
+**Files:**
+- Modify: `plugins/postgres/conformance_test.go` (or `entity_store_test.go`)
+
+- [ ] **Step 1: Write tests**
+
+```go
+func TestEntityStore_ConcurrentSameEntityUpdate_FirstWins(t *testing.T) {
+	// ... boilerplate ...
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'shared', 'M', '1', 1, false, '{}'::jsonb)
+	`)
+
+	var wg sync.WaitGroup
+	results := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			txID, txCtx, err := tm.Begin(ctx)
+			if err != nil {
+				results <- err
+				return
+			}
+			es, _ := factory.EntityStore(txCtx)
+			// Each tx reads, then writes — classic race.
+			if _, err := es.Get(txCtx, "shared"); err != nil {
+				results <- err
+				_ = tm.Rollback(ctx, txID)
+				return
+			}
+			entity := &spi.Entity{
+				Meta: spi.EntityMeta{
+					ID:       "shared",
+					TenantID: "t1",
+					ModelRef: spi.ModelRef{EntityName: "M", ModelVersion: "1"},
+				},
+				Data: []byte(fmt.Sprintf(`{"by":%d}`, i)),
+			}
+			if _, err := es.Save(txCtx, entity); err != nil {
+				results <- err
+				_ = tm.Rollback(ctx, txID)
+				return
+			}
+			results <- tm.Commit(ctx, txID)
+		}(i)
+	}
+	wg.Wait()
+	close(results)
+
+	var success, conflict int
+	for err := range results {
+		if err == nil {
+			success++
+		} else if errors.Is(err, spi.ErrConflict) {
+			conflict++
+		} else {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	if success != 1 || conflict != 1 {
+		t.Errorf("want exactly 1 success + 1 conflict; got success=%d conflict=%d", success, conflict)
+	}
+}
+
+func TestEntityStore_ReadThenConcurrentDelete_Conflict(t *testing.T) {
+	// Tx A reads e1; concurrent tx B deletes e1 and commits; A's commit fails.
+	// ... boilerplate + seed e1 at v=1 ...
+	txA, txCtxA, _ := tm.Begin(ctx)
+	esA, _ := factory.EntityStore(txCtxA)
+	if _, err := esA.Get(txCtxA, "e1"); err != nil { t.Fatalf("A.Get: %v", err) }
+
+	txB, txCtxB, _ := tm.Begin(ctx)
+	esB, _ := factory.EntityStore(txCtxB)
+	if err := esB.Delete(txCtxB, "e1"); err != nil { t.Fatalf("B.Delete: %v", err) }
+	if err := tm.Commit(ctx, txB); err != nil { t.Fatalf("B.Commit: %v", err) }
+
+	err := tm.Commit(ctx, txA)
+	if !errors.Is(err, spi.ErrConflict) {
+		t.Errorf("want ErrConflict, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./plugins/postgres/ -run "TestEntityStore_ConcurrentSameEntityUpdate_FirstWins|TestEntityStore_ReadThenConcurrentDelete_Conflict" -v -count=5`
+Expected: PASS (all 5 iterations)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/postgres/
+git commit -m "test(postgres): same-entity race and read-then-concurrent-delete conflict"
+```
+
+---
+
+### Task 18: End-to-end — large read-set chunking
+
+**Files:**
+- Modify: `plugins/postgres/commit_validator_test.go`
+
+- [ ] **Step 1: Write test**
+
+```go
+func TestCommit_LargeReadSet_ChunkedValidation(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+
+	// Seed 2500 entities — forces 3 chunks at the default size of 1000.
+	for i := 0; i < 2500; i++ {
+		id := fmt.Sprintf("bulk-%05d", i)
+		_, _ = pool.Exec(ctx, `
+			INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+			VALUES ('t1', $1, 'M', '1', 1, false, '{}'::jsonb)
+		`, id)
+	}
+
+	txID, txCtx, _ := tm.Begin(ctx)
+	state, _ := postgres.LookupTxStateForTest(tm, txID)
+	for i := 0; i < 2500; i++ {
+		state.RecordRead(fmt.Sprintf("bulk-%05d", i), 1)
+	}
+
+	// Commit must succeed — no concurrent modifications, chunking is
+	// internal. Main assertion: no error / no hang.
+	start := time.Now()
+	if err := tm.Commit(ctx, txID); err != nil {
+		t.Fatalf("commit with large read-set: %v", err)
+	}
+	if d := time.Since(start); d > 5*time.Second {
+		t.Errorf("large read-set commit took too long: %v (suggests chunking is broken)", d)
+	}
+	_ = txCtx
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `go test ./plugins/postgres/ -run TestCommit_LargeReadSet_ChunkedValidation -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/postgres/commit_validator_test.go
+git commit -m "test(postgres): large read-set commit uses chunked validation"
+```
+
+---
+
+### Task 19: End-to-end — savepoint rollback drops read-set conflict
+
+**Files:**
+- Modify: `plugins/postgres/transaction_manager_test.go`
+
+- [ ] **Step 1: Write test**
+
+```go
+func TestTxManager_SavepointRollback_DropsReadSet_CommitSucceeds(t *testing.T) {
+	// Setup: seed x,y. Tx A reads x; push savepoint; reads y; concurrent
+	// tx modifies y; Tx A rolls back to savepoint; Tx A commits.
+	// Expected: commit succeeds — y is no longer in readSet, so the
+	// concurrent modification is not a conflict.
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'x', 'M', '1', 1, false, '{}'::jsonb),
+		       ('t1', 'y', 'M', '1', 1, false, '{}'::jsonb)
+	`)
+	factory, _ := postgres.NewStoreFactoryForTest(pool, newTestUUIDGenerator(), tm)
+
+	txID, txCtx, _ := tm.Begin(ctx)
+	es, _ := factory.EntityStore(txCtx)
+	if _, err := es.Get(txCtx, "x"); err != nil { t.Fatalf("read x: %v", err) }
+
+	spID, err := tm.Savepoint(txCtx, txID)
+	if err != nil { t.Fatalf("Savepoint: %v", err) }
+
+	if _, err := es.Get(txCtx, "y"); err != nil { t.Fatalf("read y: %v", err) }
+
+	// Concurrent tx bumps y's version.
+	txB, txCtxB, _ := tm.Begin(ctx)
+	_, _ = pool.Exec(ctx, `UPDATE entities SET version=2 WHERE tenant_id='t1' AND entity_id='y'`) // fallback if UPDATE through tx2 doesn't apply; prefer to route via txB
+	_ = tm.Commit(ctx, txB)
+	_ = txCtxB
+
+	// Rollback to savepoint — y drops out of read-set.
+	if err := tm.RollbackToSavepoint(txCtx, txID, spID); err != nil {
+		t.Fatalf("RollbackToSavepoint: %v", err)
+	}
+
+	// Commit must succeed — x's version is unchanged; y is no longer validated.
+	if err := tm.Commit(ctx, txID); err != nil {
+		t.Errorf("commit should succeed after rollback-to drops y; got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run**
+
+Run: `go test ./plugins/postgres/ -run TestTxManager_SavepointRollback_DropsReadSet_CommitSucceeds -v`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/postgres/transaction_manager_test.go
+git commit -m "test(postgres): savepoint rollback drops read-set entries for commit"
+```
+
+---
+
+### Task 20: Conformance-suite alignment
+
+**Files:**
+- Modify: `internal/spitest/` — the concurrency test file (path determined by `ls internal/spitest/` at execution time).
+
+- [ ] **Step 1: Inventory the existing spitest concurrency tests**
+
+Run: `grep -rn "Concurrent" internal/spitest/`
+
+Identify tests matching the #17 scenario and any "same-entity race" / "savepoint semantics" tests.
+
+- [ ] **Step 2: Update or add expectations**
+
+For the `DifferentEntities` test: remove any plugin-specific skips or `-count=1` workarounds; confirm it runs on postgres without flake under the new design.
+
+For any `SameEntity` concurrency test: assert "exactly one success + one ErrConflict" across memory, postgres, and (via a separate test run or CI) cassandra.
+
+For the savepoint divergence: if the spitest harness has a savepoint-specific test, add a `// DIVERGENCE:` comment next to any assertion that reflects the postgres-preserves / cassandra-clears behavior. If no such test exists yet, add one that asserts the divergence-tolerant behavior (either "post-savepoint reads are validated after rollback-to" OR accept both). The spec documents this explicitly; the conformance test should mirror that.
+
+- [ ] **Step 3: Run full spitest conformance**
+
+Run: `go test ./internal/spitest/... -v`
+Expected: all PASS
+
+Run: `go test ./internal/e2e/... -v`
+Expected: all PASS (E2E tests use postgres via testcontainers)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/spitest/
+git commit -m "test(spitest): align conformance with SI+FCW semantics and savepoint divergence"
+```
+
+---
+
+### Task 21: Close #17 and file the cross-plugin parity check
+
+**Files:**
+- Run full parity suite; no code changes if everything is green.
+
+- [ ] **Step 1: Run parity suite 20×**
+
+Run: `for i in {1..20}; do go test ./plugins/postgres/ ./internal/spitest/... ./internal/e2e/... || break; done`
+Expected: all 20 runs PASS.
+
+- [ ] **Step 2: Run full module tests**
+
+Run: `go test ./... -v`
+Expected: all PASS. Follow-up on any failures.
+
+- [ ] **Step 3: Vet**
+
+Run: `go vet ./...`
+Expected: no output.
+
+- [ ] **Step 4: Confirm #35 and #17 are in the PR description**
+
+Draft a PR description that:
+- Closes #17 (the flake scenario passes reliably now).
+- References #18 (this work).
+- References #35 (follow-up coverage for non-entity stores).
+- References cyoda-go-cassandra#22 (sibling on cassandra).
+- Links the design spec and this plan.
+
+- [ ] **Step 5: Commit any remaining cleanup and push**
+
+No code commit at this step unless something turned up. If so:
+
+```bash
+git add ...
+git commit -m "chore: final cleanup for SI+FCW PR"
+```
+
+Then the human opens the PR. No automated push from the plan.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Goals 1 (parity with cassandra), 2 (eliminate page-level false positives), 3 (no SPI changes), 4 (snapshot + RYW preserved), 5 (multi-node via Join) — all covered by the task chain. Goal 4 specifically verified by Task 8's regression test.
+- Non-goals 1–4 honored: non-entity store coverage out of scope (#35 referenced, not implemented); no advisory locks; no retry wrapper; multi-node deployments without proxying not addressed.
+- Mechanism points (RR flip, readSet/writeSet, validation at commit, savepoint handling, chunking, sorted lock order, FOR SHARE rationale) — each mapped to a task.
+- Known-limitation "phantom reads" — Task 14 adds the per-method annotations.
+- Test coverage (14 tests in spec § Test strategy) — all present: read-set conflict (Task 10), write-set conflict (Task 17), disjoint-rows no-conflict (Task 16), insert-no-read-set-interference (implicit in Task 12), tenant-scoped (Task 9), batched query (Task 9), deleted-entity (Task 17), large-read-set (Task 18), sorted lock acquisition (Task 4 and Task 18 combined), savepoint-rollback-drops-read-set (Task 19).
+
+**Placeholder scan:** no TBDs; no "add appropriate error handling"; every code step has a concrete block; no "similar to Task N" — code is repeated where needed.
+
+**Type consistency:** `*txState`, `readSet map[string]int64`, `writeSet map[string]int64`, `savepointEntry`, `SortedUnionIDs`, `ValidateReadSet`, `ValidateWriteSet`, `RecordRead`, `RecordWrite`, `PushSavepoint`, `RestoreSavepoint`, `ReleaseSavepoint`, `recordReadIfInTx`, `recordWriteIfInTx`, `validateInChunks` — names consistent across tasks. `tm.txStates` / `tm.txStatesMu` / `tm.lookupTxState` / `tm.removeTxState` — consistent. `TxStateForTest` interface + `LookupTxStateForTest` / `ReadSetVersionForTest` / `WriteSetVersionForTest` / `ValidateInChunksForTest` — consistent test-accessor nomenclature.
+
+**Scope:** 21 tasks, each 2-5 minute steps, one coherent codebase (plugins/postgres + minimal spitest touch). Appropriate for a single implementation session.

--- a/docs/superpowers/reviews/2026-04-15-postgres-si-first-committer-wins-review-01.md
+++ b/docs/superpowers/reviews/2026-04-15-postgres-si-first-committer-wins-review-01.md
@@ -1,0 +1,79 @@
+# Design Review: Postgres SI + Row-Granular First-Committer-Wins
+
+## Overall Assessment
+This is a well-written, carefully reasoned design. The core approach — downgrading from SERIALIZABLE to REPEATABLE READ and implementing application-level first-committer-wins via commit-time version validation — is sound and well-matched to the stated goal of behavioral parity with the Cassandra plugin. The motivation is clearly articulated, the scope is appropriately bounded, and the non-goals are honest about deferred work.
+That said, I have a few concerns ranging from a potential correctness gap to operational considerations.
+
+## 1. Correctness: FOR SHARE under RR and the 40001 claim
+The design states:
+
+Under RR, if that row was modified by a concurrent committed tx after our snapshot, postgres raises ERROR: could not serialize access due to concurrent update (SQLSTATE 40001) automatically.
+
+This is correct per the Postgres docs. Under Repeatable Read, SELECT ... FOR SHARE will block if the target row has an uncommitted concurrent modification, and will raise 40001 if that concurrent transaction commits a modification before our lock attempt resolves. This is the standard RR write-conflict detection behavior applied to locking reads. So the mechanism the design relies on is valid.
+However, there's a subtlety worth noting: the 40001 from FOR SHARE fires only when a concurrent transaction has modified the row. If a concurrent transaction merely read the same row (even with FOR SHARE), there's no conflict — FOR SHARE locks are compatible with each other. This is exactly the desired behavior for first-committer-wins, so it's correct here, but it's worth calling out in implementation comments so future readers understand why FOR SHARE (not FOR UPDATE) was chosen.
+
+## 2. Potential race: validate-then-commit window under FOR SHARE
+The design uses FOR SHARE rather than FOR UPDATE. This means the validate-then-commit window is protected against concurrent writes to the same rows, but a third transaction could still acquire its own FOR SHARE lock on the same rows concurrently.
+Consider: Tx A and Tx B both read entity X at version 5, both write it, and both enter the commit phase simultaneously. Both issue SELECT ... FOR SHARE. Since FOR SHARE is compatible with FOR SHARE, both succeed, both see version 5, both validate successfully, and both call pgxTx.Commit(). At the Commit point, the actual UPDATE statements were already executed earlier in the transaction under RR, so the second committer's UPDATE would trigger Postgres's own RR concurrent-update detection — but only if both transactions wrote to the same row.
+This scenario is actually handled correctly because: (a) the writes already happened during the tx, meaning Postgres holds row-level exclusive locks from the UPDATE/INSERT statements themselves, and (b) under RR, a second transaction trying to update a row already modified by a concurrent in-progress transaction will block on the row lock, not on the FOR SHARE lock.
+So the FOR SHARE really serves as a read-set validator, and write-write conflicts on the same row are caught by Postgres's own tuple-level locking from the earlier UPDATE statements. This is fine, but the design should explicitly state this dual-mechanism argument — that write-set conflicts are caught by Postgres's inherent row locks from the DML, while FOR SHARE catches read-set staleness. Right now the document somewhat blurs these two mechanisms together.
+
+## 3. Insert conflict detection gap
+The design says:
+
+Write-set: expected pre-write version must equal current; version 0 (new insert) requires the row to not yet exist in current.
+
+For inserts, writeSet[id] = 0 means "this entity didn't exist when I wrote it." At commit time, the validation checks that the entity ID is absent from the SELECT ... FOR SHARE results. But there's a subtle issue: if two transactions concurrently insert the same entity ID, the SELECT ... FOR SHARE at commit time will find the row only if the other transaction has already committed. If both are in-flight:
+
+Tx A inserts entity X → row exists with a tuple lock
+Tx B inserts entity X → this would already fail at INSERT time with a unique constraint violation (assuming (tenant_id, id) is unique), not at commit-time validation
+
+So the design is correct in practice if the entities table has a unique constraint on (tenant_id, id), which it presumably does. But this should be explicitly stated as a precondition, since the commit-time SELECT ... FOR SHARE path alone wouldn't catch concurrent inserts of the same ID if both are still uncommitted.
+
+## 4. Deleted rows in the read-set
+The design correctly handles the case where a concurrent committer deletes a row that's in our read-set:
+
+Missing current (deleted by concurrent committer) → conflict.
+
+But this depends on deletes being "soft deletes" (the row still exists with a bumped version) or on the delete being committed before our SELECT ... FOR SHARE runs. If deletes are hard deletes (DELETE FROM entities WHERE ...), a committed hard delete would cause the row to be absent from the FOR SHARE results. The design mentions "soft delete bumps version" in the store-layer table, which is good — but it's worth confirming that all entity deletion paths go through soft delete. If any path does a hard DELETE, the FOR SHARE approach degrades: the row simply vanishes from the result set, which the read-set validator would catch as "missing = conflict," so it's still correct but the error message/path differs.
+
+## 5. Performance: single batched query is good, but watch cardinality
+The commit-time validation issues a single SELECT id, version FROM entities WHERE tenant_id = $1 AND id = ANY($2) FOR SHARE. This is a good design — one round-trip, batch processing. A few operational notes:
+
+Large read/write sets: If a transaction touches hundreds or thousands of entities, the ANY($2) array could get large. Postgres handles ANY(array) well up to a few thousand elements, but beyond that, query planning can degrade. Consider documenting an upper-bound expectation or, for defense, chunking the validation if len(ids) > N.
+Index usage: The query should hit an index on (tenant_id, id). If the primary key or a unique index covers this, the FOR SHARE scan is efficient. Worth confirming this in the implementation PR.
+Lock acquisition ordering: When many concurrent transactions validate at the same time, FOR SHARE locks are acquired in whatever order the index scan returns rows. Since FOR SHARE is compatible with FOR SHARE, this doesn't cause deadlocks by itself. But if a transaction also holds row-exclusive locks from prior writes, and another transaction's FOR SHARE needs to wait on those, there's potential for deadlock if the lock acquisition order differs between transactions. Postgres will detect this and raise 40P01, which classifyError already maps to ErrConflict — so the behavior is correct, but deadlock-induced aborts could become a performance concern under high contention. Sorting ids before issuing the query would make lock acquisition deterministic and eliminate this class of deadlock.
+
+
+## 6. Savepoint semantics: intentional divergence from Cassandra
+The design notes:
+
+This diverges from cassandra's "clear read-set on savepoint" semantic — this divergence is intentional because postgres tracks row visibility natively and the read-set in this plugin is purely commit-validation bookkeeping.
+
+This is a reasonable decision, but it means the plugins are no longer perfectly behavioral-parity on savepoints. The conformance test suite (spitest) should include a savepoint-specific concurrency test that documents the expected behavior difference, or the spitest framework should allow plugin-specific expected results for savepoint edge cases. Otherwise a future contributor might see this divergence and treat it as a bug.
+
+## 7. GetAsAt and GetVersionHistory not tracked — correct, but document the threat model
+The decision not to track GetAsAt (point-in-time reads) and GetVersionHistory makes sense: these are reads of immutable historical data that don't participate in first-committer-wins. However, if application logic reads a historical version via GetAsAt and then makes a decision that leads to a write in the same transaction, that decision is based on data that isn't validated at commit time. This is acceptable under the stated semantic (only live-row reads are tracked), but it's worth adding a one-line comment in the code to prevent a future developer from "fixing" this by adding tracking.
+
+## 8. Minor: cleanupTx on error paths
+The commit code calls tm.cleanupTx(txID) followed by pgxTx.Rollback(context.Background()) on error paths. The order seems fine, but if cleanupTx removes the txState entry before Rollback completes, and Rollback itself triggers any callback that consults txState, there could be an issue. This is likely not a real problem given the architecture, but it's worth confirming that Rollback doesn't reference txState anywhere.
+Also, using context.Background() for the rollback (rather than the original ctx) is correct — you don't want a cancelled context to prevent cleanup. Good.
+
+## 9. Test strategy is strong
+The test list is comprehensive. A few additions I'd suggest:
+
+TestCommit_DeletedEntityConflict: Tx A reads entity X; concurrent Tx B deletes X (soft delete); A's commit detects the version bump from the delete.
+TestCommit_LargeReadSet: Stress test with a transaction reading 500+ entities to verify the batched query performs acceptably.
+TestCommit_SavepointRollbackThenConflict: A transaction reads entity X, takes a savepoint, reads entity Y, rolls back to savepoint (dropping Y from the read-set), then a concurrent tx modifies Y. The commit should succeed because Y is no longer in the validated read-set.
+
+
+## Summary
+The design is solid. The core mechanism correctly leverages Postgres RR's built-in concurrent-update detection via FOR SHARE to implement row-granular first-committer-wins, and the explicit version validation catches the cases that Postgres's native checks wouldn't (e.g., read-set staleness without a write attempt on that row). The main items I'd want addressed before or during implementation:
+
+Explicitly document the dual mechanism (Postgres row locks for write-write conflicts, FOR SHARE + version check for read-set validation) so reviewers and future maintainers understand the full safety argument.
+Add a precondition note about the (tenant_id, id) unique constraint being required for insert-conflict correctness.
+Sort ids before the validation query to ensure deterministic lock acquisition order and prevent deadlocks under contention.
+Document the savepoint divergence from Cassandra in the conformance test suite, not just in this design doc.
+Consider the additional test cases listed above.
+
+None of these are blockers — the design is ready for implementation planning as stated. These are refinements that would strengthen the implementation and its long-term maintainability.

--- a/docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md
+++ b/docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md
@@ -110,6 +110,16 @@ Every method on `EntityStore` that touches an entity row inside a tx context rec
 
 Non-tx reads (no `txCtx`) bypass bookkeeping entirely. A public HTTP GET on `/entities/{id}` reads the current snapshot without recording anything.
 
+#### Known limitation: phantom reads on range/list queries
+
+`GetAll(txCtx, ref)` records the IDs of the **entities returned** into `readSet`. Commit-time validation is strictly ID-indexed, so it detects changes to those specific rows — but it **does not detect a concurrent transaction inserting a new row that would have satisfied the `GetAll` predicate**. This is a classic phantom-read anomaly that snapshot isolation with ID-granular first-committer-wins cannot prevent.
+
+Cassandra's plugin has the same limitation by construction (its per-entity read-set tracking is also ID-indexed; the earlier architecture report on `cyoda-go-cassandra` confirms phantom reads are not prevented). Parity with cassandra is preserved.
+
+**What this means for application developers:** do not rely on `GetAll` / `ListEntities` / `Count` results being serializable against concurrent inserts within a transaction. If a workflow's correctness depends on "no new entity of kind X existed at the time of my decision," an ID-indexed first-committer-wins model — on either plugin — will not enforce that invariant. Application-level locking on the logical resource (e.g., the model ref) is the correct remediation when/if a path requires it.
+
+Implementation note: `GetAll` and `Count` carry a code comment documenting this limitation so a future contributor does not "fix" the omission by adding range-predicate tracking.
+
 Helper: `plugins/postgres/txstate.go` exposes
 
 ```go

--- a/docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md
+++ b/docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md
@@ -32,7 +32,7 @@ The postgres plugin implements first-committer-wins by:
 1. Running every tx at `REPEATABLE READ` (snapshot isolation) instead of `SERIALIZABLE` (SSI).
 2. Tracking `(entity_id → expected_version)` for every entity read within the tx, in a plugin-local per-tx state map.
 3. Tracking `(entity_id → pre-write version)` for every entity write within the tx.
-4. At `Commit`, issuing one batched `SELECT ... FOR SHARE` over the union of read-set and write-set rows. Postgres's own RR-level concurrent-update detection raises `40001` if any of those rows was modified by a concurrent committer since our snapshot. The returned versions are compared to the expected versions; any mismatch → `spi.ErrConflict`. On success, row-level locks held until `pgxTx.Commit` protect the validate-then-commit window.
+4. At `Commit`, issuing one batched `SELECT ... FOR SHARE` over the read-set rows only. Postgres's own RR-level concurrent-update detection raises `40001` if any of those rows was modified by a concurrent committer since our snapshot. The returned versions are compared to the expected versions; any mismatch → `spi.ErrConflict`. On success, row-level locks held until `pgxTx.Commit` protect the validate-then-commit window. Write-write conflicts are caught by postgres's native tuple-level DML locks at `UPDATE`/`INSERT` time — before commit phase runs.
 
 The entire mechanism lives inside the postgres plugin. No SPI changes.
 
@@ -100,8 +100,8 @@ Every method on `EntityStore` that touches an entity row inside a tx context rec
 |---|---|
 | `Get(txCtx, id)` | `readSet[id] = entity.Meta.Version` (if not already present) |
 | `GetAll(txCtx, ref)` | For each returned entity: `readSet[id] = version` |
-| `Save(txCtx, entity)` | `writeSet[id] = previousVersion` (or `0` for INSERT) |
-| `SaveAll(txCtx, iter)` | Per-entity: `writeSet[id] = previousVersion` |
+| `Save(txCtx, entity)` | Updates: `writeSet[id] = previousVersion`. Fresh inserts: **not recorded in writeSet** — write-write conflicts on new rows are enforced by the unique constraint + tuple-level DML lock at INSERT time. |
+| `SaveAll(txCtx, iter)` | Per-entity: same as `Save` — updates recorded, fresh inserts not. |
 | `CompareAndSave(txCtx, entity, ifMatch)` | `writeSet[id] = parsedIfMatch` |
 | `Delete(txCtx, id)` | `writeSet[id] = previousVersion` (soft delete bumps version) |
 | `GetAsAt(txCtx, id, t)` | **Not tracked** — point-in-time reads target an immutable historical version, not the live row; they don't participate in first-committer-wins. If application logic reads a historical version and then decides a live-row write, the decision is intentionally not validated at commit (the "live-row only" semantic). The implementation should carry a code comment stating this explicitly so a future contributor doesn't "fix" the omission by adding tracking. |
@@ -159,17 +159,19 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
         return fmt.Errorf("Commit: tx state for %s not found", txID)
     }
 
-    // Collect all distinct entity IDs from read+write set, sorted.
+    // Collect all distinct entity IDs from the read-set only, sorted.
+    // writeSet is NOT validated here — see "Design divergence: writeSet not
+    // validated at commit" section below for the full rationale.
     // Sorting makes FOR SHARE lock acquisition order deterministic across
     // concurrent committers, eliminating a class of deadlock (40P01) that
     // would otherwise surface as ErrConflict under contention. postgres
     // still may deadlock-abort in pathological cases — classifyError maps
     // 40P01 to ErrConflict — but sorted acquisition keeps that to the
     // genuinely unavoidable cases.
-    ids := state.sortedUnionIDs()
+    ids := state.sortedReadIDs()
 
     if len(ids) > 0 {
-        // Single batched FOR SHARE over the union set, scoped to tenant
+        // Single batched FOR SHARE over the read-set, scoped to tenant
         // for defence-in-depth alongside RLS. Chunked to keep the ANY($2)
         // array within planner-friendly bounds (see validateInChunks).
         // FOR SHARE (not FOR UPDATE) is the right mode: we want to detect
@@ -194,14 +196,9 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
             _ = pgxTx.Rollback(context.Background())
             return fmt.Errorf("%w: %w", spi.ErrConflict, err)
         }
-
-        // Write-set check: every write target must still be at the
-        // pre-write version we expected. (Inserts: 0 expected / absent.)
-        if err := state.validateWriteSet(current); err != nil {
-            tm.cleanupTx(txID)
-            _ = pgxTx.Rollback(context.Background())
-            return fmt.Errorf("%w: %w", spi.ErrConflict, err)
-        }
+        // Write-set is NOT validated here — write-write conflicts are caught
+        // by postgres's tuple-level DML locks (SQLSTATE 40001) at
+        // UPDATE/INSERT time. See "Design divergence" section.
     }
 
     // Existing: capture submit time, commit pgxTx, record submit time.
@@ -214,30 +211,31 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 }
 ```
 
-`validateReadSet` / `validateWriteSet` are straightforward map compares. Semantics:
+`validateReadSet` is a straightforward map compare. Semantics:
 
 - Read-set: captured version must equal current; missing current (deleted by concurrent committer) → conflict.
-- Write-set: expected pre-write version must equal current; version `0` (new insert) requires the row to not yet exist in `current`.
+
+`validateWriteSet` is retained on `txState` for the readSet-disjoint invariant and future use (#35), but is **not called at commit time** (see "Design divergence" section).
 
 `classifyError` already maps pgcode `40001` and `40P01` to `spi.ErrConflict`. We rely on it for errors raised from the validation query itself (postgres raising concurrent-update mid-SELECT-FOR-SHARE).
 
 ### Batch size guard
 
-A single tx's read+write set is typically tens of entities, but pathological workloads (long workflows with re-entrant processors, bulk imports) may produce hundreds or thousands. Postgres handles `ANY($1::uuid[])` efficiently up to a few thousand elements, but planning cost grows and very large arrays degrade predictably. The validator chunks accordingly:
+A single tx's read-set is typically tens of entities, but pathological workloads (long workflows with re-entrant processors, bulk reads) may produce hundreds or thousands. Postgres handles `ANY($1::uuid[])` efficiently up to a few thousand elements, but planning cost grows and very large arrays degrade predictably. The validator chunks accordingly:
 
 ```go
 const validateChunkSize = 1000  // conservative — well under planner thresholds.
 
 func (tm *TransactionManager) validateInChunks(
-    ctx context.Context, tx pgx.Tx, tenantID spi.TenantID, sortedIDs []string,
+    ctx context.Context, tx pgx.Tx, tenantID spi.TenantID, sortedReadIDs []string,
 ) (map[string]int64, error) {
-    current := make(map[string]int64, len(sortedIDs))
-    for i := 0; i < len(sortedIDs); i += validateChunkSize {
+    current := make(map[string]int64, len(sortedReadIDs))
+    for i := 0; i < len(sortedReadIDs); i += validateChunkSize {
         end := i + validateChunkSize
-        if end > len(sortedIDs) {
-            end = len(sortedIDs)
+        if end > len(sortedReadIDs) {
+            end = len(sortedReadIDs)
         }
-        chunk := sortedIDs[i:end]
+        chunk := sortedReadIDs[i:end]
         rows, err := tx.Query(ctx, `
             SELECT id, version
               FROM entities
@@ -263,7 +261,20 @@ func (tm *TransactionManager) validateInChunks(
 }
 ```
 
-Because `sortedIDs` is sorted and chunks are taken in order, lock acquisition order remains deterministic across chunks within one tx and across concurrent txs — the deadlock prevention property of sorted acquisition is preserved through chunking.
+Because `sortedReadIDs` is sorted and chunks are taken in order, lock acquisition order remains deterministic across chunks within one tx and across concurrent txs — the deadlock prevention property of sorted acquisition is preserved through chunking.
+
+### Design divergence: writeSet not validated at commit
+
+**Root cause.** `FOR SHARE` executed inside the same `pgx.Tx` as the DML reads the tx's own *uncommitted* writes (read-your-own-writes under Repeatable Read). When the commit-phase validator issues `SELECT id, version FROM entities WHERE id = ANY($1) FOR SHARE` over the write-set, postgres returns the post-write version that the *current tx* already wrote — not the committed version that a concurrent committer might have written. As a result, `validateWriteSet` would always see the expected pre-write version matching the current returned version, making the check trivially pass even in the face of real conflicts — or, equivalently, it would never see the concurrent committer's version, producing neither correct detection nor spurious errors from this path.
+
+**Consequence.** Including writeSet IDs in the `FOR SHARE` set does not add correctness: the `current` map entry for a written entity always reflects this tx's own write, making the version comparison useless (the check would compare `preWriteVersion` against `preWriteVersion + 1` — always a mismatch — which means every commit involving a write would produce a spurious `ErrConflict`).
+
+**The fix.** Only `readSet` is validated via `FOR SHARE`. Write-write conflicts rely exclusively on postgres's native **tuple-level DML locks**:
+
+- Under Repeatable Read, when two concurrent transactions both attempt to `UPDATE` or `INSERT` the same entity row, the second one blocks until the first commits or rolls back. If the first committed, postgres raises `SQLSTATE 40001` (`could not serialize access due to concurrent update`) immediately on the second tx's DML statement — well before commit phase. `classifyError` maps `40001` → `spi.ErrConflict`.
+- The unique constraint on `(tenant_id, id)` covers the concurrent-insert case for new entities: two txs inserting the same entity ID collide at INSERT time with a duplicate-key error, which `classifyError` likewise maps to `spi.ErrConflict`.
+
+**writeSet is still maintained.** `txState.writeSet` is populated on every write and is used to enforce the readSet-disjoint invariant (an entity ID cannot appear in both `readSet` and `writeSet` with inconsistent expected versions). It is also preserved for future use under [#35](https://github.com/Cyoda-platform/cyoda-go/issues/35), which may extend first-committer-wins validation to non-entity stores where the read-your-own-writes problem may not apply in the same way.
 
 ### Rollback
 

--- a/docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md
+++ b/docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md
@@ -40,13 +40,24 @@ The entire mechanism lives inside the postgres plugin. No SPI changes.
 
 Cassandra's mechanism (for reference): every entity read captures `expected_version`; commit phase validates each via a coordinated version-check fan-out against the owning shard plus a `shard_commit_log` SSI check ("anyone committed a write to this entity's row after my snapshot HLC?"). Both the version check and the SSI check are **per-entity (row-level)**.
 
-Postgres's native RR gives us both checks for free:
+Postgres's native RR gives us both checks for free — but via **two distinct mechanisms** working in concert. Making the distinction explicit is important for reviewer intuition:
 
-- `SELECT id, version FROM entities WHERE id = ANY($1) AND tenant_id = $2 FOR SHARE` reads the **latest committed** row version, not the snapshot version. Comparing to `expected_version` catches the version-mismatch case.
-- Under RR, if that row was modified by a concurrent committed tx after our snapshot, postgres raises `ERROR: could not serialize access due to concurrent update` (SQLSTATE `40001`) automatically. That's the SSI-style "committed after snapshot" check, performed at row granularity by postgres itself.
-- `FOR SHARE` holds the row locks until our tx commits or rolls back, protecting the validate → commit window.
+- **Write-write conflicts (writeSet vs concurrent writer)** are caught by postgres's **inherent tuple-level locks** from the DML statements themselves. When our tx's `INSERT` / `UPDATE` / `DELETE` runs against the entity row, postgres takes a row-exclusive lock and, under RR, raises `40001` immediately if another concurrent tx has already committed a write to that row. This protection is already in place before the commit phase runs.
+- **Read-set staleness (readSet vs concurrent committer we never wrote against)** is what our commit-time validation catches. A tx that reads X at v=5, decides something based on it, and writes Y (not X) has no native DB mechanism surfacing the fact that X moved to v=6 under a concurrent committer. That's the case our `SELECT ... FOR SHARE` + version compare covers.
+
+Put together:
+
+- `SELECT id, version FROM entities WHERE id = ANY($1) AND tenant_id = $2 FOR SHARE` reads the **latest committed** row version, not the snapshot version. Comparing to `expected_version` catches the read-set staleness case.
+- Under RR, if that row was modified by a concurrent committed tx after our snapshot, postgres raises `40001` automatically on the `FOR SHARE` itself (`could not serialize access due to concurrent update`). That's a second, redundant guard that mirrors the SSI-style "committed after snapshot" check at row granularity.
+- `FOR SHARE` (not `FOR UPDATE`) is the right lock mode: we need to detect concurrent writers, not block concurrent readers. Two concurrent committing txs both issuing `FOR SHARE` on the same unchanged row succeed compatibly — exactly what we want; the first-committer-wins enforcement is still intact because any write-write overlap was already caught by the DML's tuple locks upstream.
+- `FOR SHARE` holds the row locks until our tx commits or rolls back, protecting the validate → commit window from a fourth-party committing mid-window.
 
 The coverage contract is explicit: this applies to entity reads/writes only. Non-entity stores (Model, KV, Message, Workflow, SMAudit) are untracked and operate at plain SI — identical to cassandra's data-store paths. #35 tracks the symmetric follow-up.
+
+### Preconditions on the `entities` schema
+
+1. **Unique constraint on `(tenant_id, id)`.** Required for insert-conflict correctness: two concurrent txs inserting the same entity ID must collide at DML time, not leak through the commit-time validator. The commit-time `SELECT ... FOR SHARE` would not detect a concurrent uncommitted insert on its own — the unique constraint is what surfaces it (as a duplicate-key error from the `INSERT`).
+2. **Index usable by `WHERE tenant_id = $1 AND id = ANY($2)`.** The unique constraint above covers this if it is a btree index leading with `(tenant_id, id)`. Any commit with a non-trivial read-set runs this query; a missing or mis-ordered index would turn it into a seq scan per commit. Validate in the implementation PR.
 
 ## Data structures
 
@@ -93,7 +104,7 @@ Every method on `EntityStore` that touches an entity row inside a tx context rec
 | `SaveAll(txCtx, iter)` | Per-entity: `writeSet[id] = previousVersion` |
 | `CompareAndSave(txCtx, entity, ifMatch)` | `writeSet[id] = parsedIfMatch` |
 | `Delete(txCtx, id)` | `writeSet[id] = previousVersion` (soft delete bumps version) |
-| `GetAsAt(txCtx, id, t)` | **Not tracked** — point-in-time reads don't participate in first-committer-wins (they target a historical version, not the live row) |
+| `GetAsAt(txCtx, id, t)` | **Not tracked** — point-in-time reads target an immutable historical version, not the live row; they don't participate in first-committer-wins. If application logic reads a historical version and then decides a live-row write, the decision is intentionally not validated at commit (the "live-row only" semantic). The implementation should carry a code comment stating this explicitly so a future contributor doesn't "fix" the omission by adding tracking. |
 | `GetVersionHistory(txCtx, id)` | **Not tracked** — history reads are observational |
 | `Count(txCtx, ref)` | **Not tracked** — coarse aggregate, no per-row identity to validate |
 
@@ -138,19 +149,25 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
         return fmt.Errorf("Commit: tx state for %s not found", txID)
     }
 
-    // Collect all distinct entity IDs from read+write set.
-    ids := state.unionIDs()
+    // Collect all distinct entity IDs from read+write set, sorted.
+    // Sorting makes FOR SHARE lock acquisition order deterministic across
+    // concurrent committers, eliminating a class of deadlock (40P01) that
+    // would otherwise surface as ErrConflict under contention. postgres
+    // still may deadlock-abort in pathological cases — classifyError maps
+    // 40P01 to ErrConflict — but sorted acquisition keeps that to the
+    // genuinely unavoidable cases.
+    ids := state.sortedUnionIDs()
 
     if len(ids) > 0 {
         // Single batched FOR SHARE over the union set, scoped to tenant
-        // for defence-in-depth alongside RLS.
-        rows, err := pgxTx.Query(ctx, `
-            SELECT id, version
-              FROM entities
-             WHERE tenant_id = $1
-               AND id = ANY($2)
-             FOR SHARE
-        `, state.tenantID, ids)
+        // for defence-in-depth alongside RLS. Chunked to keep the ANY($2)
+        // array within planner-friendly bounds (see validateInChunks).
+        // FOR SHARE (not FOR UPDATE) is the right mode: we want to detect
+        // concurrent committed writers, not block concurrent readers.
+        // Two committing txs both issuing FOR SHARE on the same unchanged
+        // row succeed compatibly; any write-write overlap between them
+        // was already caught by tuple-level locks on the DML upstream.
+        current, err := tm.validateInChunks(ctx, pgxTx, state.tenantID, ids)
         if err != nil {
             // 40001 here is exactly the signal we want — postgres caught
             // a concurrent committer since our snapshot. Map to ErrConflict.
@@ -158,20 +175,6 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
             _ = pgxTx.Rollback(context.Background())
             return classifyError(fmt.Errorf("Commit: validate: %w", err))
         }
-
-        current := make(map[string]int64, len(ids))
-        for rows.Next() {
-            var id string
-            var v int64
-            if err := rows.Scan(&id, &v); err != nil {
-                rows.Close()
-                tm.cleanupTx(txID)
-                _ = pgxTx.Rollback(context.Background())
-                return fmt.Errorf("Commit: scan: %w", err)
-            }
-            current[id] = v
-        }
-        rows.Close()
 
         // Read-set check: every captured entity must still exist at the
         // captured version. Missing row = deleted by a concurrent
@@ -208,6 +211,50 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 
 `classifyError` already maps pgcode `40001` and `40P01` to `spi.ErrConflict`. We rely on it for errors raised from the validation query itself (postgres raising concurrent-update mid-SELECT-FOR-SHARE).
 
+### Batch size guard
+
+A single tx's read+write set is typically tens of entities, but pathological workloads (long workflows with re-entrant processors, bulk imports) may produce hundreds or thousands. Postgres handles `ANY($1::uuid[])` efficiently up to a few thousand elements, but planning cost grows and very large arrays degrade predictably. The validator chunks accordingly:
+
+```go
+const validateChunkSize = 1000  // conservative — well under planner thresholds.
+
+func (tm *TransactionManager) validateInChunks(
+    ctx context.Context, tx pgx.Tx, tenantID spi.TenantID, sortedIDs []string,
+) (map[string]int64, error) {
+    current := make(map[string]int64, len(sortedIDs))
+    for i := 0; i < len(sortedIDs); i += validateChunkSize {
+        end := i + validateChunkSize
+        if end > len(sortedIDs) {
+            end = len(sortedIDs)
+        }
+        chunk := sortedIDs[i:end]
+        rows, err := tx.Query(ctx, `
+            SELECT id, version
+              FROM entities
+             WHERE tenant_id = $1
+               AND id = ANY($2)
+             FOR SHARE
+        `, tenantID, chunk)
+        if err != nil {
+            return nil, err
+        }
+        for rows.Next() {
+            var id string
+            var v int64
+            if err := rows.Scan(&id, &v); err != nil {
+                rows.Close()
+                return nil, err
+            }
+            current[id] = v
+        }
+        rows.Close()
+    }
+    return current, nil
+}
+```
+
+Because `sortedIDs` is sorted and chunks are taken in order, lock acquisition order remains deterministic across chunks within one tx and across concurrent txs — the deadlock prevention property of sorted acquisition is preserved through chunking.
+
 ### Rollback
 
 Same as today, plus `tm.cleanupTx(txID)` to drop the txState entry.
@@ -240,12 +287,17 @@ Failure mode: if the origin node dies mid-tx, the pgx connection drops, the tx a
 7. `TestCommit_DisjointRowsNoConflict` — the #17 scenario: 8 concurrent txs writing distinct UUIDs, all commit. (Regression guard.)
 8. `TestCommit_InsertNoReadSetInterference` — pure INSERT of a new entity with no prior reads does not hit validation overhead.
 9. `TestCommit_TenantScoped` — validation query is tenant-scoped; entities in other tenants cannot collide.
-10. `TestCommit_BatchedQuery` — a tx touching N entities triggers exactly one SELECT at commit (observable via pg logs / query count).
+10. `TestCommit_BatchedQuery` — a tx touching N entities (N ≤ `validateChunkSize`) triggers exactly one SELECT at commit.
+11. `TestCommit_DeletedEntityConflict` — tx A reads entity X; concurrent tx B (soft-)deletes X; A's commit detects the version bump and returns `ErrConflict`.
+12. `TestCommit_LargeReadSet` — tx touching > `validateChunkSize` entities validates via multiple chunked SELECTs in sorted order; commit succeeds when no conflicts, and performance stays within a documented bound.
+13. `TestCommit_SortedLockAcquisition` — two concurrent committers with overlapping read-sets in different insertion orders both issue their validation queries in the same sorted order; no deadlock-induced `40P01`.
+14. `TestCommit_SavepointRollbackDropsReadSet` — tx reads X, takes savepoint, reads Y, rolls back to savepoint; Y is dropped from readSet; concurrent tx modifies Y; commit succeeds because Y is no longer validated.
 
 **Updated conformance tests** in `internal/spitest`:
 
 - `TestConformance/Entity/Concurrent/DifferentEntities` (the #17 flake case) now passes reliably on postgres. Issue #17 closes.
 - Add a `TestConformance/Entity/Concurrent/SameEntity` scenario: two txs race an update on the same entity, expect exactly one success and one `ErrConflict` on both memory and postgres plugins. Cassandra behavior unchanged (it already passes).
+- **Savepoint semantic note.** The postgres plugin preserves readSet across savepoint via snapshot/restore; the cassandra plugin clears readSet on savepoint. The two are *not* behaviorally identical on the edge case of "read inside savepoint → rollback → commit main tx": on postgres the read is validated, on cassandra it is not. The conformance harness documents this divergence explicitly (a `// DIVERGENCE:` comment on the relevant assertion) so a future contributor doesn't file it as a bug. If we later choose to converge the two plugins, that's a separate, scoped change.
 
 **Parity verification:**
 

--- a/docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md
+++ b/docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md
@@ -1,0 +1,266 @@
+# Postgres plugin: SI + row-granular first-committer-wins
+
+**Status:** Design, ready for implementation planning
+**Issues:** [#18](https://github.com/Cyoda-platform/cyoda-go/issues/18) (structural fix), [#17](https://github.com/Cyoda-platform/cyoda-go/issues/17) (flake this obsoletes), [#35](https://github.com/Cyoda-platform/cyoda-go/issues/35) (non-entity-store coverage follow-up)
+**Related:** [cyoda-go-cassandra#22](https://github.com/Cyoda-platform/cyoda-go-cassandra/issues/22) (sibling coverage issue on cassandra)
+
+## Motivation
+
+Postgres `SERIALIZABLE` (SSI) tracks read/write dependencies at b-tree **page** granularity, producing false-positive `40001` aborts when concurrent transactions write to disjoint rows that happen to share pages. This manifests as the flake in #17 and, more broadly, as unpredictable tail latency under concurrent entity writes within the same tenant.
+
+Cyoda's published semantic is **Snapshot Isolation with first-committer-wins at entity-row granularity** — the same guarantee the cassandra plugin implements via per-transaction read-set tracking and commit-time version validation. The postgres plugin currently over-delivers (SSI strength) at a page-granular implementation that produces false positives. This design replaces the page-granular SSI implementation with a row-granular first-committer-wins implementation, matching the cassandra plugin exactly.
+
+## Goals
+
+1. **Behavioral parity with cyoda-go-cassandra** on entity operations: same commit semantics, same conflict detection boundaries, same `spi.ErrConflict` surface.
+2. **Eliminate SSI page-level false positives.** The #17 flake and its class go away.
+3. **No SPI changes.** `TransactionManager` and all `Store` interfaces stay identical. The fix is entirely inside `plugins/postgres`.
+4. **Preserve snapshot isolation + read-your-own-writes** semantics for all tx participants.
+5. **Preserve existing multi-node routing** via `Join`.
+
+## Non-goals
+
+1. **Non-entity-store coverage.** `ModelStore`, `KVStore`, `MessageStore`, `WorkflowStore`, `StateMachineAuditStore` remain at plain SI without read-set tracking. Identical coverage gap to cassandra; tracked as #35 for later resolution in lockstep with cassandra's #22.
+2. **Advisory locks** on model lock/unlock/change-level or other invariant paths. Deferred to #35.
+3. **Retry wrappers** for remaining 40001s. Deferred; can be layered later as defense-in-depth.
+4. **Distributed read-set bookkeeping** across multiple postgres-connected processes without proxying. Current multi-node topology anchors a tx to its origin node; that stays.
+
+## Design overview
+
+The postgres plugin implements first-committer-wins by:
+
+1. Running every tx at `REPEATABLE READ` (snapshot isolation) instead of `SERIALIZABLE` (SSI).
+2. Tracking `(entity_id → expected_version)` for every entity read within the tx, in a plugin-local per-tx state map.
+3. Tracking `(entity_id → pre-write version)` for every entity write within the tx.
+4. At `Commit`, issuing one batched `SELECT ... FOR SHARE` over the union of read-set and write-set rows. Postgres's own RR-level concurrent-update detection raises `40001` if any of those rows was modified by a concurrent committer since our snapshot. The returned versions are compared to the expected versions; any mismatch → `spi.ErrConflict`. On success, row-level locks held until `pgxTx.Commit` protect the validate-then-commit window.
+
+The entire mechanism lives inside the postgres plugin. No SPI changes.
+
+## Why this preserves the published semantic
+
+Cassandra's mechanism (for reference): every entity read captures `expected_version`; commit phase validates each via a coordinated version-check fan-out against the owning shard plus a `shard_commit_log` SSI check ("anyone committed a write to this entity's row after my snapshot HLC?"). Both the version check and the SSI check are **per-entity (row-level)**.
+
+Postgres's native RR gives us both checks for free:
+
+- `SELECT id, version FROM entities WHERE id = ANY($1) AND tenant_id = $2 FOR SHARE` reads the **latest committed** row version, not the snapshot version. Comparing to `expected_version` catches the version-mismatch case.
+- Under RR, if that row was modified by a concurrent committed tx after our snapshot, postgres raises `ERROR: could not serialize access due to concurrent update` (SQLSTATE `40001`) automatically. That's the SSI-style "committed after snapshot" check, performed at row granularity by postgres itself.
+- `FOR SHARE` holds the row locks until our tx commits or rolls back, protecting the validate → commit window.
+
+The coverage contract is explicit: this applies to entity reads/writes only. Non-entity stores (Model, KV, Message, Workflow, SMAudit) are untracked and operate at plain SI — identical to cassandra's data-store paths. #35 tracks the symmetric follow-up.
+
+## Data structures
+
+New type inside `plugins/postgres`:
+
+```go
+// txState holds per-transaction bookkeeping for first-committer-wins
+// validation. One instance per active tx, indexed by txID.
+type txState struct {
+    mu       sync.Mutex
+    tenantID spi.TenantID
+    readSet  map[string]int64  // entity_id → expected version at read time
+    writeSet map[string]int64  // entity_id → pre-write version
+    // savepoints stack: each entry snapshots readSet/writeSet at the
+    // moment Savepoint() was called, for restore on RollbackToSavepoint().
+    savepoints []savepointEntry
+}
+
+type savepointEntry struct {
+    id       string
+    readSet  map[string]int64
+    writeSet map[string]int64
+}
+```
+
+Stored in a parallel map on the `TransactionManager`:
+
+```go
+txStates    map[string]*txState
+txStatesMu  sync.Mutex
+```
+
+The existing `txRegistry` (which maps `txID → pgx.Tx`) stays focused on pgx connection lookup; read/write-set state is separate.
+
+## Store-layer changes
+
+Every method on `EntityStore` that touches an entity row inside a tx context records into `txState`:
+
+| Method | Action on txState |
+|---|---|
+| `Get(txCtx, id)` | `readSet[id] = entity.Meta.Version` (if not already present) |
+| `GetAll(txCtx, ref)` | For each returned entity: `readSet[id] = version` |
+| `Save(txCtx, entity)` | `writeSet[id] = previousVersion` (or `0` for INSERT) |
+| `SaveAll(txCtx, iter)` | Per-entity: `writeSet[id] = previousVersion` |
+| `CompareAndSave(txCtx, entity, ifMatch)` | `writeSet[id] = parsedIfMatch` |
+| `Delete(txCtx, id)` | `writeSet[id] = previousVersion` (soft delete bumps version) |
+| `GetAsAt(txCtx, id, t)` | **Not tracked** — point-in-time reads don't participate in first-committer-wins (they target a historical version, not the live row) |
+| `GetVersionHistory(txCtx, id)` | **Not tracked** — history reads are observational |
+| `Count(txCtx, ref)` | **Not tracked** — coarse aggregate, no per-row identity to validate |
+
+Non-tx reads (no `txCtx`) bypass bookkeeping entirely. A public HTTP GET on `/entities/{id}` reads the current snapshot without recording anything.
+
+Helper: `plugins/postgres/txstate.go` exposes
+
+```go
+func recordRead(ctx context.Context, tm *TransactionManager, entityID string, version int64)
+func recordWrite(ctx context.Context, tm *TransactionManager, entityID string, prevVersion int64)
+```
+
+called from the store methods. Both are no-ops when the context carries no tx.
+
+## Transaction manager changes
+
+### Begin
+```go
+pgxTx, err := tm.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead}) // was: Serializable
+```
+
+Plus: allocate and register a fresh `*txState{tenantID: tenantID}` in `tm.txStates[txID]`. The tenantID is already resolved for RLS; cache it on the txState for use in the commit-time validation query.
+
+### Savepoint / RollbackToSavepoint / ReleaseSavepoint
+
+- `Savepoint` pushes a deep copy of the current `readSet` / `writeSet` onto `savepoints`, then executes the `SAVEPOINT` SQL as today.
+- `RollbackToSavepoint` restores `readSet` / `writeSet` from the named savepoint entry and trims later entries, then executes `ROLLBACK TO SAVEPOINT` as today.
+- `ReleaseSavepoint` drops the savepoint entry without touching the sets (work is kept), then executes `RELEASE SAVEPOINT` as today.
+
+This mirrors how a RR-level save-restore model treats the read-set. It diverges from cassandra's "clear read-set on savepoint" semantic — this divergence is intentional because postgres tracks row visibility natively and the read-set in this plugin is purely commit-validation bookkeeping, not a linearization fence. Tests will cover the savepoint semantics explicitly.
+
+### Commit
+
+```go
+func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
+    pgxTx, ok := tm.registry.Lookup(txID)
+    if !ok {
+        return fmt.Errorf("Commit: transaction %s not found", txID)
+    }
+    state, ok := tm.lookupTxState(txID)
+    if !ok {
+        return fmt.Errorf("Commit: tx state for %s not found", txID)
+    }
+
+    // Collect all distinct entity IDs from read+write set.
+    ids := state.unionIDs()
+
+    if len(ids) > 0 {
+        // Single batched FOR SHARE over the union set, scoped to tenant
+        // for defence-in-depth alongside RLS.
+        rows, err := pgxTx.Query(ctx, `
+            SELECT id, version
+              FROM entities
+             WHERE tenant_id = $1
+               AND id = ANY($2)
+             FOR SHARE
+        `, state.tenantID, ids)
+        if err != nil {
+            // 40001 here is exactly the signal we want — postgres caught
+            // a concurrent committer since our snapshot. Map to ErrConflict.
+            tm.cleanupTx(txID)
+            _ = pgxTx.Rollback(context.Background())
+            return classifyError(fmt.Errorf("Commit: validate: %w", err))
+        }
+
+        current := make(map[string]int64, len(ids))
+        for rows.Next() {
+            var id string
+            var v int64
+            if err := rows.Scan(&id, &v); err != nil {
+                rows.Close()
+                tm.cleanupTx(txID)
+                _ = pgxTx.Rollback(context.Background())
+                return fmt.Errorf("Commit: scan: %w", err)
+            }
+            current[id] = v
+        }
+        rows.Close()
+
+        // Read-set check: every captured entity must still exist at the
+        // captured version. Missing row = deleted by a concurrent
+        // committer; version mismatch = updated by a concurrent committer.
+        if err := state.validateReadSet(current); err != nil {
+            tm.cleanupTx(txID)
+            _ = pgxTx.Rollback(context.Background())
+            return fmt.Errorf("%w: %w", spi.ErrConflict, err)
+        }
+
+        // Write-set check: every write target must still be at the
+        // pre-write version we expected. (Inserts: 0 expected / absent.)
+        if err := state.validateWriteSet(current); err != nil {
+            tm.cleanupTx(txID)
+            _ = pgxTx.Rollback(context.Background())
+            return fmt.Errorf("%w: %w", spi.ErrConflict, err)
+        }
+    }
+
+    // Existing: capture submit time, commit pgxTx, record submit time.
+    // Map 40001 from the Commit itself (pure write-write conflict on
+    // the same row) to ErrConflict as today.
+    // ... (existing commit logic unchanged) ...
+
+    tm.cleanupTx(txID)
+    return nil
+}
+```
+
+`validateReadSet` / `validateWriteSet` are straightforward map compares. Semantics:
+
+- Read-set: captured version must equal current; missing current (deleted by concurrent committer) → conflict.
+- Write-set: expected pre-write version must equal current; version `0` (new insert) requires the row to not yet exist in `current`.
+
+`classifyError` already maps pgcode `40001` and `40P01` to `spi.ErrConflict`. We rely on it for errors raised from the validation query itself (postgres raising concurrent-update mid-SELECT-FOR-SHARE).
+
+### Rollback
+
+Same as today, plus `tm.cleanupTx(txID)` to drop the txState entry.
+
+## Store-layer error handling
+
+No new error types. Any query that raises `40001` (`serialization_failure`) or `40P01` (`deadlock_detected`) during normal tx operations — which should be rare under RR but possible — continues to map to `spi.ErrConflict` via the existing `classifyError`.
+
+## Multi-node behavior
+
+A tx is anchored to the cyoda-go node that called `Begin`. That node owns:
+
+- The `pgx.Tx` connection (existing behavior).
+- The `*txState` with read/write sets (new).
+
+Other cyoda-go nodes that receive a CRUD request referencing this txID proxy it back to the origin node (existing routing via `Join`). All read-set/write-set bookkeeping happens on the origin. Single source of truth; no cross-node state synchronization needed.
+
+Failure mode: if the origin node dies mid-tx, the pgx connection drops, the tx aborts server-side, and `txState` is lost with the process — same behavior as today. No regression.
+
+## Test strategy
+
+**New unit tests** in `plugins/postgres`:
+
+1. `TestTxState_RecordRead` — read-set populated on `EntityStore.Get` inside a tx.
+2. `TestTxState_RecordWrite` — write-set populated on `Save` / `CompareAndSave` / `Delete`.
+3. `TestTxState_NonTxReadsNotTracked` — reads without `txCtx` do not populate any state.
+4. `TestTxState_SavepointSnapshot` — `Savepoint` snapshots sets; `RollbackToSavepoint` restores; `ReleaseSavepoint` preserves.
+5. `TestCommit_ReadSetConflict` — tx A reads entity X; concurrent tx B modifies X and commits; A's commit returns `ErrConflict`.
+6. `TestCommit_WriteSetConflict` — two txs race an update on the same entity; first wins, second sees `ErrConflict`.
+7. `TestCommit_DisjointRowsNoConflict` — the #17 scenario: 8 concurrent txs writing distinct UUIDs, all commit. (Regression guard.)
+8. `TestCommit_InsertNoReadSetInterference` — pure INSERT of a new entity with no prior reads does not hit validation overhead.
+9. `TestCommit_TenantScoped` — validation query is tenant-scoped; entities in other tenants cannot collide.
+10. `TestCommit_BatchedQuery` — a tx touching N entities triggers exactly one SELECT at commit (observable via pg logs / query count).
+
+**Updated conformance tests** in `internal/spitest`:
+
+- `TestConformance/Entity/Concurrent/DifferentEntities` (the #17 flake case) now passes reliably on postgres. Issue #17 closes.
+- Add a `TestConformance/Entity/Concurrent/SameEntity` scenario: two txs race an update on the same entity, expect exactly one success and one `ErrConflict` on both memory and postgres plugins. Cassandra behavior unchanged (it already passes).
+
+**Parity verification:**
+
+- Run full spitest conformance suite across memory / postgres / cassandra. All three plugins must produce identical conflict semantics on the concurrency scenarios.
+
+## Migration / rollout
+
+1. Land behind no feature flag — this is a bug fix (page-granular SSI was wrong-shaped, not a design we want to keep opt-in).
+2. Pre-merge: run spitest suite 20× in a loop to confirm no SI-specific anomalies surface on production-shape workflows.
+3. Pre-merge: run the full parity suite against all three plugins.
+4. Close #17 (flake obsolete). Reference #35 in the PR description for follow-up visibility.
+
+## Out of scope / future work
+
+- **#35** — extend first-committer-wins to non-entity stores in postgres. To be addressed in coordination with cassandra's #22.
+- **Advisory locks** on model lock/unlock/change-level and async-search status transitions. May land as part of #35's resolution.
+- **Retry wrapper** (originally cyoda-go#3). Not load-bearing after this change; may still be useful as defense-in-depth for the legitimate write-write 40001s that surface cleanly under the new design.
+- **Distributed read-set** across non-proxying multi-node deployments. Not on the current roadmap.

--- a/plugins/postgres/commit_validator.go
+++ b/plugins/postgres/commit_validator.go
@@ -1,0 +1,64 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+const defaultValidateChunkSize = 1000
+
+// validateInChunks issues SELECT entity_id, version FROM entities WHERE
+// tenant_id=$1 AND entity_id=ANY($2::text[]) FOR SHARE over sortedIDs,
+// chunked at chunkSize.
+//
+// Returns map of entity_id → current committed version. Entities absent
+// from the DB are absent from the returned map.
+//
+// FOR SHARE (not FOR UPDATE): concurrent readers are not blocked; only
+// concurrent writers are detected. Write-write conflicts on DML rows
+// are caught by postgres's own tuple-level locks upstream; this query
+// validates the read-set staleness + locks the rows for the
+// validate-then-commit window. See design spec for the dual-mechanism
+// argument.
+func (tm *TransactionManager) validateInChunks(
+	ctx context.Context, tx pgx.Tx, tenantID spi.TenantID, sortedIDs []string, chunkSize int,
+) (map[string]int64, error) {
+	if chunkSize <= 0 {
+		chunkSize = defaultValidateChunkSize
+	}
+	current := make(map[string]int64, len(sortedIDs))
+	for i := 0; i < len(sortedIDs); i += chunkSize {
+		end := i + chunkSize
+		if end > len(sortedIDs) {
+			end = len(sortedIDs)
+		}
+		chunk := sortedIDs[i:end]
+		rows, err := tx.Query(ctx, `
+			SELECT entity_id, version
+			  FROM entities
+			 WHERE tenant_id = $1
+			   AND entity_id = ANY($2::text[])
+			 FOR SHARE
+		`, string(tenantID), chunk)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var id string
+			var v int64
+			if err := rows.Scan(&id, &v); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			current[id] = v
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
+	return current, nil
+}

--- a/plugins/postgres/commit_validator_test.go
+++ b/plugins/postgres/commit_validator_test.go
@@ -1,0 +1,96 @@
+package postgres_test
+
+import (
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/plugins/postgres"
+)
+
+func TestValidateInChunks_EmptyIDs(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(ctx, txID) //nolint:errcheck
+	tx, _ := tm.LookupTx(txID)
+	current, err := postgres.ValidateInChunksForTest(tm, txCtx, tx, "t1", nil, 100)
+	if err != nil {
+		t.Fatalf("validateInChunks(nil): %v", err)
+	}
+	if len(current) != 0 {
+		t.Errorf("want empty map, got %v", current)
+	}
+}
+
+func TestValidateInChunks_SingleChunk(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'e1', 'M', '1', 3, false, '{}'::jsonb),
+		       ('t1', 'e2', 'M', '1', 7, false, '{}'::jsonb)
+	`)
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(ctx, txID) //nolint:errcheck
+	tx, _ := tm.LookupTx(txID)
+	current, err := postgres.ValidateInChunksForTest(tm, txCtx, tx, "t1", []string{"e1", "e2"}, 100)
+	if err != nil {
+		t.Fatalf("validateInChunks: %v", err)
+	}
+	if current["e1"] != 3 || current["e2"] != 7 {
+		t.Errorf("versions: want {e1:3,e2:7}, got %v", current)
+	}
+}
+
+func TestValidateInChunks_MultipleChunks(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+	for i, id := range []string{"a", "b", "c", "d", "e"} {
+		_, _ = pool.Exec(ctx, `
+			INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+			VALUES ('t1', $1, 'M', '1', $2, false, '{}'::jsonb)
+		`, id, int64(i+1))
+	}
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(ctx, txID) //nolint:errcheck
+	tx, _ := tm.LookupTx(txID)
+	current, err := postgres.ValidateInChunksForTest(tm, txCtx, tx, "t1",
+		[]string{"a", "b", "c", "d", "e"}, 2) // chunk size 2 → 3 chunks
+	if err != nil {
+		t.Fatalf("validateInChunks: %v", err)
+	}
+	if len(current) != 5 {
+		t.Errorf("want 5, got %d: %v", len(current), current)
+	}
+}
+
+func TestValidateInChunks_TenantScoped(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'e1', 'M', '1', 1, false, '{}'::jsonb),
+		       ('t2', 'e1', 'M', '1', 99, false, '{}'::jsonb)
+	`)
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(ctx, txID) //nolint:errcheck
+	tx, _ := tm.LookupTx(txID)
+	current, err := postgres.ValidateInChunksForTest(tm, txCtx, tx, "t1", []string{"e1"}, 100)
+	if err != nil {
+		t.Fatalf("validateInChunks: %v", err)
+	}
+	if current["e1"] != 1 {
+		t.Errorf("tenant scoping: want t1's e1=1, got %d", current["e1"])
+	}
+}

--- a/plugins/postgres/entity_store.go
+++ b/plugins/postgres/entity_store.go
@@ -82,6 +82,14 @@ func (s *entityStore) Save(ctx context.Context, entity *spi.Entity) (int64, erro
 
 	entity.Meta.Version = nextVersion
 
+	if s.tm != nil {
+		var preWriteVersion int64
+		if !isNew {
+			preWriteVersion = nextVersion - 1
+		}
+		s.tm.recordWriteIfInTx(ctx, eid, preWriteVersion)
+	}
+
 	// Set metadata based on whether this is a new or updated entity.
 	if isNew {
 		entity.Meta.ChangeType = "CREATED"
@@ -154,9 +162,17 @@ func (s *entityStore) Get(ctx context.Context, entityID string) (*spi.Entity, er
 		}
 		return nil, fmt.Errorf("failed to get entity %s: %w", entityID, err)
 	}
-	return unmarshalEntityDoc(doc)
+	entity, err := unmarshalEntityDoc(doc)
+	if err != nil {
+		return nil, err
+	}
+	if s.tm != nil {
+		s.tm.recordReadIfInTx(ctx, entity.Meta.ID, entity.Meta.Version)
+	}
+	return entity, nil
 }
 
+// Deliberately not tracked in readSet: historical reads target immutable versions. See spec §Known limitation.
 func (s *entityStore) GetAsAt(ctx context.Context, entityID string, asAt time.Time) (*spi.Entity, error) {
 	// Round up to the next millisecond boundary (matching memory implementation).
 	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
@@ -204,9 +220,19 @@ func (s *entityStore) GetAll(ctx context.Context, modelRef spi.ModelRef) ([]*spi
 	}
 	defer rows.Close()
 
-	return scanEntities(rows)
+	entities, err := scanEntities(rows)
+	if err != nil {
+		return nil, err
+	}
+	if s.tm != nil {
+		for _, e := range entities {
+			s.tm.recordReadIfInTx(ctx, e.Meta.ID, e.Meta.Version)
+		}
+	}
+	return entities, nil
 }
 
+// Deliberately not tracked in readSet: historical reads target immutable versions. See spec §Known limitation.
 func (s *entityStore) GetAllAsAt(ctx context.Context, modelRef spi.ModelRef, asAt time.Time) ([]*spi.Entity, error) {
 	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
 
@@ -246,6 +272,10 @@ func (s *entityStore) Delete(ctx context.Context, entityID string) error {
 			return fmt.Errorf("ENTITY_NOT_FOUND: entity %s not found: %w", entityID, spi.ErrNotFound)
 		}
 		return fmt.Errorf("failed to get entity %s for delete: %w", entityID, err)
+	}
+
+	if s.tm != nil {
+		s.tm.recordWriteIfInTx(ctx, entityID, maxVersion)
 	}
 
 	current, err := unmarshalEntityDoc(doc)
@@ -326,6 +356,7 @@ func (s *entityStore) DeleteAll(ctx context.Context, modelRef spi.ModelRef) erro
 	return nil
 }
 
+// Deliberately not tracked in readSet: boolean probe; no version to validate.
 func (s *entityStore) Exists(ctx context.Context, entityID string) (bool, error) {
 	var exists bool
 	err := s.q.QueryRow(ctx,
@@ -337,6 +368,7 @@ func (s *entityStore) Exists(ctx context.Context, entityID string) (bool, error)
 	return exists, nil
 }
 
+// Deliberately not tracked in readSet: aggregate with no per-row identity. See spec §Known limitation (phantom reads).
 func (s *entityStore) Count(ctx context.Context, modelRef spi.ModelRef) (int64, error) {
 	var count int64
 	err := s.q.QueryRow(ctx,
@@ -348,6 +380,7 @@ func (s *entityStore) Count(ctx context.Context, modelRef spi.ModelRef) (int64, 
 	return count, nil
 }
 
+// Deliberately not tracked in readSet: observational reads of version history.
 func (s *entityStore) GetVersionHistory(ctx context.Context, entityID string) ([]spi.EntityVersion, error) {
 	rows, err := s.q.Query(ctx,
 		`SELECT doc, version, valid_time FROM entity_versions

--- a/plugins/postgres/entity_store.go
+++ b/plugins/postgres/entity_store.go
@@ -17,6 +17,7 @@ import (
 type entityStore struct {
 	q        Querier
 	tenantID spi.TenantID
+	tm       *TransactionManager
 }
 
 func (s *entityStore) SaveAll(ctx context.Context, entities iter.Seq[*spi.Entity]) ([]int64, error) {

--- a/plugins/postgres/entity_store.go
+++ b/plugins/postgres/entity_store.go
@@ -20,6 +20,9 @@ type entityStore struct {
 	tm       *TransactionManager
 }
 
+// SaveAll delegates to Save per-entity via spi.DefaultSaveAll; each Save
+// call records in writeSet (for updates) via recordWriteIfInTx. If this
+// is ever optimized to a batch INSERT, the writeSet hooks must be preserved.
 func (s *entityStore) SaveAll(ctx context.Context, entities iter.Seq[*spi.Entity]) ([]int64, error) {
 	return spi.DefaultSaveAll(s, ctx, entities)
 }

--- a/plugins/postgres/entity_store.go
+++ b/plugins/postgres/entity_store.go
@@ -82,12 +82,14 @@ func (s *entityStore) Save(ctx context.Context, entity *spi.Entity) (int64, erro
 
 	entity.Meta.Version = nextVersion
 
-	if s.tm != nil {
-		var preWriteVersion int64
-		if !isNew {
-			preWriteVersion = nextVersion - 1
-		}
-		s.tm.recordWriteIfInTx(ctx, eid, preWriteVersion)
+	// Record writes only for updates (not fresh inserts). Fresh inserts
+	// (isNew=true) are not tracked in writeSet: the UPSERT's ON CONFLICT DO
+	// UPDATE means concurrent inserts are gracefully converted to updates by
+	// the database — no insert race can produce a false conflict. Tracking
+	// fresh inserts would falsely fire because validateInChunks runs inside the
+	// current transaction and sees the tx's own uncommitted writes.
+	if s.tm != nil && !isNew {
+		s.tm.recordWriteIfInTx(ctx, eid, nextVersion-1)
 	}
 
 	// Set metadata based on whether this is a new or updated entity.

--- a/plugins/postgres/entity_store_test.go
+++ b/plugins/postgres/entity_store_test.go
@@ -634,9 +634,12 @@ func TestEntityStore_Get_NoTxContext_DoesNotRecord(t *testing.T) {
 	}
 }
 
-// TestEntityStore_Save_FreshInsertRecordsZero verifies that a fresh Save
-// records preWriteVersion=0 in the writeSet.
-func TestEntityStore_Save_FreshInsertRecordsZero(t *testing.T) {
+// TestEntityStore_Save_FreshInsertNotRecorded verifies that a fresh Save
+// (new entity) does NOT record in the writeSet. Fresh inserts are not tracked
+// because the UPSERT's ON CONFLICT DO UPDATE handles concurrent inserts
+// gracefully at the DB level, and tracking would cause false positives when
+// validateInChunks (running inside the same tx) sees the tx's own insert.
+func TestEntityStore_Save_FreshInsertNotRecorded(t *testing.T) {
 	factory, tm := setupEntityTestWithTM(t)
 	ctx := ctxWithTenant("hook-tenant")
 
@@ -657,12 +660,9 @@ func TestEntityStore_Save_FreshInsertRecordsZero(t *testing.T) {
 	if !ok {
 		t.Fatal("txState not found")
 	}
-	v, present := postgres.WriteSetVersionForTest(state, "new-e1")
-	if !present {
-		t.Fatal("new-e1 not found in writeSet")
-	}
-	if v != 0 {
-		t.Errorf("writeSet[new-e1] = %d, want 0 (fresh insert)", v)
+	_, present := postgres.WriteSetVersionForTest(state, "new-e1")
+	if present {
+		t.Error("fresh insert must NOT be recorded in writeSet")
 	}
 }
 

--- a/plugins/postgres/entity_store_test.go
+++ b/plugins/postgres/entity_store_test.go
@@ -9,6 +9,25 @@ import (
 	"github.com/cyoda-platform/cyoda-go/plugins/postgres"
 )
 
+// setupEntityTestWithTM creates a StoreFactory that has a TransactionManager
+// wired in. Used by hook tests.
+func setupEntityTestWithTM(t *testing.T) (*postgres.StoreFactory, *postgres.TransactionManager) {
+	t.Helper()
+	pool := newTestPool(t)
+	if err := postgres.DropSchemaForTest(pool); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+	if err := postgres.Migrate(pool); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+	t.Cleanup(func() { _ = postgres.DropSchemaForTest(pool) })
+
+	uuids := newTestUUIDGenerator()
+	tm := postgres.NewTransactionManager(pool, uuids)
+	factory := postgres.NewStoreFactoryWithTMForTest(pool, tm)
+	return factory, tm
+}
+
 func setupEntityTest(t *testing.T) *postgres.StoreFactory {
 	t.Helper()
 	pool := newTestPool(t)
@@ -546,5 +565,220 @@ func TestEntityStore_DeleteCreatesVersionEntry(t *testing.T) {
 	}
 	if history[1].ChangeType != "DELETED" {
 		t.Errorf("expected ChangeType=DELETED, got %q", history[1].ChangeType)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// readSet / writeSet hook tests
+// ---------------------------------------------------------------------------
+
+// TestEntityStore_Get_PopulatesReadSet verifies that a Get within a
+// transaction records the entity's version in the readSet.
+func TestEntityStore_Get_PopulatesReadSet(t *testing.T) {
+	factory, tm := setupEntityTestWithTM(t)
+	ctx := ctxWithTenant("hook-tenant")
+
+	// Seed e1 at version 3 (save three times).
+	seedStore, _ := factory.EntityStore(ctx)
+	e := makeEntity("e1-read")
+	e.Meta.ModelRef = spi.ModelRef{EntityName: "Hook", ModelVersion: "1"}
+	seedStore.Save(ctx, e) // v1
+	seedStore.Save(ctx, e) // v2
+	seedStore.Save(ctx, e) // v3
+
+	// Begin a transaction.
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(txCtx, txID) //nolint:errcheck
+
+	// Get within the transaction.
+	txStore, _ := factory.EntityStore(txCtx)
+	got, err := txStore.Get(txCtx, "e1-read")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Meta.Version != 3 {
+		t.Fatalf("expected version 3, got %d", got.Meta.Version)
+	}
+
+	// Verify readSet recorded version 3.
+	state, ok := postgres.LookupTxStateForTest(tm, txID)
+	if !ok {
+		t.Fatal("txState not found")
+	}
+	if v := postgres.ReadSetVersionForTest(state, "e1-read"); v != 3 {
+		t.Errorf("readSet[e1-read] = %d, want 3", v)
+	}
+}
+
+// TestEntityStore_Get_NoTxContext_DoesNotRecord verifies that Get outside
+// a transaction does not panic and records nothing.
+func TestEntityStore_Get_NoTxContext_DoesNotRecord(t *testing.T) {
+	factory, _ := setupEntityTestWithTM(t)
+	ctx := ctxWithTenant("hook-tenant")
+
+	store, _ := factory.EntityStore(ctx)
+	e := makeEntity("e1-notx")
+	e.Meta.ModelRef = spi.ModelRef{EntityName: "Hook", ModelVersion: "1"}
+	store.Save(ctx, e)
+
+	// Get outside a transaction — no panic expected.
+	got, err := store.Get(ctx, "e1-notx")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil entity")
+	}
+}
+
+// TestEntityStore_Save_FreshInsertRecordsZero verifies that a fresh Save
+// records preWriteVersion=0 in the writeSet.
+func TestEntityStore_Save_FreshInsertRecordsZero(t *testing.T) {
+	factory, tm := setupEntityTestWithTM(t)
+	ctx := ctxWithTenant("hook-tenant")
+
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(txCtx, txID) //nolint:errcheck
+
+	txStore, _ := factory.EntityStore(txCtx)
+	e := makeEntity("new-e1")
+	e.Meta.ModelRef = spi.ModelRef{EntityName: "Hook", ModelVersion: "1"}
+	if _, err := txStore.Save(txCtx, e); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	state, ok := postgres.LookupTxStateForTest(tm, txID)
+	if !ok {
+		t.Fatal("txState not found")
+	}
+	v, present := postgres.WriteSetVersionForTest(state, "new-e1")
+	if !present {
+		t.Fatal("new-e1 not found in writeSet")
+	}
+	if v != 0 {
+		t.Errorf("writeSet[new-e1] = %d, want 0 (fresh insert)", v)
+	}
+}
+
+// TestEntityStore_Save_UpdateRecordsPreWriteVersion verifies that updating
+// an existing entity records preWriteVersion = nextVersion-1 in the writeSet.
+func TestEntityStore_Save_UpdateRecordsPreWriteVersion(t *testing.T) {
+	factory, tm := setupEntityTestWithTM(t)
+	ctx := ctxWithTenant("hook-tenant")
+
+	// Seed existing entity at v4.
+	seedStore, _ := factory.EntityStore(ctx)
+	e := makeEntity("existing-e1")
+	e.Meta.ModelRef = spi.ModelRef{EntityName: "Hook", ModelVersion: "1"}
+	for i := 0; i < 4; i++ {
+		seedStore.Save(ctx, e)
+	}
+
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(txCtx, txID) //nolint:errcheck
+
+	txStore, _ := factory.EntityStore(txCtx)
+	if _, err := txStore.Save(txCtx, e); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	state, ok := postgres.LookupTxStateForTest(tm, txID)
+	if !ok {
+		t.Fatal("txState not found")
+	}
+	v, present := postgres.WriteSetVersionForTest(state, "existing-e1")
+	if !present {
+		t.Fatal("existing-e1 not found in writeSet")
+	}
+	if v != 4 {
+		t.Errorf("writeSet[existing-e1] = %d, want 4 (preWriteVersion = nextVersion-1)", v)
+	}
+}
+
+// TestEntityStore_Delete_RecordsWriteSet verifies that Delete records the
+// entity's pre-delete version in the writeSet.
+func TestEntityStore_Delete_RecordsWriteSet(t *testing.T) {
+	factory, tm := setupEntityTestWithTM(t)
+	ctx := ctxWithTenant("hook-tenant")
+
+	// Seed del-e at v6.
+	seedStore, _ := factory.EntityStore(ctx)
+	e := makeEntity("del-e")
+	e.Meta.ModelRef = spi.ModelRef{EntityName: "Hook", ModelVersion: "1"}
+	for i := 0; i < 6; i++ {
+		seedStore.Save(ctx, e)
+	}
+
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(txCtx, txID) //nolint:errcheck
+
+	txStore, _ := factory.EntityStore(txCtx)
+	if err := txStore.Delete(txCtx, "del-e"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	state, ok := postgres.LookupTxStateForTest(tm, txID)
+	if !ok {
+		t.Fatal("txState not found")
+	}
+	v, present := postgres.WriteSetVersionForTest(state, "del-e")
+	if !present {
+		t.Fatal("del-e not found in writeSet")
+	}
+	if v != 6 {
+		t.Errorf("writeSet[del-e] = %d, want 6", v)
+	}
+}
+
+// TestEntityStore_GetAll_RecordsEachReadSet verifies that GetAll within a
+// transaction records each returned entity's version in the readSet.
+func TestEntityStore_GetAll_RecordsEachReadSet(t *testing.T) {
+	factory, tm := setupEntityTestWithTM(t)
+	ctx := ctxWithTenant("hook-tenant")
+
+	ref := spi.ModelRef{EntityName: "Hook", ModelVersion: "1"}
+
+	seedStore, _ := factory.EntityStore(ctx)
+	for _, id := range []string{"ga-1", "ga-2", "ga-3"} {
+		e := makeEntity(id)
+		e.Meta.ModelRef = ref
+		seedStore.Save(ctx, e)
+	}
+
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(txCtx, txID) //nolint:errcheck
+
+	txStore, _ := factory.EntityStore(txCtx)
+	all, err := txStore.GetAll(txCtx, ref)
+	if err != nil {
+		t.Fatalf("GetAll: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 entities, got %d", len(all))
+	}
+
+	state, ok := postgres.LookupTxStateForTest(tm, txID)
+	if !ok {
+		t.Fatal("txState not found")
+	}
+	for _, id := range []string{"ga-1", "ga-2", "ga-3"} {
+		if v := postgres.ReadSetVersionForTest(state, id); v != 1 {
+			t.Errorf("readSet[%s] = %d, want 1", id, v)
+		}
 	}
 }

--- a/plugins/postgres/export_test.go
+++ b/plugins/postgres/export_test.go
@@ -1,5 +1,20 @@
 package postgres
 
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// ValidateInChunksForTest exposes validateInChunks for integration testing.
+func ValidateInChunksForTest(
+	tm *TransactionManager, ctx context.Context, tx pgx.Tx, tenantID spi.TenantID, sortedIDs []string, chunkSize int,
+) (map[string]int64, error) {
+	return tm.validateInChunks(ctx, tx, tenantID, sortedIDs, chunkSize)
+}
+
 // DropSchemaForTest exposes dropSchema (the unexported implementation) to
 // _test.go files in this package and any external test packages that import
 // "github.com/cyoda-platform/cyoda-go/plugins/postgres". The export_test.go

--- a/plugins/postgres/export_test.go
+++ b/plugins/postgres/export_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 )
@@ -77,4 +78,12 @@ func WriteSetVersionForTest(s TxStateForTest, entityID string) (int64, bool) {
 	defer inner.mu.Unlock()
 	v, present := inner.writeSet[entityID]
 	return v, present
+}
+
+// NewStoreFactoryWithTMForTest creates a StoreFactory with the given pool and
+// TransactionManager pre-wired. Use only in tests.
+func NewStoreFactoryWithTMForTest(pool *pgxpool.Pool, tm *TransactionManager) *StoreFactory {
+	f := NewStoreFactory(pool)
+	f.setTransactionManager(tm)
+	return f
 }

--- a/plugins/postgres/export_test.go
+++ b/plugins/postgres/export_test.go
@@ -18,3 +18,48 @@ var MigrateDownForTest = migrateDown
 // ClassifyErrorForTest exposes classifyError to allow unit-testing of the
 // serialization/deadlock classification logic without requiring a live database.
 var ClassifyErrorForTest = classifyError
+
+// HasTxState reports whether the given txID has an active txState entry.
+func HasTxState(tm *TransactionManager, txID string) bool {
+	tm.txStatesMu.Lock()
+	defer tm.txStatesMu.Unlock()
+	_, ok := tm.txStates[txID]
+	return ok
+}
+
+// TxStateForTest exposes the recording/savepoint methods needed by tests.
+type TxStateForTest interface {
+	RecordRead(id string, version int64)
+	RecordWrite(id string, preWriteVersion int64)
+	PushSavepoint(id string)
+	RestoreSavepoint(id string) error
+	ReleaseSavepoint(id string) error
+}
+
+// LookupTxStateForTest returns the TxStateForTest for the given txID.
+func LookupTxStateForTest(tm *TransactionManager, txID string) (TxStateForTest, bool) {
+	return tm.lookupTxState(txID)
+}
+
+// ReadSetVersionForTest returns the captured readSet version for the given entity, or 0 if not present.
+func ReadSetVersionForTest(s TxStateForTest, entityID string) int64 {
+	inner, ok := s.(*txState)
+	if !ok {
+		return 0
+	}
+	inner.mu.Lock()
+	defer inner.mu.Unlock()
+	return inner.readSet[entityID]
+}
+
+// WriteSetVersionForTest returns the captured writeSet version and whether it exists.
+func WriteSetVersionForTest(s TxStateForTest, entityID string) (int64, bool) {
+	inner, ok := s.(*txState)
+	if !ok {
+		return 0, false
+	}
+	inner.mu.Lock()
+	defer inner.mu.Unlock()
+	v, present := inner.writeSet[entityID]
+	return v, present
+}

--- a/plugins/postgres/export_test.go
+++ b/plugins/postgres/export_test.go
@@ -37,8 +37,8 @@ var ClassifyErrorForTest = classifyError
 
 // HasTxState reports whether the given txID has an active txState entry.
 func HasTxState(tm *TransactionManager, txID string) bool {
-	tm.txStatesMu.Lock()
-	defer tm.txStatesMu.Unlock()
+	tm.txStatesMu.RLock()
+	defer tm.txStatesMu.RUnlock()
 	_, ok := tm.txStates[txID]
 	return ok
 }

--- a/plugins/postgres/fcw_test.go
+++ b/plugins/postgres/fcw_test.go
@@ -1,0 +1,457 @@
+package postgres_test
+
+// fcw_test.go — end-to-end first-committer-wins (FCW) concurrency tests.
+//
+// These tests exercise the SI + FCW mechanisms end-to-end against a real
+// PostgreSQL instance (provided by CYODA_TEST_DB_URL / testcontainers-go
+// in CI). Each test is completely self-contained: it creates its own pool,
+// runs migrations, seeds data, exercises concurrency, and cleans up.
+//
+// Conflict detection mechanisms (see DESIGN NOTE in the task brief):
+//   - Read-set staleness: readSet validated via FOR SHARE at commit time.
+//   - Write-write: caught by postgres native tuple-level DML locks (SQLSTATE 40001).
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/postgres"
+)
+
+// setupFCWTest creates an isolated pool + schema + wired StoreFactory+TM.
+// The schema is dropped on t.Cleanup.
+func setupFCWTest(t *testing.T) (*postgres.StoreFactory, *postgres.TransactionManager) {
+	t.Helper()
+	pool := newTestPool(t)
+	if err := postgres.DropSchemaForTest(pool); err != nil {
+		t.Fatalf("reset schema: %v", err)
+	}
+	if err := postgres.Migrate(pool); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+	t.Cleanup(func() { _ = postgres.DropSchemaForTest(pool) })
+
+	uuids := newTestUUIDGenerator()
+	tm := postgres.NewTransactionManager(pool, uuids)
+	factory := postgres.NewStoreFactoryWithTMForTest(pool, tm)
+	return factory, tm
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Regression — disjoint concurrent inserts must not conflict (#17)
+// ---------------------------------------------------------------------------
+
+// TestFCW_DisjointConcurrentInserts_NoFalseConflicts is a regression guard for
+// issue #17. Under SSI, page-level SIReadLocks caused serialization failures
+// (~40001) for concurrent inserts of distinct UUIDs into the same tenant after
+// the b-tree had ≥200 rows. Under SI + FCW, disjoint inserts must all commit.
+//
+// Run with -count=5 for stability verification:
+//
+//	go test ./plugins/postgres/ -run TestFCW_DisjointConcurrentInserts -v -count=5
+func TestFCW_DisjointConcurrentInserts_NoFalseConflicts(t *testing.T) {
+	factory, tm := setupFCWTest(t)
+	ctx := ctxWithTenant("fcw-tenant-1")
+
+	// Seed 200 rows to fill the b-tree (mirrors #17 reproducer).
+	seedStore, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore (seed): %v", err)
+	}
+	for i := 0; i < 200; i++ {
+		e := makeEntity(fmt.Sprintf("seed-%04d", i))
+		if _, err := seedStore.Save(ctx, e); err != nil {
+			t.Fatalf("seed Save %d: %v", i, err)
+		}
+	}
+
+	// 8 goroutines each insert one unique entity in its own transaction.
+	const workers = 8
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			txID, txCtx, err := tm.Begin(ctx)
+			if err != nil {
+				errs <- fmt.Errorf("worker %d Begin: %w", i, err)
+				return
+			}
+			txStore, err := factory.EntityStore(txCtx)
+			if err != nil {
+				_ = tm.Rollback(txCtx, txID)
+				errs <- fmt.Errorf("worker %d EntityStore: %w", i, err)
+				return
+			}
+			e := makeEntity(fmt.Sprintf("concurrent-%d", i))
+			if _, err := txStore.Save(txCtx, e); err != nil {
+				_ = tm.Rollback(txCtx, txID)
+				errs <- fmt.Errorf("worker %d Save: %w", i, err)
+				return
+			}
+			if err := tm.Commit(ctx, txID); err != nil {
+				errs <- fmt.Errorf("worker %d Commit: %w", i, err)
+				return
+			}
+			errs <- nil
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for e := range errs {
+		if e != nil {
+			t.Errorf("unexpected error (expected zero conflicts for disjoint inserts): %v", e)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Same-entity race — first committer wins
+// ---------------------------------------------------------------------------
+
+// TestFCW_SameEntityUpdate_FirstCommitterWins verifies that when two
+// transactions both read the same entity and then write it, exactly one
+// succeeds and the other gets spi.ErrConflict.
+//
+// Conflict detection mechanism: The second committer's readSet validation
+// detects the version change committed by the first committer. Under
+// REPEATABLE READ (SI), two concurrent UPDATEs on the same row will be
+// serialized by postgres's tuple-level locks — the second UPDATE blocks
+// until the first commits (then either proceeds or gets 40001). Both
+// mechanisms (readSet staleness + DB-level 40001) map to spi.ErrConflict.
+//
+// Design note: we do NOT use a commit barrier here. Under REPEATABLE READ,
+// one goroutine's Save (UPDATE) will block on the row lock until the other's
+// transaction ends. We let the two goroutines race naturally; one of them
+// either gets 40001 from the UPDATE itself or ErrConflict from the readSet
+// validation at commit. Both outcomes satisfy the FCW contract.
+func TestFCW_SameEntityUpdate_FirstCommitterWins(t *testing.T) {
+	factory, tm := setupFCWTest(t)
+	ctx := ctxWithTenant("fcw-tenant-2")
+
+	// Seed shared entity at v=1.
+	seedStore, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore (seed): %v", err)
+	}
+	e := makeEntity("shared")
+	if _, err := seedStore.Save(ctx, e); err != nil {
+		t.Fatalf("seed shared: %v", err)
+	}
+
+	// Tx A and Tx B: begin both, read shared, then write + commit concurrently.
+	// Both transactions start before any commit so both see v=1 in their snapshot.
+	txIDA, txCtxA, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Tx A Begin: %v", err)
+	}
+	txIDB, txCtxB, err := tm.Begin(ctx)
+	if err != nil {
+		_ = tm.Rollback(txCtxA, txIDA)
+		t.Fatalf("Tx B Begin: %v", err)
+	}
+
+	storeA, err := factory.EntityStore(txCtxA)
+	if err != nil {
+		_ = tm.Rollback(txCtxA, txIDA)
+		_ = tm.Rollback(txCtxB, txIDB)
+		t.Fatalf("Tx A EntityStore: %v", err)
+	}
+	storeB, err := factory.EntityStore(txCtxB)
+	if err != nil {
+		_ = tm.Rollback(txCtxA, txIDA)
+		_ = tm.Rollback(txCtxB, txIDB)
+		t.Fatalf("Tx B EntityStore: %v", err)
+	}
+
+	// Both read shared while in their snapshot — both see v=1.
+	gotA, err := storeA.Get(txCtxA, "shared")
+	if err != nil {
+		_ = tm.Rollback(txCtxA, txIDA)
+		_ = tm.Rollback(txCtxB, txIDB)
+		t.Fatalf("Tx A Get: %v", err)
+	}
+	gotB, err := storeB.Get(txCtxB, "shared")
+	if err != nil {
+		_ = tm.Rollback(txCtxA, txIDA)
+		_ = tm.Rollback(txCtxB, txIDB)
+		t.Fatalf("Tx B Get: %v", err)
+	}
+
+	// Now commit-race them concurrently. Under REPEATABLE READ the two
+	// UPDATEs contend on the same row; exactly one will win.
+	type result struct{ err error }
+	results := make(chan result, 2)
+
+	go func() {
+		gotA.Meta.State = "UPDATED_BY_A"
+		if _, err := storeA.Save(txCtxA, gotA); err != nil {
+			_ = tm.Rollback(txCtxA, txIDA)
+			results <- result{err}
+			return
+		}
+		results <- result{tm.Commit(ctx, txIDA)}
+	}()
+	go func() {
+		gotB.Meta.State = "UPDATED_BY_B"
+		if _, err := storeB.Save(txCtxB, gotB); err != nil {
+			_ = tm.Rollback(txCtxB, txIDB)
+			results <- result{err}
+			return
+		}
+		results <- result{tm.Commit(ctx, txIDB)}
+	}()
+
+	var successes, conflicts int
+	for i := 0; i < 2; i++ {
+		r := <-results
+		if r.err == nil {
+			successes++
+		} else if errors.Is(r.err, spi.ErrConflict) {
+			conflicts++
+		} else {
+			t.Errorf("unexpected non-conflict error: %v", r.err)
+		}
+	}
+
+	if successes != 1 || conflicts != 1 {
+		t.Errorf("expected successes=1 conflicts=1, got successes=%d conflicts=%d",
+			successes, conflicts)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Read-then-concurrent-delete conflict
+// ---------------------------------------------------------------------------
+
+// TestFCW_ReadThenConcurrentDelete_Conflict verifies that a commit is
+// rejected when another transaction has deleted an entity that this
+// transaction read (the readSet version is bumped by the soft-delete).
+//
+// Scenario (sequential, not concurrent):
+//  1. Tx A: Begin, Get e1 (readSet captures v=1).
+//  2. Tx B: Begin, Delete e1, Commit (marks deleted, bumps to v=2).
+//  3. Tx A: Commit → ErrConflict (readSet v=1 vs current v=2).
+func TestFCW_ReadThenConcurrentDelete_Conflict(t *testing.T) {
+	factory, tm := setupFCWTest(t)
+	ctx := ctxWithTenant("fcw-tenant-3")
+
+	// Seed e1 at v=1.
+	seedStore, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore (seed): %v", err)
+	}
+	if _, err := seedStore.Save(ctx, makeEntity("e1")); err != nil {
+		t.Fatalf("seed e1: %v", err)
+	}
+
+	// Tx A: Begin and read e1.
+	txA, txCtxA, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Tx A Begin: %v", err)
+	}
+	defer func() { _ = tm.Rollback(txCtxA, txA) }()
+
+	storeA, err := factory.EntityStore(txCtxA)
+	if err != nil {
+		t.Fatalf("Tx A EntityStore: %v", err)
+	}
+	got, err := storeA.Get(txCtxA, "e1")
+	if err != nil {
+		t.Fatalf("Tx A Get e1: %v", err)
+	}
+	if got.Meta.Version != 1 {
+		t.Fatalf("expected e1@v1, got v%d", got.Meta.Version)
+	}
+
+	// Tx B: Begin, Delete e1, Commit (bumps version to 2, marks deleted).
+	txB, txCtxB, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Tx B Begin: %v", err)
+	}
+	storeB, err := factory.EntityStore(txCtxB)
+	if err != nil {
+		t.Fatalf("Tx B EntityStore: %v", err)
+	}
+	if err := storeB.Delete(txCtxB, "e1"); err != nil {
+		_ = tm.Rollback(txCtxB, txB)
+		t.Fatalf("Tx B Delete e1: %v", err)
+	}
+	if err := tm.Commit(ctx, txB); err != nil {
+		t.Fatalf("Tx B Commit: %v", err)
+	}
+
+	// Tx A: Commit must fail with ErrConflict.
+	err = tm.Commit(ctx, txA)
+	if err == nil {
+		t.Fatal("expected ErrConflict on Tx A commit, got nil")
+	}
+	if !errors.Is(err, spi.ErrConflict) {
+		t.Errorf("expected ErrConflict, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Large read-set chunked validation
+// ---------------------------------------------------------------------------
+
+// TestFCW_LargeReadSet_ChunkedValidation verifies that a transaction with
+// 2500+ readSet entries commits successfully via multiple FOR SHARE chunks
+// within 5 seconds, when no concurrent modifications have occurred.
+func TestFCW_LargeReadSet_ChunkedValidation(t *testing.T) {
+	factory, tm := setupFCWTest(t)
+	ctx := ctxWithTenant("fcw-tenant-4")
+
+	const entityCount = 2500
+
+	// Seed 2500 entities.
+	seedStore, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore (seed): %v", err)
+	}
+	for i := 0; i < entityCount; i++ {
+		e := makeEntity(fmt.Sprintf("large-%04d", i))
+		if _, err := seedStore.Save(ctx, e); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+
+	// Begin tx and manually populate readSet with all 2500 entities at v=1.
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer func() { _ = tm.Rollback(txCtx, txID) }()
+
+	state, ok := postgres.LookupTxStateForTest(tm, txID)
+	if !ok {
+		t.Fatal("txState not found")
+	}
+	for i := 0; i < entityCount; i++ {
+		state.RecordRead(fmt.Sprintf("large-%04d", i), 1)
+	}
+
+	// Commit — must succeed with no concurrent modifications; assert < 5s.
+	start := time.Now()
+	if err := tm.Commit(ctx, txID); err != nil {
+		t.Fatalf("Commit with large readSet failed: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > 5*time.Second {
+		t.Errorf("large readSet commit took %v, want < 5s", elapsed)
+	}
+	t.Logf("large readSet (%d entities) commit elapsed: %v", entityCount, elapsed)
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: Savepoint rollback drops read-set entries, commit succeeds
+// ---------------------------------------------------------------------------
+
+// TestFCW_SavepointRollback_DropsReadSet_CommitSucceeds verifies that after a
+// rollback-to-savepoint, entity IDs added to the readSet after the savepoint
+// are dropped. A concurrent modification to those dropped entities must not
+// cause a conflict on the outer transaction's commit.
+//
+// Scenario:
+//  1. Tx A: Begin, Get x (readSet: {x:1}).
+//  2. Tx A: Savepoint sp (snapshot: {x:1}).
+//  3. Tx A: Get y (readSet: {x:1, y:1}).
+//  4. Tx B: Begin, Delete y, Commit (y→v2 deleted).
+//  5. Tx A: RollbackToSavepoint sp → readSet restored to {x:1}; y dropped.
+//  6. Tx A: Commit → SUCCEEDS (x unchanged; y not in readSet).
+func TestFCW_SavepointRollback_DropsReadSet_CommitSucceeds(t *testing.T) {
+	factory, tm := setupFCWTest(t)
+	ctx := ctxWithTenant("fcw-tenant-5")
+
+	// Seed x and y at v=1.
+	seedStore, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore (seed): %v", err)
+	}
+	for _, id := range []string{"sp-x", "sp-y"} {
+		if _, err := seedStore.Save(ctx, makeEntity(id)); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	// Tx A: Begin.
+	txA, txCtxA, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Tx A Begin: %v", err)
+	}
+	defer func() { _ = tm.Rollback(txCtxA, txA) }()
+
+	storeA, err := factory.EntityStore(txCtxA)
+	if err != nil {
+		t.Fatalf("Tx A EntityStore: %v", err)
+	}
+
+	// Step 1: Get x — readSet captures {sp-x: 1}.
+	if _, err := storeA.Get(txCtxA, "sp-x"); err != nil {
+		t.Fatalf("Tx A Get sp-x: %v", err)
+	}
+
+	// Verify readSet has x.
+	stateA, ok := postgres.LookupTxStateForTest(tm, txA)
+	if !ok {
+		t.Fatal("txState not found")
+	}
+	if v := postgres.ReadSetVersionForTest(stateA, "sp-x"); v != 1 {
+		t.Fatalf("expected readSet[sp-x]=1, got %d", v)
+	}
+
+	// Step 2: Savepoint.
+	spID, err := tm.Savepoint(txCtxA, txA)
+	if err != nil {
+		t.Fatalf("Savepoint: %v", err)
+	}
+
+	// Step 3: Get y — readSet becomes {sp-x: 1, sp-y: 1}.
+	if _, err := storeA.Get(txCtxA, "sp-y"); err != nil {
+		t.Fatalf("Tx A Get sp-y: %v", err)
+	}
+	if v := postgres.ReadSetVersionForTest(stateA, "sp-y"); v != 1 {
+		t.Fatalf("expected readSet[sp-y]=1 before rollback, got %d", v)
+	}
+
+	// Step 4: Tx B deletes y and commits (y's version becomes 2, deleted=true).
+	txB, txCtxB, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Tx B Begin: %v", err)
+	}
+	storeB, err := factory.EntityStore(txCtxB)
+	if err != nil {
+		t.Fatalf("Tx B EntityStore: %v", err)
+	}
+	if err := storeB.Delete(txCtxB, "sp-y"); err != nil {
+		_ = tm.Rollback(txCtxB, txB)
+		t.Fatalf("Tx B Delete sp-y: %v", err)
+	}
+	if err := tm.Commit(ctx, txB); err != nil {
+		t.Fatalf("Tx B Commit: %v", err)
+	}
+
+	// Step 5: RollbackToSavepoint — y drops from readSet; x stays.
+	if err := tm.RollbackToSavepoint(txCtxA, txA, spID); err != nil {
+		t.Fatalf("RollbackToSavepoint: %v", err)
+	}
+
+	if v := postgres.ReadSetVersionForTest(stateA, "sp-y"); v != 0 {
+		t.Errorf("sp-y should be absent from readSet after rollback, got version %d", v)
+	}
+	if v := postgres.ReadSetVersionForTest(stateA, "sp-x"); v != 1 {
+		t.Errorf("sp-x should remain in readSet at v1 after rollback, got %d", v)
+	}
+
+	// Step 6: Tx A commits — must succeed because y is no longer validated.
+	if err := tm.Commit(ctx, txA); err != nil {
+		t.Errorf("Tx A Commit must succeed after savepoint rollback dropped y: %v", err)
+	}
+}

--- a/plugins/postgres/fcw_test.go
+++ b/plugins/postgres/fcw_test.go
@@ -12,6 +12,7 @@ package postgres_test
 //   - Write-write: caught by postgres native tuple-level DML locks (SQLSTATE 40001).
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -453,5 +454,104 @@ func TestFCW_SavepointRollback_DropsReadSet_CommitSucceeds(t *testing.T) {
 	// Step 6: Tx A commits — must succeed because y is no longer validated.
 	if err := tm.Commit(ctx, txA); err != nil {
 		t.Errorf("Tx A Commit must succeed after savepoint rollback dropped y: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Pure readSet-only conflict — no write-write overlap
+// ---------------------------------------------------------------------------
+
+// TestFCW_PureReadSetConflict_NoWriteOverlap proves that readSet validation
+// catches staleness even when the conflicting entity has no write-write overlap.
+//
+// Scenario:
+//  1. Seed x at v=1 and y at v=1.
+//  2. Tx A: Begin, Get x (readSet: {x:1}), Save y (writeSet: {y:1}).
+//  3. Tx B: Begin, update x to v=2 via raw SQL, Commit.
+//  4. Tx A: Commit → spi.ErrConflict (readSet[x]=1 vs current x=2).
+//
+// Without FCW readSet validation this would silently commit: PostgreSQL DML
+// locks only catch write-write contention on the same row; y≠x, so no DML
+// conflict arises. The only protection is the application-layer readSet check.
+func TestFCW_PureReadSetConflict_NoWriteOverlap(t *testing.T) {
+	factory, tm := setupFCWTest(t)
+	ctx := ctxWithTenant("fcw-tenant-6")
+
+	// Step 1: Seed x and y at v=1.
+	seedStore, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore (seed): %v", err)
+	}
+	for _, id := range []string{"prs-x", "prs-y"} {
+		if _, err := seedStore.Save(ctx, makeEntity(id)); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	// Step 2: Tx A: Begin, Get x (records x in readSet), Save y (records y in writeSet).
+	txA, txCtxA, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Tx A Begin: %v", err)
+	}
+	defer func() { _ = tm.Rollback(txCtxA, txA) }()
+
+	storeA, err := factory.EntityStore(txCtxA)
+	if err != nil {
+		t.Fatalf("Tx A EntityStore: %v", err)
+	}
+
+	gotX, err := storeA.Get(txCtxA, "prs-x")
+	if err != nil {
+		t.Fatalf("Tx A Get prs-x: %v", err)
+	}
+	if gotX.Meta.Version != 1 {
+		t.Fatalf("expected prs-x@v1, got v%d", gotX.Meta.Version)
+	}
+
+	// Verify x is captured in the readSet.
+	stateA, ok := postgres.LookupTxStateForTest(tm, txA)
+	if !ok {
+		t.Fatal("txState A not found")
+	}
+	if v := postgres.ReadSetVersionForTest(stateA, "prs-x"); v != 1 {
+		t.Fatalf("expected readSet[prs-x]=1, got %d", v)
+	}
+
+	// Save y — puts y into writeSet; prs-x must NOT appear in writeSet.
+	gotY, err := storeA.Get(txCtxA, "prs-y")
+	if err != nil {
+		t.Fatalf("Tx A Get prs-y (pre-save): %v", err)
+	}
+	gotY.Meta.State = "UPDATED_BY_A"
+	if _, err := storeA.Save(txCtxA, gotY); err != nil {
+		t.Fatalf("Tx A Save prs-y: %v", err)
+	}
+	if _, inWrite := postgres.WriteSetVersionForTest(stateA, "prs-x"); inWrite {
+		t.Fatal("prs-x must not be in Tx A writeSet — it was only read, not written")
+	}
+
+	// Step 3: Tx B: Begin, update x to v=2 via raw SQL, Commit.
+	txB, txCtxB, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Tx B Begin: %v", err)
+	}
+	pgxTxB, _ := tm.LookupTx(txB)
+	if _, err := pgxTxB.Exec(txCtxB,
+		`UPDATE entities SET version=2 WHERE tenant_id='fcw-tenant-6' AND entity_id='prs-x'`); err != nil {
+		_ = tm.Rollback(txCtxB, txB)
+		t.Fatalf("Tx B update prs-x: %v", err)
+	}
+	if err := tm.Commit(context.Background(), txB); err != nil {
+		t.Fatalf("Tx B Commit: %v", err)
+	}
+
+	// Step 4: Tx A Commit must fail with ErrConflict.
+	// readSet[prs-x]=1 but current version is 2; y has no overlap with B's writes.
+	err = tm.Commit(ctx, txA)
+	if err == nil {
+		t.Fatal("expected ErrConflict on Tx A commit (stale readSet[prs-x]), got nil")
+	}
+	if !errors.Is(err, spi.ErrConflict) {
+		t.Errorf("expected spi.ErrConflict, got: %v", err)
 	}
 }

--- a/plugins/postgres/store_factory.go
+++ b/plugins/postgres/store_factory.go
@@ -72,7 +72,7 @@ func (f *StoreFactory) EntityStore(ctx context.Context) (spi.EntityStore, error)
 	if err != nil {
 		return nil, err
 	}
-	return &entityStore{q: f.querier(), tenantID: tid}, nil
+	return &entityStore{q: f.querier(), tenantID: tid, tm: f.tm}, nil
 }
 
 func (f *StoreFactory) ModelStore(ctx context.Context) (spi.ModelStore, error) {

--- a/plugins/postgres/transaction_manager.go
+++ b/plugins/postgres/transaction_manager.go
@@ -114,14 +114,21 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 		return fmt.Errorf("Commit: tx state for %s not found", txID)
 	}
 
-	// --- First-committer-wins validation ---
-	// Fetch current committed versions for all entities touched by this tx
-	// and compare against the captured read/write sets. A mismatch means a
-	// concurrent committer has changed data we depended on; abort with
+	// --- First-committer-wins validation (read-set) ---
+	// Re-read the current committed versions of all entities we read in this tx
+	// and compare against the captured readSet. A version mismatch or missing row
+	// means a concurrent committer changed data we made decisions on; abort with
 	// ErrConflict so the caller can retry on a fresh snapshot.
-	ids := state.SortedUnionIDs()
-	if len(ids) > 0 {
-		current, err := tm.validateInChunks(ctx, pgxTx, state.tenantID, ids, 0)
+	//
+	// Write-write conflicts (writeSet) are handled by PostgreSQL's own tuple-level
+	// locks from the DML statements (INSERT/UPDATE/DELETE) — they raise SQLSTATE
+	// 40001 at DML time or commit time, which classifyError maps to ErrConflict.
+	// We do NOT validate writeSet versions here: the validateInChunks query runs
+	// inside the current transaction and therefore sees the tx's own uncommitted
+	// writes, making writeSet version comparison unreliable.
+	readIDs := state.SortedReadIDs()
+	if len(readIDs) > 0 {
+		current, err := tm.validateInChunks(ctx, pgxTx, state.tenantID, readIDs, 0)
 		if err != nil {
 			tm.registry.Remove(txID)
 			tm.removeTenant(txID)
@@ -130,13 +137,6 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 			return classifyError(fmt.Errorf("Commit: validate: %w", err))
 		}
 		if verr := state.ValidateReadSet(current); verr != nil {
-			tm.registry.Remove(txID)
-			tm.removeTenant(txID)
-			tm.removeTxState(txID)
-			_ = pgxTx.Rollback(context.Background())
-			return fmt.Errorf("%w: Commit: %w", spi.ErrConflict, verr)
-		}
-		if verr := state.ValidateWriteSet(current); verr != nil {
 			tm.registry.Remove(txID)
 			tm.removeTenant(txID)
 			tm.removeTxState(txID)
@@ -283,41 +283,63 @@ func (tm *TransactionManager) lookupTxState(txID string) (*txState, bool) {
 	return s, ok
 }
 
-// Savepoint creates a named savepoint within the given PostgreSQL transaction.
+// Savepoint creates a named savepoint within the given PostgreSQL transaction
+// and pushes a snapshot of the current readSet/writeSet onto the txState stack.
 func (tm *TransactionManager) Savepoint(ctx context.Context, txID string) (string, error) {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
 		return "", fmt.Errorf("Savepoint: transaction %s not found", txID)
+	}
+	state, ok := tm.lookupTxState(txID)
+	if !ok {
+		return "", fmt.Errorf("Savepoint: tx state for %s not found", txID)
 	}
 	spID := uuid.UUID(tm.uuids.NewTimeUUID()).String()
 	spName := "sp_" + spID
 	if _, err := pgxTx.Exec(ctx, "SAVEPOINT "+pgx.Identifier{spName}.Sanitize()); err != nil {
 		return "", fmt.Errorf("Savepoint: %w", err)
 	}
+	state.PushSavepoint(spID)
 	return spID, nil
 }
 
-// RollbackToSavepoint rolls back all work done since the named savepoint.
+// RollbackToSavepoint rolls back all work done since the named savepoint and
+// restores the txState readSet/writeSet to the snapshot captured at that savepoint.
 func (tm *TransactionManager) RollbackToSavepoint(ctx context.Context, txID string, savepointID string) error {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
 		return fmt.Errorf("RollbackToSavepoint: transaction %s not found", txID)
 	}
+	state, ok := tm.lookupTxState(txID)
+	if !ok {
+		return fmt.Errorf("RollbackToSavepoint: tx state for %s not found", txID)
+	}
 	spName := "sp_" + savepointID
 	if _, err := pgxTx.Exec(ctx, "ROLLBACK TO SAVEPOINT "+pgx.Identifier{spName}.Sanitize()); err != nil {
+		return fmt.Errorf("RollbackToSavepoint: %w", err)
+	}
+	if err := state.RestoreSavepoint(savepointID); err != nil {
 		return fmt.Errorf("RollbackToSavepoint: %w", err)
 	}
 	return nil
 }
 
 // ReleaseSavepoint releases a savepoint, merging its work into the parent transaction.
+// The txState snapshot for this savepoint is dropped; work done after the push is kept.
 func (tm *TransactionManager) ReleaseSavepoint(ctx context.Context, txID string, savepointID string) error {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
 		return fmt.Errorf("ReleaseSavepoint: transaction %s not found", txID)
 	}
+	state, ok := tm.lookupTxState(txID)
+	if !ok {
+		return fmt.Errorf("ReleaseSavepoint: tx state for %s not found", txID)
+	}
 	spName := "sp_" + savepointID
 	if _, err := pgxTx.Exec(ctx, "RELEASE SAVEPOINT "+pgx.Identifier{spName}.Sanitize()); err != nil {
+		return fmt.Errorf("ReleaseSavepoint: %w", err)
+	}
+	if err := state.ReleaseSavepoint(savepointID); err != nil {
 		return fmt.Errorf("ReleaseSavepoint: %w", err)
 	}
 	return nil

--- a/plugins/postgres/transaction_manager.go
+++ b/plugins/postgres/transaction_manager.go
@@ -35,7 +35,7 @@ type TransactionManager struct {
 	// reconstruct the TransactionState without requiring tenant in the
 	// joining context.
 	tenants    map[string]spi.TenantID
-	txStatesMu sync.Mutex
+	txStatesMu sync.RWMutex
 	txStates   map[string]*txState
 }
 
@@ -275,8 +275,8 @@ func (tm *TransactionManager) removeTxState(txID string) {
 
 // lookupTxState returns the txState for the given txID.
 func (tm *TransactionManager) lookupTxState(txID string) (*txState, bool) {
-	tm.txStatesMu.Lock()
-	defer tm.txStatesMu.Unlock()
+	tm.txStatesMu.RLock()
+	defer tm.txStatesMu.RUnlock()
 	s, ok := tm.txStates[txID]
 	return s, ok
 }

--- a/plugins/postgres/transaction_manager.go
+++ b/plugins/postgres/transaction_manager.go
@@ -19,8 +19,9 @@ import (
 const submitTimeTTL = 1 * time.Hour
 
 // TransactionManager implements spi.TransactionManager backed by PostgreSQL
-// with SERIALIZABLE isolation. Each Begin() acquires a real pgx.Tx and
-// registers it in the txRegistry so that stores can look it up by ID.
+// with SERIALIZABLE isolation. Each Begin() acquires a real pgx.Tx,
+// registers it in the txRegistry, and allocates a *txState for read/write
+// bookkeeping used by Commit.
 type TransactionManager struct {
 	pool     *pgxpool.Pool
 	registry *txRegistry
@@ -32,7 +33,9 @@ type TransactionManager struct {
 	// tenants records the tenant for each active transaction so Join can
 	// reconstruct the TransactionState without requiring tenant in the
 	// joining context.
-	tenants map[string]spi.TenantID
+	tenants    map[string]spi.TenantID
+	txStatesMu sync.Mutex
+	txStates   map[string]*txState
 }
 
 // NewTransactionManager creates a new PostgreSQL-backed TransactionManager.
@@ -43,6 +46,7 @@ func NewTransactionManager(pool *pgxpool.Pool, uuids spi.UUIDGenerator) *Transac
 		uuids:       uuids,
 		submitTimes: make(map[string]time.Time),
 		tenants:     make(map[string]spi.TenantID),
+		txStates:    make(map[string]*txState),
 	}
 }
 
@@ -75,12 +79,16 @@ func (tm *TransactionManager) Begin(ctx context.Context) (string, context.Contex
 	tm.tenants[txID] = tenantID
 	tm.mu.Unlock()
 
-	txState := &spi.TransactionState{
+	tm.txStatesMu.Lock()
+	tm.txStates[txID] = newTxState(tenantID)
+	tm.txStatesMu.Unlock()
+
+	txSpiState := &spi.TransactionState{
 		ID:       txID,
 		TenantID: tenantID,
 	}
 
-	return txID, spi.WithTransaction(ctx, txState), nil
+	return txID, spi.WithTransaction(ctx, txSpiState), nil
 }
 
 // Commit commits the transaction and records its submit time.
@@ -102,6 +110,7 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 	if tsErr := pgxTx.QueryRow(ctx, "SELECT CURRENT_TIMESTAMP").Scan(&submitTime); tsErr != nil {
 		tm.registry.Remove(txID)
 		tm.removeTenant(txID)
+		tm.removeTxState(txID)
 		// Only classify as ErrConflict when the probe fails specifically because
 		// the transaction is already in an aborted state (SQLSTATE 25P02:
 		// in_failed_sql_transaction). Any other error (context cancellation,
@@ -126,11 +135,13 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 		_ = pgxTx.Rollback(ctx)
 		tm.registry.Remove(txID)
 		tm.removeTenant(txID)
+		tm.removeTxState(txID)
 		return classifyError(fmt.Errorf("Commit: %w", err))
 	}
 
 	tm.registry.Remove(txID)
 	tm.removeTenant(txID)
+	tm.removeTxState(txID)
 
 	tm.mu.Lock()
 	tm.submitTimes[txID] = submitTime
@@ -155,6 +166,7 @@ func (tm *TransactionManager) Rollback(ctx context.Context, txID string) error {
 	err := pgxTx.Rollback(ctx)
 	tm.registry.Remove(txID)
 	tm.removeTenant(txID)
+	tm.removeTxState(txID)
 
 	if err != nil {
 		return fmt.Errorf("Rollback: %w", err)
@@ -203,8 +215,23 @@ func (tm *TransactionManager) LookupTx(txID string) (pgx.Tx, bool) {
 // removeTenant cleans up the tenant mapping for a completed transaction.
 func (tm *TransactionManager) removeTenant(txID string) {
 	tm.mu.Lock()
+	defer tm.mu.Unlock()
 	delete(tm.tenants, txID)
-	tm.mu.Unlock()
+}
+
+// removeTxState removes the txState entry for a completed transaction.
+func (tm *TransactionManager) removeTxState(txID string) {
+	tm.txStatesMu.Lock()
+	defer tm.txStatesMu.Unlock()
+	delete(tm.txStates, txID)
+}
+
+// lookupTxState returns the txState for the given txID.
+func (tm *TransactionManager) lookupTxState(txID string) (*txState, bool) {
+	tm.txStatesMu.Lock()
+	defer tm.txStatesMu.Unlock()
+	s, ok := tm.txStates[txID]
+	return s, ok
 }
 
 // Savepoint creates a named savepoint within the given PostgreSQL transaction.

--- a/plugins/postgres/transaction_manager.go
+++ b/plugins/postgres/transaction_manager.go
@@ -19,7 +19,8 @@ import (
 const submitTimeTTL = 1 * time.Hour
 
 // TransactionManager implements spi.TransactionManager backed by PostgreSQL
-// with SERIALIZABLE isolation. Each Begin() acquires a real pgx.Tx,
+// with REPEATABLE READ isolation plus application-layer row-granular
+// first-committer-wins validation. Each Begin() acquires a real pgx.Tx,
 // registers it in the txRegistry, and allocates a *txState for read/write
 // bookkeeping used by Commit.
 type TransactionManager struct {
@@ -50,8 +51,12 @@ func NewTransactionManager(pool *pgxpool.Pool, uuids spi.UUIDGenerator) *Transac
 	}
 }
 
-// Begin starts a new SERIALIZABLE transaction and returns the transaction ID
-// and a context carrying the TransactionState.
+// Begin starts a new REPEATABLE READ transaction (snapshot isolation) and
+// returns the transaction ID and a context carrying the TransactionState.
+//
+// Row-granular first-committer-wins is enforced in application code via
+// txState bookkeeping (readSet/writeSet) and commit-time validation — see
+// Commit() and docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md.
 func (tm *TransactionManager) Begin(ctx context.Context) (string, context.Context, error) {
 	tenantID, err := resolveTenant(ctx)
 	if err != nil {
@@ -60,7 +65,7 @@ func (tm *TransactionManager) Begin(ctx context.Context) (string, context.Contex
 
 	txID := uuid.UUID(tm.uuids.NewTimeUUID()).String()
 
-	pgxTx, err := tm.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	pgxTx, err := tm.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead})
 	if err != nil {
 		return "", nil, fmt.Errorf("Begin: failed to start transaction: %w", err)
 	}

--- a/plugins/postgres/transaction_manager.go
+++ b/plugins/postgres/transaction_manager.go
@@ -101,11 +101,48 @@ func (tm *TransactionManager) Begin(ctx context.Context) (string, context.Contex
 }
 
 // Commit commits the transaction and records its submit time.
-// Returns spi.ErrConflict on serialization failure (PostgreSQL error 40001).
+// Returns spi.ErrConflict on serialization failure (PostgreSQL error 40001)
+// or when the application-layer first-committer-wins validation detects a
+// stale read or write set.
 func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
 		return fmt.Errorf("Commit: transaction %s not found", txID)
+	}
+	state, ok := tm.lookupTxState(txID)
+	if !ok {
+		return fmt.Errorf("Commit: tx state for %s not found", txID)
+	}
+
+	// --- First-committer-wins validation ---
+	// Fetch current committed versions for all entities touched by this tx
+	// and compare against the captured read/write sets. A mismatch means a
+	// concurrent committer has changed data we depended on; abort with
+	// ErrConflict so the caller can retry on a fresh snapshot.
+	ids := state.SortedUnionIDs()
+	if len(ids) > 0 {
+		current, err := tm.validateInChunks(ctx, pgxTx, state.tenantID, ids, 0)
+		if err != nil {
+			tm.registry.Remove(txID)
+			tm.removeTenant(txID)
+			tm.removeTxState(txID)
+			_ = pgxTx.Rollback(context.Background())
+			return classifyError(fmt.Errorf("Commit: validate: %w", err))
+		}
+		if verr := state.ValidateReadSet(current); verr != nil {
+			tm.registry.Remove(txID)
+			tm.removeTenant(txID)
+			tm.removeTxState(txID)
+			_ = pgxTx.Rollback(context.Background())
+			return fmt.Errorf("%w: Commit: %w", spi.ErrConflict, verr)
+		}
+		if verr := state.ValidateWriteSet(current); verr != nil {
+			tm.registry.Remove(txID)
+			tm.removeTenant(txID)
+			tm.removeTxState(txID)
+			_ = pgxTx.Rollback(context.Background())
+			return fmt.Errorf("%w: Commit: %w", spi.ErrConflict, verr)
+		}
 	}
 
 	// Capture the database timestamp before committing.

--- a/plugins/postgres/transaction_manager.go
+++ b/plugins/postgres/transaction_manager.go
@@ -80,13 +80,17 @@ func (tm *TransactionManager) Begin(ctx context.Context) (string, context.Contex
 
 	tm.registry.Register(txID, pgxTx)
 
-	tm.mu.Lock()
-	tm.tenants[txID] = tenantID
-	tm.mu.Unlock()
+	func() {
+		tm.mu.Lock()
+		defer tm.mu.Unlock()
+		tm.tenants[txID] = tenantID
+	}()
 
-	tm.txStatesMu.Lock()
-	tm.txStates[txID] = newTxState(tenantID)
-	tm.txStatesMu.Unlock()
+	func() {
+		tm.txStatesMu.Lock()
+		defer tm.txStatesMu.Unlock()
+		tm.txStates[txID] = newTxState(tenantID)
+	}()
 
 	txSpiState := &spi.TransactionState{
 		ID:       txID,
@@ -187,9 +191,12 @@ func (tm *TransactionManager) Join(ctx context.Context, txID string) (context.Co
 		return nil, fmt.Errorf("Join: transaction %s not found", txID)
 	}
 
-	tm.mu.Lock()
-	tenantID := tm.tenants[txID]
-	tm.mu.Unlock()
+	var tenantID spi.TenantID
+	func() {
+		tm.mu.Lock()
+		defer tm.mu.Unlock()
+		tenantID = tm.tenants[txID]
+	}()
 
 	txState := &spi.TransactionState{
 		ID:       txID,

--- a/plugins/postgres/transaction_manager.go
+++ b/plugins/postgres/transaction_manager.go
@@ -130,16 +130,12 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 	if len(readIDs) > 0 {
 		current, err := tm.validateInChunks(ctx, pgxTx, state.tenantID, readIDs, 0)
 		if err != nil {
-			tm.registry.Remove(txID)
-			tm.removeTenant(txID)
-			tm.removeTxState(txID)
+			tm.cleanupTx(txID)
 			_ = pgxTx.Rollback(context.Background())
 			return classifyError(fmt.Errorf("Commit: validate: %w", err))
 		}
 		if verr := state.ValidateReadSet(current); verr != nil {
-			tm.registry.Remove(txID)
-			tm.removeTenant(txID)
-			tm.removeTxState(txID)
+			tm.cleanupTx(txID)
 			_ = pgxTx.Rollback(context.Background())
 			return fmt.Errorf("%w: Commit: %w", spi.ErrConflict, verr)
 		}
@@ -154,9 +150,7 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 	// stored on an error path.
 	var submitTime time.Time
 	if tsErr := pgxTx.QueryRow(ctx, "SELECT CURRENT_TIMESTAMP").Scan(&submitTime); tsErr != nil {
-		tm.registry.Remove(txID)
-		tm.removeTenant(txID)
-		tm.removeTxState(txID)
+		tm.cleanupTx(txID)
 		// Only classify as ErrConflict when the probe fails specifically because
 		// the transaction is already in an aborted state (SQLSTATE 25P02:
 		// in_failed_sql_transaction). Any other error (context cancellation,
@@ -179,25 +173,23 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 		// the pgx.Tx still holds the connection. Rollback explicitly to release
 		// it back to the pool; ignore the rollback error (tx is already invalid).
 		_ = pgxTx.Rollback(ctx)
-		tm.registry.Remove(txID)
-		tm.removeTenant(txID)
-		tm.removeTxState(txID)
+		tm.cleanupTx(txID)
 		return classifyError(fmt.Errorf("Commit: %w", err))
 	}
 
-	tm.registry.Remove(txID)
-	tm.removeTenant(txID)
-	tm.removeTxState(txID)
+	tm.cleanupTx(txID)
 
-	tm.mu.Lock()
-	tm.submitTimes[txID] = submitTime
-	evictBefore := time.Now().Add(-submitTimeTTL)
-	for id, t := range tm.submitTimes {
-		if t.Before(evictBefore) {
-			delete(tm.submitTimes, id)
+	func() {
+		tm.mu.Lock()
+		defer tm.mu.Unlock()
+		tm.submitTimes[txID] = submitTime
+		evictBefore := time.Now().Add(-submitTimeTTL)
+		for id, t := range tm.submitTimes {
+			if t.Before(evictBefore) {
+				delete(tm.submitTimes, id)
+			}
 		}
-	}
-	tm.mu.Unlock()
+	}()
 
 	return nil
 }
@@ -210,9 +202,7 @@ func (tm *TransactionManager) Rollback(ctx context.Context, txID string) error {
 	}
 
 	err := pgxTx.Rollback(ctx)
-	tm.registry.Remove(txID)
-	tm.removeTenant(txID)
-	tm.removeTxState(txID)
+	tm.cleanupTx(txID)
 
 	if err != nil {
 		return fmt.Errorf("Rollback: %w", err)
@@ -259,6 +249,14 @@ func (tm *TransactionManager) GetSubmitTime(_ context.Context, txID string) (tim
 // layer (resolveQuerier). Production code should prefer resolveQuerier.
 func (tm *TransactionManager) LookupTx(txID string) (pgx.Tx, bool) {
 	return tm.registry.Lookup(txID)
+}
+
+// cleanupTx removes all per-transaction state (registry, tenant, txState).
+// Called on every Commit/Rollback exit path.
+func (tm *TransactionManager) cleanupTx(txID string) {
+	tm.registry.Remove(txID)
+	tm.removeTenant(txID)
+	tm.removeTxState(txID)
 }
 
 // removeTenant cleans up the tenant mapping for a completed transaction.

--- a/plugins/postgres/transaction_manager_test.go
+++ b/plugins/postgres/transaction_manager_test.go
@@ -346,3 +346,37 @@ func TestCommitProbe_NonPGError_NotConflict(t *testing.T) {
 		t.Errorf("original error must remain in the error chain; got: %v", result)
 	}
 }
+
+func TestTxManager_BeginAllocatesTxState(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctx := ctxWithTenant("tx-tenant")
+	txID, _, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if !postgres.HasTxState(tm, txID) {
+		t.Errorf("expected txState registered for %s", txID)
+	}
+	if err := tm.Commit(ctx, txID); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if postgres.HasTxState(tm, txID) {
+		t.Errorf("expected txState removed after Commit for %s", txID)
+	}
+}
+
+func TestTxManager_RollbackCleansTxState(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctx := ctxWithTenant("tx-tenant")
+	txID, _, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if err := tm.Rollback(ctx, txID); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if postgres.HasTxState(tm, txID) {
+		t.Errorf("expected txState removed after Rollback for %s", txID)
+	}
+}
+

--- a/plugins/postgres/transaction_manager_test.go
+++ b/plugins/postgres/transaction_manager_test.go
@@ -447,3 +447,45 @@ func TestTxManager_RepeatableRead_SnapshotAndReadYourOwnWrites(t *testing.T) {
 	}
 	_ = tm.Rollback(ctx, txID2)
 }
+
+func TestTxManager_Commit_ReadSetConflict(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+
+	// Seed.
+	_, _ = pool.Exec(ctx, `
+		INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+		VALUES ('t1', 'e1', 'M', '1', 5, false, '{}'::jsonb)
+	`)
+
+	// Tx A: begin, record a read at version 5.
+	txA, _, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin A: %v", err)
+	}
+	stateA, _ := postgres.LookupTxStateForTest(tm, txA)
+	stateA.RecordRead("e1", 5)
+
+	// Tx B: bumps e1 to version 6 and commits.
+	txB, txCtxB, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin B: %v", err)
+	}
+	txBpgx, _ := tm.LookupTx(txB)
+	if _, err := txBpgx.Exec(txCtxB,
+		`UPDATE entities SET version=6 WHERE tenant_id='t1' AND entity_id='e1'`); err != nil {
+		t.Fatalf("B update: %v", err)
+	}
+	if err := tm.Commit(ctx, txB); err != nil {
+		t.Fatalf("B commit: %v", err)
+	}
+
+	// Tx A: commit must fail with ErrConflict.
+	err = tm.Commit(ctx, txA)
+	if err == nil {
+		t.Fatal("want ErrConflict on A.Commit, got nil")
+	}
+	if !errors.Is(err, spi.ErrConflict) {
+		t.Errorf("want ErrConflict, got %v", err)
+	}
+}

--- a/plugins/postgres/transaction_manager_test.go
+++ b/plugins/postgres/transaction_manager_test.go
@@ -381,7 +381,7 @@ func TestTxManager_RollbackCleansTxState(t *testing.T) {
 }
 
 func TestTxManager_RepeatableRead_SnapshotAndReadYourOwnWrites(t *testing.T) {
-	tm, pool := newTestTxManager(t)
+	tm, _ := newTestTxManager(t)
 	ctx := ctxWithTenant("t1")
 
 	// Tx1: insert a row.
@@ -445,6 +445,5 @@ func TestTxManager_RepeatableRead_SnapshotAndReadYourOwnWrites(t *testing.T) {
 	if v2 != 1 {
 		t.Errorf("snapshot preserved after concurrent commit: want 1, got %d", v2)
 	}
-	_ = pool
 	_ = tm.Rollback(ctx, txID2)
 }

--- a/plugins/postgres/transaction_manager_test.go
+++ b/plugins/postgres/transaction_manager_test.go
@@ -380,3 +380,71 @@ func TestTxManager_RollbackCleansTxState(t *testing.T) {
 	}
 }
 
+func TestTxManager_RepeatableRead_SnapshotAndReadYourOwnWrites(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("t1")
+
+	// Tx1: insert a row.
+	txID1, txCtx1, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin 1: %v", err)
+	}
+	tx1, _ := tm.LookupTx(txID1)
+	if _, err := tx1.Exec(txCtx1,
+		`INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+         VALUES ('t1', 'e1', 'M', '1', 1, false, '{}'::jsonb)`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	// Read-your-own-writes.
+	var v int64
+	if err := tx1.QueryRow(txCtx1,
+		`SELECT version FROM entities WHERE tenant_id='t1' AND entity_id='e1'`).Scan(&v); err != nil {
+		t.Fatalf("read own write: %v", err)
+	}
+	if v != 1 {
+		t.Errorf("want version=1, got %d", v)
+	}
+	if err := tm.Commit(ctx, txID1); err != nil {
+		t.Fatalf("Commit 1: %v", err)
+	}
+
+	// Tx2: takes snapshot.
+	txID2, txCtx2, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin 2: %v", err)
+	}
+	tx2, _ := tm.LookupTx(txID2)
+	var v2 int64
+	if err := tx2.QueryRow(txCtx2,
+		`SELECT version FROM entities WHERE tenant_id='t1' AND entity_id='e1'`).Scan(&v2); err != nil {
+		t.Fatalf("tx2 read: %v", err)
+	}
+	if v2 != 1 {
+		t.Errorf("tx2 snapshot: want 1, got %d", v2)
+	}
+
+	// Tx3 (outside tx2) commits a version bump.
+	txID3, txCtx3, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin 3: %v", err)
+	}
+	tx3, _ := tm.LookupTx(txID3)
+	if _, err := tx3.Exec(txCtx3,
+		`UPDATE entities SET version=2 WHERE tenant_id='t1' AND entity_id='e1'`); err != nil {
+		t.Fatalf("tx3 update: %v", err)
+	}
+	if err := tm.Commit(ctx, txID3); err != nil {
+		t.Fatalf("Commit 3: %v", err)
+	}
+
+	// Tx2 should STILL see version 1 (snapshot preserved).
+	if err := tx2.QueryRow(txCtx2,
+		`SELECT version FROM entities WHERE tenant_id='t1' AND entity_id='e1'`).Scan(&v2); err != nil {
+		t.Fatalf("tx2 re-read: %v", err)
+	}
+	if v2 != 1 {
+		t.Errorf("snapshot preserved after concurrent commit: want 1, got %d", v2)
+	}
+	_ = pool
+	_ = tm.Rollback(ctx, txID2)
+}

--- a/plugins/postgres/transaction_manager_test.go
+++ b/plugins/postgres/transaction_manager_test.go
@@ -489,3 +489,81 @@ func TestTxManager_Commit_ReadSetConflict(t *testing.T) {
 		t.Errorf("want ErrConflict, got %v", err)
 	}
 }
+
+// TestTxManager_Savepoint_RollsBackTxStateEntries verifies that
+// RollbackToSavepoint restores the txState readSet/writeSet to the
+// snapshot captured at Savepoint time: entries added after the savepoint
+// are dropped, entries added before are preserved.
+func TestTxManager_Savepoint_RollsBackTxStateEntries(t *testing.T) {
+	tm, pool := newTestTxManager(t)
+	ctx := ctxWithTenant("sp-tenant")
+
+	// Seed two entities x and y at version 1.
+	for _, id := range []string{"sp-x", "sp-y"} {
+		_, err := pool.Exec(ctx, `
+			INSERT INTO entities (tenant_id, entity_id, model_name, model_version, version, deleted, doc)
+			VALUES ('sp-tenant', $1, 'M', '1', 1, false, '{}'::jsonb)`, id)
+		if err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM entities WHERE tenant_id='sp-tenant'`)
+	})
+
+	txID, txCtx, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer tm.Rollback(txCtx, txID) //nolint:errcheck
+
+	pgxTx, _ := tm.LookupTx(txID)
+	state, ok := postgres.LookupTxStateForTest(tm, txID)
+	if !ok {
+		t.Fatal("txState not found")
+	}
+
+	// Read x within the transaction (records x in readSet).
+	var vx int64
+	if err := pgxTx.QueryRow(txCtx,
+		`SELECT version FROM entities WHERE tenant_id='sp-tenant' AND entity_id='sp-x'`).Scan(&vx); err != nil {
+		t.Fatalf("read x: %v", err)
+	}
+	state.RecordRead("sp-x", vx)
+
+	// Push savepoint — x is in readSet at this point.
+	spID, err := tm.Savepoint(txCtx, txID)
+	if err != nil {
+		t.Fatalf("Savepoint: %v", err)
+	}
+
+	// Read y within the transaction (records y in readSet after the savepoint).
+	var vy int64
+	if err := pgxTx.QueryRow(txCtx,
+		`SELECT version FROM entities WHERE tenant_id='sp-tenant' AND entity_id='sp-y'`).Scan(&vy); err != nil {
+		t.Fatalf("read y: %v", err)
+	}
+	state.RecordRead("sp-y", vy)
+
+	// Verify both are in readSet before rollback.
+	if postgres.ReadSetVersionForTest(state, "sp-x") != 1 {
+		t.Errorf("pre-rollback: sp-x not in readSet at v1")
+	}
+	if postgres.ReadSetVersionForTest(state, "sp-y") != 1 {
+		t.Errorf("pre-rollback: sp-y not in readSet at v1")
+	}
+
+	// Rollback to savepoint — should drop y, preserve x.
+	if err := tm.RollbackToSavepoint(txCtx, txID, spID); err != nil {
+		t.Fatalf("RollbackToSavepoint: %v", err)
+	}
+
+	// y must be gone from readSet.
+	if v := postgres.ReadSetVersionForTest(state, "sp-y"); v != 0 {
+		t.Errorf("post-rollback: sp-y should be absent from readSet, got version %d", v)
+	}
+	// x must still be present.
+	if v := postgres.ReadSetVersionForTest(state, "sp-x"); v != 1 {
+		t.Errorf("post-rollback: sp-x should remain in readSet at v1, got %d", v)
+	}
+}

--- a/plugins/postgres/txstate.go
+++ b/plugins/postgres/txstate.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
@@ -198,6 +199,34 @@ func (s *txState) RestoreSavepoint(id string) error {
 	}
 	s.savepoints = s.savepoints[:idx+1]
 	return nil
+}
+
+// recordReadIfInTx records a read into the tx's state, if the context
+// carries a transaction. No-op for non-tx reads.
+func (tm *TransactionManager) recordReadIfInTx(ctx context.Context, entityID string, version int64) {
+	txState := spi.GetTransaction(ctx)
+	if txState == nil {
+		return
+	}
+	s, ok := tm.lookupTxState(txState.ID)
+	if !ok {
+		return
+	}
+	s.RecordRead(entityID, version)
+}
+
+// recordWriteIfInTx records a write into the tx's state, if the context
+// carries a transaction. No-op for non-tx writes.
+func (tm *TransactionManager) recordWriteIfInTx(ctx context.Context, entityID string, preWriteVersion int64) {
+	txState := spi.GetTransaction(ctx)
+	if txState == nil {
+		return
+	}
+	s, ok := tm.lookupTxState(txState.ID)
+	if !ok {
+		return
+	}
+	s.RecordWrite(entityID, preWriteVersion)
 }
 
 // ReleaseSavepoint drops the savepoint entry without touching the current

--- a/plugins/postgres/txstate.go
+++ b/plugins/postgres/txstate.go
@@ -109,6 +109,22 @@ func (s *txState) SortedUnionIDs() []string {
 	return ids
 }
 
+// SortedReadIDs returns a sorted slice of entity IDs in readSet only.
+// Used by Commit to restrict the FOR SHARE validation query to entities we
+// read but did not write in this transaction. Write-write conflicts are
+// detected by PostgreSQL's tuple-level locks (SQLSTATE 40001), so writeSet
+// entities do not need to be included in the validation query.
+func (s *txState) SortedReadIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ids := make([]string, 0, len(s.readSet))
+	for id := range s.readSet {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
 // ValidateReadSet checks that every entity in readSet still exists in
 // the DB at the captured version. Returns an error describing the first
 // mismatch; nil if all match.

--- a/plugins/postgres/txstate.go
+++ b/plugins/postgres/txstate.go
@@ -16,8 +16,13 @@ import (
 // Invariants:
 //   - An entity ID appears in at most one of readSet/writeSet at any time.
 //   - readSet[id] = the version as first observed by a Get within this tx.
-//   - writeSet[id] = the pre-write version for an entity we wrote; 0 for
-//     a fresh insert.
+//   - writeSet[id] = the pre-write version for an entity we updated or deleted.
+//
+// writeSet is maintained for the readSet-disjoint invariant (RecordRead skips
+// entities in writeSet, keeping readSet correct) and for future use with
+// advisory locks / non-entity stores (tracked as #35). writeSet is NOT
+// validated at commit time in the current implementation — PostgreSQL's
+// native tuple-level DML locks catch write-write conflicts.
 //
 // See docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md
 // for the full semantic model.
@@ -89,26 +94,6 @@ func (s *txState) RecordWrite(id string, preWriteVersion int64) {
 	s.writeSet[id] = preWriteVersion
 }
 
-// SortedUnionIDs returns a sorted slice of all entity IDs appearing in
-// either readSet or writeSet. The sorted order provides a deterministic
-// lock-acquisition sequence for the commit-time validation phase.
-//
-// The readSet and writeSet are guaranteed disjoint by the RecordRead/RecordWrite
-// invariants, so no deduplication is needed.
-func (s *txState) SortedUnionIDs() []string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	ids := make([]string, 0, len(s.readSet)+len(s.writeSet))
-	for id := range s.readSet {
-		ids = append(ids, id)
-	}
-	for id := range s.writeSet {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-	return ids
-}
-
 // SortedReadIDs returns a sorted slice of entity IDs in readSet only.
 // Used by Commit to restrict the FOR SHARE validation query to entities we
 // read but did not write in this transaction. Write-write conflicts are
@@ -138,30 +123,6 @@ func (s *txState) ValidateReadSet(current map[string]int64) error {
 		}
 		if got != expected {
 			return fmt.Errorf("read-set validation: entity %s version changed: expected %d, current %d", id, expected, got)
-		}
-	}
-	return nil
-}
-
-// ValidateWriteSet checks that every entity in writeSet is still at its
-// captured pre-write version (for updates/deletes) or absent from the DB
-// (for fresh inserts, pre-write version 0).
-func (s *txState) ValidateWriteSet(current map[string]int64) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for id, expected := range s.writeSet {
-		got, ok := current[id]
-		if expected == 0 {
-			if ok {
-				return fmt.Errorf("write-set validation: entity %s lost insert race — concurrent committer created it at version %d", id, got)
-			}
-			continue
-		}
-		if !ok {
-			return fmt.Errorf("write-set validation: entity %s deleted by concurrent committer (expected pre-write version %d)", id, expected)
-		}
-		if got != expected {
-			return fmt.Errorf("write-set validation: entity %s pre-write version changed: expected %d, current %d", id, expected, got)
 		}
 	}
 	return nil

--- a/plugins/postgres/txstate.go
+++ b/plugins/postgres/txstate.go
@@ -1,0 +1,222 @@
+package postgres
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// txState holds per-transaction bookkeeping for first-committer-wins
+// validation. One instance per active tx, indexed by txID on the
+// TransactionManager.
+//
+// Invariants:
+//   - An entity ID appears in at most one of readSet/writeSet at any time.
+//   - readSet[id] = the version as first observed by a Get within this tx.
+//   - writeSet[id] = the pre-write version for an entity we wrote; 0 for
+//     a fresh insert.
+//
+// See docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md
+// for the full semantic model.
+type txState struct {
+	mu         sync.Mutex
+	tenantID   spi.TenantID
+	readSet    map[string]int64
+	writeSet   map[string]int64
+	savepoints []savepointEntry
+}
+
+type savepointEntry struct {
+	id       string
+	readSet  map[string]int64
+	writeSet map[string]int64
+}
+
+func newTxState(tenantID spi.TenantID) *txState {
+	return &txState{
+		tenantID: tenantID,
+		readSet:  make(map[string]int64),
+		writeSet: make(map[string]int64),
+	}
+}
+
+// RecordRead records a read of the given entity at the given version.
+//
+// Invariants enforced:
+//   - No-op if id ∈ writeSet: we wrote it; our own writes don't need
+//     cross-tx read validation.
+//   - No-op if id ∈ readSet: first-read-wins — we capture the version we
+//     made decisions on, not a later re-read.
+func (s *txState) RecordRead(id string, version int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Invariant: writeSet takes precedence — skip if we already wrote this entity.
+	if _, inWrite := s.writeSet[id]; inWrite {
+		return
+	}
+	// Invariant: first-read-wins — skip if already in readSet.
+	if _, inRead := s.readSet[id]; inRead {
+		return
+	}
+	s.readSet[id] = version
+}
+
+// RecordWrite records a write (save/delete) of the given entity with the
+// given pre-write version. Pass 0 for a fresh insert.
+//
+// Invariants enforced:
+//   - First-write-wins: if id ∈ writeSet, keep the original pre-write version.
+//   - Promotion: if id ∈ readSet, move to writeSet using the readSet's captured
+//     version (they agree by construction) and remove from readSet.
+func (s *txState) RecordWrite(id string, preWriteVersion int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Invariant: first-write-wins — keep original pre-write version.
+	if _, inWrite := s.writeSet[id]; inWrite {
+		return
+	}
+	// Invariant: readSet promotion — if we read it, promote to writeSet using
+	// the read's captured version (not the caller's preWriteVersion, which must
+	// agree but the readSet version is the authoritative captured value).
+	if readVersion, inRead := s.readSet[id]; inRead {
+		s.writeSet[id] = readVersion
+		delete(s.readSet, id)
+		return
+	}
+	s.writeSet[id] = preWriteVersion
+}
+
+// SortedUnionIDs returns a sorted slice of all entity IDs appearing in
+// either readSet or writeSet. The sorted order provides a deterministic
+// lock-acquisition sequence for the commit-time validation phase.
+func (s *txState) SortedUnionIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	seen := make(map[string]struct{}, len(s.readSet)+len(s.writeSet))
+	for id := range s.readSet {
+		seen[id] = struct{}{}
+	}
+	for id := range s.writeSet {
+		seen[id] = struct{}{}
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// ValidateReadSet checks that every entity in readSet still exists in
+// the DB at the captured version. Returns an error describing the first
+// mismatch; nil if all match.
+func (s *txState) ValidateReadSet(current map[string]int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, expected := range s.readSet {
+		got, ok := current[id]
+		if !ok {
+			return fmt.Errorf("read-set validation: entity %s deleted by concurrent committer (expected version %d)", id, expected)
+		}
+		if got != expected {
+			return fmt.Errorf("read-set validation: entity %s version changed: expected %d, current %d", id, expected, got)
+		}
+	}
+	return nil
+}
+
+// ValidateWriteSet checks that every entity in writeSet is still at its
+// captured pre-write version (for updates/deletes) or absent from the DB
+// (for fresh inserts, pre-write version 0).
+func (s *txState) ValidateWriteSet(current map[string]int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, expected := range s.writeSet {
+		got, ok := current[id]
+		if expected == 0 {
+			if ok {
+				return fmt.Errorf("write-set validation: entity %s lost insert race — concurrent committer created it at version %d", id, got)
+			}
+			continue
+		}
+		if !ok {
+			return fmt.Errorf("write-set validation: entity %s deleted by concurrent committer (expected pre-write version %d)", id, expected)
+		}
+		if got != expected {
+			return fmt.Errorf("write-set validation: entity %s pre-write version changed: expected %d, current %d", id, expected, got)
+		}
+	}
+	return nil
+}
+
+// PushSavepoint stores a deep copy of the current readSet/writeSet under
+// the given savepoint ID. Subsequent RestoreSavepoint(id) restores both
+// sets to this snapshot and trims later savepoints (postgres nested
+// savepoint semantics).
+func (s *txState) PushSavepoint(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	snap := savepointEntry{
+		id:       id,
+		readSet:  make(map[string]int64, len(s.readSet)),
+		writeSet: make(map[string]int64, len(s.writeSet)),
+	}
+	for k, v := range s.readSet {
+		snap.readSet[k] = v
+	}
+	for k, v := range s.writeSet {
+		snap.writeSet[k] = v
+	}
+	s.savepoints = append(s.savepoints, snap)
+}
+
+// RestoreSavepoint restores readSet/writeSet to the snapshot captured at
+// PushSavepoint(id) and trims any savepoints pushed after id. The named
+// savepoint itself remains (mirroring postgres ROLLBACK TO SAVEPOINT).
+func (s *txState) RestoreSavepoint(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := -1
+	for i, sp := range s.savepoints {
+		if sp.id == id {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("unknown savepoint %q", id)
+	}
+	snap := s.savepoints[idx]
+	s.readSet = make(map[string]int64, len(snap.readSet))
+	s.writeSet = make(map[string]int64, len(snap.writeSet))
+	for k, v := range snap.readSet {
+		s.readSet[k] = v
+	}
+	for k, v := range snap.writeSet {
+		s.writeSet[k] = v
+	}
+	s.savepoints = s.savepoints[:idx+1]
+	return nil
+}
+
+// ReleaseSavepoint drops the savepoint entry without touching the current
+// readSet/writeSet — work done after the push is kept. Mirrors postgres
+// RELEASE SAVEPOINT semantics.
+func (s *txState) ReleaseSavepoint(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	idx := -1
+	for i, sp := range s.savepoints {
+		if sp.id == id {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("unknown savepoint %q", id)
+	}
+	s.savepoints = append(s.savepoints[:idx], s.savepoints[idx+1:]...)
+	return nil
+}

--- a/plugins/postgres/txstate.go
+++ b/plugins/postgres/txstate.go
@@ -91,18 +91,17 @@ func (s *txState) RecordWrite(id string, preWriteVersion int64) {
 // SortedUnionIDs returns a sorted slice of all entity IDs appearing in
 // either readSet or writeSet. The sorted order provides a deterministic
 // lock-acquisition sequence for the commit-time validation phase.
+//
+// The readSet and writeSet are guaranteed disjoint by the RecordRead/RecordWrite
+// invariants, so no deduplication is needed.
 func (s *txState) SortedUnionIDs() []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	seen := make(map[string]struct{}, len(s.readSet)+len(s.writeSet))
+	ids := make([]string, 0, len(s.readSet)+len(s.writeSet))
 	for id := range s.readSet {
-		seen[id] = struct{}{}
+		ids = append(ids, id)
 	}
 	for id := range s.writeSet {
-		seen[id] = struct{}{}
-	}
-	ids := make([]string, 0, len(seen))
-	for id := range seen {
 		ids = append(ids, id)
 	}
 	sort.Strings(ids)

--- a/plugins/postgres/txstate_test.go
+++ b/plugins/postgres/txstate_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"strings"
 	"testing"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
@@ -165,5 +166,99 @@ func TestSortedUnionIDs_Disjoint(t *testing.T) {
 	}
 	if len(ids) > 0 && ids[0] != "e1" {
 		t.Errorf("ids[0] = %q, want e1", ids[0])
+	}
+}
+
+// TestValidateReadSet_AllMatch verifies that no error is returned when all
+// readSet entities match the current snapshot.
+func TestValidateReadSet_AllMatch(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.RecordRead("e2", 10)
+	current := map[string]int64{"e1": 5, "e2": 10, "e3": 99}
+	if err := s.ValidateReadSet(current); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestValidateReadSet_VersionMismatch verifies that a version mismatch
+// returns an error containing the entity ID.
+func TestValidateReadSet_VersionMismatch(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	current := map[string]int64{"e1": 6}
+	err := s.ValidateReadSet(current)
+	if err == nil {
+		t.Fatal("expected error for version mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "e1") {
+		t.Errorf("error does not mention entity ID: %v", err)
+	}
+}
+
+// TestValidateReadSet_MissingEntity verifies that a deleted entity (absent
+// from current snapshot) returns an error.
+func TestValidateReadSet_MissingEntity(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	current := map[string]int64{}
+	err := s.ValidateReadSet(current)
+	if err == nil {
+		t.Fatal("expected error for missing entity, got nil")
+	}
+	if !strings.Contains(err.Error(), "e1") {
+		t.Errorf("error does not mention entity ID: %v", err)
+	}
+}
+
+// TestValidateWriteSet_UpdateMatch verifies that no error is returned when
+// an update entity's pre-write version matches the current snapshot.
+func TestValidateWriteSet_UpdateMatch(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 5)
+	current := map[string]int64{"e1": 5}
+	if err := s.ValidateWriteSet(current); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestValidateWriteSet_FreshInsertAbsent verifies that a fresh insert
+// (preWriteVersion 0) with no current entry returns no error.
+func TestValidateWriteSet_FreshInsertAbsent(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 0)
+	current := map[string]int64{}
+	if err := s.ValidateWriteSet(current); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestValidateWriteSet_FreshInsertRaceLost verifies that a fresh insert
+// (preWriteVersion 0) fails when the current snapshot already has the entity.
+func TestValidateWriteSet_FreshInsertRaceLost(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 0)
+	current := map[string]int64{"e1": 1}
+	err := s.ValidateWriteSet(current)
+	if err == nil {
+		t.Fatal("expected error for insert race, got nil")
+	}
+	if !strings.Contains(err.Error(), "e1") {
+		t.Errorf("error does not mention entity ID: %v", err)
+	}
+}
+
+// TestValidateWriteSet_UpdateVersionMismatch verifies that an update entity
+// whose pre-write version differs from current returns an error.
+func TestValidateWriteSet_UpdateVersionMismatch(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 5)
+	current := map[string]int64{"e1": 6}
+	err := s.ValidateWriteSet(current)
+	if err == nil {
+		t.Fatal("expected error for version mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "e1") {
+		t.Errorf("error does not mention entity ID: %v", err)
 	}
 }

--- a/plugins/postgres/txstate_test.go
+++ b/plugins/postgres/txstate_test.go
@@ -262,3 +262,118 @@ func TestValidateWriteSet_UpdateVersionMismatch(t *testing.T) {
 		t.Errorf("error does not mention entity ID: %v", err)
 	}
 }
+
+// TestPushSavepoint_DeepCopiesSets verifies that PushSavepoint stores
+// independent copies of readSet and writeSet (mutations after push don't
+// affect the snapshot).
+func TestPushSavepoint_DeepCopiesSets(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.RecordWrite("e2", 10)
+	s.PushSavepoint("sp1")
+
+	// Mutate state after the push.
+	s.RecordRead("e3", 99)
+	s.RecordWrite("e4", 77)
+
+	if len(s.savepoints) != 1 {
+		t.Fatalf("savepoints len = %d, want 1", len(s.savepoints))
+	}
+	snap := s.savepoints[0]
+	if _, ok := snap.readSet["e3"]; ok {
+		t.Error("snapshot readSet should not contain e3 added after push")
+	}
+	if _, ok := snap.writeSet["e4"]; ok {
+		t.Error("snapshot writeSet should not contain e4 added after push")
+	}
+	// Original entries should be in snapshot.
+	if snap.readSet["e1"] != 5 {
+		t.Errorf("snapshot readSet[e1] = %d, want 5", snap.readSet["e1"])
+	}
+	if snap.writeSet["e2"] != 10 {
+		t.Errorf("snapshot writeSet[e2] = %d, want 10", snap.writeSet["e2"])
+	}
+}
+
+// TestRestoreSavepoint_RestoresSets verifies that RestoreSavepoint reverts
+// readSet and writeSet to the snapshot and that the savepoint itself is
+// preserved (postgres ROLLBACK TO SAVEPOINT semantics).
+func TestRestoreSavepoint_RestoresSets(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.PushSavepoint("sp1")
+
+	// Do more work after the savepoint.
+	s.RecordRead("e2", 20)
+	s.RecordWrite("e3", 30)
+
+	if err := s.RestoreSavepoint("sp1"); err != nil {
+		t.Fatalf("RestoreSavepoint: %v", err)
+	}
+
+	// Sets should be back to snapshot state.
+	if len(s.readSet) != 1 || s.readSet["e1"] != 5 {
+		t.Errorf("readSet after restore = %v, want {e1:5}", s.readSet)
+	}
+	if len(s.writeSet) != 0 {
+		t.Errorf("writeSet after restore = %v, want empty", s.writeSet)
+	}
+	// Savepoint itself is preserved.
+	if len(s.savepoints) != 1 || s.savepoints[0].id != "sp1" {
+		t.Errorf("savepoints after restore = %v, want [sp1]", s.savepoints)
+	}
+}
+
+// TestRestoreSavepoint_TrimsLaterSavepoints verifies that restoring sp1
+// trims sp2 (which was pushed after sp1) but keeps sp1.
+func TestRestoreSavepoint_TrimsLaterSavepoints(t *testing.T) {
+	s := newTxState("t1")
+	s.PushSavepoint("sp1")
+	s.RecordRead("e1", 1)
+	s.PushSavepoint("sp2")
+
+	if err := s.RestoreSavepoint("sp1"); err != nil {
+		t.Fatalf("RestoreSavepoint: %v", err)
+	}
+
+	if len(s.savepoints) != 1 {
+		t.Errorf("savepoints len = %d, want 1", len(s.savepoints))
+	}
+	if s.savepoints[0].id != "sp1" {
+		t.Errorf("savepoints[0].id = %q, want sp1", s.savepoints[0].id)
+	}
+}
+
+// TestReleaseSavepoint_DropsEntryKeepsWork verifies that ReleaseSavepoint
+// removes the savepoint entry but leaves the current readSet/writeSet intact.
+func TestReleaseSavepoint_DropsEntryKeepsWork(t *testing.T) {
+	s := newTxState("t1")
+	s.PushSavepoint("sp1")
+	s.RecordRead("e1", 5)
+	s.RecordWrite("e2", 10)
+
+	if err := s.ReleaseSavepoint("sp1"); err != nil {
+		t.Fatalf("ReleaseSavepoint: %v", err)
+	}
+
+	if len(s.savepoints) != 0 {
+		t.Errorf("savepoints len = %d, want 0", len(s.savepoints))
+	}
+	// Work done after the push is preserved.
+	if s.readSet["e1"] != 5 {
+		t.Errorf("readSet[e1] = %d, want 5", s.readSet["e1"])
+	}
+	if s.writeSet["e2"] != 10 {
+		t.Errorf("writeSet[e2] = %d, want 10", s.writeSet["e2"])
+	}
+}
+
+// TestRestoreSavepoint_Unknown verifies that restoring an unknown savepoint
+// returns an error.
+func TestRestoreSavepoint_Unknown(t *testing.T) {
+	s := newTxState("t1")
+	err := s.RestoreSavepoint("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unknown savepoint, got nil")
+	}
+}

--- a/plugins/postgres/txstate_test.go
+++ b/plugins/postgres/txstate_test.go
@@ -80,3 +80,42 @@ func TestRecordRead_MultipleEntities(t *testing.T) {
 		t.Errorf("readSet len = %d, want 3", len(s.readSet))
 	}
 }
+
+// TestRecordWrite_FirstWriteWins verifies that the first write version is
+// kept and subsequent writes of the same entity are ignored.
+func TestRecordWrite_FirstWriteWins(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 5)
+	s.RecordWrite("e1", 7) // should be ignored
+	if got := s.writeSet["e1"]; got != 5 {
+		t.Errorf("writeSet[e1] = %d, want 5", got)
+	}
+	if len(s.writeSet) != 1 {
+		t.Errorf("writeSet len = %d, want 1", len(s.writeSet))
+	}
+}
+
+// TestRecordWrite_PromotesFromReadSet verifies that an entity already in
+// readSet is promoted to writeSet using the readSet's captured version
+// and removed from readSet.
+func TestRecordWrite_PromotesFromReadSet(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.RecordWrite("e1", 5)
+	if _, ok := s.readSet["e1"]; ok {
+		t.Error("e1 should have been removed from readSet after promotion")
+	}
+	if got := s.writeSet["e1"]; got != 5 {
+		t.Errorf("writeSet[e1] = %d, want 5", got)
+	}
+}
+
+// TestRecordWrite_FreshInsertZero verifies that a fresh insert (version 0)
+// is recorded in writeSet with value 0.
+func TestRecordWrite_FreshInsertZero(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 0)
+	if got, ok := s.writeSet["e1"]; !ok || got != 0 {
+		t.Errorf("writeSet[e1] = %d (ok=%v), want 0 and present", got, ok)
+	}
+}

--- a/plugins/postgres/txstate_test.go
+++ b/plugins/postgres/txstate_test.go
@@ -1,0 +1,33 @@
+package postgres
+
+import (
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// TestNewTxState_ZeroValue verifies that a freshly constructed txState has
+// the expected tenantID and empty/nil collections.
+func TestNewTxState_ZeroValue(t *testing.T) {
+	tid := spi.TenantID("tenant-1")
+	s := newTxState(tid)
+
+	if s.tenantID != tid {
+		t.Errorf("tenantID = %q, want %q", s.tenantID, tid)
+	}
+	if s.readSet == nil {
+		t.Error("readSet is nil, want empty map")
+	}
+	if len(s.readSet) != 0 {
+		t.Errorf("readSet len = %d, want 0", len(s.readSet))
+	}
+	if s.writeSet == nil {
+		t.Error("writeSet is nil, want empty map")
+	}
+	if len(s.writeSet) != 0 {
+		t.Errorf("writeSet len = %d, want 0", len(s.writeSet))
+	}
+	if s.savepoints != nil {
+		t.Errorf("savepoints = %v, want nil", s.savepoints)
+	}
+}

--- a/plugins/postgres/txstate_test.go
+++ b/plugins/postgres/txstate_test.go
@@ -377,3 +377,29 @@ func TestRestoreSavepoint_Unknown(t *testing.T) {
 		t.Fatal("expected error for unknown savepoint, got nil")
 	}
 }
+
+// TestValidateWriteSet_UpdateDeletedByConcurrent verifies that an update
+// target (expected > 0) absent from the current snapshot — meaning a
+// concurrent committer deleted it — returns an error containing the entity ID.
+func TestValidateWriteSet_UpdateDeletedByConcurrent(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordWrite("e1", 5) // update: pre-write version 5
+	current := map[string]int64{} // e1 absent — deleted by concurrent committer
+	err := s.ValidateWriteSet(current)
+	if err == nil {
+		t.Fatal("expected error for deleted entity, got nil")
+	}
+	if !strings.Contains(err.Error(), "e1") {
+		t.Errorf("error does not mention entity ID: %v", err)
+	}
+}
+
+// TestReleaseSavepoint_Unknown verifies that releasing an unknown savepoint
+// returns an error.
+func TestReleaseSavepoint_Unknown(t *testing.T) {
+	s := newTxState("t1")
+	err := s.ReleaseSavepoint("bogus")
+	if err == nil {
+		t.Fatal("expected error for unknown savepoint, got nil")
+	}
+}

--- a/plugins/postgres/txstate_test.go
+++ b/plugins/postgres/txstate_test.go
@@ -121,54 +121,6 @@ func TestRecordWrite_FreshInsertZero(t *testing.T) {
 	}
 }
 
-// TestSortedUnionIDs_EmptyState verifies that an empty txState returns an
-// empty (non-nil) slice.
-func TestSortedUnionIDs_EmptyState(t *testing.T) {
-	s := newTxState("t1")
-	ids := s.SortedUnionIDs()
-	if ids == nil {
-		t.Error("SortedUnionIDs() = nil, want empty slice")
-	}
-	if len(ids) != 0 {
-		t.Errorf("SortedUnionIDs() len = %d, want 0", len(ids))
-	}
-}
-
-// TestSortedUnionIDs_MixedReadAndWrite verifies that IDs from both readSet
-// and writeSet are returned together in sorted order.
-func TestSortedUnionIDs_MixedReadAndWrite(t *testing.T) {
-	s := newTxState("t1")
-	s.RecordRead("c", 1)
-	s.RecordRead("a", 2)
-	s.RecordWrite("d", 3)
-	s.RecordWrite("b", 4)
-	ids := s.SortedUnionIDs()
-	want := []string{"a", "b", "c", "d"}
-	if len(ids) != len(want) {
-		t.Fatalf("SortedUnionIDs() = %v, want %v", ids, want)
-	}
-	for i, w := range want {
-		if ids[i] != w {
-			t.Errorf("ids[%d] = %q, want %q", i, ids[i], w)
-		}
-	}
-}
-
-// TestSortedUnionIDs_Disjoint verifies that after a read-then-write
-// promotion, the entity ID appears exactly once in the result.
-func TestSortedUnionIDs_Disjoint(t *testing.T) {
-	s := newTxState("t1")
-	s.RecordRead("e1", 5)
-	s.RecordWrite("e1", 5) // promotes from readSet to writeSet
-	ids := s.SortedUnionIDs()
-	if len(ids) != 1 {
-		t.Errorf("SortedUnionIDs() len = %d, want 1 (got %v)", len(ids), ids)
-	}
-	if len(ids) > 0 && ids[0] != "e1" {
-		t.Errorf("ids[0] = %q, want e1", ids[0])
-	}
-}
-
 // TestValidateReadSet_AllMatch verifies that no error is returned when all
 // readSet entities match the current snapshot.
 func TestValidateReadSet_AllMatch(t *testing.T) {
@@ -205,58 +157,6 @@ func TestValidateReadSet_MissingEntity(t *testing.T) {
 	err := s.ValidateReadSet(current)
 	if err == nil {
 		t.Fatal("expected error for missing entity, got nil")
-	}
-	if !strings.Contains(err.Error(), "e1") {
-		t.Errorf("error does not mention entity ID: %v", err)
-	}
-}
-
-// TestValidateWriteSet_UpdateMatch verifies that no error is returned when
-// an update entity's pre-write version matches the current snapshot.
-func TestValidateWriteSet_UpdateMatch(t *testing.T) {
-	s := newTxState("t1")
-	s.RecordWrite("e1", 5)
-	current := map[string]int64{"e1": 5}
-	if err := s.ValidateWriteSet(current); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-// TestValidateWriteSet_FreshInsertAbsent verifies that a fresh insert
-// (preWriteVersion 0) with no current entry returns no error.
-func TestValidateWriteSet_FreshInsertAbsent(t *testing.T) {
-	s := newTxState("t1")
-	s.RecordWrite("e1", 0)
-	current := map[string]int64{}
-	if err := s.ValidateWriteSet(current); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-// TestValidateWriteSet_FreshInsertRaceLost verifies that a fresh insert
-// (preWriteVersion 0) fails when the current snapshot already has the entity.
-func TestValidateWriteSet_FreshInsertRaceLost(t *testing.T) {
-	s := newTxState("t1")
-	s.RecordWrite("e1", 0)
-	current := map[string]int64{"e1": 1}
-	err := s.ValidateWriteSet(current)
-	if err == nil {
-		t.Fatal("expected error for insert race, got nil")
-	}
-	if !strings.Contains(err.Error(), "e1") {
-		t.Errorf("error does not mention entity ID: %v", err)
-	}
-}
-
-// TestValidateWriteSet_UpdateVersionMismatch verifies that an update entity
-// whose pre-write version differs from current returns an error.
-func TestValidateWriteSet_UpdateVersionMismatch(t *testing.T) {
-	s := newTxState("t1")
-	s.RecordWrite("e1", 5)
-	current := map[string]int64{"e1": 6}
-	err := s.ValidateWriteSet(current)
-	if err == nil {
-		t.Fatal("expected error for version mismatch, got nil")
 	}
 	if !strings.Contains(err.Error(), "e1") {
 		t.Errorf("error does not mention entity ID: %v", err)
@@ -375,22 +275,6 @@ func TestRestoreSavepoint_Unknown(t *testing.T) {
 	err := s.RestoreSavepoint("nonexistent")
 	if err == nil {
 		t.Fatal("expected error for unknown savepoint, got nil")
-	}
-}
-
-// TestValidateWriteSet_UpdateDeletedByConcurrent verifies that an update
-// target (expected > 0) absent from the current snapshot — meaning a
-// concurrent committer deleted it — returns an error containing the entity ID.
-func TestValidateWriteSet_UpdateDeletedByConcurrent(t *testing.T) {
-	s := newTxState("t1")
-	s.RecordWrite("e1", 5) // update: pre-write version 5
-	current := map[string]int64{} // e1 absent — deleted by concurrent committer
-	err := s.ValidateWriteSet(current)
-	if err == nil {
-		t.Fatal("expected error for deleted entity, got nil")
-	}
-	if !strings.Contains(err.Error(), "e1") {
-		t.Errorf("error does not mention entity ID: %v", err)
 	}
 }
 

--- a/plugins/postgres/txstate_test.go
+++ b/plugins/postgres/txstate_test.go
@@ -31,3 +31,52 @@ func TestNewTxState_ZeroValue(t *testing.T) {
 		t.Errorf("savepoints = %v, want nil", s.savepoints)
 	}
 }
+
+// TestRecordRead_FirstReadWins verifies that the first read version is
+// captured and a subsequent read of the same entity is ignored.
+func TestRecordRead_FirstReadWins(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.RecordRead("e1", 7) // should be ignored
+	if got := s.readSet["e1"]; got != 5 {
+		t.Errorf("readSet[e1] = %d, want 5", got)
+	}
+	if len(s.readSet) != 1 {
+		t.Errorf("readSet len = %d, want 1", len(s.readSet))
+	}
+}
+
+// TestRecordRead_SkipIfWritten verifies that RecordRead is a no-op when the
+// entity is already in writeSet.
+func TestRecordRead_SkipIfWritten(t *testing.T) {
+	s := newTxState("t1")
+	s.writeSet["e1"] = 3 // pre-populate directly
+	s.RecordRead("e1", 7)
+	if _, ok := s.readSet["e1"]; ok {
+		t.Error("readSet should not contain e1 after writeSet pre-populate")
+	}
+	if s.writeSet["e1"] != 3 {
+		t.Errorf("writeSet[e1] = %d, want 3", s.writeSet["e1"])
+	}
+}
+
+// TestRecordRead_MultipleEntities verifies that distinct entities are
+// recorded independently.
+func TestRecordRead_MultipleEntities(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 1)
+	s.RecordRead("e2", 2)
+	s.RecordRead("e3", 3)
+	if got := s.readSet["e1"]; got != 1 {
+		t.Errorf("readSet[e1] = %d, want 1", got)
+	}
+	if got := s.readSet["e2"]; got != 2 {
+		t.Errorf("readSet[e2] = %d, want 2", got)
+	}
+	if got := s.readSet["e3"]; got != 3 {
+		t.Errorf("readSet[e3] = %d, want 3", got)
+	}
+	if len(s.readSet) != 3 {
+		t.Errorf("readSet len = %d, want 3", len(s.readSet))
+	}
+}

--- a/plugins/postgres/txstate_test.go
+++ b/plugins/postgres/txstate_test.go
@@ -119,3 +119,51 @@ func TestRecordWrite_FreshInsertZero(t *testing.T) {
 		t.Errorf("writeSet[e1] = %d (ok=%v), want 0 and present", got, ok)
 	}
 }
+
+// TestSortedUnionIDs_EmptyState verifies that an empty txState returns an
+// empty (non-nil) slice.
+func TestSortedUnionIDs_EmptyState(t *testing.T) {
+	s := newTxState("t1")
+	ids := s.SortedUnionIDs()
+	if ids == nil {
+		t.Error("SortedUnionIDs() = nil, want empty slice")
+	}
+	if len(ids) != 0 {
+		t.Errorf("SortedUnionIDs() len = %d, want 0", len(ids))
+	}
+}
+
+// TestSortedUnionIDs_MixedReadAndWrite verifies that IDs from both readSet
+// and writeSet are returned together in sorted order.
+func TestSortedUnionIDs_MixedReadAndWrite(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("c", 1)
+	s.RecordRead("a", 2)
+	s.RecordWrite("d", 3)
+	s.RecordWrite("b", 4)
+	ids := s.SortedUnionIDs()
+	want := []string{"a", "b", "c", "d"}
+	if len(ids) != len(want) {
+		t.Fatalf("SortedUnionIDs() = %v, want %v", ids, want)
+	}
+	for i, w := range want {
+		if ids[i] != w {
+			t.Errorf("ids[%d] = %q, want %q", i, ids[i], w)
+		}
+	}
+}
+
+// TestSortedUnionIDs_Disjoint verifies that after a read-then-write
+// promotion, the entity ID appears exactly once in the result.
+func TestSortedUnionIDs_Disjoint(t *testing.T) {
+	s := newTxState("t1")
+	s.RecordRead("e1", 5)
+	s.RecordWrite("e1", 5) // promotes from readSet to writeSet
+	ids := s.SortedUnionIDs()
+	if len(ids) != 1 {
+		t.Errorf("SortedUnionIDs() len = %d, want 1 (got %v)", len(ids), ids)
+	}
+	if len(ids) > 0 && ids[0] != "e1" {
+		t.Errorf("ids[0] = %q, want e1", ids[0])
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces postgres `SERIALIZABLE` (page-granular SSI) with `REPEATABLE READ` + application-layer row-granular first-committer-wins, matching cyoda-go-cassandra's semantics exactly
- Per-transaction `readSet` tracks entity versions on every `EntityStore.Get`/`GetAll`; at `Commit`, a batched `SELECT ... FOR SHARE` (sorted, chunked at 1000) validates that no concurrent committer modified any read-set entity since the tx's snapshot
- Write-write conflicts are caught natively by postgres's tuple-level DML locks (SQLSTATE 40001 under RR) — no application-level write-set validation needed
- Savepoint snapshot/restore correctly mirrors read-set state (rollback-to-savepoint drops post-savepoint reads from validation)
- Eliminates the #17 class of false-positive 40001 aborts from b-tree page-level SIReadLock collisions

## Design divergence from original spec

`writeSet` is **not** validated at commit time. Postgres `FOR SHARE` inside the same `pgx.Tx` sees the tx's own uncommitted writes (read-your-own-writes in RR), making version comparison unreliable — it would always see post-write versions rather than pre-write committed versions. Write-write conflicts are already detected by postgres's native tuple-level locks at DML time. `writeSet` is retained on `txState` for the readSet-disjoint invariant and future use (non-entity store coverage, #35).

## Test plan

- [x] 16 unit tests for txState primitives (no DB, in-memory)
- [x] 4 integration tests for validateInChunks (real postgres via testcontainers)
- [x] 5 E2E first-committer-wins tests:
  - Disjoint concurrent inserts — #17 regression guard (stable over 5 runs)
  - Same-entity race — exactly 1 success + 1 ErrConflict
  - Read-then-concurrent-delete conflict
  - Large read-set chunked validation (2500 entities, <7ms commit)
  - Savepoint-rollback drops read-set, commit succeeds
- [x] Store-hook tests: Get/GetAll populate readSet; Save/Delete populate writeSet; non-tx reads don't record
- [x] Snapshot isolation + read-your-own-writes regression test
- [x] Full conformance suite passes; full module tests pass
- [x] `go vet ./...` clean

## Related issues

- Closes #17 (false-positive 40001 flake on concurrent disjoint inserts)
- Closes #18 (this work)
- References #35 (non-entity store coverage follow-up)
- References cyoda-go-cassandra#22 (sibling coverage gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)