### PR TITLE
fix(match): matchArray numeric comparison via opEquals (issue #24 part 3/3)

### DIFF
--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -160,7 +160,8 @@ func matchArray(c *predicate.ArrayCondition, data []byte) (bool, error) {
 
 		// Delegate to opEquals: it handles numeric-aware comparison
 		// (gjson.Number actual + numeric expected) consistently with
-		// scalar EQUALS, so per-element semantics don't diverge.
+		// scalar EQUALS, so per-element semantics don't diverge from
+		// scalar EQUALS.
 		if !result.Exists() || !opEquals(result, expected) {
 			return false, nil
 		}

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -158,8 +158,10 @@ func matchArray(c *predicate.ArrayCondition, data []byte) (bool, error) {
 		elemPath := fmt.Sprintf("%s.%d", basePath, i)
 		result := gjson.GetBytes(data, elemPath)
 
-		expStr := fmt.Sprintf("%v", expected)
-		if !result.Exists() || result.String() != expStr {
+		// Delegate to opEquals: it handles numeric-aware comparison
+		// (gjson.Number actual + numeric expected) consistently with
+		// scalar EQUALS, so per-element semantics don't diverge.
+		if !result.Exists() || !opEquals(result, expected) {
 			return false, nil
 		}
 	}

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -822,3 +822,26 @@ func TestMatchArrayCondition_TypeMismatch(t *testing.T) {
 		t.Error("expected no match: numeric expected against string JSON array element")
 	}
 }
+
+// TestMatchArrayCondition_NumericFormatDivergence proves the regression that
+// motivated this fix. Pre-fix, matchArray compared fmt.Sprintf("%v", expected)
+// to gjson's result.String(). For float64(1e10), Sprintf renders "1e+10"
+// while gjson decimal-expands the JSON literal 1e10 to "10000000000". These
+// strings differ even though the values are equal. The pre-fix code would
+// return no-match; opEquals does numeric comparison (actual.Float() ==
+// toFloat64(expected)) and returns match. This case is the executable proof
+// that the change has user-visible behavioral effect.
+func TestMatchArrayCondition_NumericFormatDivergence(t *testing.T) {
+	data := []byte(`{"scores":[1e10]}`) // gjson.String() = "10000000000"
+	cond := &predicate.ArrayCondition{
+		JsonPath: "$.scores",
+		Values:   []any{float64(1e10)}, // Sprintf renders "1e+10"
+	}
+	got, err := Match(cond, data, meta())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("expected match: float64(1e10) against JSON 1e10 — numeric equality required, string comparison would fail")
+	}
+}

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -1,6 +1,7 @@
 package match
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -740,5 +741,84 @@ func TestMatchNestedField(t *testing.T) {
 	}
 	if !got {
 		t.Error("expected true")
+	}
+}
+
+// --- Issue #24: matchArray numeric-aware comparison ---
+
+func TestMatchArrayCondition_NumericInt(t *testing.T) {
+	data := []byte(`{"scores":[1,2,3]}`)
+	cond := &predicate.ArrayCondition{
+		JsonPath: "$.scores",
+		Values:   []any{1, 2, 3}, // Go int
+	}
+	got, err := Match(cond, data, meta())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("expected match for int values against numeric JSON array")
+	}
+}
+
+func TestMatchArrayCondition_NumericInt64(t *testing.T) {
+	data := []byte(`{"scores":[1,2,3]}`)
+	cond := &predicate.ArrayCondition{
+		JsonPath: "$.scores",
+		Values:   []any{int64(1), int64(2), int64(3)},
+	}
+	got, err := Match(cond, data, meta())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("expected match for int64 values against numeric JSON array")
+	}
+}
+
+func TestMatchArrayCondition_NumericFloat64(t *testing.T) {
+	data := []byte(`{"scores":[1,2,3]}`)
+	cond := &predicate.ArrayCondition{
+		JsonPath: "$.scores",
+		Values:   []any{1.0, 2.0, 3.0},
+	}
+	got, err := Match(cond, data, meta())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("expected match for float64 values against numeric JSON array")
+	}
+}
+
+func TestMatchArrayCondition_JSONNumber(t *testing.T) {
+	// Predicates built from XML imports (after PR-2) deliver json.Number.
+	data := []byte(`{"scores":[1.5]}`)
+	cond := &predicate.ArrayCondition{
+		JsonPath: "$.scores",
+		Values:   []any{json.Number("1.5")},
+	}
+	got, err := Match(cond, data, meta())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("expected match for json.Number expected against numeric JSON array")
+	}
+}
+
+func TestMatchArrayCondition_TypeMismatch(t *testing.T) {
+	// String entity field, numeric expected — must NOT match.
+	data := []byte(`{"tags":["go"]}`)
+	cond := &predicate.ArrayCondition{
+		JsonPath: "$.tags",
+		Values:   []any{42},
+	}
+	got, err := Match(cond, data, meta())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Error("expected no match: numeric expected against string JSON array element")
 	}
 }

--- a/internal/match/operators.go
+++ b/internal/match/operators.go
@@ -1,6 +1,7 @@
 package match
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -250,6 +251,8 @@ func toFloat64(v any) (float64, error) {
 		return float64(n), nil
 	case int64:
 		return float64(n), nil
+	case json.Number:
+		return n.Float64()
 	case string:
 		return strconv.ParseFloat(n, 64)
 	default:

--- a/internal/match/operators_test.go
+++ b/internal/match/operators_test.go
@@ -3,6 +3,8 @@ package match
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
 )
 
 func TestToFloat64_JSONNumber(t *testing.T) {
@@ -25,5 +27,28 @@ func TestToFloat64_JSONNumber(t *testing.T) {
 				t.Errorf("toFloat64(%q) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestOpEquals_JSONNumber proves that the toFloat64 extension propagates
+// through opEquals on the scalar EQUALS path — not just the array path.
+// Spec Section 4.3 calls for this integration-level coverage explicitly,
+// because PR-2's XML import produces json.Number values that flow into
+// EQUALS predicates against scalar entity fields, not only into array
+// predicates. This test guards against future regressions to opEquals
+// or toFloat64 that would silently break the scalar EQUALS path.
+func TestOpEquals_JSONNumber(t *testing.T) {
+	data := []byte(`{"score":1.5}`)
+	cond := &predicate.SimpleCondition{
+		JsonPath:     "$.score",
+		OperatorType: "EQUALS",
+		Value:        json.Number("1.5"),
+	}
+	got, err := Match(cond, data, meta())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got {
+		t.Error("expected match: scalar EQUALS with json.Number(\"1.5\") against JSON 1.5")
 	}
 }

--- a/internal/match/operators_test.go
+++ b/internal/match/operators_test.go
@@ -1,0 +1,29 @@
+package match
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestToFloat64_JSONNumber(t *testing.T) {
+	cases := []struct {
+		in   json.Number
+		want float64
+	}{
+		{"0", 0},
+		{"42", 42},
+		{"-1.5", -1.5},
+		{"1e10", 1e10},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.in), func(t *testing.T) {
+			got, err := toFloat64(tc.in)
+			if err != nil {
+				t.Fatalf("toFloat64(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("toFloat64(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #24. matchArray now delegates element comparison to opEquals so it picks up the existing numeric-aware path (gjson.Number actual + numeric expected). toFloat64 extended to handle json.Number — required after PR-2 made XML imports produce json.Number values, and benefits all numeric operators uniformly.

## Test plan

- [x] New tests cover int / int64 / float64 / json.Number predicates against numeric JSON arrays
- [x] String-vs-numeric type-mismatch test guards against false positives
- [x] Existing array-condition tests still pass (regression guard)
- [x] `go vet ./...` clean
- [x] `go test -race ./...` green for `internal/match/...` and unrelated packages (preexisting `e2e/parity/sqlite` teardown I/O-incomplete is unaffected by this change)

Generated with Claude Code