### PR TITLE
docs: sync ARCHITECTURE.md and PRD.md with codebase; split storage content to plugins/; add CONSISTENCY.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ go.work.sum
 
 # Docker build context staged by scripts/dev/run-docker-dev.sh
 /.buildctx/
+.worktree-scratch/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -438,6 +438,16 @@ Tags are updated whenever a compute member joins or leaves a node. The update is
 
 This handles simultaneous startup of all nodes. Memberlist is self-healing and merges transient split clusters before the stability window elapses.
 
+In Kubernetes deployments, `BindAddr` is `0.0.0.0` (all interfaces)
+while seeds are pod DNS names (e.g.
+`cyoda-0.cyoda-headless.cyoda.svc.cluster.local:7946`). Because the
+string-level comparison `0.0.0.0:7946 != <dns-name>:7946` never
+matches, no pod filters itself out. This is intentional: the Helm
+chart's ConfigMap emits every pod's DNS name in the seed list so
+every pod has real peers (at least N-1 non-self) to join. At
+`replicas=1`, the single pod's seed list effectively reduces to
+itself and it proceeds as a cluster of one.
+
 **Failure detection:** Automatic via SWIM protocol. Dead nodes are evicted from the membership list within seconds. No manual intervention required.
 
 **Graceful leave:** `Deregister()` calls `list.Leave(5s)` then `list.Shutdown()`, giving peers time to update their membership views.
@@ -455,6 +465,17 @@ type Claims struct {
 ```
 
 Token format: `base64url(json_payload).base64url(hmac_sha256(json_payload, secret))`
+
+`CYODA_HMAC_SECRET` is hex-encoded bytes by convention (the Helm
+chart's generated secret is a 64-char hex string decoded to 32 raw
+bytes); the binary's `envHexFromSecret` decodes hex if valid,
+falling back to raw bytes otherwise. Transaction tokens use
+base64url for both the JSON payload and the HMAC signature:
+`base64url(json_payload).base64url(hmac_sha256(json_payload, secret))`.
+Inter-node dispatch authentication uses a hex-encoded HMAC in the
+`X-Dispatch-HMAC` header — *not* base64. The distinction matters: a
+client or peer-forwarding handler that encodes the dispatch HMAC
+as base64url will be rejected.
 
 The token is opaque to the client. The router decodes it to extract `nodeID` without any network call -- address resolution is a local scan over `list.Members()`.
 
@@ -529,6 +550,10 @@ Three strategy interfaces, each with a default implementation:
    - HMAC-SHA256 signed body (X-Dispatch-HMAC header)
    - Peer deserializes, calls its own local dispatch, returns result
 ```
+
+Dispatch forwarding reuses a shared `http.Transport` (`MaxIdleConns: 20`,
+`MaxIdleConnsPerHost: 5`, timeout via `CYODA_DISPATCH_FORWARD_TIMEOUT`,
+default 30s) across all peer requests.
 
 **Internal dispatch endpoints:**
 
@@ -811,8 +836,13 @@ The workflow engine (`internal/domain/workflow/Engine`) implements a finite stat
 
 A `WorkflowDefinition` contains:
 - **States:** Named states (e.g., `NEW`, `PROCESSING`, `DONE`).
-- **Transitions:** Named edges between states, each with:
-  - `type`: `AUTOMATIC` or `MANUAL`
+- **Transitions:** Named edges between states, each with two boolean
+  flags — `Manual: bool` (true means operator-initiated only) and
+  `Disabled: bool` (true removes the edge). A transition is
+  *automatic* when `Manual == false && Disabled == false`; these fire
+  on state entry when criteria match. The cascade logic in
+  `internal/domain/workflow/engine.go:434` skips any transition where
+  `tr.Disabled || tr.Manual`. Each transition also carries:
   - `criteria`: Optional conditions (predicate or function) that must be satisfied.
   - `processors`: Ordered list of processors executed when the transition fires.
 - **Initial state:** The starting state for new entities.
@@ -828,7 +858,7 @@ Three entry points into the engine:
 
 ### 5.3 Cascade Logic
 
-After any transition fires, the engine cascades: it scans all `AUTOMATIC` transitions from the new state and fires the first whose criteria match. This continues until no automatic transition matches or a safety limit is hit.
+After any transition fires, the engine cascades: it scans all automatic transitions (i.e. where `Manual == false && Disabled == false`) from the new state and fires the first whose criteria match. This continues until no automatic transition matches or a safety limit is hit.
 
 **Loop protection:**
 
@@ -847,7 +877,7 @@ Processors are dispatched via the `ExternalProcessingService` SPI. In multi-node
 
 ### 5.5 Audit Trail
 
-The engine records state machine events to `StateMachineAuditStore` throughout execution. 13 event types:
+The engine records state machine events to `StateMachineAuditStore` throughout execution. 12 event types:
 
 | Event Type | Constant | Meaning |
 |------------|----------|---------|
@@ -861,7 +891,6 @@ The engine records state machine events to `StateMachineAuditStore` throughout e
 | `TRANSITION_MAKE` | `SMEventTransitionMade` | Transition fired |
 | `TRANSITION_NOT_FOUND` | `SMEventTransitionNotFound` | Named transition not in workflow |
 | `TRANSITION_NOT_MATCH_CRITERION` | `SMEventTransitionCriterionNoMatch` | Transition criterion failed |
-| `PROCESS_NOT_MATCH_CRITERION` | `SMEventProcessCriterionNoMatch` | Processor criterion failed |
 | `PAUSE_FOR_PROCESSING` | `SMEventProcessingPaused` | Waiting for async processor |
 | `STATE_PROCESS_RESULT` | `SMEventStateProcessResult` | Processor result received |
 
@@ -871,21 +900,26 @@ The engine records state machine events to `StateMachineAuditStore` throughout e
 
 ### 6.1 CloudEventsService
 
-The gRPC service implements 6 RPCs matching the Cyoda platform:
+The gRPC service is defined in `proto/cyoda/cyoda-cloud-api.proto`
+and exposes six RPCs — one bidirectional stream, four unary, and two
+server-streaming — all carrying `io.cloudevents.v1.CloudEvent` payloads:
 
 ```protobuf
 service CloudEventsService {
-    rpc SendCloudEvent(CloudEvent) returns (CloudEvent);
-    rpc SendCloudEventStream(stream CloudEvent) returns (CloudEvent);
-    rpc ReceiveCloudEventStream(CloudEvent) returns (stream CloudEvent);
-    rpc StartStreaming(stream CloudEvent) returns (stream CloudEvent);
-    rpc SendCloudEvents(stream CloudEvent) returns (CloudEvent);
-    rpc ReceiveCloudEvents(CloudEvent) returns (stream CloudEvent);
+    rpc startStreaming(stream io.cloudevents.v1.CloudEvent) returns (stream io.cloudevents.v1.CloudEvent);
+    rpc entityModelManage(io.cloudevents.v1.CloudEvent) returns (io.cloudevents.v1.CloudEvent);
+    rpc entityManage(io.cloudevents.v1.CloudEvent) returns (io.cloudevents.v1.CloudEvent);
+    rpc entityManageCollection(io.cloudevents.v1.CloudEvent) returns (stream io.cloudevents.v1.CloudEvent);
+    rpc entitySearch(io.cloudevents.v1.CloudEvent) returns (io.cloudevents.v1.CloudEvent);
+    rpc entitySearchCollection(io.cloudevents.v1.CloudEvent) returns (stream io.cloudevents.v1.CloudEvent);
 }
-
 ```
 
-`StartStreaming` is the primary RPC -- a bidirectional stream used for the full member lifecycle.
+`startStreaming` is the primary RPC — a bidirectional stream used for
+the full calculation-member lifecycle (join, greet, keep-alive, dispatch,
+response, leave). The unary and server-streaming RPCs carry the entity
+management, model management, and search CloudEvent types enumerated in
+§6.5.
 
 ### 6.2 Member Lifecycle
 
@@ -923,7 +957,13 @@ When the member responds, the streaming handler matches the response's `requestI
 
 **Model management:** `EntityModelImportRequest/Response`, `EntityModelExportRequest/Response`, `EntityModelTransitionRequest/Response`, `EntityModelDeleteRequest/Response`, `EntityModelGetAllRequest/Response`
 
-**Search/query:** `EntityGetRequest`, `EntityGetAllRequest`, `EntitySnapshotSearchRequest/Response`, `EntityResponse`, `SnapshotCancelRequest`, `SnapshotGetRequest`, `SnapshotGetStatusRequest`, `EntitySearchRequest`, `EntityStatsGetRequest/Response`, `EntityStatsByStateGetRequest/Response`, `EntityChangesMetadataGetRequest/Response`
+**Search/query:** `EntityGetRequest`, `EntityGetAllRequest`, `EntitySnapshotSearchRequest/Response`, `EntityResponse`, `EntitySearchRequest`, `EntityStatsGetRequest/EntityStatsResponse`, `EntityStatsByStateGetRequest/EntityStatsByStateResponse`, `EntityChangesMetadataGetRequest/EntityChangesMetadataResponse`
+
+**Snapshot lifecycle (no dedicated response CloudEvent type):**
+`SnapshotCancelRequest`, `SnapshotGetRequest`, `SnapshotGetStatusRequest`
+are one-way request events; replies are carried on the generic
+`EntityResponse` / `EventAckResponse` envelopes rather than dedicated
+`*Response` types. See `internal/grpc/cloudevent_types.go`.
 
 ---
 
@@ -966,11 +1006,46 @@ This is critical for multi-node clusters: all nodes sharing the same RSA private
 
 **OBO (On-Behalf-Of) exchange:** A compute member authenticated via M2M credentials can exchange its token for an OBO token carrying the original user's tenant and identity. This allows CRUD callbacks to carry the correct authorization context.
 
-**Bootstrap M2M client:** Optionally created at startup via `CYODA_BOOTSTRAP_CLIENT_ID`. Secret is either provided via `CYODA_BOOTSTRAP_CLIENT_SECRET` or auto-generated and printed to stdout.
+**Bootstrap M2M client:** Bootstrap M2M client creation is opt-in. In
+`jwt` mode, `CYODA_BOOTSTRAP_CLIENT_ID` and
+`CYODA_BOOTSTRAP_CLIENT_SECRET` must be set together (both present) or
+both left empty. Half-configured states are rejected at startup with an
+error naming the missing variable (see
+`app/app.go:validateBootstrapConfig`). When set, the bootstrap M2M
+client is created at startup and can be used to mint access tokens. In
+`mock` mode, both variables are ignored. The Helm chart provisions the
+secret via a chart-managed Kubernetes Secret with a GitOps-safety guard.
 
 ### 7.3 Authorization
 
 Currently `mockiam.NewAuthorizationService()` -- a permissive stub. The gRPC streaming endpoint enforces `ROLE_M2M` for calculation members.
+
+### 7.4 Admin listener authentication
+
+The admin listener (`/livez`, `/readyz`, `/metrics` on
+`CYODA_ADMIN_PORT`, default `9091`) is served separately from the
+main API listener and has its own authentication policy:
+
+- **`/livez` and `/readyz`** are always unauthenticated. Kubelet
+  probes carry no bearer token; authenticating these endpoints
+  would break the standard readiness contract.
+- **`/metrics`** is optionally bearer-gated. When
+  `CYODA_METRICS_BEARER` (or `CYODA_METRICS_BEARER_FILE`) is
+  non-empty, a request must carry `Authorization: Bearer <token>`
+  and the token must match (constant-time compare) or the request
+  receives `401 Unauthorized`.
+- **`CYODA_METRICS_REQUIRE_AUTH=true`** is a coupled-predicate
+  safety: if set true but `CYODA_METRICS_BEARER` is empty, startup
+  fails with a fatal error naming the missing variable. Protects
+  against "I thought I turned auth on" misconfiguration.
+
+The canonical Helm chart binds the admin listener to `0.0.0.0`
+(kubelet probes and Prometheus scraping reach the pod-facing
+interface) and sets `CYODA_METRICS_REQUIRE_AUTH=true` with a
+chart-managed bearer secret projected into the pod via a
+projected-volume `_FILE` mount. Defense in depth: bind-address +
+bearer + NetworkPolicy restricting :9091 ingress to the monitoring
+namespace.
 
 ---
 
@@ -1024,11 +1099,14 @@ In `verbose` mode (`CYODA_ERROR_RESPONSE_MODE=verbose`), internal error details 
 | `ENTITY_NOT_FOUND` | Requested entity does not exist |
 | `VALIDATION_FAILED` | Entity data fails model schema validation |
 | `TRANSITION_NOT_FOUND` | Named transition not in workflow |
+| `WORKFLOW_NOT_FOUND` | No workflow matches the entity / model context |
 | `WORKFLOW_FAILED` | Workflow engine error |
 | `CONFLICT` | Optimistic concurrency conflict (retryable) |
+| `EPOCH_MISMATCH` | Operation targeted a stale model epoch (model has been re-locked since) |
 | `BAD_REQUEST` | Malformed request |
 | `UNAUTHORIZED` | Missing or invalid credentials |
 | `FORBIDDEN` | Insufficient permissions |
+| `NOT_IMPLEMENTED` | Feature is reachable but not yet implemented |
 | `SERVER_ERROR` | Internal server error (with ticket) |
 
 **Cluster errors:**
@@ -1050,6 +1128,24 @@ In `verbose` mode (`CYODA_ERROR_RESPONSE_MODE=verbose`), internal error details 
 | `DISPATCH_TIMEOUT` | Dispatch response not received in time |
 | `COMPUTE_MEMBER_DISCONNECTED` | Compute member stream closed during dispatch |
 
+**Transaction errors:**
+
+| Code | Meaning |
+|------|---------|
+| `TX_REQUIRED` | Operation requires an active transaction but none was present on the context |
+| `TX_CONFLICT` | Commit-time serialization failure (first-committer-wins) |
+| `TX_COORDINATOR_NOT_CONFIGURED` | Cluster-mode coordinator features invoked on a binary without cluster enabled |
+| `TX_NO_STATE` | Transaction state missing on context (programmer error or lost coordinator hand-off) |
+
+**Search errors:**
+
+| Code | Meaning |
+|------|---------|
+| `SEARCH_JOB_NOT_FOUND` | Async search job ID unknown (or reaped) |
+| `SEARCH_JOB_ALREADY_TERMINAL` | Cancel/update attempted on a job in a terminal status |
+| `SEARCH_SHARD_TIMEOUT` | Per-shard scan exceeded its budget |
+| `SEARCH_RESULT_LIMIT` | Result set would exceed the configured result limit |
+
 ### 8.4 Warning/Error Accumulation
 
 ```go
@@ -1065,6 +1161,32 @@ Warnings and errors are accumulated in the request context and propagated to the
 
 All values configurable via environment variables with the `CYODA_` prefix. Plugin-specific variables use the plugin's name as a secondary namespace (`CYODA_POSTGRES_*`, `CYODA_SQLITE_*`). Plugin-scoped variables are documented in the per-plugin reference under `docs/plugins/`. `./cyoda --help` on any binary renders the variables for the plugins it ships with — the help text is generated at runtime from the registered plugins' `ConfigVars()`.
 
+### Credential loading (`_FILE` suffix)
+
+Every credential-shaped environment variable accepts a `_FILE`
+variant that reads the value from a file path. Precedence: `_FILE`
+wins if both `<NAME>` and `<NAME>_FILE` are set. Trailing
+whitespace (spaces, tabs, CR, LF) is stripped from file contents,
+so multi-line PEM keys and DSN strings both round-trip cleanly. If
+`<NAME>_FILE` is set to a path that cannot be read, the binary
+fails at startup with the path and error.
+
+Applies to: `CYODA_POSTGRES_URL`, `CYODA_JWT_SIGNING_KEY`,
+`CYODA_HMAC_SECRET`, `CYODA_BOOTSTRAP_CLIENT_SECRET`,
+`CYODA_METRICS_BEARER`. Plugin-scoped credentials are documented in
+the per-plugin reference.
+
+This is the canonical Docker / Kubernetes pattern for wiring
+credentials from Secrets into the process without exposing them in
+`env` output. Reference implementation: `app/config_secret_env.go`
+`ResolveSecretEnv`.
+
+### Profiles
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CYODA_PROFILES` | (none) | Comma-separated list of profile names; loads `.env` then `.env.<profile>` in declaration order. Shell environment always wins over file values. Example: `CYODA_PROFILES=postgres,otel`. |
+
 ### Server
 
 | Variable | Default | Description |
@@ -1074,6 +1196,30 @@ All values configurable via environment variables with the `CYODA_` prefix. Plug
 | `CYODA_ERROR_RESPONSE_MODE` | `sanitized` | `sanitized` or `verbose` (dev only) |
 | `CYODA_MAX_STATE_VISITS` | `10` | Per-state visit limit for cascade loop protection |
 | `CYODA_LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
+| `CYODA_STARTUP_TIMEOUT` | `30s` | Deadline for binary startup (plugin factory init, migrations, cluster join). Fatal on expiry. |
+| `CYODA_SUPPRESS_BANNER` | `false` | Suppress the ASCII banner at startup (useful for structured-logging environments). |
+
+### Admin & metrics
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CYODA_ADMIN_PORT` | `9091` | Admin listener port (`/livez`, `/readyz`, `/metrics`). |
+| `CYODA_ADMIN_BIND_ADDRESS` | `127.0.0.1` | Admin listener bind address. Helm chart sets `0.0.0.0` so kubelet probes and Prometheus can reach the pod. |
+| `CYODA_METRICS_REQUIRE_AUTH` | `false` | Coupled predicate: if `true` and `CYODA_METRICS_BEARER` is empty, startup fails. |
+| `CYODA_METRICS_BEARER` (with `_FILE` variant) | (none) | Bearer token required on `/metrics` when non-empty. Constant-time compare. |
+
+See §7.4 for the authentication policy on admin endpoints.
+
+### Observability
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CYODA_OTEL_ENABLED` | `false` | Enable OpenTelemetry SDK and `otelhttp` middleware. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | (OTel SDK default) | Standard OTel environment variable — honored directly, no cyoda-specific alias. |
+
+The trace sampler is swappable at runtime via `POST /api/admin/trace-sampler`
+(see §11). The initial sampler honors `OTEL_TRACES_SAMPLER` and
+`OTEL_TRACES_SAMPLER_ARG` at startup.
 
 ### Storage — plugin selection
 
@@ -1085,31 +1231,47 @@ Per-store routing is **not supported** — a running binary uses one plugin for 
 
 ### PostgreSQL plugin (`CYODA_STORAGE_BACKEND=postgres`)
 
-Advertised via `DescribablePlugin.ConfigVars()`; rendered in the binary's `--help`.
+Advertised via `DescribablePlugin.ConfigVars()`; rendered in the binary's `--help`. Full reference: [docs/plugins/POSTGRES.md](plugins/POSTGRES.md).
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CYODA_POSTGRES_URL` | (none, **required**) | PostgreSQL connection string |
+| `CYODA_POSTGRES_URL` (with `_FILE` variant) | (none, **required**) | PostgreSQL connection string |
 | `CYODA_POSTGRES_MAX_CONNS` | `25` | Maximum pool connections |
 | `CYODA_POSTGRES_MIN_CONNS` | `5` | Minimum pool connections |
 | `CYODA_POSTGRES_MAX_CONN_IDLE_TIME` | `5m` | Max idle time before connection is closed |
 | `CYODA_POSTGRES_AUTO_MIGRATE` | `true` | Run embedded SQL migrations at startup |
+
+### SQLite plugin (`CYODA_STORAGE_BACKEND=sqlite`)
+
+Advertised via `DescribablePlugin.ConfigVars()`; rendered in the binary's `--help`. Full reference: [docs/plugins/SQLITE.md](plugins/SQLITE.md).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CYODA_SQLITE_PATH` | Platform-specific (see below) | Database file path. |
+| `CYODA_SQLITE_AUTO_MIGRATE` | `true` | Run embedded schema migrations at startup. |
+| `CYODA_SQLITE_BUSY_TIMEOUT` | `5s` | SQLite `busy_timeout` pragma. |
+| `CYODA_SQLITE_CACHE_SIZE` | `64000` | SQLite `cache_size` pragma (KiB). |
+| `CYODA_SQLITE_SEARCH_SCAN_LIMIT` | `100000` | Max rows scanned by a predicate-pushed search before it falls back to post-filter. |
+
+Default `CYODA_SQLITE_PATH`: on Linux / macOS, `$XDG_DATA_HOME/cyoda/cyoda.db` with fallback to `~/.local/share/cyoda/cyoda.db`; on Windows, `%LocalAppData%\cyoda\cyoda.db`.
 
 ### IAM
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CYODA_IAM_MODE` | `mock` | `mock` (dev) or `jwt` (production) |
-| `CYODA_JWT_SIGNING_KEY` | (none) | PEM-encoded RSA private key (or base64-encoded PEM) |
+| `CYODA_JWT_SIGNING_KEY` (with `_FILE` variant) | (none) | PEM-encoded RSA private key (or base64-encoded PEM) |
 | `CYODA_JWT_ISSUER` | `cyoda` | JWT issuer claim |
 | `CYODA_JWT_EXPIRY_SECONDS` | `3600` | Token expiry in seconds |
+| `CYODA_REQUIRE_JWT` | `false` | Production safety floor: when `true`, the binary refuses to start unless `CYODA_IAM_MODE=jwt` AND `CYODA_JWT_SIGNING_KEY` is set. Protects against silently shipping a mock-auth deployment. |
+| `CYODA_IAM_MOCK_ROLES` | `ROLE_ADMIN,ROLE_M2M` | Comma-separated roles attached to the default mock user (mock mode only). |
 
 ### Bootstrap
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CYODA_BOOTSTRAP_CLIENT_ID` | (none) | M2M client ID to create at startup |
-| `CYODA_BOOTSTRAP_CLIENT_SECRET` | (none) | M2M client secret (generated if empty) |
+| `CYODA_BOOTSTRAP_CLIENT_ID` | (none) | M2M client ID to create at startup. Must be set together with `CYODA_BOOTSTRAP_CLIENT_SECRET` or both left empty — half-configured rejected (jwt mode). |
+| `CYODA_BOOTSTRAP_CLIENT_SECRET` (with `_FILE` variant) | (none) | M2M client secret. Required when `CYODA_BOOTSTRAP_CLIENT_ID` is set in jwt mode; ignored in mock mode. |
 | `CYODA_BOOTSTRAP_TENANT_ID` | `default-tenant` | Tenant for bootstrap client |
 | `CYODA_BOOTSTRAP_USER_ID` | `admin` | User ID for bootstrap client |
 | `CYODA_BOOTSTRAP_ROLES` | `ROLE_ADMIN,ROLE_M2M` | Comma-separated roles |
@@ -1136,7 +1298,7 @@ Advertised via `DescribablePlugin.ConfigVars()`; rendered in the binary's `--hel
 | `CYODA_TX_REAP_INTERVAL` | `10s` | Frequency of transaction TTL reaper |
 | `CYODA_PROXY_TIMEOUT` | `30s` | HTTP proxy response header timeout |
 | `CYODA_TX_OUTCOME_TTL` | `5m` | How long completed transaction outcomes are retained |
-| `CYODA_HMAC_SECRET` | (none) | Hex-encoded secret for token signing + gossip encryption (required if cluster enabled) |
+| `CYODA_HMAC_SECRET` (with `_FILE` variant) | (none) | Hex-encoded secret for token signing + gossip encryption (required if cluster enabled). See §4.2 for encoding details. |
 | `CYODA_DISPATCH_WAIT_TIMEOUT` | `5s` | How long to poll for a compute member with matching tags |
 | `CYODA_DISPATCH_FORWARD_TIMEOUT` | `30s` | HTTP timeout for cross-node dispatch forwarding |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -292,6 +292,12 @@ as the open-source plugins — operators select it at runtime via
 - Append-only point-in-time storage with full historical reads
 - No single points of failure
 - Multi-node consistency
+- **Cluster-coordinated transactions** — transactions are not pinned
+  to a single owning cyoda-go node. A transaction survives the
+  unavailability of individual cluster nodes mid-flight, eliminating
+  the `TRANSACTION_NODE_UNAVAILABLE` failure mode that the postgres
+  plugin exposes under node affinity (see §4 Multi-Node Routing and
+  PRD §4 Multi-Node Transaction Affinity)
 
 **When it fits:** workloads whose write volume or availability
 requirements outgrow a single-primary PostgreSQL deployment — while

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,7 +65,7 @@ plugins/                  Each plugin is its own Go module
     go.mod                module github.com/cyoda-platform/cyoda-go/plugins/sqlite
     plugin.go             init() → spi.Register; Name() + NewFactory() + ConfigVars()
     store_factory.go      Implements spi.StoreFactory
-    txmanager.go          Application-layer SI+FCW (ported from memory plugin)
+    txmanager.go          Application-layer SI+FCW
     entity_store.go, model_store.go, kv_store.go, message_store.go
     workflow_store.go, sm_audit_store.go, search_store.go
     query_planner.go, searcher.go, post_filter.go  Predicate pushdown to SQL
@@ -261,10 +261,9 @@ detail in [docs/plugins/IN_MEMORY.md](plugins/IN_MEMORY.md).
 
 Persistent, zero-ops single-node storage. Embedded in-process via a
 pure-Go (WASM) SQLite driver, exclusive file lock, application-layer
-SI+FCW concurrency control ported from the memory plugin, search
-predicate pushdown to SQL. Default for desktop binary, edge
-deployments, and containerised single-node production. Full detail in
-[docs/plugins/SQLITE.md](plugins/SQLITE.md).
+SI+FCW concurrency control, search predicate pushdown to SQL. Default
+for desktop binary, edge deployments, and containerised single-node
+production. Full detail in [docs/plugins/SQLITE.md](plugins/SQLITE.md).
 
 ### 2.3 The `postgres` plugin (`plugins/postgres/`)
 
@@ -367,7 +366,7 @@ The property remains load-bearing for the cluster design: see DD-2 in [Section 1
 Each plugin provides its own `TransactionManager` whose semantics match its storage engine — all delivering the same published Snapshot Isolation + first-committer-wins contract (see §3.7 and [docs/CONSISTENCY.md](CONSISTENCY.md)):
 
 - **memory plugin** — in-process SI+FCW with entity-level read/write sets and a committed-transaction log ([docs/plugins/IN_MEMORY.md](plugins/IN_MEMORY.md)).
-- **sqlite plugin** — same SI+FCW engine code as the memory plugin, ported to persist through a SQLite file with an exclusive file lock ([docs/plugins/SQLITE.md](plugins/SQLITE.md)).
+- **sqlite plugin** — application-layer SI+FCW over a SQLite file with an exclusive file lock ([docs/plugins/SQLITE.md](plugins/SQLITE.md)).
 - **postgres plugin** — PostgreSQL `REPEATABLE READ` for the engine-level snapshot, plus application-layer read-set validation at commit time ([docs/plugins/POSTGRES.md](plugins/POSTGRES.md)). The TM assigns IDs, tracks active/committed sets with timestamps, and supports savepoints as a local stack.
 - **Commercial plugins** (e.g. the Cassandra plugin from Cyoda)
   implement their own `TransactionManager` against their underlying
@@ -386,7 +385,7 @@ guarantee does not.
 | Plugin | Engine-level mechanism | Application-layer validation | Effective guarantee | Conflict granularity |
 |---|---|---|---|---|
 | `memory` | n/a — all in-process Go | committed-log + read/write-set tracking | SI+FCW | per-entity |
-| `sqlite` | DB-level write lock | same SI+FCW engine code ported from memory | SI+FCW | per-entity |
+| `sqlite` | DB-level write lock | application-layer SI+FCW | SI+FCW | per-entity |
 | `postgres` | `REPEATABLE READ` + tuple locks | entity-keyed read-set validation at commit; `40001`/`40P01` retry | SI+FCW | per-entity |
 | `cassandra` (commercial) | *(proprietary)* | *(plugin-internal)* | SI+FCW | per-entity |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -386,7 +386,7 @@ guarantee does not.
 | Plugin | Engine-level mechanism | Application-layer validation | Effective guarantee | Conflict granularity |
 |---|---|---|---|---|
 | `memory` | n/a — all in-process Go | committed-log + read/write-set tracking | SI+FCW | per-entity |
-| `sqlite` | DB-level write lock | same SSI-engine code ported from memory | SI+FCW | per-entity |
+| `sqlite` | DB-level write lock | same SI+FCW engine code ported from memory | SI+FCW | per-entity |
 | `postgres` | `REPEATABLE READ` + tuple locks | entity-keyed read-set validation at commit; `40001`/`40P01` retry | SI+FCW | per-entity |
 | `cassandra` (commercial) | *(proprietary)* | *(plugin-internal)* | SI+FCW | per-entity |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,9 +31,11 @@ For product-level context, see the [PRD](PRD.md).
 
 ## 1. System Overview
 
-Cyoda-Go is a **modular monolith** organized by Domain-Driven Design boundaries, with a **pluggable storage layer** defined by an external SPI module. The storage contract (`cyoda-go-spi`) is a small, stable, stdlib-only Go module. Storage implementations live in separately versioned Go modules — stock plugins (`plugins/memory`, `plugins/postgres`) under this repository, proprietary and third-party plugins in their own repositories. The `cyoda-go` binary resolves its active plugin at startup via `spi.GetPlugin(cfg.StorageBackend)`; a custom binary including a third-party plugin is a one-file edit (blank import) of the `main` package.
+Cyoda-Go is a **modular monolith with a ports-and-adapters architecture**. The stable external port is `cyoda-go-spi`, a small stdlib-only Go module that defines the storage contract. Adapters are storage plugins in separately versioned Go modules — stock plugins (`plugins/memory`, `plugins/sqlite`, `plugins/postgres`) under this repository, proprietary and third-party plugins in their own repositories. The `cyoda-go` binary resolves its active plugin at startup via `spi.GetPlugin(cfg.StorageBackend)`; a custom binary including a third-party plugin is a one-file edit (blank import) of the `main` package.
 
-Non-storage cross-cutting concerns (authentication, audit, processing dispatch, cluster registry) are defined as internal-to-cyoda-go Go interfaces in `internal/contract/`. These are consumer-side contracts between cyoda-go's own layers — not plugin concerns.
+Non-storage cross-cutting concerns (authentication, audit, processing dispatch, cluster registry) are defined as internal-to-cyoda-go Go interfaces in `internal/contract/`. These are consumer-side ports between cyoda-go's own layers — not plugin concerns.
+
+Domain concepts are grouped under `internal/domain/` by responsibility (`entity`, `workflow`, `model`, `search`, `messaging`, `audit`, `account`). Each follows a consistent handler/service layering over the storage port.
 
 ### Repositories
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,10 +1,10 @@
 # Cyoda-Go Architecture
 
-**Version:** 2.0
-**Date:** 2026-04-14
-**Status:** Target state after the storage-plugin architecture refactor (Plans 1–5). See `docs/superpowers/specs/2026-04-13-storage-plugin-architecture-design.md` for the refactor plan.
+**Version:** 2.1
+**Date:** 2026-04-18
+**Status:** Current as of 2026-04-18 (Helm provisioning shipped in PR #60; docs reconciled against commit at branch tip).
 
-Technical architecture reference for Cyoda-Go, a Go implementation of the Cyoda platform with a pluggable storage layer. This document targets system architects familiar with distributed systems concepts (CAP theorem, SERIALIZABLE isolation, SWIM gossip protocols, Serializable Snapshot Isolation).
+Technical architecture reference for Cyoda-Go, a Go implementation of the Cyoda platform with a pluggable storage layer. This document targets system architects familiar with distributed systems concepts (CAP theorem, Snapshot Isolation, SWIM gossip protocols, first-committer-wins validation).
 
 For product-level context, see the [PRD](PRD.md).
 
@@ -41,32 +41,41 @@ Non-storage cross-cutting concerns (authentication, audit, processing dispatch, 
 |--------|------|---------|---------|
 | `cyoda-go` | github.com/cyoda-platform/cyoda-go | Application core + stock plugins | Apache 2.0 |
 | `cyoda-go-spi` | github.com/cyoda-platform/cyoda-go-spi | Storage-plugin contract (stdlib only) | Apache 2.0 |
-| `cyoda-go-cassandra` | github.com/cyoda-platform/cyoda-go-cassandra | Proprietary Cassandra storage plugin + full binary | Proprietary |
 
 ### Package Layout (`cyoda-go`)
 
 ```
 cmd/
-  cyoda-go/main.go        Entrypoint; blank-imports stock plugins
+  cyoda/main.go           Entrypoint; blank-imports stock plugins
   compute-test-client/    Local compute harness for parity tests
 go.mod                    module github.com/cyoda-platform/cyoda-go
-go.work                   Lists ., plugins/memory, plugins/postgres
+go.work                   Lists ., plugins/memory, plugins/postgres, plugins/sqlite
 
 plugins/                  Each plugin is its own Go module
   memory/
     go.mod                module github.com/cyoda-platform/cyoda-go/plugins/memory
     plugin.go             init() → spi.Register; Name() + NewFactory()
     store_factory.go      Implements spi.StoreFactory
-    txmanager.go          Implements spi.TransactionManager (in-process SSI)
+    txmanager.go          Implements spi.TransactionManager (in-process SI+FCW)
     entity_store.go
     model_store.go, kv_store.go, message_store.go, workflow_store.go
     sm_audit_store.go, search_store.go
     doc.go                Reference example for plugin authors
+  sqlite/
+    go.mod                module github.com/cyoda-platform/cyoda-go/plugins/sqlite
+    plugin.go             init() → spi.Register; Name() + NewFactory() + ConfigVars()
+    store_factory.go      Implements spi.StoreFactory
+    txmanager.go          Application-layer SI+FCW (ported from memory plugin)
+    entity_store.go, model_store.go, kv_store.go, message_store.go
+    workflow_store.go, sm_audit_store.go, search_store.go
+    query_planner.go, searcher.go, post_filter.go  Predicate pushdown to SQL
+    migrate.go            Embedded schema migrations
+    migrations/
   postgres/
     go.mod                module github.com/cyoda-platform/cyoda-go/plugins/postgres
     plugin.go             init() → spi.Register; Name() + NewFactory() + ConfigVars()
     store_factory.go      Implements spi.StoreFactory
-    txmanager.go          Lifecycle-only tx manager (~150 loc)
+    txmanager.go          Lifecycle + savepoint tx manager (~370 loc)
     entity_store.go, entity_doc.go
     model_store.go, kv_store.go, message_store.go, workflow_store.go
     sm_audit_store.go, search_store.go
@@ -141,7 +150,7 @@ The AST is stdlib-only. A plugin that translates predicates to its own query dia
 
 type Plugin interface {
     Name() string
-    NewFactory(getenv func(string) string, opts ...FactoryOption) (StoreFactory, error)
+    NewFactory(ctx context.Context, getenv func(string) string, opts ...FactoryOption) (StoreFactory, error)
 }
 
 type DescribablePlugin interface {   // optional — for --help rendering
@@ -174,6 +183,7 @@ A plugin registers itself from `init()`. The `cyoda-go/main.go` blank-imports th
 import (
     _ "github.com/cyoda-platform/cyoda-go/plugins/memory"
     _ "github.com/cyoda-platform/cyoda-go/plugins/postgres"
+    _ "github.com/cyoda-platform/cyoda-go/plugins/sqlite"
 )
 ```
 
@@ -228,9 +238,8 @@ if clusterSvc != nil && clusterSvc.Broadcaster() != nil {
 factory, err := plugin.NewFactory(ctx, os.Getenv, opts...)
 
 // Start runs BEFORE TransactionManager: plugins whose TM depends on
-// Start's side effects (e.g. cassandra's shard-rebalance wait) would
-// otherwise init a half-ready TM. Plugins with no background
-// lifecycle (memory, postgres) don't implement Startable and this is
+// Start's side effects would otherwise init a half-ready TM. Plugins
+// with no background lifecycle don't implement Startable and this is
 // a no-op for them.
 if s, ok := factory.(spi.Startable); ok {
     s.Start(ctx)
@@ -241,128 +250,56 @@ txMgr, _ := factory.TransactionManager(ctx)
 
 No per-store routing. No swap logic for transaction managers. Every store in the binary comes from the same plugin, and the plugin supplies its own `TransactionManager` whose semantics match its storage engine.
 
-### 2.1 The `memory` Plugin
+### 2.1 The `memory` plugin (`plugins/memory/`)
 
-The default plugin. A single standalone instance with zero external dependencies — all data lives in Go maps protected by synchronization primitives. Not multi-node compatible. Intended for rapid development and agent-driven application engineering.
+Ephemeral, in-process state with microsecond-latency SI+FCW concurrency
+control. Default for tests, local development, and high-throughput
+digital-twin workloads where durability is delegated elsewhere. Full
+detail in [docs/plugins/IN_MEMORY.md](plugins/IN_MEMORY.md).
 
-**Concurrency model:**
+### 2.2 The `sqlite` plugin (`plugins/sqlite/`)
 
-- **Service-level `sync.RWMutex`** on `StoreFactory` -- serializes writes to the shared entity data maps during transaction commit.
-- **Per-transaction `OpMu`** (`sync.RWMutex` on `TransactionState`) -- gates concurrent operations within a single transaction and ensures in-flight operations complete before commit/rollback.
+Persistent, zero-ops single-node storage. Embedded in-process via a
+pure-Go (WASM) SQLite driver, exclusive file lock, application-layer
+SI+FCW concurrency control ported from the memory plugin, search
+predicate pushdown to SQL. Default for desktop binary, edge
+deployments, and containerised single-node production. Full detail in
+[docs/plugins/SQLITE.md](plugins/SQLITE.md).
 
-**Serializable Snapshot Isolation (SSI):**
+### 2.3 The `postgres` plugin (`plugins/postgres/`)
 
-Each transaction captures a `SnapshotTime` at `Begin()`. Reads see only data committed before the snapshot. Writes are buffered in a per-transaction `Buffer` map. At commit time, the committed log is scanned for conflicts:
+Durable multi-node storage. PostgreSQL `REPEATABLE READ` provides
+snapshot isolation; an application-layer read-set validation at commit
+time provides first-committer-wins on entity-level conflicts. Works
+against any managed PostgreSQL 14+ platform (RDS, Cloud SQL, Azure,
+Supabase, Neon, Aiven, Crunchy Bridge, self-hosted, etc.). Full detail
+in [docs/plugins/POSTGRES.md](plugins/POSTGRES.md).
 
-```go
-type TransactionState struct {
-    ID           string
-    TenantID     TenantID
-    SnapshotTime time.Time
-    ReadSet      map[string]bool      // entity IDs read
-    WriteSet     map[string]bool      // entity IDs written
-    Buffer       map[string]*Entity   // buffered writes
-    Deletes      map[string]bool      // buffered deletes
-    OpMu         sync.RWMutex         // per-tx operation gate
-    Closed       bool
-    RolledBack   bool
-}
-```
+### 2.4 The `cassandra` plugin (commercial)
 
-**Conflict detection algorithm (committed log scan):**
+A Cassandra-backed storage plugin is available as a commercial offering
+from Cyoda. It slots into cyoda-go through the same `spi.Plugin` contract
+as the open-source plugins — operators select it at runtime via
+`CYODA_STORAGE_BACKEND=cassandra`.
 
-```
-FOR EACH committed_tx IN committedLog WHERE committed_tx.submitTime > tx.SnapshotTime:
-    FOR EACH entityID IN committed_tx.writeSet:
-        IF entityID IN tx.ReadSet OR entityID IN tx.WriteSet:
-            ABORT with ErrConflict
-```
+**Capability envelope:**
 
-**TOCTOU guard:** A `committing` map prevents double-commit races. The commit sequence acquires `tx.OpMu.Lock()` (waits for in-flight ops), then `factory.mu.Lock()` (exclusive data access), then `tm.mu.Lock()` (committed log check), in that order.
+- Horizontal write scalability across a Cassandra cluster
+- Snapshot isolation with first-committer-wins semantics (same
+  published contract as the open-source plugins — see
+  [docs/CONSISTENCY.md](CONSISTENCY.md))
+- Append-only point-in-time storage with full historical reads
+- No single points of failure
+- Multi-node consistency
 
-**Committed log pruning:** After each commit, entries older than the oldest active transaction's snapshot time are removed. When no transactions are active, the entire log is cleared.
+**When it fits:** workloads whose write volume or availability
+requirements outgrow a single-primary PostgreSQL deployment — while
+keeping the same EDBMS semantics (entities, workflows, temporal
+history, uniform isolation contract) that the open-source binary
+provides on top of the in-memory / sqlite / postgres plugins.
 
-### 2.2 The `postgres` Plugin
-
-Production-grade storage backed by PostgreSQL with `SERIALIZABLE` isolation. The postgres plugin's `TransactionManager` is a lightweight in-process lifecycle tracker — the durable work happens inside stores via pgx. The actual serialization guarantee comes from the database, not the TM.
-
-**Connection pooling:** pgx `pgxpool.Pool` with configurable bounds (default: 25 max, 5 min connections).
-
-**Bi-temporal versioning:**
-
-The `entity_versions` table provides full temporal history:
-
-```sql
-CREATE TABLE entity_versions (
-    tenant_id        TEXT        NOT NULL,
-    entity_id        TEXT        NOT NULL,
-    model_name       TEXT        NOT NULL,
-    model_version    TEXT        NOT NULL,
-    version          BIGINT      NOT NULL,
-    valid_time       TIMESTAMPTZ NOT NULL,
-    transaction_time TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    wall_clock_time  TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
-    doc              JSONB       NOT NULL,
-    PRIMARY KEY (tenant_id, entity_id, version)
-);
-```
-
-- `valid_time`: application-supplied timestamp (entity's logical time)
-- `transaction_time`: database `CURRENT_TIMESTAMP` (when PG recorded the row)
-- `wall_clock_time`: `clock_timestamp()` (actual wall-clock, independent of transaction)
-
-As-at queries filter by `valid_time`:
-
-```sql
-SELECT doc FROM entity_versions
-WHERE tenant_id = $1 AND entity_id = $2 AND valid_time <= $3
-ORDER BY valid_time DESC, transaction_time DESC
-LIMIT 1;
-```
-
-**Row-level security (RLS):**
-
-Every table has RLS enabled with a policy that compares `tenant_id` against the session variable `app.current_tenant`, set via `SET LOCAL` at transaction start:
-
-```sql
-ALTER TABLE entities ENABLE ROW LEVEL SECURITY;
-CREATE POLICY tenant_isolation_entities ON entities
-    USING (tenant_id = current_setting('app.current_tenant', true));
-```
-
-This provides defense-in-depth: even if application code has a tenant-scoping bug, PostgreSQL enforces isolation at the row level.
-
-**Schema (all tables):**
-
-| Table | Purpose | Partitioned by |
-|-------|---------|----------------|
-| `entities` | Current entity state (one row per entity) | `(tenant_id, entity_id)` PK |
-| `entity_versions` | Append-only bi-temporal history | `(tenant_id, entity_id, version)` PK |
-| `models` | Model descriptors (JSON) | `(tenant_id, model_name, model_version)` PK |
-| `kv_store` | Generic key-value (workflows, configs) | `(tenant_id, namespace, key)` PK |
-| `messages` | Edge messages with binary payload | `(tenant_id, message_id)` PK |
-| `workflows` | (stored in `kv_store`) | via namespace |
-| `sm_audit_events` | State machine audit trail | `(tenant_id, entity_id, event_id)` PK |
-| `search_jobs` | Async search job metadata | `id` PK, `tenant_id` indexed |
-| `search_job_results` | Entity ID results per job | `(job_id, seq)` PK, FK to `search_jobs` |
-
-**Migrations:** Embedded SQL files via `embed.FS`, applied at startup with `golang-migrate` when `CYODA_POSTGRES_AUTO_MIGRATE=true`.
-
-### 2.3 The `cassandra` Plugin (proprietary, ships as `cyoda-go-cassandra`)
-
-The `cassandra` plugin is a proprietary module in a separate repository (`github.com/cyoda-platform/cyoda-go-cassandra`). It implements the same `spi.Plugin` contract as the stock plugins. The `cyoda-go-cassandra` binary is a custom `main.go` that blank-imports memory + postgres + cassandra, so operators choose any backend at runtime via `CYODA_STORAGE_BACKEND`.
-
-Cassandra alone does not provide cross-partition serializability. The plugin achieves SSI by layering a custom coordinator protocol on top of Cassandra primitives, with a message broker (Kafka / Redpanda) providing work queuing and shard-ownership rebalancing. Summary of the approach:
-
-- **Hybrid Logical Clock (HLC)** — every write uses `USING TIMESTAMP hlc.Now()` so Cassandra's Last-Writer-Wins fences out zombie writers.
-- **Shard epoch ownership** — shards are assigned to nodes via the broker's consumer-group rebalancing; each takeover increments an `epoch` via a Cassandra LWT and cancels in-flight writes from the revoked owner via a fenced context.
-- **Transaction coordinator** — a per-node singleton that consumes `CommitRequest` messages, runs a 5-phase 2PC protocol, and publishes the result. Phases: set PENDING → load read/write sets → fan out version checks to entity shard owners → write COMMITTED (linearization point) → materialize to the durable version + index + checkpoint tables.
-- **Transaction reaper** — scans `transaction_log_idx` on startup and periodically, idempotently replaying materialization for committed-but-unfinished transactions (LWW makes replay safe).
-- **`ClusterBroadcaster` integration** — the cassandra plugin consumes `spi.ClusterBroadcaster` (supplied by cyoda-go's `MemberlistBroadcaster`) via an internal adapter for its clock-gossip channel. All other channels (commit commands, version checks, search events) remain strictly inside the plugin over the broker.
-
-**Full design:** see `docs/CASSANDRA_BACKEND_DESIGN.md` inside the proprietary `cyoda-go-cassandra` repository. Operators interacting only with `cyoda-go` need not read it; operators running the cassandra-included binary should.
-
-**Configuration:** plugin-namespaced env vars `CYODA_CASSANDRA_*` and `CYODA_REDPANDA_*`. The plugin advertises them via `spi.DescribablePlugin.ConfigVars()` so the binary's `--help` output renders them automatically.
+**Interested?** Get in touch with Cyoda at
+[cyoda.com](https://www.cyoda.com) and use its contact page.
 
 ---
 
@@ -377,60 +314,30 @@ type TransactionManager interface {
     Rollback(ctx context.Context, txID string) error
     Join(ctx context.Context, txID string) (txCtx context.Context, err error)
     GetSubmitTime(ctx context.Context, txID string) (time.Time, error)
+    Savepoint(ctx context.Context, txID string) (savepointID string, err error)
+    RollbackToSavepoint(ctx context.Context, txID string, savepointID string) error
+    ReleaseSavepoint(ctx context.Context, txID string, savepointID string) error
 }
 ```
 
 - `Begin`: Resolves tenant from context, generates a UUID txID, creates a transaction, returns a new context carrying the `TransactionState`.
 - `Join`: Attaches to an existing active transaction by txID. Used when a proxied CRUD request arrives at the transaction-owning node. Verifies tenant match.
-- `Commit`: Validates, flushes, records. Returns `common.ErrConflict` on serialization failure.
+- `Commit`: Validates, flushes, records. Returns `common.ErrConflict` on serialization failure (Snapshot Isolation with first-committer-wins (SI+FCW); see [docs/CONSISTENCY.md](CONSISTENCY.md) for the full contract and per-plugin implementation).
 - `Rollback`: Marks transaction rolled back, clears from active map. Waits for in-flight operations via `OpMu`.
 - `GetSubmitTime`: Returns the database timestamp captured at commit. Used for temporal ordering.
+- `Savepoint` / `RollbackToSavepoint` / `ReleaseSavepoint`: nested-savepoint support used by the workflow engine's `ASYNC_NEW_TX` execution mode. The plugin returns a savepoint ID that the caller passes back for rollback or release. Plugins that don't support savepoints may return `common.ErrUnsupported`.
 
-### 3.2 In-Memory SSI Conflict Detection
+### 3.2 In-Memory SI+FCW Conflict Detection
 
-The in-memory `TransactionManager` implements Serializable Snapshot Isolation with a committed log:
+Extracted to [docs/plugins/IN_MEMORY.md](plugins/IN_MEMORY.md).
+See also [docs/CONSISTENCY.md](CONSISTENCY.md) for the cross-plugin
+contract.
 
-**Commit sequence (critical section):**
+### 3.3 Postgres SI+FCW via `REPEATABLE READ` + commit-time validation
 
-```
-1. Acquire tx.OpMu.Lock()         -- wait for in-flight ops to finish
-2. Acquire factory.mu.Lock()      -- exclusive access to shared data
-3. Acquire tm.mu.Lock()           -- scan committed log
-4. FOR EACH committed_tx where submitTime > tx.SnapshotTime:
-     IF committed_tx.writeSet intersects (tx.ReadSet UNION tx.WriteSet):
-       ABORT → ErrConflict
-5. Flush tx.Buffer to factory.entityData (deep copy)
-6. Apply tx.Deletes (append tombstone versions)
-7. Append to committedLog: {txID, submitTime, writeSet}
-8. Record submitTime in submitTimes map
-9. Remove from active map
-10. Prune committedLog (entries older than oldest active snapshot)
-11. Release all locks
-```
-
-The committed log grows only as long as there are concurrent transactions. When all active transactions complete, the log is cleared entirely. The `submitTimes` map grows without bound -- acceptable for in-memory single-node use.
-
-### 3.3 PostgreSQL SERIALIZABLE + Error Code 40001
-
-The PostgreSQL `TransactionManager` delegates conflict detection entirely to the database:
-
-```go
-pgxTx, err := tm.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
-```
-
-Every transaction begins with `SET LOCAL app.current_tenant = $1` for RLS. On commit, PostgreSQL detects serialization failures and returns error code `40001`, which is mapped to `common.ErrConflict`:
-
-```go
-func classifyError(err error) error {
-    var pgErr *pgconn.PgError
-    if errors.As(err, &pgErr) && pgErr.Code == "40001" {
-        return common.ErrConflict
-    }
-    return err
-}
-```
-
-Before committing, the transaction captures `SELECT CURRENT_TIMESTAMP` for the submit time -- this is the database's view of commit time, not the application's wall clock.
+Extracted to [docs/plugins/POSTGRES.md](plugins/POSTGRES.md).
+See also [docs/CONSISTENCY.md](CONSISTENCY.md) for the cross-plugin
+contract.
 
 ### 3.4 Transaction Lifecycle Manager
 
@@ -449,26 +356,48 @@ type Manager struct {
 - **Outcome tracking:** `RecordOutcome(txID, committed|rolledBack)` -- moves from active to outcomes map. Outcomes expire after `outcomeTTL`.
 - **Cluster visibility:** `ListByNode(nodeID)` -- returns all active transactions owned by a specific node.
 
-### 3.5 pgx.Tx Single-Owner Property
+### 3.5 `pgx.Tx` Single-Owner Property
 
-A critical safety property: **a `pgx.Tx` is held by exactly one goroutine on exactly one node.** There is no mechanism for two nodes to share a PostgreSQL transaction. This means:
+Extracted to [docs/plugins/POSTGRES.md](plugins/POSTGRES.md).
 
-- No distributed locking is needed for transaction access.
-- No fencing tokens are needed to prevent stale writes.
-- If the owning node dies, PostgreSQL automatically rolls back the transaction (idle timeout).
-- The `txRegistry` (a `sync.RWMutex`-protected map of `txID -> pgx.Tx`) is the single source of truth for active transactions on a node.
-
-This is why DD-2 (fencing tokens not required) holds. See [Section 13](#13-design-decisions-log).
+The property remains load-bearing for the cluster design: see DD-2 in [Section 13](#13-design-decisions-log) — fencing tokens are not required because no two nodes can share a PostgreSQL transaction.
 
 ### 3.6 Plugin-Specific Transaction Managers
 
-Each plugin provides its own `TransactionManager` whose semantics match its storage engine:
+Each plugin provides its own `TransactionManager` whose semantics match its storage engine — all delivering the same published Snapshot Isolation + first-committer-wins contract (see §3.7 and [docs/CONSISTENCY.md](CONSISTENCY.md)):
 
-- **memory plugin** — in-process SSI with entity-level read/write sets and a committed-transaction log (Section 3.2).
-- **postgres plugin** — lightweight in-process lifecycle tracker. The real serialization guarantee comes from PostgreSQL's `SERIALIZABLE` isolation inside the stores (Section 3.3). The TM assigns IDs, tracks active/committed sets with timestamps, and supports savepoints as a local stack.
-- **cassandra plugin** — a coordinator-managed 2PC over a message broker, with HLC fencing, per-shard epoch ownership, and committed-log replay for recovery (see Section 2.3). Owns its own TM because Cassandra has neither `SERIALIZABLE` nor native multi-partition transactions.
+- **memory plugin** — in-process SI+FCW with entity-level read/write sets and a committed-transaction log ([docs/plugins/IN_MEMORY.md](plugins/IN_MEMORY.md)).
+- **sqlite plugin** — same SI+FCW engine code as the memory plugin, ported to persist through a SQLite file with an exclusive file lock ([docs/plugins/SQLITE.md](plugins/SQLITE.md)).
+- **postgres plugin** — PostgreSQL `REPEATABLE READ` for the engine-level snapshot, plus application-layer read-set validation at commit time ([docs/plugins/POSTGRES.md](plugins/POSTGRES.md)). The TM assigns IDs, tracks active/committed sets with timestamps, and supports savepoints as a local stack.
+- **Commercial plugins** (e.g. the Cassandra plugin from Cyoda)
+  implement their own `TransactionManager` against their underlying
+  store's primitives. See §2.4 for the capability envelope of the
+  commercial Cassandra plugin.
 
 The core `cyoda-go` never picks a TM. It asks the plugin via `factory.TransactionManager(ctx)` and wraps the result with its tracing decorator when OTel is enabled.
+
+### 3.7 Cross-plugin isolation contract
+
+All four storage plugins deliver the same semantic guarantee:
+**Snapshot Isolation with First-Committer-Wins on entity-level
+conflicts.** The implementation mechanism differs by plugin — the
+guarantee does not.
+
+| Plugin | Engine-level mechanism | Application-layer validation | Effective guarantee | Conflict granularity |
+|---|---|---|---|---|
+| `memory` | n/a — all in-process Go | committed-log + read/write-set tracking | SI+FCW | per-entity |
+| `sqlite` | DB-level write lock | same SSI-engine code ported from memory | SI+FCW | per-entity |
+| `postgres` | `REPEATABLE READ` + tuple locks | entity-keyed read-set validation at commit; `40001`/`40P01` retry | SI+FCW | per-entity |
+| `cassandra` (commercial) | *(proprietary)* | *(plugin-internal)* | SI+FCW | per-entity |
+
+This contract catches dirty read, non-repeatable read, lost update,
+and entity-level write-write / write-after-read conflicts. It does
+NOT prevent predicate-based phantom anomalies. Workflow authors
+observe an operational rule: do not branch on
+`search(predicate).count()` inside a transactional workflow step.
+See [docs/CONSISTENCY.md](CONSISTENCY.md) for the full contract,
+worked scenarios, the operational rule with three robust
+alternatives, and the isolation-level taxonomy.
 
 ---
 
@@ -663,7 +592,7 @@ Participants:
 
 ```
 t0   Client --> POST /entity create --> Node A
-t1   Node A: BEGIN tx-123, generate txToken --> PG: BEGIN SERIALIZABLE
+t1   Node A: BEGIN tx-123, generate txToken --> PG: BEGIN REPEATABLE READ
 t2   Node A: Save entity --> PG: INSERT entity (in tx-123)
 t3   Node A: SM engine dispatches to processor
 t3a  Node A: Check local MemberRegistry --> not found
@@ -816,7 +745,7 @@ SAFE: All cases lead to rollback or retry. No data corruption possible because t
 
 | Category | Finding | Needed Mechanism |
 |----------|---------|-----------------|
-| **Consistency** | All partition scenarios lead to rollback or clean commit. No split-brain possible because `pgx.Tx` is single-owner. PG `SERIALIZABLE` catches conflicting concurrent writes. | None (inherently safe) |
+| **Consistency** | All partition scenarios lead to rollback or clean commit. No split-brain possible because `pgx.Tx` is single-owner. PG `REPEATABLE READ` + commit-time read-set validation (SI+FCW, see §3.7) catches conflicting concurrent writes. | None (inherently safe) |
 | **Duplicate operations** | Client <-> Node A partition at any point can cause the client to retry, creating a second transaction for the same intent. Both may commit without conflicting. | Idempotency keys |
 | **Commit ambiguity** | L5 partition at COMMIT time: Node A cannot tell if PG committed or not. | Commit marker (write marker row before COMMIT; check on reconnect) |
 | **Timeout / liveness** | Several failure modes depend on timeouts (gRPC keepalive, PG TCP keepalive) that may be slow (minutes). Flow chain can hang waiting for dead compute nodes. | Transaction TTL + deadline propagation via context |
@@ -1134,7 +1063,7 @@ Warnings and errors are accumulated in the request context and propagated to the
 
 ## 9. Configuration Reference
 
-All values configurable via environment variables with the `CYODA_` prefix. Plugin-specific variables use the plugin's name as a secondary namespace (`CYODA_POSTGRES_*`, `CYODA_CASSANDRA_*`). `./cyoda --help` on any binary renders the variables for the plugins it ships with — the help text is generated at runtime from the registered plugins' `ConfigVars()`.
+All values configurable via environment variables with the `CYODA_` prefix. Plugin-specific variables use the plugin's name as a secondary namespace (`CYODA_POSTGRES_*`, `CYODA_SQLITE_*`). Plugin-scoped variables are documented in the per-plugin reference under `docs/plugins/`. `./cyoda --help` on any binary renders the variables for the plugins it ships with — the help text is generated at runtime from the registered plugins' `ConfigVars()`.
 
 ### Server
 
@@ -1165,25 +1094,6 @@ Advertised via `DescribablePlugin.ConfigVars()`; rendered in the binary's `--hel
 | `CYODA_POSTGRES_MIN_CONNS` | `5` | Minimum pool connections |
 | `CYODA_POSTGRES_MAX_CONN_IDLE_TIME` | `5m` | Max idle time before connection is closed |
 | `CYODA_POSTGRES_AUTO_MIGRATE` | `true` | Run embedded SQL migrations at startup |
-
-### Cassandra plugin (`CYODA_STORAGE_BACKEND=cassandra`, available only in the `cyoda-go-cassandra` binary)
-
-The cassandra plugin has the largest config surface of any shipped plugin. Only the most common operator-facing options are listed here; the plugin's `ConfigVars()` (rendered in `--help`) is authoritative.
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `CYODA_CASSANDRA_CONTACT_POINTS` | (none, **required**) | Comma-separated `host:port` list |
-| `CYODA_CASSANDRA_KEYSPACE` | `cyoda_go` | Keyspace name |
-| `CYODA_CASSANDRA_REPLICATION` | SimpleStrategy RF=3 | CQL replication strategy JSON |
-| `CYODA_CASSANDRA_NUM_SHARDS` | `32` | Virtual shard count (immutable after first use) |
-| `CYODA_CASSANDRA_AUTO_MIGRATE` | `true` | Run schema migrations at startup |
-| `CYODA_CASSANDRA_CONSISTENCY_LEVEL` | `QUORUM` | CQL consistency level for reads and writes |
-| `CYODA_CASSANDRA_MAX_CONCURRENT_WRITES` | `32` | Max concurrent CQL writes per node |
-| `CYODA_CASSANDRA_USERNAME` | (none) | Auth username (optional) |
-| `CYODA_CASSANDRA_PASSWORD` | (none) | Auth password (optional) |
-| `CYODA_REDPANDA_BROKERS` | (none, **required**) | Comma-separated broker list (Kafka-compatible) |
-| `CYODA_REDPANDA_CONSUMER_GROUP` | `cyoda-go` | Consumer group identifier |
-| `CYODA_CASSANDRA_REDPANDA_SESSION_TIMEOUT_SEC` | `30` | Consumer session timeout |
 
 ### IAM
 
@@ -1279,7 +1189,7 @@ Architecture:
 
 - **nginx:** Round-robin load balancer. Proxies `/api/*` paths only. Internal paths (`/internal/*`) are not exposed.
 - **Gossip:** Each node runs a memberlist listener on a distinct port. Seed nodes are configured so all nodes discover each other.
-- **Shared PostgreSQL:** All nodes connect to the same PostgreSQL instance. `SERIALIZABLE` isolation + RLS ensure correctness.
+- **Shared PostgreSQL:** All nodes connect to the same PostgreSQL instance. `REPEATABLE READ` + application-layer SI+FCW validation + RLS ensure correctness (see [docs/CONSISTENCY.md](CONSISTENCY.md)).
 - **Shared secrets:** All nodes share the same HMAC secret (for token verification and gossip encryption) and the same JWT signing key (for deterministic KID derivation).
 
 **Scripts:**
@@ -1307,19 +1217,26 @@ OpenTelemetry is integrated end-to-end. The OTel SDK is initialised in `internal
 
 **Workflow and dispatch:** spans for `workflow.execute`, `workflow.manual_transition`, `workflow.loopback`; `dispatch.processor` and `dispatch.criteria` with `cyoda.dispatch.duration` and `cyoda.dispatch.count` metrics.
 
-**Plugin-level instrumentation:** plugins are free to add their own spans and metrics under a plugin-specific namespace (e.g., `cyoda.cassandra.cql.duration`, `cyoda.cassandra.batch.duration`, `cyoda.cassandra.limiter.*`, commit-protocol phase spans). The `memory` and `postgres` plugins emit minimal plugin-level telemetry (their behavior is well-captured by the core transaction/workflow/dispatch spans); the `cassandra` plugin adds detailed CQL, batch, and commit-protocol instrumentation because its hot-path semantics warrant finer visibility.
+**Plugin-level instrumentation:** plugins are free to add their own
+spans and metrics under a plugin-specific namespace. The `memory`
+and `postgres` plugins do not emit custom plugin-level telemetry;
+their behaviour is fully captured by the core transaction /
+workflow / dispatch spans listed above. Other plugins may add
+detailed instrumentation scoped to their own namespace as their
+hot-path semantics warrant.
 
 **Exporter endpoint:** `OTEL_EXPORTER_OTLP_ENDPOINT` (standard OTel env var). The bundled docker setup ships a Grafana / Prometheus / Tempo stack via `grafana/otel-lgtm` with a pre-provisioned `Cyoda-Go Overview` dashboard covering HTTP, transactions, and workflow/dispatch.
 
 **Runtime sampler control.** The trace sampler is swappable at runtime via `POST /api/admin/trace-sampler` (requires `ROLE_ADMIN`), mirroring `/api/admin/log-level`. Operators can toggle between 100% sampling, probabilistic sampling, and off without restarting the service. The initial sampler honors the standard OTel env vars `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` at startup.
 
-**Known gaps (carried forward from `cyoda-light-go`):** trace context propagation through the cassandra plugin's broker messages, search pipeline, and external-processor gRPC/CloudEvents is incomplete. Issues will be re-opened in their respective repositories when scheduled.
+**Known gaps:** trace context propagation through the search pipeline
+and external-processor gRPC/CloudEvents is incomplete.
 
 ---
 
 ## 12. Planned Features (Not Yet Implemented)
 
-Items carried forward from the `cyoda-light-go` predecessor repository. Issues will be re-opened in the appropriate repository (`cyoda-go` for core, `cyoda-go-cassandra` for cassandra plugin) when each item is scheduled.
+Items carried forward from the `cyoda-light-go` predecessor repository. Issues will be re-opened in `cyoda-go` when each item is scheduled.
 
 ### Carried to `cyoda-go`
 
@@ -1330,17 +1247,7 @@ Items carried forward from the `cyoda-light-go` predecessor repository. Issues w
 | Multi-node E2E tests with proxy routing | Automated testing of the full cluster topology |
 | Batch `SaveResults` with `pgx.CopyFrom` (PostgreSQL plugin) | Performance optimization for async search result insertion |
 | Idempotency keys | Client-provided keys to prevent duplicate operations on retry |
-| Plugin conformance test suite (`cyoda-go-spi/spitest/`) | Shared behavioral conformance harness any plugin can run against its own `StoreFactory`. Scheduled after the cassandra plugin extraction. |
-
-### Carried to `cyoda-go-cassandra`
-
-| Feature | Purpose |
-|---------|---------|
-| HLC monotonicity fix on shard takeover | Close the clock-gossip monotonicity gap documented in ADRs 0001 and 0002 (see Plan 4 in the storage plugin spec) |
-| Parallelize version-check publish + await | Cut commit latency for large collection saves |
-| Bound shard takeover scans | Make startup time data-independent |
-| Parallelize `MutationBatch.ExecuteChunked` | Cut materialize latency for large writes |
-| Trace context propagation through the broker | Unified commit trace waterfall |
+| Plugin conformance test suite (`cyoda-go-spi/spitest/`) | Shared behavioral conformance harness any plugin can run against its own `StoreFactory`. |
 
 ### Cross-cutting
 
@@ -1436,11 +1343,11 @@ This section describes where Cyoda-Go is expected to encounter limits. These are
 | Dimension | Scaling Behavior | Limit |
 |-----------|-----------------|-------|
 | **Node count** | Linear improvement in compute dispatch capacity (more nodes = more compute members). No improvement in write throughput — all writes go through PostgreSQL. | 10–20 nodes practical maximum. Beyond this, gossip metadata size grows (per-tenant tag sets × nodes), and the probability of proxy hops increases. |
-| **Write throughput** | Bounded by PostgreSQL SERIALIZABLE isolation. Every transaction holds a `pgx.Tx` for its full duration (including external compute phases). | Single PG instance is the bottleneck. Connection pool default is 25 per node; with 10 nodes that's 250 concurrent PG connections. Long-held transactions reduce effective throughput. |
+| **Write throughput** | Bounded by PostgreSQL `REPEATABLE READ` + application-layer SI+FCW validation (see §3.7). Every transaction holds a `pgx.Tx` for its full duration (including external compute phases). | Single PG instance is the bottleneck. Connection pool default is 25 per node; with 10 nodes that's 250 concurrent PG connections. Long-held transactions reduce effective throughput. |
 | **Read throughput** | Scales with node count for non-transactional reads (entity queries, search). Each node can serve reads independently from PG. | Bounded by PG read capacity. Point-in-time queries require version table scans. |
 | **Compute throughput** | Scales with compute member count across the cluster. Each node can host multiple compute members. Cross-node dispatch adds one HTTP hop (~1ms intra-cluster). | Bounded by compute member availability per tag. If only one node has a member for a given tag, that node is the bottleneck for that tag. |
 
-**Contrast with Cyoda Cloud:** Cyoda Cloud uses a fully distributed storage layer (Cassandra) with no single-node write bottleneck. Cyoda-Go trades unlimited write scalability for PostgreSQL's stronger isolation guarantees and simpler operational model.
+**Contrast with Cyoda Cloud:** Cyoda Cloud uses a fully distributed storage layer with no single-node write bottleneck. The open-source cyoda-go binary trades unlimited write scalability for simpler operational requirements (a single primary PostgreSQL — or none at all, with the memory or sqlite plugins).
 
 ### 14.2 Transaction Timing and Duration
 
@@ -1483,14 +1390,14 @@ This section describes where Cyoda-Go is expected to encounter limits. These are
 
 **Single point of failure:** PostgreSQL. If PG is down, the cluster is effectively down for writes. This is by design — PG is the consistency authority. HA PostgreSQL (streaming replication with automatic failover) is the recommended mitigation.
 
-**No split-brain:** The `pgx.Tx` single-owner property ensures that no two nodes can commit the same transaction. PostgreSQL SERIALIZABLE isolation catches conflicting concurrent writes from different transactions. There is no application-level consensus needed because PG is the sole arbiter.
+**No split-brain:** The `pgx.Tx` single-owner property ensures that no two nodes can commit the same transaction. PostgreSQL `REPEATABLE READ` plus the application-layer SI+FCW validation (§3.7) catches conflicting concurrent writes from different transactions. There is no application-level consensus needed because PG is the sole arbiter.
 
 ### 14.5 Consistency Guarantees and Caveats
 
 | Guarantee | Strength | Caveat |
 |-----------|----------|--------|
 | **Read-your-own-writes** | Strong (within a transaction) | Guaranteed by `pgx.Tx` — all reads within a transaction see its own buffered writes. Across transactions, reads are snapshot-isolated. |
-| **Snapshot isolation** | Strong (SERIALIZABLE in PG) | PG SERIALIZABLE may abort transactions with serialization failures (error 40001). The application retries. Under high contention, retry storms are possible. |
+| **Snapshot isolation** | Strong (SI+FCW across all plugins; see §3.7 and [docs/CONSISTENCY.md](CONSISTENCY.md)) | Commit-time conflict detection may abort with `ErrConflict` (40001 / 40P01 on PostgreSQL). The application retries. Under high contention, retry storms are possible. |
 | **Cross-node consistency** | Strong (PG is the authority) | All nodes share the same PG instance. There is no eventual consistency between nodes — they all see the same data at the same isolation level. Gossip metadata (node registry, compute tags) is eventually consistent with sub-second convergence. |
 | **Temporal consistency** | Strong (point-in-time queries) | `GetAsAt` returns the entity as it was at a specific timestamp. Accuracy depends on PG clock precision (microsecond) and correct use of `transaction_time` vs `wall_clock_time`. |
 | **Commit ambiguity** | **Gap** (planned: #56) | If the network partitions between Node A and PG at COMMIT time, Node A cannot determine whether PG committed or not. The planned commit marker (#56) will resolve this. Until then, the client may see a false failure for a transaction that actually committed. |

--- a/docs/CONSISTENCY.md
+++ b/docs/CONSISTENCY.md
@@ -1,0 +1,389 @@
+# Cyoda-Go Transactional Consistency
+
+**Version:** 1.0
+**Date:** 2026-04-18
+**Status:** Canonical reference for cyoda-go's isolation and consistency semantics.
+
+This document is the source of truth for what cyoda-go guarantees, what it
+doesn't, and what operational rules apply to workflow authors. ARCHITECTURE.md
+§3 (Transaction Model) and PRD.md §4 (Transaction Model) point here for depth.
+
+---
+
+## 1. The contract at a glance
+
+Every cyoda-go storage plugin delivers the same semantic guarantee:
+
+> **Snapshot Isolation with First-Committer-Wins on entity-level conflicts.**
+
+- Reads within a transaction see a consistent snapshot taken at `Begin`.
+- Writes within a transaction are visible to its own subsequent reads
+  (read-your-own-writes).
+- At commit time, if any entity in the transaction's read-set has been
+  modified by a concurrent transaction that committed first, the
+  transaction aborts with `spi.ErrConflict`. The first transaction to
+  commit wins; losers can retry.
+- Write-write conflicts on the same entity are caught by the same
+  mechanism (and, on the postgres plugin, additionally by row-level tuple
+  locks that raise `40001` at DML time before the commit phase even runs).
+
+The guarantee is **entity-granular**: it is expressed in terms of entity
+identities, not row identities, predicate ranges, or table partitions.
+All four plugins (memory, sqlite, postgres, and the commercial cassandra
+plugin) implement this same contract against very different underlying
+engines.
+
+## 2. What this contract catches
+
+All three anomalies classically prevented by Snapshot Isolation:
+
+- **Dirty read.** A transaction never observes another transaction's
+  uncommitted writes. Cyoda transactions take a consistent snapshot at
+  `Begin` and see only that snapshot plus their own writes.
+- **Non-repeatable read.** Re-reading an entity within the same transaction
+  always returns the same value. A concurrent committer's update is
+  invisible to us until we commit (at which point we either succeed, if our
+  read-set is still valid, or abort on conflict).
+- **Lost update.** Two transactions reading the same entity, both updating
+  it, both committing: exactly one commits, the other aborts. The "last
+  committer wins silently" anomaly of READ COMMITTED cannot occur.
+
+Plus the conflict class SI+FCW adds on top of plain SI:
+
+- **Write-write conflicts on the same entity.** Even if both transactions
+  read the same initial version and their writes do not depend on each
+  other's, only the first to commit succeeds.
+- **Write-after-read conflicts on the same entity.** If transaction T1
+  reads entity `E` and T2 concurrently writes `E`, T1 cannot commit after
+  T2 has committed — T1's read-set validation fails.
+
+## 3. What this contract does NOT catch
+
+**Phantom anomalies from predicate reads.** This is the only anomaly class
+that cyoda's SI+FCW does not prevent, and it deserves a precise statement
+because workflow authors must understand it.
+
+Consider:
+
+```text
+T1: search("status = ACTIVE")           returns [A, B, C]
+T1: insert entity X (also ACTIVE)
+T1: commit
+
+T2: search("status = ACTIVE")           returns [A, B, C]    (T2 started
+                                                              before T1 commit)
+T2: insert entity Y (also ACTIVE)
+T2: commit
+```
+
+Both transactions see `[A, B, C]`, both add one matching entity to the
+ACTIVE set, both commit successfully. Neither's read-set included the
+other's new entity (how could it? the entity didn't exist at snapshot
+time, and a predicate range is not something the read-set can capture
+without full predicate locking). No conflict is detected.
+
+In isolation-level terms: cyoda provides **Snapshot Isolation with
+First-Committer-Wins on entity-level conflicts** — not full Serializability.
+This matches the semantic Oracle's `SERIALIZABLE`, SQL Server's `SNAPSHOT`,
+and MySQL InnoDB's `REPEATABLE READ` with commit-time validation deliver.
+It is weaker than PostgreSQL's native `SERIALIZABLE` (Cahill SSI with
+rw-antidependency tracking) on precisely this one anomaly class.
+
+The cyoda postgres plugin deliberately runs at `REPEATABLE READ` and
+layers first-committer-wins on top, rather than using PostgreSQL's native
+`SERIALIZABLE`. The design rationale is captured in
+`docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md`
+— PostgreSQL's SSI uses b-tree *page* granularity for its dependency
+tracking, producing false-positive `40001` aborts on concurrent writes to
+disjoint rows that happen to share a page. The FCW implementation gives
+entity-row granularity across all plugins and eliminates those false
+positives, at the cost of not catching predicate-phantom anomalies. This
+is an accepted trade-off captured in cyoda's published semantic contract.
+
+## 4. Why the transactional umbrella doesn't fix this by itself
+
+Every transaction in cyoda is started by an entity create/update at the
+API surface — `BeginTx` is called in exactly five places, all inside
+`internal/domain/entity/service.go` (create, delete, delete-all, batch
+create, XML import). All cross-entity CRUD performed by workflow
+processors during transition execution happens inside that enclosing
+transaction.
+
+This "transactional umbrella" bounds *when* a transaction exists and
+*what work falls under a single commit point*. But it does not prevent
+phantom-driven write-skew, because two concurrent transactions anchored
+on *different* entities can still both perform the same predicate search
+and both insert matching entities:
+
+```text
+T1 (anchored on order #42):
+  update order #42
+  search("status = ACTIVE AND type = premium")    returns 3 matches
+  insert subordinate entity based on that count
+  commit
+
+T2 (anchored on order #43):
+  update order #43
+  search("status = ACTIVE AND type = premium")    returns 3 matches
+  insert subordinate entity based on that count
+  commit
+```
+
+Different anchors, disjoint write-sets on the subordinates, both count
+results are "3" at their respective snapshot times, both commit
+successfully. Five matching entities now exist although both transactions
+thought there would be four.
+
+The umbrella limits the scope of a transaction; it doesn't eliminate the
+phantom class.
+
+## 5. Operational rule: don't count inside a transaction
+
+The single canonical rule that workflow authors must observe:
+
+> **Workflow criterion and processor implementations must not perform a
+> search within a transactional workflow step and branch on the result
+> count or set completeness.**
+
+Code patterns like `search(predicate).count() < threshold` or
+`if !search(predicate).any() { ... }` inside a transition criterion or a
+processor are susceptible to phantom anomalies. Entity-level reads and
+writes (operating on a known entity ID, not a predicate range) are safe.
+
+If your business logic requires a count-based invariant, there are three
+robust alternatives:
+
+**(a) Promote the count to a materialised counter entity.** Instead of
+searching, read and update a dedicated counter entity by its known ID.
+Counter reads land in the read-set; counter writes land in the write-set;
+FCW handles contention naturally. Two concurrent transactions racing on
+the same counter will serialise via first-committer-wins.
+
+**(b) Encode the invariant as a state-machine precondition.** If the
+invariant is "at most N entities of type X can be in state Y at once",
+express that as a transition criterion on the individual entity's
+state-machine rather than as a global count check. The criterion
+evaluates entity-local reads (safe), and the transition commit's FCW
+validation handles concurrent contenders.
+
+**(c) Add a post-commit reconciliation step.** If the invariant can be
+violated temporarily and a reaper/reconciler pass can detect and correct
+it, model that explicitly. This is often the right shape for invariants
+that are emergent rather than point-in-time — e.g., "no more than N
+active sessions per user" where the correction is to close the oldest.
+
+Workflow authors who follow this rule get effectively-serialisable
+behaviour for the transaction classes they write. The isolation level is
+still SI+FCW underneath; the rule keeps their workloads inside the
+anomaly-free region of it.
+
+## 6. Per-plugin implementation
+
+All plugins honour the same contract. Implementation strategy varies.
+
+| Plugin | Engine-level mechanism | Application-layer validation | Effective guarantee | Conflict granularity |
+|---|---|---|---|---|
+| **memory** | n/a — all in-process Go | Committed-log + per-transaction read/write-set tracking; first-committer-wins at commit | **SI+FCW** | per-entity |
+| **sqlite** | Database-level write lock (single writer at the engine level) | Same SSI-engine code ported from memory; SQLite is the durability layer only | **SI+FCW** | per-entity |
+| **postgres** | `REPEATABLE READ` (snapshot) + row-level tuple locks on entity tables | Entity-keyed read-set validation at commit; `40001` (`could not serialize access`) and `40P01` (`deadlock_detected`) mapped to `spi.ErrConflict` with bounded retry | **SI+FCW** | per-entity (via tuple locks on 1-to-1 `entities` table) |
+| **cassandra** (commercial) | *(proprietary)* | *(plugin-internal)* | **SI+FCW** | per-entity |
+
+Entity tables on the postgres plugin are keyed by `(tenant_id, entity_id)`
+for `entities` and by `(tenant_id, entity_id, version)` for
+`entity_versions`. Because `entities` is 1-to-1 with logical entities,
+PostgreSQL's tuple-level row lock on an `entities` row is semantically
+equivalent to an entity-level lock.
+
+The application-layer read-set in `plugins/postgres/txstate.go` is keyed
+by entity ID (`readSet map[string]int64`, value = version observed).
+Validation at commit compares each entity's expected version to the
+latest committed version via a batched `SELECT ... FOR SHARE` over the
+read-set rows. Mismatches raise `spi.ErrConflict`; PostgreSQL's own
+`40001` on the `FOR SHARE` is a second, redundant guard for the same
+condition. Write-write conflicts are caught earlier, at the DML statement
+that tries to `UPDATE`/`INSERT` the entity row, by PostgreSQL's implicit
+tuple-exclusive lock.
+
+## 7. Worked scenarios
+
+### 7.1 Concurrent updates to the same entity — FCW serialises them
+
+```text
+Initial: entity E version 1.
+
+T1: read E @ v1, update E (write-set captures pre-write version 1)
+T2: read E @ v1, update E (write-set captures pre-write version 1)
+
+T1 commits first.
+- Memory/sqlite: writes E@v2 to committedLog, prunes older versions.
+- Postgres: DML UPDATE takes tuple-exclusive lock; commits E@v2.
+
+T2 tries to commit.
+- Memory/sqlite: read-set validation finds E moved from v1 to v2 →
+  ErrConflict.
+- Postgres: either (a) T2's UPDATE raised 40001 at DML time because T1's
+  commit had already landed, or (b) commit-phase `FOR SHARE` raises 40001
+  on the stale snapshot. Either way, ErrConflict.
+
+Result: T1 succeeds, T2 aborts. T2 retries with a fresh snapshot.
+```
+
+Safe. All plugins handle this identically from the caller's perspective.
+
+### 7.2 Read one entity, write another — FCW catches cross-entity conflict
+
+```text
+Initial: entity A v1, entity B v1.
+
+T1: read A @ v1 (captures A:v1 in read-set),
+    update B based on A's data (captures B's pre-write version in write-set)
+T2: update A (captures A's pre-write version in write-set)
+
+T2 commits first → A@v2.
+
+T1 tries to commit.
+- Read-set validation: A was read at v1, latest committed is v2 → ErrConflict.
+
+Result: T1 aborts. T1 retries, observes A@v2, recomputes B's update
+based on the new A data.
+```
+
+Safe. The cross-entity dependency `B depends on A` is captured in T1's
+read-set explicitly (T1 read A), so FCW validates it at commit.
+
+### 7.3 Predicate-based count — NOT safe (the phantom case)
+
+```text
+Initial: 3 entities matching "status = ACTIVE".
+
+T1: search("status = ACTIVE") → [A, B, C]; "3 < 5, ok to add another"
+    insert X with status = ACTIVE
+T2: search("status = ACTIVE") → [A, B, C]; "3 < 5, ok to add another"
+    insert Y with status = ACTIVE
+
+Neither transaction's read-set contains the other's new entity (X and Y
+didn't exist at snapshot time). The commit validation cannot detect
+anything wrong.
+
+T1 commits. T2 commits. Now there are 5 ACTIVE entities, though each
+transaction believed there would be 4.
+```
+
+**This is the anomaly class the operational rule in §5 exists to prevent.**
+The workaround is any of §5 (a), (b), or (c) — most commonly, promote
+the count to a counter entity the workflow can read/write by ID.
+
+### 7.4 Workflow-encoded invariant — safe by design
+
+State-machine transitions naturally funnel the "should I do X?" decision
+through entity-local criteria that evaluate against the anchor entity's
+own state. A transition's criterion is evaluated within the transaction
+that performs the transition, and the criterion's reads enter the
+transaction's read-set.
+
+Consider an Order entity whose "SHIP" transition has the criterion
+`order.approvals_received >= 2`. If two concurrent transactions both try
+to fire SHIP on the same order:
+
+- Both read `order.approvals_received` = 2 and the criterion passes.
+- Both capture `order@current-version` in their read-set.
+- Both attempt to write the new state.
+- First committer wins via FCW on the `order` entity. Second aborts with
+  `ErrConflict` and retries; on retry, the order may already be in state
+  SHIPPED and the transition no longer applicable.
+
+Because the invariant is expressed as a criterion on the entity being
+transitioned, FCW on that entity is the guard. No phantom can slip past.
+
+## 8. Multi-node routing preserves the contract
+
+cyoda-go runs as a cluster (3–10 stateless nodes behind a load balancer
+for the postgres plugin; other plugins have their own topologies). The
+per-node `TransactionManager` holds per-transaction state (read-set,
+write-set, postgres `pgx.Tx` handle) in the process memory of the node
+that called `Begin`. Subsequent requests inside the same transaction
+must route back to that node — enforced by the cluster-mode dispatch
+layer (signed transaction tokens + HMAC-authenticated forwarding).
+
+The isolation contract is therefore preserved end-to-end: an API caller
+interacting with transaction `T` always lands on the same node for the
+duration of `T`; the `Commit` that finally applies FCW validation
+executes on the node that owns `T`. Cluster membership changes (node
+failure, scale-out) may cause in-flight transactions on the affected
+node to abort, but they cannot cause a committed transaction to be
+observed out of order or a concurrent transaction to slip past FCW
+validation.
+
+The memory and sqlite plugins are single-process: multi-node deployment
+is not supported (memory has no shared store; sqlite holds an exclusive
+file lock for the process lifetime). The postgres plugin is designed for
+multi-node; the commercial cassandra plugin is designed for
+multi-cluster.
+
+## 9. Isolation-level taxonomy for orientation
+
+For readers familiar with the standard isolation-level vocabulary:
+
+| Anomaly | READ COMMITTED | REPEATABLE READ (SI) | cyoda SI+FCW | Cahill SSI / PostgreSQL `SERIALIZABLE` |
+|---|---|---|---|---|
+| Dirty read | prevented | prevented | prevented | prevented |
+| Non-repeatable read | not prevented | prevented | prevented | prevented |
+| Phantom read | not prevented | partially prevented | partially prevented | prevented |
+| Lost update | not prevented | depends on engine | prevented | prevented |
+| Write-skew | not prevented | not prevented | not prevented for predicate reads; prevented for entity-level reads | prevented |
+
+**cyoda-go SI+FCW sits between plain SI and full Serializability.** It
+catches all the anomalies SI catches plus lost-update plus entity-level
+write-skew. The one remaining class is predicate-based write-skew, which
+the operational rule in §5 keeps workloads out of.
+
+PostgreSQL's native `SERIALIZABLE` catches predicate-based write-skew
+too, but at the cost of b-tree-page-granular dependency tracking that
+produces false-positive `40001` aborts on concurrent writes to disjoint
+rows that happen to share a page. Cyoda explicitly chose to not use that
+mode — see the postgres-si-first-committer-wins design spec for the
+trade-off analysis.
+
+## 10. Practical guidance for workflow authors
+
+A short checklist:
+
+1. **Express invariants as transition criteria on the entity being
+   transitioned.** Those criteria's reads are captured in the read-set;
+   FCW guards them.
+2. **If you need a count, keep the counter as an entity.** A "counters"
+   entity with well-known IDs you read/write by name is indistinguishable
+   from any other entity to the isolation layer — fully FCW-protected.
+3. **Never branch on `search(predicate).count()` inside a transactional
+   workflow step.** If you catch yourself writing this, step back and
+   apply (a) or (b) from §5.
+4. **Expect `spi.ErrConflict`; don't wrap it as an internal error.**
+   Conflicts are a normal signal that a concurrent transaction beat yours
+   to the commit. The retry loop lives at the API boundary (the HTTP
+   handler and gRPC service translate `ErrConflict` to `409 Conflict`
+   with `retryable: true`); internal code should let it bubble.
+5. **Keep transactions short.** Long-running transactions hold a larger
+   read-set, widening the window in which a concurrent committer can
+   invalidate it. If a workflow step needs to do slow work (e.g. an
+   external HTTP call), prefer `ASYNC_NEW_TX` so the slow part runs in a
+   separate transaction with its own short lifespan.
+6. **Don't assume Serializable-class isolation.** If your use case truly
+   needs phantom protection (e.g. compliance-driven "no more than N
+   entities in state X per tenant, ever"), either materialise the count
+   or add a reconciliation step.
+
+## 11. References
+
+- `docs/ARCHITECTURE.md` §3 — Transaction Model overview.
+- `docs/PRD.md` §4 — Transaction Model at the product level.
+- `docs/plugins/IN_MEMORY.md`, `SQLITE.md`, `POSTGRES.md` — per-plugin
+  implementation specifics.
+- `docs/superpowers/specs/2026-04-15-postgres-si-first-committer-wins-design.md`
+  — rationale for postgres plugin running at `REPEATABLE READ` instead
+  of native `SERIALIZABLE`.
+- `docs/superpowers/specs/2026-04-15-sqlite-storage-plugin-design.md` —
+  rationale for porting the memory plugin's SSI engine into sqlite.
+
+The commercial Cassandra plugin's own design document (shipped with the
+proprietary binary) captures the same semantic contract with the same
+§5 operational rule, verbatim.

--- a/docs/CONSISTENCY.md
+++ b/docs/CONSISTENCY.md
@@ -744,3 +744,211 @@ state for the rate-limited transition, and read all peer entities in
 the processor. The cap check then runs against a materialised peer set
 inside the transaction, and FCW converts concurrent violations into
 retryable conflicts.
+
+---
+
+## Appendix B: Scaling the fence — `Doctor` + `DutyRoster`
+
+Appendix A's processor calls `GetAll(Doctor)` on every `PROMOTE` and
+`STEP_DOWN`. That is O(total doctors) work per transition. In a small
+ward it is fine; in a hospital with ten thousand doctors across
+hundreds of shifts it becomes a scan hot path. Appendix B keeps the
+same SI+FCW fence guarantee but makes the contended read O(1).
+
+The idea concretises §5 alternative (a) — "promote the count to a
+materialised counter entity" — for the roster case: keep the roster
+membership in a dedicated `DutyRoster` entity with a well-known ID.
+Every `PROMOTE` / `STEP_DOWN` reads and writes that one entity;
+concurrent transitions collide on it via FCW.
+
+### B.1 Two-entity model
+
+Two entity types participate:
+
+- **`Doctor`** — the same FSM as Appendix A (`OFF_DUTY`,
+  `PENDING_ON_DUTY`, `ON_DUTY`, `STEPPING_DOWN`). Carries identity and
+  doctor-specific attributes.
+- **`DutyRoster`** — a long-lived coordination entity with a
+  deterministic ID (e.g. `"main"`, or one per shift/ward —
+  `"ward-A/shift-night"`). Holds the current membership and the cap.
+
+```text
+Doctor                          DutyRoster (id = "main")
+├─ id                           ├─ id
+├─ name, credentials, ...       ├─ max_cap:      int       // N
+└─ state: OFF_DUTY | PENDING_   ├─ min_cap:      int       // M, may be 0
+         ON_DUTY | ON_DUTY |    ├─ on_duty_ids:  [doctor_id]  (size ≤ max_cap)
+         STEPPING_DOWN          └─ stepping_down_ids: [doctor_id]
+```
+
+`DutyRoster` exists once per ward/shift and is provisioned at tenant
+setup. It has a trivial FSM — a single `ACTIVE` state is sufficient;
+no transition-level workflow is needed on it, only entity-level reads
+and writes from the `Doctor` transitions.
+
+### B.2 Doctor FSM and roster touch-points
+
+The `Doctor` FSM is exactly Appendix A's combined max-cap + min-cap
+diagram (§A.6). What changes is **where** the criterion and processor
+do their work: against the `DutyRoster` entity, not a `GetAll(Doctor)`
+scan.
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> OFF_DUTY: CREATE
+    OFF_DUTY --> PENDING_ON_DUTY: REQUEST_DUTY
+    PENDING_ON_DUTY --> OFF_DUTY: WITHDRAW
+    PENDING_ON_DUTY --> ON_DUTY: PROMOTE<br/>(reads/writes DutyRoster)
+    ON_DUTY --> STEPPING_DOWN: REQUEST_STEP_DOWN
+    STEPPING_DOWN --> ON_DUTY: CANCEL_STEP_DOWN
+    STEPPING_DOWN --> OFF_DUTY: STEP_DOWN<br/>(reads/writes DutyRoster)
+```
+
+| Doctor transition    | Reads `DutyRoster` | Writes `DutyRoster`            |
+|----------------------|--------------------|--------------------------------|
+| `CREATE`             | —                  | —                              |
+| `REQUEST_DUTY`       | —                  | —                              |
+| `WITHDRAW`           | —                  | —                              |
+| `PROMOTE`            | yes (get)          | yes (append self.id)           |
+| `REQUEST_STEP_DOWN`  | —                  | —                              |
+| `CANCEL_STEP_DOWN`   | —                  | —                              |
+| `STEP_DOWN`          | yes (get)          | yes (remove self.id)           |
+
+`REQUEST_DUTY`, `WITHDRAW`, `REQUEST_STEP_DOWN`, `CANCEL_STEP_DOWN` do
+not touch the roster. They are local-to-Doctor state changes with no
+invariant at stake. Only the transitions that cross the cap boundary
+go through the shared entity.
+
+### B.3 Criterion and processor pseudocode
+
+```text
+// PROMOTE: PENDING_ON_DUTY → ON_DUTY
+criterion promote_ok(self):
+    roster := entityStore.Get(DutyRoster, rosterIDFor(self))
+    return len(roster.on_duty_ids) < roster.max_cap
+
+processor promote(self):
+    roster := entityStore.Get(DutyRoster, rosterIDFor(self))  // read-set
+    if len(roster.on_duty_ids) >= roster.max_cap:
+        return error("cap reached")
+    roster.on_duty_ids = roster.on_duty_ids + [self.id]
+    entityStore.Save(DutyRoster, roster)                      // write-set
+    self.state = ON_DUTY
+
+// STEP_DOWN: STEPPING_DOWN → OFF_DUTY
+criterion step_down_ok(self):
+    roster := entityStore.Get(DutyRoster, rosterIDFor(self))
+    remaining := len(roster.on_duty_ids) + len(roster.stepping_down_ids)
+                 - 1  // subtract self
+    return remaining >= roster.min_cap
+
+processor step_down(self):
+    roster := entityStore.Get(DutyRoster, rosterIDFor(self))  // read-set
+    roster.on_duty_ids       = remove(roster.on_duty_ids,       self.id)
+    roster.stepping_down_ids = remove(roster.stepping_down_ids, self.id)
+    remaining := len(roster.on_duty_ids) + len(roster.stepping_down_ids)
+    if remaining < roster.min_cap:
+        return error("min-cap violated")
+    entityStore.Save(DutyRoster, roster)                      // write-set
+    self.state = OFF_DUTY
+```
+
+`REQUEST_STEP_DOWN` (`ON_DUTY → STEPPING_DOWN`) and its cancel path
+should also update `stepping_down_ids` on the roster — both are
+membership moves within the cap-relevant set. Mechanically they are
+the same pattern (read `DutyRoster`, mutate the two lists, save). For
+brevity those variants are omitted.
+
+### B.4 Why this is still a fence
+
+Two concurrent `PROMOTE` transactions, both seeing `len(on_duty_ids) =
+cap − 1`:
+
+```text
+T1 (promote Carol):
+  read  DutyRoster@v1 → on_duty_ids=[Alice,Bob], max_cap=3
+  write DutyRoster@v2 (on_duty_ids=[Alice,Bob,Carol])
+  write Carol.state = ON_DUTY
+
+T2 (promote Dave):
+  read  DutyRoster@v1 → on_duty_ids=[Alice,Bob], max_cap=3
+  write DutyRoster@v2 (on_duty_ids=[Alice,Bob,Dave])
+  write Dave.state = ON_DUTY
+```
+
+Both transactions attempt a write to the **same** `DutyRoster` entity.
+Cyoda's entity-level conflict detection resolves this two ways, either
+of which is sufficient:
+
+- **Write-write at DML time** (postgres): whichever transaction's
+  `UPDATE` on the `DutyRoster` row reaches the engine first takes the
+  tuple-exclusive lock. The second `UPDATE` blocks on that lock; when
+  the first commits, the second raises `40001`
+  (`could not serialize access due to concurrent update`) → mapped to
+  `spi.ErrConflict`.
+- **Read-set validation at commit** (all plugins): the loser read
+  `DutyRoster@v1`, but the winner committed `DutyRoster@v2`.
+  `ValidateReadSet` (`plugins/postgres/txstate.go:116`) finds the
+  mismatch and returns `spi.ErrConflict`.
+
+One succeeds; the other retries. On retry it re-reads the roster, sees
+the cap now full, and its criterion returns `false`. No scan required.
+
+### B.5 Cost comparison
+
+Per `PROMOTE` / `STEP_DOWN` transaction:
+
+| Approach                       | Entities in read-set | Entities in write-set |
+|--------------------------------|----------------------|-----------------------|
+| Appendix A (`GetAll(Doctor)`)  | total Doctor count   | `{self, DutyRoster?}` → `{self}` |
+| Appendix B (`DutyRoster`)      | `{DutyRoster}`       | `{self, DutyRoster}`  |
+
+Appendix A scales O(total doctors). Appendix B scales O(1) —
+independent of how many doctors exist in the tenant.
+
+The read-set size matters for commit cost: on postgres the commit
+phase runs `SELECT ... FOR SHARE` across the read-set
+(`plugins/postgres/commit_validator.go`); a large read-set means a
+large validation query.
+
+### B.6 Sharding to avoid global contention
+
+The price of Appendix B is that every promotion in a ward funnels
+through one entity. That is correct behaviour — it is precisely the
+serialisation the invariant requires — but it means a single
+`DutyRoster` is a contention point for the whole ward.
+
+Two mitigations, both natural in the entity model:
+
+- **Partition by scope.** Use `DutyRoster` per ward, per shift, or per
+  speciality, whichever matches the business-level invariant. The cap
+  is usually scoped anyway ("at most 3 on duty **per ward**"); the
+  roster should be scoped to match. Promotions in different wards
+  contend on different `DutyRoster` entities and proceed in parallel.
+
+  ```text
+  rosterIDFor(doctor) = "ward-" + doctor.ward + "/shift-" + doctor.shift
+  ```
+
+- **Accept expected retry rate.** Under realistic promotion rates
+  (human operators, not machine-driven), contention on a single
+  per-ward roster is low. `spi.ErrConflict` → HTTP `409 retryable` is
+  the correct API-level signal; the client retries and succeeds on the
+  next snapshot.
+
+The fence itself does not change; only the sharding key does.
+
+### B.7 When to pick A vs B
+
+- **Appendix A** is the right starting point when the roster is small
+  (tens of doctors per tenant) and the ops rate is low. It has no
+  extra entity to provision or migrate; the membership is reconstructible
+  from `Doctor` state alone.
+- **Appendix B** is the right starting point when rosters are large
+  or ops rates are high, or when the roster itself is a user-visible
+  concept ("who is on duty right now?") — that single read is already
+  natural to surface through the API.
+
+Both use the same fence; neither depends on Cahill SSI. The choice is
+a cost trade-off, not a correctness trade-off.

--- a/docs/CONSISTENCY.md
+++ b/docs/CONSISTENCY.md
@@ -473,30 +473,95 @@ enforce two invariants:
    `ON_DUTY` and `PENDING_ON_DUTY`. It does **not** call
    `Count`/`CountByState`.
 
-The model:
+#### A.3.1 State diagram
 
-```text
-states:      OFF_DUTY, PENDING_ON_DUTY, ON_DUTY
-transitions: OFF_DUTY        → PENDING_ON_DUTY   (REQUEST_DUTY)
-             PENDING_ON_DUTY → ON_DUTY           (PROMOTE)
-             PENDING_ON_DUTY → OFF_DUTY          (WITHDRAW)
-             ON_DUTY         → OFF_DUTY          (STEP_DOWN)
+There is **no** transition into `ON_DUTY` except `PROMOTE` from
+`PENDING_ON_DUTY`. Creation lands in `OFF_DUTY` only. This is the whole
+point of the fence: the FSM itself forbids the write-skew-enabling
+direct path.
 
-PROMOTE processor (pseudocode):
-  all := entityStore.GetAll(Doctor)              // populates read-set
-  onDuty   := filter(all, state = ON_DUTY)
-  pending  := filter(all, state = PENDING_ON_DUTY)
-  if len(onDuty) >= N: return error("cap reached")
-  // Optional ordering rule to pick a winner deterministically on retry:
-  // require self.id == min(pending.id) or similar.
-  self.state = ON_DUTY
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> OFF_DUTY: CREATE
+    OFF_DUTY --> PENDING_ON_DUTY: REQUEST_DUTY
+    PENDING_ON_DUTY --> OFF_DUTY: WITHDRAW
+    PENDING_ON_DUTY --> ON_DUTY: PROMOTE<br/>(fence: criterion + processor)
+    ON_DUTY --> OFF_DUTY: STEP_DOWN
 ```
 
-The critical step is `GetAll(Doctor)`. On the postgres plugin that call
-walks the entities table and, per
-`plugins/postgres/entity_store.go:232-236`, calls `recordReadIfInTx` for
-every returned row. Every current `Doctor` — whatever its state —
-enters the transaction's read-set with its observed version.
+ASCII equivalent for terminal readers:
+
+```text
+                 CREATE
+                   │
+                   ▼
+              ┌─────────┐   REQUEST_DUTY   ┌──────────────────┐
+              │ OFF_DUTY │ ───────────────▶ │ PENDING_ON_DUTY  │
+              │         │ ◀─────────────── │                  │
+              └─────────┘    WITHDRAW      └──────────────────┘
+                   ▲                                │
+                   │                        PROMOTE │ ← fence here
+                   │ STEP_DOWN                      │   (criterion + processor
+                   │                                │    read all Doctors)
+                   │                                ▼
+                   └──────────────────────── ┌──────────┐
+                                             │ ON_DUTY  │
+                                             └──────────┘
+
+Forbidden paths (enforced by the FSM — no such transitions exist):
+  × CREATE → ON_DUTY          (no direct admit)
+  × OFF_DUTY → ON_DUTY        (must go through PENDING_ON_DUTY)
+  × any path bypassing PROMOTE's criterion/processor
+```
+
+#### A.3.2 Transition table
+
+| Transition    | From              | To                | Criterion        | Processor    |
+|---------------|-------------------|-------------------|------------------|--------------|
+| `CREATE`      | `[*]`             | `OFF_DUTY`        | —                | —            |
+| `REQUEST_DUTY`| `OFF_DUTY`        | `PENDING_ON_DUTY` | —                | —            |
+| `WITHDRAW`    | `PENDING_ON_DUTY` | `OFF_DUTY`        | —                | —            |
+| `PROMOTE`     | `PENDING_ON_DUTY` | `ON_DUTY`         | `promote_ok`     | `promote`    |
+| `STEP_DOWN`   | `ON_DUTY`         | `OFF_DUTY`        | `step_down_ok`   | —            |
+
+#### A.3.3 Criterion and processor pseudocode
+
+The two invariant-bearing callbacks live on `PROMOTE`. Both do an
+**entity-level** read of all peers — `GetAll` on the postgres plugin
+walks the entities table and calls `recordReadIfInTx` for every row
+(`plugins/postgres/entity_store.go:232-236`), so every peer's version
+enters the transaction's read-set.
+
+```text
+criterion promote_ok(self):
+    all := entityStore.GetAll(model = Doctor)   // populates read-set
+    onDuty := [ d for d in all if d.state == ON_DUTY ]
+    return len(onDuty) < N
+
+processor promote(self):
+    all := entityStore.GetAll(model = Doctor)   // populates read-set
+    onDuty  := [ d for d in all if d.state == ON_DUTY ]
+    pending := [ d for d in all if d.state == PENDING_ON_DUTY ]
+    if len(onDuty) >= N:
+        return error("cap reached")
+    // Optional deterministic-winner rule (reduces useless retries
+    // under contention; not required for the fence):
+    //   if self.id != min(d.id for d in pending):
+    //       return error("yield to earlier PENDING candidate")
+    self.state = ON_DUTY
+```
+
+Non-negotiables for the author:
+
+- Use `GetAll` (or an equivalent predicate scan that returns entities).
+  **Never** use `Count` / `CountByState` here — aggregates do not
+  populate the read-set and silently disable the fence.
+- Read then filter. Filter-then-read via a non-transactional pre-fetch
+  shrinks the read-set and lets peers slip past.
+- The criterion's `GetAll` and the processor's `GetAll` hit the same
+  read-set (first-read-wins — `plugins/postgres/txstate.go:58-70`). The
+  redundancy is harmless; collapse to one if preferred.
 
 ### A.4 Why this is a fence — step by step
 
@@ -558,23 +623,76 @@ FCW needs.
 
 ### A.6 The symmetric case: minimum-cap
 
-The invariant "at least one doctor must be `ON_DUTY`" uses the same
-structure in reverse. Introduce a `STEPPING_DOWN` state. The transition
-`STEPPING_DOWN → OFF_DUTY` carries a processor that reads all doctors,
-confirms at least one remaining would be in `ON_DUTY` or
-`STEPPING_DOWN` but committing their own step-down, and writes the
-self state.
+The invariant "at least `M` doctors must be `ON_DUTY`" uses the same
+structure in reverse. Introduce a `STEPPING_DOWN` state. `ON_DUTY`
+exits only through `STEPPING_DOWN`; `STEPPING_DOWN → OFF_DUTY` carries
+the fence criterion/processor.
 
-Two doctors concurrently stepping down from `ON_DUTY` each capture the
-other in the read-set (peer is `ON_DUTY`), each writes their own
-entity. One commits; the other aborts on read-set validation because
-the peer's `ON_DUTY → STEPPING_DOWN` or `STEPPING_DOWN → OFF_DUTY`
-write landed first. The user retries, re-evaluates the criterion, and
-now sees correctly that dropping below 1 would violate the invariant.
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> OFF_DUTY: CREATE
+    OFF_DUTY --> PENDING_ON_DUTY: REQUEST_DUTY
+    PENDING_ON_DUTY --> OFF_DUTY: WITHDRAW
+    PENDING_ON_DUTY --> ON_DUTY: PROMOTE<br/>(max-cap fence)
+    ON_DUTY --> STEPPING_DOWN: REQUEST_STEP_DOWN
+    STEPPING_DOWN --> ON_DUTY: CANCEL_STEP_DOWN
+    STEPPING_DOWN --> OFF_DUTY: STEP_DOWN<br/>(min-cap fence)
+```
 
-The `STEPPING_DOWN` intermediate state is the symmetric mirror of
-`PENDING_ON_DUTY`: it serialises the conflict through a read-before-write
-point where peer entities are observable.
+ASCII equivalent:
+
+```text
+ CREATE
+   │
+   ▼
+┌─────────┐ REQUEST_DUTY ┌──────────────┐  PROMOTE   ┌──────────┐
+│OFF_DUTY │─────────────▶│PENDING_ON_DTY│───────────▶│ ON_DUTY  │
+│         │◀─────────────│              │            │          │
+└─────────┘   WITHDRAW   └──────────────┘            └──────────┘
+   ▲                                                       │
+   │                                                       │ REQUEST_STEP_DOWN
+   │ STEP_DOWN (min-cap fence)                             ▼
+   │                                                 ┌──────────────┐
+   └──────────────────────────────────────────────── │STEPPING_DOWN │
+                                                     │              │
+                                                     └──────────────┘
+                                                           ▲
+                                                           │ CANCEL_STEP_DOWN
+                                                           │ (back to ON_DUTY)
+
+Forbidden paths (enforced by the FSM):
+  × ON_DUTY → OFF_DUTY direct        (must pass STEPPING_DOWN)
+  × STEPPING_DOWN → OFF_DUTY without criterion   (no such transition)
+```
+
+Criterion and processor pseudocode:
+
+```text
+criterion step_down_ok(self):
+    all := entityStore.GetAll(model = Doctor)   // populates read-set
+    // Peer count of doctors who will still be ON_DUTY or
+    // STEPPING_DOWN after this transition. Self is excluded since
+    // we're leaving the set.
+    remaining := [
+        d for d in all
+        if d.id != self.id and d.state in (ON_DUTY, STEPPING_DOWN)
+    ]
+    return len(remaining) >= M
+```
+
+Two doctors concurrently invoking `STEP_DOWN`:
+
+- Each `GetAll` captures the other in the read-set (both were `ON_DUTY`
+  or `STEPPING_DOWN` at the respective snapshots).
+- Each writes its own entity (own state → `OFF_DUTY`).
+- First committer wins. Second's `ValidateReadSet` observes peer has
+  moved and returns `spi.ErrConflict`. The retry re-reads the now-
+  depleted set and the criterion correctly rejects dropping below `M`.
+
+The `STEPPING_DOWN` intermediate state mirrors `PENDING_ON_DUTY`: it
+serialises the conflict through a read-before-write point where peer
+entities are observable.
 
 ### A.7 Residual phantoms the fence does NOT close
 

--- a/docs/CONSISTENCY.md
+++ b/docs/CONSISTENCY.md
@@ -184,7 +184,7 @@ All plugins honour the same contract. Implementation strategy varies.
 | Plugin | Engine-level mechanism | Application-layer validation | Effective guarantee | Conflict granularity |
 |---|---|---|---|---|
 | **memory** | n/a — all in-process Go | Committed-log + per-transaction read/write-set tracking; first-committer-wins at commit | **SI+FCW** | per-entity |
-| **sqlite** | Database-level write lock (single writer at the engine level) | Same SI+FCW engine code ported from memory; SQLite is the durability layer only | **SI+FCW** | per-entity |
+| **sqlite** | Database-level write lock (single writer at the engine level) | Application-layer SI+FCW; SQLite is the durability layer only | **SI+FCW** | per-entity |
 | **postgres** | `REPEATABLE READ` (snapshot) + row-level tuple locks on entity tables | Entity-keyed read-set validation at commit; `40001` (`could not serialize access`) and `40P01` (`deadlock_detected`) mapped to `spi.ErrConflict` with bounded retry | **SI+FCW** | per-entity (via tuple locks on 1-to-1 `entities` table) |
 | **cassandra** (commercial) | *(proprietary)* | *(plugin-internal)* | **SI+FCW** | per-entity |
 

--- a/docs/CONSISTENCY.md
+++ b/docs/CONSISTENCY.md
@@ -84,9 +84,9 @@ without full predicate locking). No conflict is detected.
 
 In isolation-level terms: cyoda provides **Snapshot Isolation with
 First-Committer-Wins on entity-level conflicts** — not full Serializability.
-This matches the semantic Oracle's `SERIALIZABLE`, SQL Server's `SNAPSHOT`,
-and MySQL InnoDB's `REPEATABLE READ` with commit-time validation deliver.
-It is weaker than PostgreSQL's native `SERIALIZABLE` (Cahill SSI with
+This matches the semantic that Oracle's `SERIALIZABLE` mode (snapshot
+isolation with commit-time read-set validation) delivers. It is weaker
+than PostgreSQL's native `SERIALIZABLE` (Cahill SSI with
 rw-antidependency tracking) on precisely this one anomaly class.
 
 The cyoda postgres plugin deliberately runs at `REPEATABLE READ` and

--- a/docs/CONSISTENCY.md
+++ b/docs/CONSISTENCY.md
@@ -749,17 +749,51 @@ retryable conflicts.
 
 ## Appendix B: Scaling the fence — `Doctor` + `DutyRoster`
 
-Appendix A's processor calls `GetAll(Doctor)` on every `PROMOTE` and
-`STEP_DOWN`. That is O(total doctors) work per transition. In a small
-ward it is fine; in a hospital with ten thousand doctors across
-hundreds of shifts it becomes a scan hot path. Appendix B keeps the
-same SI+FCW fence guarantee but makes the contended read O(1).
+Doctors on call is a teaching example. The class of invariants it
+represents — "at most N members of a set may be in state Y, at any
+time" — is pervasive in production workloads, and in most of them the
+member population is orders of magnitude larger than a hospital
+roster:
+
+- **Payments.** "A customer may have at most K pending authorisations
+  against an account." Peer population: every authorisation in the
+  system — millions per tenant, tens of thousands per account.
+- **Consumer systems.** "A user may have at most N active sessions,
+  subscriptions, or API keys." Peer population: every session ever
+  created for that user.
+- **Inventory and oversell protection.** "At most `stock` orders may
+  hold a reserved unit of SKU X at any time." Peer population: every
+  reservation against that SKU.
+- **Rate-limited resources.** "At most N jobs may be in state RUNNING
+  for this queue." Peer population: every job routed through the queue.
+- **Regulated caps.** "A tenant may have at most N entities of type X
+  in state Y" for compliance-driven quotas. Peer population: the full
+  tenant corpus.
+
+Appendix A's processor calls `GetAll(Doctor)` on every `PROMOTE` /
+`STEP_DOWN`. That is O(peer population) per transition. For a small
+ward it is fine. For any of the examples above it is catastrophic: a
+payment-authorisation workflow doing a full scan of authorisations per
+write is not viable at any meaningful throughput, and the read-set it
+produces would make commit-time validation (`SELECT ... FOR SHARE`
+over the read-set on postgres) the bottleneck even before engine-level
+concerns kick in.
+
+The dual-entity model cuts this to O(1). The workflow stops asking
+"what is true of the whole peer population?" and instead reads and
+writes a dedicated **coordination entity** that maintains just the
+cap-relevant summary. Every transition that can violate the invariant
+passes through that single entity, and FCW on it serialises
+concurrent violators. The peer scan disappears; the fence remains.
 
 The idea concretises §5 alternative (a) — "promote the count to a
-materialised counter entity" — for the roster case: keep the roster
-membership in a dedicated `DutyRoster` entity with a well-known ID.
-Every `PROMOTE` / `STEP_DOWN` reads and writes that one entity;
-concurrent transitions collide on it via FCW.
+materialised counter entity" — for invariants over large populations.
+For the roster, the coordination entity is `DutyRoster`. For payments
+it would be `AccountAuthorizationCounter`; for sessions,
+`UserSessionCounter`; for inventory, the SKU's `Reservation` record.
+The shape is the same: one long-lived entity with a deterministic ID,
+read and written by every transition that crosses the cap boundary,
+contended-on by FCW.
 
 ### B.1 Two-entity model
 

--- a/docs/CONSISTENCY.md
+++ b/docs/CONSISTENCY.md
@@ -387,3 +387,242 @@ A short checklist:
 The commercial Cassandra plugin's own design document (shipped with the
 proprietary binary) captures the same semantic contract with the same
 §5 operational rule, verbatim.
+
+---
+
+## Appendix A: Worked example — the Doctor On-Call Roster
+
+The Doctor On-Call Roster is the classic write-skew teaching example. It
+is instructive for cyoda because it shows, concretely, how the
+state-machine discipline turns a predicate anti-dependency (which SI+FCW
+does not catch) into an entity-level read/write conflict (which it does).
+
+### A.1 The invariant and the naive failure
+
+A hospital has an on-call roster. The invariant for this appendix:
+
+> **At most `N` doctors may be ON_DUTY at any one time.**
+
+(The symmetric "at least one must be ON_DUTY" works the same way;
+A.6 addresses it briefly.)
+
+Naive model: a `Doctor` entity with two states, `OFF_DUTY` and `ON_DUTY`.
+The promotion transition `OFF_DUTY → ON_DUTY` carries a criterion that
+counts current ON_DUTY doctors and rejects if the cap would be exceeded.
+
+```text
+transition PROMOTE:
+  from:      OFF_DUTY
+  to:        ON_DUTY
+  criterion: Count(Doctor where state = ON_DUTY) < N
+```
+
+Two concurrent transactions, each promoting a different doctor, both
+start before either commits:
+
+```text
+Initial: Alice, Bob ON_DUTY (count = 2). Cap N = 3. Carol, Dave OFF_DUTY.
+
+T1: promote Carol to ON_DUTY
+    Count(ON_DUTY) = 2 at snapshot → 2 < 3 → criterion passes
+    write Carol @ state = ON_DUTY
+
+T2: promote Dave to ON_DUTY
+    Count(ON_DUTY) = 2 at snapshot → 2 < 3 → criterion passes
+    write Dave @ state = ON_DUTY
+
+T1 commits. T2 commits. Final: 4 ON_DUTY. Invariant violated.
+```
+
+This is the phantom case from §7.3, expressed at the workflow level.
+
+### A.2 Why SI+FCW does not catch it out of the box
+
+Under cyoda's contract (§1), FCW triggers when a transaction's read-set
+intersects a concurrent committer's write-set. In the naive design:
+
+- T1's read-set contains `{Alice, Bob}` (the ON_DUTY doctors Count
+  would surface) — but the postgres plugin's `Count` does not populate
+  the read-set at all: it is an aggregate with no per-row identity, and
+  `plugins/postgres/entity_store.go:376` documents that exclusion
+  explicitly.
+- T1's write-set contains `{Carol}`.
+- T2's read-set (if populated) would be the same `{Alice, Bob}`; its
+  write-set is `{Dave}`.
+
+Read-sets and write-sets are entity-identity-disjoint across T1 and T2.
+Nothing for FCW to latch onto. Both commit. The predicate "how many
+ON_DUTY doctors exist" is not an entity — it is a count over a range —
+and the snapshot neither of T1 nor of T2 saw the other's addition
+because the addition didn't exist at their respective `Begin`.
+
+### A.3 The workflow fence: `PENDING_ON_DUTY`
+
+Introduce a third state, `PENDING_ON_DUTY`, and make the workflow
+enforce two invariants:
+
+1. **All admissions go through `PENDING_ON_DUTY` first.** A `Doctor`
+   entity can only enter `ON_DUTY` from `PENDING_ON_DUTY`, never
+   directly from `OFF_DUTY` or from creation. Enforced by the FSM: no
+   transition `OFF_DUTY → ON_DUTY` exists; there is only
+   `OFF_DUTY → PENDING_ON_DUTY` and `PENDING_ON_DUTY → ON_DUTY`.
+2. **The promotion processor reads every peer candidate by entity, not
+   by aggregate.** The `PENDING_ON_DUTY → ON_DUTY` transition's
+   processor calls `entityStore.GetAll(Doctor)` (or an equivalent that
+   returns individual entities) and filters in-memory for states
+   `ON_DUTY` and `PENDING_ON_DUTY`. It does **not** call
+   `Count`/`CountByState`.
+
+The model:
+
+```text
+states:      OFF_DUTY, PENDING_ON_DUTY, ON_DUTY
+transitions: OFF_DUTY        → PENDING_ON_DUTY   (REQUEST_DUTY)
+             PENDING_ON_DUTY → ON_DUTY           (PROMOTE)
+             PENDING_ON_DUTY → OFF_DUTY          (WITHDRAW)
+             ON_DUTY         → OFF_DUTY          (STEP_DOWN)
+
+PROMOTE processor (pseudocode):
+  all := entityStore.GetAll(Doctor)              // populates read-set
+  onDuty   := filter(all, state = ON_DUTY)
+  pending  := filter(all, state = PENDING_ON_DUTY)
+  if len(onDuty) >= N: return error("cap reached")
+  // Optional ordering rule to pick a winner deterministically on retry:
+  // require self.id == min(pending.id) or similar.
+  self.state = ON_DUTY
+```
+
+The critical step is `GetAll(Doctor)`. On the postgres plugin that call
+walks the entities table and, per
+`plugins/postgres/entity_store.go:232-236`, calls `recordReadIfInTx` for
+every returned row. Every current `Doctor` — whatever its state —
+enters the transaction's read-set with its observed version.
+
+### A.4 Why this is a fence — step by step
+
+Now replay the scenario. Carol and Dave start in `PENDING_ON_DUTY`, not
+`OFF_DUTY`.
+
+```text
+Initial: Alice, Bob ON_DUTY. Carol, Dave PENDING_ON_DUTY. Cap N = 3.
+
+T1: PROMOTE Carol
+    GetAll → {Alice@v, Bob@v, Carol@v, Dave@v} all enter read-set
+    onDuty = {Alice, Bob}; pending = {Carol, Dave}
+    len(onDuty)=2 < 3 → criterion passes
+    write Carol @ state=ON_DUTY  (Carol promoted from read-set to write-set)
+    T1 commit snapshot: read-set = {Alice, Bob, Dave}, write-set = {Carol}
+
+T2: PROMOTE Dave
+    GetAll → {Alice@v, Bob@v, Carol@v, Dave@v} all enter read-set
+    onDuty = {Alice, Bob}; pending = {Carol, Dave}
+    len(onDuty)=2 < 3 → criterion passes
+    write Dave @ state=ON_DUTY
+    T2 commit snapshot: read-set = {Alice, Bob, Carol}, write-set = {Dave}
+```
+
+Compare read-sets to concurrent write-sets:
+
+- `T1.readSet ∩ T2.writeSet = {Alice,Bob,Dave} ∩ {Dave} = {Dave}` — non-empty.
+- `T2.readSet ∩ T1.writeSet = {Alice,Bob,Carol} ∩ {Carol} = {Carol}` — non-empty.
+
+Whichever commits first wins; the other's `ValidateReadSet` finds the
+peer it observed has been modified and returns `spi.ErrConflict`. FCW
+has transformed what was a predicate-level anti-dependency into a
+concrete entity-level read/write conflict it can see.
+
+The mechanism is exactly what `plugins/postgres/txstate.go:116-129`
+describes: at commit, every entity in the read-set is checked against
+its latest committed version; any mismatch aborts.
+
+### A.5 What the two invariants are buying
+
+Each invariant plugs a specific leak.
+
+**Invariant 1 (all admissions through `PENDING_ON_DUTY`)** exists
+because a blind direct insert in `ON_DUTY` — `create Doctor with
+state=ON_DUTY` — is a *new* entity. It does not exist at any concurrent
+transaction's snapshot, so it cannot enter their read-sets. Two
+concurrent blind inserts, each reading `Count(ON_DUTY) < N`, both
+commit. The `PENDING_ON_DUTY` pre-registration makes every candidate a
+discoverable entity in the transaction system *before* its promotion
+becomes visible, so concurrent promotion transactions see each other's
+candidates as peers in their read-sets.
+
+**Invariant 2 (entity-level read, not aggregate)** exists because `Count`
+and `CountByState` do not populate the read-set. An author who writes
+`if CountByState(Doctor, [ON_DUTY]).sum() < N` inside a criterion gets
+the exact naive-failure mode from A.1 even with `PENDING_ON_DUTY` in
+the model. `GetAll`-and-filter preserves the per-entity identity that
+FCW needs.
+
+### A.6 The symmetric case: minimum-cap
+
+The invariant "at least one doctor must be `ON_DUTY`" uses the same
+structure in reverse. Introduce a `STEPPING_DOWN` state. The transition
+`STEPPING_DOWN → OFF_DUTY` carries a processor that reads all doctors,
+confirms at least one remaining would be in `ON_DUTY` or
+`STEPPING_DOWN` but committing their own step-down, and writes the
+self state.
+
+Two doctors concurrently stepping down from `ON_DUTY` each capture the
+other in the read-set (peer is `ON_DUTY`), each writes their own
+entity. One commits; the other aborts on read-set validation because
+the peer's `ON_DUTY → STEPPING_DOWN` or `STEPPING_DOWN → OFF_DUTY`
+write landed first. The user retries, re-evaluates the criterion, and
+now sees correctly that dropping below 1 would violate the invariant.
+
+The `STEPPING_DOWN` intermediate state is the symmetric mirror of
+`PENDING_ON_DUTY`: it serialises the conflict through a read-before-write
+point where peer entities are observable.
+
+### A.7 Residual phantoms the fence does NOT close
+
+The fence is only as strong as invariants 1 and 2. Specific residuals:
+
+- **Creation that bypasses `PENDING_ON_DUTY`.** If the API surface
+  allows a doctor to be created directly with `state=ON_DUTY` (whether
+  via admin tooling, import, or a badly modelled FSM), the pre-existing
+  promotion transactions cannot see that new entity until it commits,
+  and the fence is bypassed. The FSM must prohibit this transition;
+  import and administrative paths must too.
+- **Workflow author calls `CountByState` instead of `GetAll`.** Silent
+  bypass — the criterion passes, no read-set is populated. Enforceable
+  by code review and the §5 operational rule.
+- **Criterion reads a subset of candidates.** If the processor filters
+  the `GetAll` results before recording reads (e.g., by using a
+  non-transactional pre-fetch), the read-set shrinks and peers outside
+  the filter fall through. Always read then filter; never filter then
+  read.
+
+### A.8 On the "workflow fence" framing
+
+The draft article's framing — that a well-modelled workflow "fences"
+against write-skew without needing Cahill SSI — is correct **for
+cyoda's isolation model** provided the two invariants in A.3 hold. The
+mechanics:
+
+- Workflows materialise peer candidates as identifiable entities
+  (invariant 1).
+- Workflow processors read those peers by entity, not by aggregate
+  (invariant 2).
+- Entity-level reads populate the read-set; FCW at commit enforces
+  entity-level conflicts.
+- The result is the same serialisable outcome Cahill SSI would give,
+  but obtained through application-layer structure rather than
+  b-tree-page-granular engine-level dependency tracking.
+
+This is not a universal claim about workflows and databases — it is a
+specific claim about what cyoda's SI+FCW contract delivers when the
+workflow author observes §5 and follows the pattern in this appendix.
+Workloads that cannot be modelled this way (ad-hoc predicate analytics
+over uncoordinated entity sets, for instance) should use one of the
+alternatives in §5.
+
+The pattern generalises. Any invariant of the form "at most N entities
+of type X in state Y" or "at least M entities of type X in state Y"
+admits an analogous fence: introduce a pending/stepping intermediate
+state for the rate-limited transition, and read all peer entities in
+the processor. The cap check then runs against a materialised peer set
+inside the transaction, and FCW converts concurrent violations into
+retryable conflicts.

--- a/docs/CONSISTENCY.md
+++ b/docs/CONSISTENCY.md
@@ -184,7 +184,7 @@ All plugins honour the same contract. Implementation strategy varies.
 | Plugin | Engine-level mechanism | Application-layer validation | Effective guarantee | Conflict granularity |
 |---|---|---|---|---|
 | **memory** | n/a — all in-process Go | Committed-log + per-transaction read/write-set tracking; first-committer-wins at commit | **SI+FCW** | per-entity |
-| **sqlite** | Database-level write lock (single writer at the engine level) | Same SSI-engine code ported from memory; SQLite is the durability layer only | **SI+FCW** | per-entity |
+| **sqlite** | Database-level write lock (single writer at the engine level) | Same SI+FCW engine code ported from memory; SQLite is the durability layer only | **SI+FCW** | per-entity |
 | **postgres** | `REPEATABLE READ` (snapshot) + row-level tuple locks on entity tables | Entity-keyed read-set validation at commit; `40001` (`could not serialize access`) and `40P01` (`deadlock_detected`) mapped to `spi.ErrConflict` with bounded retry | **SI+FCW** | per-entity (via tuple locks on 1-to-1 `entities` table) |
 | **cassandra** (commercial) | *(proprietary)* | *(plugin-internal)* | **SI+FCW** | per-entity |
 
@@ -382,7 +382,7 @@ A short checklist:
   — rationale for postgres plugin running at `REPEATABLE READ` instead
   of native `SERIALIZABLE`.
 - `docs/superpowers/specs/2026-04-15-sqlite-storage-plugin-design.md` —
-  rationale for porting the memory plugin's SSI engine into sqlite.
+  rationale for porting the memory plugin's SI+FCW engine into sqlite.
 
 The commercial Cassandra plugin's own design document (shipped with the
 proprietary binary) captures the same semantic contract with the same

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -293,13 +293,13 @@ engine's primitives:
 | Plugin | Engine primitives | Handle |
 |--------|-------------------|--------|
 | **memory** | Application-layer committed-log scan; entity-level read set + write set tracking | In-process `Transaction` struct |
-| **sqlite** | Application-layer first-committer-wins (ported from memory); single-writer SQLite transaction under application coordination | In-process coordinator + local `sql.Tx` |
+| **sqlite** | Application-layer first-committer-wins over a single-writer SQLite transaction | In-process coordinator + local `sql.Tx` |
 | **postgres** | PostgreSQL `REPEATABLE READ` + row-level locks + commit-time read-set validation; conflicts surface as `spi.ErrConflict` | In-process lifecycle tracker; `pgx.Tx` held per-statement inside stores |
 | **cassandra** (commercial) | Proprietary mechanism against Cassandra primitives, delivering the same SI+FCW contract | Plugin-managed |
 
-SQLite plugin uses application-layer first-committer-wins ported from
-the memory plugin; the commercial Cassandra plugin implements the
-same contract against its own primitives.
+The memory and sqlite plugins share an application-layer
+first-committer-wins implementation; the commercial Cassandra plugin
+implements the same contract against its own primitives.
 
 ### Transaction Lifecycle
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -59,9 +59,16 @@ Scale envelope depends on the active storage plugin:
 
 ### Core Value Proposition
 
-Zero-compromise transactional safety. Every storage plugin delivers
-the same isolation contract: **Snapshot Isolation with
-First-Committer-Wins on entity-level conflicts.** This guarantees:
+Cyoda-Go delivers two properties that are usually traded off against
+each other: **zero-compromise transactional safety** and **immutable
+bi-temporal history at current-read performance**. Both are uniform
+across every storage plugin.
+
+#### 1. Zero-compromise transactional safety
+
+Every storage plugin delivers the same isolation contract: **Snapshot
+Isolation with First-Committer-Wins on entity-level conflicts.** This
+guarantees:
 
 - **Strict read-your-own-writes** — within a transaction, reads always
   reflect prior writes from that transaction, even before commit.
@@ -83,6 +90,43 @@ application code sees the same concurrency semantics regardless of
 which storage plugin is active. See `docs/CONSISTENCY.md` for the
 full contract, the phantom-read caveat, the operational rule for
 workflow authors, and the isolation-level taxonomy.
+
+#### 2. Immutable bi-temporal history as a first-class property
+
+Every mutation to an entity produces an **immutable version**. Prior
+versions are never overwritten and never deleted — soft-delete itself
+is a version in the chain, reversible without data loss. The version
+chain *is* the audit trail; there is no separate audit table that can
+drift from state.
+
+Every version carries two timestamps:
+
+- **`valid_time`** — when the fact was true in the domain.
+- **`transaction_time`** — when the system recorded it.
+
+This bi-temporal model answers both "what did we know, and when?" and
+"what was true, and when?" — the distinction that compliance,
+reconciliation, and historical reporting workloads require. Correcting
+a past fact adds a new version with earlier `valid_time` and current
+`transaction_time`; the original recording remains visible for audit.
+
+**Point-in-time reads run at the same performance class as current
+reads.** Current-state reads are primary-key lookups on a
+materialised `entities` table (one row per live entity). Historical
+reads (`GetAsAt`, `GetAllAsAt`) are indexed seeks against a dedicated
+bi-temporal composite index (`idx_ev_bitemporal` on
+`(tenant_id, entity_id, valid_time DESC, transaction_time DESC)` in
+the postgres plugin). Both are constant-time index operations — no
+version-chain scan, no rebuild, no reconstruction from an event log.
+
+This combination — transactional safety with no phantom-wide
+trade-offs, plus audit-grade history with no performance penalty —
+is what an Entity Database Management System is for. Systems that
+bolt on audit trails after the fact typically pay either a write-path
+tax (double-write to an audit table, eventually consistent), a
+read-path tax (reconstruct state from an event log on every historical
+read), or both. Cyoda-Go pays neither: history is the native storage
+model, and the current-state projection is the cache.
 
 ### Cost Model
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -855,21 +855,6 @@ See [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) Section 14 for detailed technical 
 
 ---
 
-## 15. Planned Features
-
-Items carried forward from the `cyoda-light-go` predecessor repository that are not yet implemented against the refactored architecture. Issue numbers will be re-opened in the `cyoda-go` repository when each item is scheduled.
-
-| Title | Category | Description |
-|-------|----------|-------------|
-| Commit marker for transaction commit ambiguity resolution | HA Safety (PostgreSQL plugin) | Resolve ambiguity when a node dies after PostgreSQL COMMIT but before responding to the client. Write a commit marker to a separate table inside the transaction; clients can query the marker to determine if their transaction actually committed. |
-| Strict context deadline propagation across flow chain | Performance, HA Safety | Propagate `context.Context` deadlines through the entire flow chain (workflow cascade, processor dispatch, gRPC callbacks). Prevent unbounded execution when upstream has already timed out. |
-| Multi-node cluster E2E test with proxy routing | Test Coverage | End-to-end test exercising the full multi-node flow: client creates entity on node A, processor callback lands on node B, node B proxies to node A, commit succeeds. Validates transaction routing under realistic conditions. |
-| Batch SaveResults with pgx.CopyFrom | Performance (PostgreSQL plugin) | Replace row-by-row INSERT in `SaveResults` with `pgx.CopyFrom` for bulk loading of search job result IDs into PostgreSQL. |
-| Idempotency keys | HA Safety | Client-provided keys to prevent duplicate operations on retry (addresses the client-side commit-ambiguity path). |
-| Conformance test suite (`cyoda-go-spi/spitest/`) | Plugin ecosystem | Shared behavioral conformance harness for any plugin to run against its own `StoreFactory`. |
-
----
-
 ## References
 
 - **Architecture:** [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -78,12 +78,15 @@ guarantees:
 - **First-committer-wins on entity-level conflicts** — two transactions
   contending on the same entity: exactly one commits, the other
   aborts with `spi.ErrConflict` and can retry.
-- **No distributed transaction coordinator** — each plugin achieves
-  the contract against its own engine primitives (PostgreSQL
-  `REPEATABLE READ` + row-level locks + commit-time read-set
-  validation; application-layer committed-log tracking in memory /
-  sqlite; proprietary mechanism in the commercial Cassandra plugin).
-  No ZooKeeper, no Paxos, no Raft in the cyoda-go process.
+- **No separate coordination daemon** — cyoda-go does not run its own
+  ZooKeeper, etcd, or Raft cluster for transaction coordination. Open-
+  source plugins achieve the contract against their storage engine's
+  own primitives (PostgreSQL `REPEATABLE READ` + row-level locks +
+  commit-time read-set validation; application-layer committed-log
+  tracking in memory / sqlite). The commercial Cassandra plugin
+  coordinates transactions plugin-internally. In every case the
+  deployment footprint is: cyoda-go + your chosen storage — nothing
+  else to operate.
 
 The uniform contract across backends is a deliberate design choice:
 application code sees the same concurrency semantics regardless of
@@ -339,9 +342,27 @@ Transactions have a configurable TTL (default: 60 seconds, set via `CYODA_TX_TTL
 
 ### Multi-Node Transaction Affinity
 
-In a multi-node cluster, the `pgx.Tx` handle lives in a single node's process memory. The transaction token encodes which node owns the transaction (see Section 9). All subsequent requests for that transaction are routed to the owning node — there is no distributed transaction protocol.
+In a multi-node cluster running the **postgres plugin**, the `pgx.Tx`
+handle lives in a single node's process memory. The transaction token
+encodes which node owns the transaction (see Section 9). All
+subsequent requests for that transaction are routed to the owning
+node — no distributed transaction coordination inside cyoda-go.
 
-If the owning node dies, the transaction dies. PostgreSQL automatically rolls back the connection. The client receives `TRANSACTION_NODE_UNAVAILABLE` and must retry from scratch.
+If the owning node dies, the transaction dies. PostgreSQL
+automatically rolls back the connection. The client receives
+`TRANSACTION_NODE_UNAVAILABLE` and must retry from scratch. Trading
+this failure mode for operational simplicity (no Paxos, no Raft, no
+ZooKeeper in the cyoda-go process) is a deliberate choice — see §9.
+
+The commercial **Cassandra plugin** takes a different approach: the
+plugin coordinates transactions across the cluster, so a transaction
+is not pinned to a single owning node and does not fail when any one
+node becomes unavailable mid-transaction. This removes the
+`TRANSACTION_NODE_UNAVAILABLE` failure mode and is one of the
+operational advantages of the Cassandra plugin over the postgres
+plugin in high-availability deployments. The coordination mechanism
+is plugin-internal; contact [Cyoda](https://www.cyoda.com) for
+architectural details.
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,14 +1,14 @@
 # Cyoda-Go: Product Requirements Document
 
-**Version:** 2.0
-**Date:** 2026-04-14
-**Status:** Target state after the storage-plugin architecture refactor (Plans 1–5). See `docs/superpowers/specs/2026-04-13-storage-plugin-architecture-design.md` for the refactor plan.
+**Version:** 2.1
+**Date:** 2026-04-18
+**Status:** Current as of 2026-04-18 (Helm provisioning shipped in PR #60; docs reconciled against commit at branch tip).
 
 ---
 
 ## 1. Product Vision and Target Use Case
 
-Cyoda-Go is an Entity Database Management System (EDBMS) — a database engine where the first-class abstraction is not a row or document but a *stateful entity* with schema, lifecycle, temporal history, and transactional integrity. Storage is provided by pluggable backends; the stock binary ships with in-memory (default) and PostgreSQL plugins, and third-party plugins can be compiled in to target other storage engines.
+Cyoda-Go is an Entity Database Management System (EDBMS) — a database engine where the first-class abstraction is not a row or document but a *stateful entity* with schema, lifecycle, temporal history, and transactional integrity. Storage is provided by pluggable backends; the stock binary ships with in-memory (default), SQLite, and PostgreSQL plugins, and third-party plugins can be compiled in to target other storage engines.
 
 ### Target Applications
 
@@ -21,23 +21,80 @@ High-complexity, high-consistency enterprise domains where correctness is non-ne
 
 ### Scale Profile
 
-Small compute clusters (3-10 stateless Go nodes) with a shared PostgreSQL instance. Active-active high availability — any node can serve any request. Moderate to high throughput bounded by PostgreSQL's write capacity.
+Scale envelope depends on the active storage plugin:
 
-> **Storage plugin architecture.** Cyoda-Go's storage layer is a plugin system defined by the stable `cyoda-go-spi` module (stdlib-only Go interfaces and value types). A running binary has exactly one active plugin, selected at startup via `CYODA_STORAGE_BACKEND`. The stock `cyoda-go` binary ships with the `memory` plugin (default, zero external dependencies) and the `postgres` plugin (durable storage with `SERIALIZABLE` isolation). A proprietary `cyoda-go-cassandra` plugin ships as a separate binary for deployments that need horizontal write scalability. Third-party plugins (Redis, ScyllaDB, FoundationDB, etc.) can be authored against `cyoda-go-spi` and compiled into a custom binary via a blank import. See `docs/ARCHITECTURE.md` Section 2 for the plugin contract and Section 9 for configuration.
+- **`memory`** — single process, bounded by host RAM.
+- **`sqlite`** — single node, persistent; throughput bounded by local
+  disk. No clustering.
+- **`postgres`** — small compute clusters (3–10 stateless Go nodes)
+  behind a load balancer, sharing a primary PostgreSQL. Active-active
+  HA; any node serves any request. Write throughput bounded by the
+  PostgreSQL primary.
+- **`cassandra`** (commercial) — multi-cluster, horizontal write
+  scale-out without a single-primary bottleneck.
+
+> **Storage plugin architecture.** Cyoda-Go's storage layer is a plugin
+> system defined by the stable `cyoda-go-spi` module (stdlib-only Go
+> interfaces and value types). A running binary has exactly one active
+> plugin, selected at startup via `CYODA_STORAGE_BACKEND`. The stock
+> `cyoda-go` binary ships with three open-source plugins:
+>
+> - **`memory`** (default) — ephemeral, microsecond-latency concurrency
+>   control for tests and high-throughput digital-twin workloads.
+> - **`sqlite`** — persistent, zero-ops single-node storage for desktop,
+>   edge, and containerised single-node production.
+> - **`postgres`** — durable multi-node storage; works against any
+>   managed PostgreSQL 14+ platform.
+>
+> A commercial `cassandra` plugin is also available from Cyoda for
+> deployments that need horizontal write scalability beyond what a
+> single-primary PostgreSQL can provide — see
+> [cyoda.com](https://www.cyoda.com) and use its contact page.
+>
+> Third-party plugins (Redis, ScyllaDB, FoundationDB, etc.) can be
+> authored against `cyoda-go-spi` and compiled into a custom binary via
+> a blank import. See `docs/ARCHITECTURE.md` for the plugin contract,
+> `docs/plugins/` for per-plugin specifics, and `docs/CONSISTENCY.md`
+> for the isolation guarantee shared across all backends.
 
 ### Core Value Proposition
 
-Zero-compromise transactional safety. Each transaction holds a `pgx.Tx` handle in a single node's process memory, executing under PostgreSQL's `SERIALIZABLE` isolation. This guarantees:
+Zero-compromise transactional safety. Every storage plugin delivers
+the same isolation contract: **Snapshot Isolation with
+First-Committer-Wins on entity-level conflicts.** This guarantees:
 
-- **Strict read-your-own-writes** — within a transaction, reads always reflect prior writes from that transaction, even before commit
-- **Snapshot isolation** — concurrent transactions see a consistent snapshot, with conflict detection at commit time
-- **No distributed transaction coordinator** — PostgreSQL is the single source of truth; no two-phase commit, no Paxos, no Raft
+- **Strict read-your-own-writes** — within a transaction, reads always
+  reflect prior writes from that transaction, even before commit.
+- **Snapshot isolation** — concurrent transactions see a consistent
+  snapshot taken at `Begin`; a concurrent committer's writes are
+  invisible to us until we commit.
+- **First-committer-wins on entity-level conflicts** — two transactions
+  contending on the same entity: exactly one commits, the other
+  aborts with `spi.ErrConflict` and can retry.
+- **No distributed transaction coordinator** — each plugin achieves
+  the contract against its own engine primitives (PostgreSQL
+  `REPEATABLE READ` + row-level locks + commit-time read-set
+  validation; application-layer committed-log tracking in memory /
+  sqlite; proprietary mechanism in the commercial Cassandra plugin).
+  No ZooKeeper, no Paxos, no Raft in the cyoda-go process.
+
+The uniform contract across backends is a deliberate design choice:
+application code sees the same concurrency semantics regardless of
+which storage plugin is active. See `docs/CONSISTENCY.md` for the
+full contract, the phantom-read caveat, the operational rule for
+workflow authors, and the isolation-level taxonomy.
 
 ### Cost Model
 
-- A standard HA PostgreSQL instance (managed or self-hosted)
-- A small number of stateless Go binaries behind a load balancer
-- No ZooKeeper, no etcd, no Kafka, no distributed cache infrastructure
+Cost shape by plugin:
+
+- `memory` / `sqlite`: zero infra. The binary is the deployment.
+- `postgres`: a standard HA PostgreSQL instance (managed or
+  self-hosted) plus a small number of stateless Go binaries behind a
+  load balancer. No ZooKeeper, no etcd, no Kafka, no distributed cache.
+- `cassandra` (commercial): a Cassandra cluster plus stateless Go
+  binaries. Aligned with the Cassandra operational model; contact
+  Cyoda for a sizing conversation.
 
 ---
 
@@ -121,7 +178,16 @@ Each entity follows a workflow — a directed graph of states connected by trans
 |------|---------|--------|
 | **Automated** | Fires on state entry when criteria are met | Criteria evaluation |
 | **Manual** | Explicit API call (`POST /entity/{entityId}/{transition}`) | Criteria evaluation |
-| **Loopback** | Self-transition that re-triggers automation from the current state | Criteria evaluation |
+
+#### Loopback
+
+Loopback is an operation, not a transition type. A client can invoke
+`PUT /entity/{id}?loopback` to re-evaluate the entity's automated
+transitions from its current state without forcing a manual transition.
+Useful for retriggering workflow logic after the entity's data has
+changed via a non-workflow path (e.g. an external processor's
+callback), or after external preconditions that criteria depend on
+have changed.
 
 ### Criteria Types
 
@@ -155,7 +221,7 @@ Processors may create or mutate other entities, triggering further workflow trav
 
 ### Audit Trail
 
-13 event types track the full state machine narrative:
+12 event types track the full state machine narrative:
 
 - Workflow selection (selected, not found)
 - Transition attempts (attempted, made, denied, failed)
@@ -171,13 +237,25 @@ Filterable by event type, severity, time range, transaction ID. Cursor-based pag
 
 ### ACID Guarantees
 
-Cyoda-Go provides full ACID transactions. Each storage plugin supplies its own `TransactionManager` matching its storage engine's semantics:
+Cyoda-Go provides ACID transactions with a specific, uniform isolation
+contract across all plugins: **Snapshot Isolation with
+First-Committer-Wins on entity-level conflicts** (SI+FCW). This is the
+"I" in ACID — it is not full ACID-Serializable, and the distinction
+matters (see `docs/CONSISTENCY.md` for the phantom-read caveat and the
+operational rule for workflow authors). Each storage plugin supplies
+its own `TransactionManager` that realises this contract against its
+engine's primitives:
 
-| Plugin | Isolation | Conflict Detection | Handle |
-|--------|-----------|-------------------|--------|
-| **memory** | Serializable Snapshot Isolation (SSI) | Entity-level read set + write set tracking | In-process `Transaction` struct |
-| **postgres** | `SERIALIZABLE` (SSI via predicate locks) | PostgreSQL-native (error `40001` mapped to `CONFLICT`) | In-process lifecycle tracker; `pgx.Tx` held per-statement inside stores |
-| **cassandra** (proprietary plugin, separate binary) | SSI via custom coordinator + 2PC over a message broker | Per-entity version checks, HLC fencing, shard-epoch LWT | Coordinator-managed, multi-phase |
+| Plugin | Engine primitives | Handle |
+|--------|-------------------|--------|
+| **memory** | Application-layer committed-log scan; entity-level read set + write set tracking | In-process `Transaction` struct |
+| **sqlite** | Application-layer first-committer-wins (ported from memory); single-writer SQLite transaction under application coordination | In-process coordinator + local `sql.Tx` |
+| **postgres** | PostgreSQL `REPEATABLE READ` + row-level locks + commit-time read-set validation; conflicts surface as `spi.ErrConflict` | In-process lifecycle tracker; `pgx.Tx` held per-statement inside stores |
+| **cassandra** (commercial) | Proprietary mechanism against Cassandra primitives, delivering the same SI+FCW contract | Plugin-managed |
+
+SQLite plugin uses application-layer first-committer-wins ported from
+the memory plugin; the commercial Cassandra plugin implements the
+same contract against its own primitives.
 
 ### Transaction Lifecycle
 
@@ -189,27 +267,31 @@ BEGIN ──► READ/WRITE ──► COMMIT
   └──► ROLLBACK ◄──── timeout (TTL reaper)
 ```
 
-1. **Begin** — Snapshot time captured. In-memory: empty read/write sets. PostgreSQL: `BEGIN SERIALIZABLE`.
+1. **Begin** — Snapshot established. Each plugin captures its own snapshot primitive (committed-log watermark for memory/sqlite; PostgreSQL transaction snapshot under `REPEATABLE READ`).
 2. **Read** — Check transaction buffer first (read-your-own-writes), then snapshot view.
 3. **Write** — Buffered in transaction. Not visible to other transactions until commit.
-4. **Commit** — Conflict detection. In-memory: check concurrent writes against read/write sets. PostgreSQL: native SSI validation. Atomic flush on success.
-5. **Rollback** — Discard buffer (in-memory) or `ROLLBACK` (PostgreSQL).
+4. **Commit** — Entity-level read-set validation at commit time. Conflicts surface as `spi.ErrConflict` (retryable).
+5. **Rollback** — Discard buffer; release plugin-level resources.
 
 ### Read-Your-Own-Writes
 
 Within a transaction, all reads reflect prior writes from that transaction, even before commit. This is critical for processor cascade correctness — a processor that creates entity B must be able to read entity B in the same transaction.
 
-**Implementation:** The transaction maintains a write buffer. Read operations check the buffer before the underlying store. This holds for both in-memory and PostgreSQL backends (PostgreSQL's `SERIALIZABLE` isolation provides this natively; the in-memory backend replicates it via explicit buffering).
+**Implementation:** The transaction maintains a write buffer. Read operations check the buffer before the underlying store. This holds uniformly across all backends.
 
 ### Conflict Detection
 
-**In-Memory SSI:** On commit, scan the committed transaction log for transactions committed after our snapshot time. If any committed transaction's write set intersects our read set or write set, abort with `CONFLICT` (409, `retryable: true`).
-
-**PostgreSQL:** Native SSI predicate locking. PostgreSQL raises a serialization failure if concurrent transactions conflict. The application catches `40001` and returns `CONFLICT`.
+Entity-level read-set validation at commit time; conflicts surface as
+`spi.ErrConflict` (retryable, returned to the client as
+`CONFLICT` / HTTP 409). The mechanism differs per plugin — memory and
+sqlite scan a committed-transaction log for intersecting write sets;
+postgres uses row-level locks plus a commit-time re-validation pass;
+the commercial cassandra plugin uses its proprietary coordinator —
+but the contract is the same. See `docs/CONSISTENCY.md` for depth.
 
 ### Transaction Timeout and Reaper
 
-Transactions have a configurable TTL (default: 30 seconds). A background reaper goroutine periodically scans for expired transactions and rolls them back. The TTL aligns with PostgreSQL's `idle_in_transaction_session_timeout`.
+Transactions have a configurable TTL (default: 60 seconds, set via `CYODA_TX_TTL`). A background reaper goroutine periodically scans for expired transactions and rolls them back. For the PostgreSQL plugin, the TTL should align with the server-side `idle_in_transaction_session_timeout`.
 
 ### Multi-Node Transaction Affinity
 
@@ -270,14 +352,22 @@ SUBMIT ──► RUNNING ──► SUCCESSFUL ──► (retrieve results) ─�
 
 **Point-in-time:** The job captures `pointInTime` at submission (caller-specified or wall clock). Result entity IDs are stored; entity data is re-fetched at the job's point-in-time on retrieval.
 
-### Predicate Operators (23)
+### Predicate Operators (26)
 
 | Category | Operators |
 |----------|-----------|
-| **Equality** | `EQUALS`, `NOT_EQUAL`, `IS_NULL`, `NOT_NULL` |
-| **Comparison** | `GREATER_THAN`, `LESS_THAN`, `GREATER_OR_EQUAL`, `LESS_OR_EQUAL`, `BETWEEN`, `BETWEEN_INCLUSIVE` |
-| **String** | `CONTAINS`, `NOT_CONTAINS`, `STARTS_WITH`, `NOT_STARTS_WITH`, `ENDS_WITH`, `NOT_ENDS_WITH`, `MATCHES_PATTERN`, `LIKE` |
-| **Case-Insensitive** | `IEQUALS`, `INOT_EQUAL`, `ICONTAINS`, `INOT_CONTAINS`, `ISTARTS_WITH`, `INOT_STARTS_WITH`, `IENDS_WITH`, `INOT_ENDS_WITH` |
+| **Equality** (4) | `EQUALS`, `NOT_EQUAL`, `IS_NULL`, `NOT_NULL` |
+| **Comparison** (6) | `GREATER_THAN`, `LESS_THAN`, `GREATER_OR_EQUAL`, `LESS_OR_EQUAL`, `BETWEEN`, `BETWEEN_INCLUSIVE` |
+| **String** (8) | `CONTAINS`, `NOT_CONTAINS`, `STARTS_WITH`, `NOT_STARTS_WITH`, `ENDS_WITH`, `NOT_ENDS_WITH`, `MATCHES_PATTERN`, `LIKE` |
+| **Case-Insensitive** (8) | `IEQUALS`, `INOT_EQUAL`, `ICONTAINS`, `INOT_CONTAINS`, `ISTARTS_WITH`, `INOT_STARTS_WITH`, `IENDS_WITH`, `INOT_ENDS_WITH` |
+
+The four category subtotals sum to 26 (4 + 6 + 8 + 8).
+
+Two additional operators, `IS_CHANGED` and `IS_UNCHANGED`, are planned
+— they are reachable in the API and routed through the predicate
+machinery, but currently return `"operator X not implemented"` at
+runtime until the feature lands. They are excluded from the 26-count
+above.
 
 ### Condition Types
 
@@ -507,7 +597,7 @@ All operations use CloudEvent envelopes with JSON payloads, matching the Cyoda C
 
 ### Single Binary
 
-Cyoda-Go compiles to a single Go binary. No runtime dependencies beyond the binary itself (in memory mode) or PostgreSQL (in postgres mode).
+Cyoda-Go compiles to a single Go binary. No runtime dependencies beyond the binary itself (in memory or sqlite mode) or PostgreSQL (in postgres mode).
 
 **Container image:** Distroless base (`gcr.io/distroless/static-debian12`). Minimal attack surface.
 
@@ -516,8 +606,9 @@ Cyoda-Go compiles to a single Go binary. No runtime dependencies beyond the bina
 | Mode | Dependencies | Use Case |
 |------|-------------|----------|
 | **Standalone (memory)** | None | Development, testing, CI |
-| **Standalone (PostgreSQL)** | PostgreSQL 17+ | Single-node production |
-| **Multi-node cluster** | PostgreSQL 17+, nginx LB | HA production |
+| **Standalone (sqlite)** | None — embedded WASM SQLite + a writable data directory | Desktop, edge, containerised single-node production |
+| **Standalone (PostgreSQL)** | PostgreSQL 14+ | Single-node production |
+| **Multi-node cluster** | PostgreSQL 14+, nginx LB | HA production |
 
 ### Multi-Node Docker Deployment
 
@@ -530,7 +621,7 @@ Cyoda-Go compiles to a single Go binary. No runtime dependencies beyond the bina
 │ Node 2  │
 │ Node 3  │
 ├─────────┤
-│PostgreSQL│ ← Shared, SERIALIZABLE isolation
+│PostgreSQL│ ← Shared primary; SI+FCW contract (REPEATABLE READ + row locks)
 └─────────┘
 ```
 
@@ -547,13 +638,16 @@ A running binary has exactly one active storage plugin. Per-store routing (mixin
 | Plugin | Dependencies | Use case |
 |--------|--------------|----------|
 | **memory** (default) | None — in-process Go maps | Rapid development, agent-driven application engineering, embedded/test usage. Single-node only; data is lost on restart. |
-| **postgres** | PostgreSQL 17+ | Production durability; single-node or multi-node clusters (3–10 nodes) behind a load balancer. All cluster state flows through PostgreSQL as the consistency authority. |
+| **sqlite** | None — WASM SQLite embedded in the binary | Persistent single-node storage for desktop, edge, and containerised single-node production. Single-process only (flock-guarded); no NFS. |
+| **postgres** | PostgreSQL 14+ | Production durability; single-node or multi-node clusters (3–10 nodes) behind a load balancer. All cluster state flows through PostgreSQL as the consistency authority. |
 
-### Proprietary Plugin (separate binary: `cyoda-go-cassandra`)
+### Commercial Plugin (available from Cyoda)
 
-| Plugin | Dependencies | Use case |
-|--------|--------------|----------|
-| **cassandra** | Apache Cassandra 4.x+, message broker (Kafka/Redpanda) | Deployments that outgrow a single PostgreSQL instance and need horizontal write scalability. SSI guarantees preserved via a custom 2-phase commit coordinator protocol. Higher operational complexity. |
+A commercial `cassandra` plugin is also available for deployments that
+need horizontal write scalability beyond what a single-primary
+PostgreSQL can provide. It delivers the same SI+FCW isolation contract
+as the stock plugins. See [cyoda.com](https://www.cyoda.com) for
+details and sizing guidance.
 
 ### Writing a Third-Party Plugin
 
@@ -570,12 +664,15 @@ Users compose a custom binary by blank-importing plugins alongside `cyoda-go`:
 ```go
 import (
     _ "github.com/cyoda-platform/cyoda-go/plugins/memory"
+    _ "github.com/cyoda-platform/cyoda-go/plugins/sqlite"
     _ "github.com/cyoda-platform/cyoda-go/plugins/postgres"
     _ "example.com/my-redis-plugin"
 )
 ```
 
-The `memory` and `postgres` plugins serve as reference implementations. See `docs/ARCHITECTURE.md` Section 2 for the full contract.
+The `memory`, `sqlite`, and `postgres` plugins serve as reference
+implementations. See `docs/ARCHITECTURE.md` for the full plugin
+contract and `docs/plugins/` for per-plugin operational detail.
 
 ---
 
@@ -645,13 +742,18 @@ Error responses follow RFC 9457 (Problem Details). Error detail level controlled
 
 ### OpenTelemetry
 
-OpenTelemetry instrumentation is implemented end-to-end. Traces, metrics, and log correlation use the OTel SDK with OTLP HTTP exporters. HTTP requests are auto-traced via `otelhttp`. Transaction lifecycle operations (`tx.begin`, `tx.commit`, `tx.rollback`, `tx.savepoint`) produce spans with duration/active/conflict metrics regardless of which plugin is active (the core wraps the plugin's `TransactionManager` with a tracing decorator). Workflow engine and externalized processor dispatch are traced. Plugins may add their own instrumentation — the `cyoda-go-cassandra` plugin, for example, emits per-CQL timing histograms, batch execution metrics, concurrency limiter metrics, and commit-protocol phase spans. A Grafana / Prometheus / Tempo dashboard ships with the bundled docker environment. Standard OTel environment variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_TRACES_SAMPLER`) configure export and sampling.
+OpenTelemetry instrumentation is implemented end-to-end. Traces, metrics, and log correlation use the OTel SDK with OTLP HTTP exporters. HTTP requests are auto-traced via `otelhttp`. Transaction lifecycle operations (`tx.begin`, `tx.commit`, `tx.rollback`, `tx.savepoint`) produce spans with duration/active/conflict metrics regardless of which plugin is active (the core wraps the plugin's `TransactionManager` with a tracing decorator). Workflow engine and externalized processor dispatch are traced. Plugins may add their own plugin-namespaced spans and metrics as their hot-path semantics warrant. A Grafana / Prometheus / Tempo dashboard ships with the bundled docker environment. Standard OTel environment variables (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_TRACES_SAMPLER`) configure export and sampling.
 
 ---
 
 ## 14. Scale Profile and Operational Boundaries
 
-### Target Operating Envelope
+### Target Operating Envelope (PostgreSQL plugin, multi-node)
+
+The envelope below characterises the multi-node PostgreSQL
+deployment. The `memory` and `sqlite` plugins are single-node and
+bounded by host resources; the commercial `cassandra` plugin has its
+own envelope (contact Cyoda).
 
 | Dimension | Sweet Spot | Upper Bound | Notes |
 |-----------|-----------|-------------|-------|
@@ -659,19 +761,19 @@ OpenTelemetry instrumentation is implemented end-to-end. Traces, metrics, and lo
 | Concurrent transactions | 50–250 | ~750 (3 nodes × 25 PG connections) | Bounded by PG connection pool × node count |
 | Entity volume | Up to millions per model | Bounded by PG storage | Version history grows monotonically (append-only, no compaction) |
 | Transaction duration | < 1 second (ideal) | 60 seconds (default TTL) | Each second of transaction duration consumes one PG connection |
-| Write throughput | 50–200 entity creates/s per node | Bounded by PG SERIALIZABLE | Contention on same entities triggers serialization failures + retries |
+| Write throughput | 50–200 entity creates/s per node | Bounded by PG primary throughput | Contention on same entities triggers SI+FCW conflicts + retries |
 | Compute processor latency | < 500 ms | 30s (default timeout) | Processor duration dominates transaction duration |
 
 ### Where This Design Excels (PostgreSQL plugin)
 
-- **Transactional correctness:** Zero-compromise SERIALIZABLE isolation. No eventual consistency, no conflict windows, no split-brain. PostgreSQL is the single source of truth.
+- **Transactional correctness:** Zero-compromise SI+FCW isolation (see `docs/CONSISTENCY.md`). No eventual consistency, no conflict windows, no split-brain. PostgreSQL is the single source of truth.
 - **Operational simplicity:** One PostgreSQL instance plus stateless Go binaries. No ZooKeeper, no Kafka, no external service discovery.
 - **Development velocity:** The `memory` plugin runs with zero dependencies. Same code, same tests, same APIs as production.
 - **Small-to-medium data volumes:** For financial ledgers, regulatory records, order management — datasets that fit comfortably in a single PostgreSQL instance (terabytes, not petabytes).
 
 ### Where This Design Has Limits (PostgreSQL plugin)
 
-- **Write-heavy workloads at scale:** All writes go through a single PostgreSQL instance. The PostgreSQL plugin cannot shard writes across storage nodes. The `cassandra` plugin (separate `cyoda-go-cassandra` binary) is the answer for deployments that outgrow a single PostgreSQL instance and need horizontal write scalability.
+- **Write-heavy workloads at scale:** All writes go through a single PostgreSQL primary. The PostgreSQL plugin cannot shard writes across storage nodes. The commercial `cassandra` plugin from Cyoda is the answer for deployments that outgrow a single PostgreSQL instance and need horizontal write scalability.
 - **Long-running transactions:** A 10-second processor holds a PG connection for 10+ seconds, limiting concurrency.
 - **Large cluster sizes:** Beyond 10 nodes, the benefits of adding nodes diminish — compute capacity scales, but write capacity does not.
 - **Unbounded version histories:** Append-only entity versioning has no built-in archival. Long-lived entities with frequent updates accumulate version chains that slow point-in-time queries.
@@ -680,8 +782,8 @@ OpenTelemetry instrumentation is implemented end-to-end. Traces, metrics, and lo
 
 | Symptom | Signal to switch | Destination |
 |---------|------------------|-------------|
-| Transactions per second saturating a single PG instance, or growth trajectory will exceed PG single-node capacity within 12 months | Write throughput ceiling | `cyoda-go-cassandra` binary (cassandra plugin) |
-| Cluster size consistently above 10 nodes with write bottleneck | Scale-out ceiling | `cyoda-go-cassandra` binary |
+| Transactions per second saturating a single PG instance, or growth trajectory will exceed PG single-node capacity within 12 months | Write throughput ceiling | Commercial `cassandra` plugin (contact Cyoda) |
+| Cluster size consistently above 10 nodes with write bottleneck | Scale-out ceiling | Commercial `cassandra` plugin (contact Cyoda) |
 | Storage engine has no match in the stock lineup (e.g. cloud-native KV store, specialized time-series engine) | Plugin fit | Third-party plugin (author against `cyoda-go-spi`) |
 
 See [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) Section 14 for detailed technical limits, latency expectations, and sizing guidance.
@@ -699,14 +801,16 @@ Items carried forward from the `cyoda-light-go` predecessor repository that are 
 | Multi-node cluster E2E test with proxy routing | Test Coverage | End-to-end test exercising the full multi-node flow: client creates entity on node A, processor callback lands on node B, node B proxies to node A, commit succeeds. Validates transaction routing under realistic conditions. |
 | Batch SaveResults with pgx.CopyFrom | Performance (PostgreSQL plugin) | Replace row-by-row INSERT in `SaveResults` with `pgx.CopyFrom` for bulk loading of search job result IDs into PostgreSQL. |
 | Idempotency keys | HA Safety | Client-provided keys to prevent duplicate operations on retry (addresses the client-side commit-ambiguity path). |
-| Conformance test suite (`cyoda-go-spi/spitest/`) | Plugin ecosystem | Shared behavioral conformance harness for any plugin to run against its own `StoreFactory`. Scheduled for after the cassandra plugin extraction. |
+| Conformance test suite (`cyoda-go-spi/spitest/`) | Plugin ecosystem | Shared behavioral conformance harness for any plugin to run against its own `StoreFactory`. |
 
 ---
 
 ## References
 
 - **Architecture:** [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)
+- **Consistency contract:** [`docs/CONSISTENCY.md`](CONSISTENCY.md)
+- **Per-plugin documentation:** [`docs/plugins/`](plugins/)
 - **Architecture Decision Records:** [`docs/adr/`](adr/)
 - **OpenAPI Specification:** `api/openapi.yaml`
 - **Storage Plugin SPI module:** [github.com/cyoda-platform/cyoda-go-spi](https://github.com/cyoda-platform/cyoda-go-spi)
-- **Proprietary Cassandra plugin:** [github.com/cyoda-platform/cyoda-go-cassandra](https://github.com/cyoda-platform/cyoda-go-cassandra) (private)
+- **Commercial Cassandra plugin:** contact Cyoda via [cyoda.com](https://www.cyoda.com)

--- a/docs/plugins/IN_MEMORY.md
+++ b/docs/plugins/IN_MEMORY.md
@@ -5,7 +5,7 @@
 Ephemeral, in-process state — no disk I/O, no network round-trips, no
 query planner on the hot path. The memory plugin's latency profile
 sits an order of magnitude ahead of any persistent backend: a full
-SSI transaction (begin → read-modify-write → commit) completes in
+SI+FCW transaction (begin → read-modify-write → commit) completes in
 the low microseconds rather than the milliseconds a Postgres
 round-trip takes.
 
@@ -15,14 +15,15 @@ workloads** — an agentic software factory where an agent swarm drives
 thousands of scenario executions per second against a behavioural
 twin of a production entity, or a simulation that replays weeks of
 production state-machine behaviour in seconds. Same workflow
-semantics, same FSM engine, same SSI guarantees as the persistent
+semantics, same FSM engine, same SI+FCW guarantees as the persistent
 backends — without the durability trade-off.
 
 ## Concurrency model
 
-The memory plugin implements Serializable Snapshot Isolation (SSI)
-entirely in-process. The concurrency controller is the plugin itself
-— there is no underlying database doing conflict detection.
+The memory plugin implements Snapshot Isolation with
+First-Committer-Wins (SI+FCW) entirely in-process. The concurrency
+controller is the plugin itself — there is no underlying database
+doing conflict detection.
 
 **Locking primitives:**
 
@@ -96,9 +97,9 @@ bounded, not growing without limit.
 
 The memory plugin implements `spi.TransactionManager` directly —
 there is no underlying engine to delegate to, so the plugin IS the
-concurrency controller. The manager owns the per-transaction
-read/write sets and the committed-log window used for conflict
-detection. Reference: `plugins/memory/txmanager.go`.
+concurrency controller for its SI+FCW contract. The manager owns
+the per-transaction read/write sets and the committed-log window
+used for conflict detection. Reference: `plugins/memory/txmanager.go`.
 
 ## Data model and schema
 

--- a/docs/plugins/IN_MEMORY.md
+++ b/docs/plugins/IN_MEMORY.md
@@ -1,0 +1,139 @@
+# `memory` storage plugin
+
+## Capabilities
+
+Ephemeral, in-process state — no disk I/O, no network round-trips, no
+query planner on the hot path. The memory plugin's latency profile
+sits an order of magnitude ahead of any persistent backend: a full
+SSI transaction (begin → read-modify-write → commit) completes in
+the low microseconds rather than the milliseconds a Postgres
+round-trip takes.
+
+That performance envelope makes the memory plugin particularly
+effective as the **state-backing for high-throughput digital-twin
+workloads** — an agentic software factory where an agent swarm drives
+thousands of scenario executions per second against a behavioural
+twin of a production entity, or a simulation that replays weeks of
+production state-machine behaviour in seconds. Same workflow
+semantics, same FSM engine, same SSI guarantees as the persistent
+backends — without the durability trade-off.
+
+## Concurrency model
+
+The memory plugin implements Serializable Snapshot Isolation (SSI)
+entirely in-process. The concurrency controller is the plugin itself
+— there is no underlying database doing conflict detection.
+
+**Locking primitives:**
+
+- **Service-level `sync.RWMutex`** on `StoreFactory` — serializes
+  writes to the shared entity data maps during transaction commit.
+- **Per-transaction `OpMu`** (`sync.RWMutex` on `TransactionState`) —
+  gates concurrent operations within a single transaction and ensures
+  in-flight operations complete before commit/rollback.
+
+**Per-transaction state:**
+
+Each transaction captures a `SnapshotTime` at `Begin()`. Reads see
+only data committed before the snapshot. Writes are buffered in a
+per-transaction `Buffer` map. At commit time, the committed log is
+scanned for conflicts.
+
+```go
+type TransactionState struct {
+    ID           string
+    TenantID     TenantID
+    SnapshotTime time.Time
+    ReadSet      map[string]bool      // entity IDs read
+    WriteSet     map[string]bool      // entity IDs written
+    Buffer       map[string]*Entity   // buffered writes
+    Deletes      map[string]bool      // buffered deletes
+    OpMu         sync.RWMutex         // per-tx operation gate
+    Closed       bool
+    RolledBack   bool
+}
+```
+
+**Commit sequence (critical section):**
+
+```
+1. Acquire tx.OpMu.Lock()         -- wait for in-flight ops to finish
+2. Acquire factory.mu.Lock()      -- exclusive access to shared data
+3. Acquire tm.mu.Lock()           -- scan committed log
+4. FOR EACH committed_tx where submitTime > tx.SnapshotTime:
+     IF committed_tx.writeSet intersects (tx.ReadSet UNION tx.WriteSet):
+       ABORT -> ErrConflict
+5. Flush tx.Buffer to factory.entityData (deep copy)
+6. Apply tx.Deletes (append tombstone versions)
+7. Append to committedLog: {txID, submitTime, writeSet}
+8. Record submitTime in submitTimes map
+9. Remove from active map
+10. Prune committedLog (entries older than oldest active snapshot)
+11. Release all locks
+```
+
+This is first-committer-wins: the transaction that reaches step 4
+first wins; any concurrent transaction whose read-set or write-set
+intersects the winner's write-set is aborted with `common.ErrConflict`
+when it attempts to commit.
+
+**TOCTOU guard:** A `committing` map prevents double-commit races.
+The lock acquisition order — `tx.OpMu` → `factory.mu` → `tm.mu` — is
+uniform across the plugin; all commits take locks in the same order,
+so there is no cycle.
+
+**Committed-log pruning:** After each commit, entries older than the
+oldest active transaction's snapshot time are removed. When no
+transactions are active, the entire log is cleared. The log therefore
+grows only as long as there are concurrent transactions in flight.
+
+**`submitTimes` retention:** Submit times survive log pruning so that
+late `GetSubmitTime(txID)` lookups still resolve. Entries are evicted
+on a 1-hour TTL (`submitTimeTTL` in `txmanager.go`) — the map is
+bounded, not growing without limit.
+
+## Transaction manager
+
+The memory plugin implements `spi.TransactionManager` directly —
+there is no underlying engine to delegate to, so the plugin IS the
+concurrency controller. The manager owns the per-transaction
+read/write sets and the committed-log window used for conflict
+detection. Reference: `plugins/memory/txmanager.go`.
+
+## Data model and schema
+
+No persistence. All state lives in Go data structures inside the
+process. Restart loses everything. Data structures mirror the
+entity / model / workflow / KV / message / audit / search
+boundaries defined by the SPI — see `plugins/memory/<type>_store.go`
+for each (`entity_store.go`, `model_store.go`, `kv_store.go`,
+`message_store.go`, `workflow_store.go`, `sm_audit_store.go`,
+`search_store.go`).
+
+## Configuration (env vars)
+
+The memory plugin has no plugin-specific environment variables. It is
+the default backend when `CYODA_STORAGE_BACKEND` is unset or set to
+`memory`. All cyoda-go core env vars (admin listener, cluster,
+search, etc.) apply normally — see
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md) §9.
+
+## Operational notes and limits
+
+- Process-local; data lost on restart.
+- Single-process only — multiple cyoda processes against the "same"
+  memory plugin would have independent state (there is no shared store).
+- No persistence snapshots. Pair with periodic exports to a durable
+  backend if agent/simulation results matter beyond the session.
+- Tenant isolation is application-layer only (same trust model as the
+  SQLite plugin).
+
+## When to use / when not to use
+
+**Use:** tests, short-lived local dev, parity baselines, high-throughput
+digital-twin simulations where durability is delegated to an external
+snapshot mechanism.
+
+**Don't use:** production where any restart would lose data;
+multi-process deployments; anywhere durable storage is a functional
+requirement.

--- a/docs/plugins/POSTGRES.md
+++ b/docs/plugins/POSTGRES.md
@@ -1,0 +1,232 @@
+# `postgres` storage plugin
+
+## Capabilities
+
+Durable multi-node storage backed by PostgreSQL. Each transaction
+holds a `pgx.Tx` handle in one cyoda node's process memory — cyoda's
+multi-node architecture pins each transaction to its owning node via
+`txID → pgx.Tx` affinity, giving active-active HA without
+distributed-transaction overhead.
+
+**Works against any managed PostgreSQL 14+ platform:** AWS RDS, Google
+Cloud SQL, Azure Database for PostgreSQL, Supabase, Neon, Aiven,
+Crunchy Bridge, Render, Fly.io Postgres, DigitalOcean Managed
+Databases, and self-hosted.
+
+## Concurrency model
+
+The postgres plugin runs every transaction under PostgreSQL's
+`REPEATABLE READ` isolation (snapshot isolation) and layers
+**application-level, row-granular first-committer-wins** validation on
+top at commit time. SERIALIZABLE is not used: the plugin's
+`TransactionManager` calls `pool.BeginTx(ctx, pgx.TxOptions{IsoLevel:
+pgx.RepeatableRead})` and relies on a per-transaction `readSet` /
+`writeSet` to detect conflicts that snapshot isolation alone would
+miss.
+
+Before `pgxTx.Commit(ctx)`, the TM re-reads the current committed
+versions of every entity the transaction read, compares them against
+the snapshot captured at read time, and aborts with
+`spi.ErrConflict` on any mismatch. Write-write conflicts are handled
+by PostgreSQL's own tuple-level locks raised from
+`INSERT`/`UPDATE`/`DELETE` statements — those surface as SQLSTATE
+`40001` at DML time or commit time.
+
+**Error-code handling (`classifyError`):** two PostgreSQL error
+classes mean "the database rolled this transaction back cleanly, a
+retry on a fresh snapshot is safe" — `40001`
+(`serialization_failure`) and `40P01` (`deadlock_detected`). Both are
+wrapped into `spi.ErrConflict` so callers can retry uniformly; the
+original `*pgconn.PgError` stays in the error chain for observability.
+
+Every transaction sets `app.current_tenant` via
+`SELECT set_config('app.current_tenant', $1, true)` immediately after
+`BEGIN`, which RLS policies on every table consult to enforce tenant
+isolation at the row level.
+
+## Transaction manager
+
+Full transaction-lifecycle implementation
+(`plugins/postgres/transaction_manager.go`, ~366 lines) covering:
+
+- **Lifecycle:** `Begin` / `Commit` / `Rollback` / `Join` /
+  `GetSubmitTime`. `Begin` allocates a time-ordered UUID, starts a
+  `REPEATABLE READ` `pgx.Tx`, sets the RLS tenant, and registers the
+  transaction in the in-process `txRegistry`.
+- **Savepoints:** full `Savepoint` / `RollbackToSavepoint` /
+  `ReleaseSavepoint` support, backed by PostgreSQL's native
+  `SAVEPOINT` / `ROLLBACK TO` / `RELEASE SAVEPOINT` plus a per-txState
+  savepoint stack that snapshots and restores the application
+  readSet/writeSet in lockstep with the database.
+- **Row-granular validation:** commit-time re-read of the readSet
+  (`validateInChunks`) drives the first-committer-wins check.
+- **Transaction registry:** the `txRegistry` is a mutex-guarded
+  `txID → pgx.Tx` map — the single source of truth for active
+  transactions on a node.
+- **Submit-time bookkeeping:** each committed transaction captures
+  `SELECT CURRENT_TIMESTAMP` before `COMMIT` and records it with a
+  1-hour TTL, surfaced via `GetSubmitTime`.
+
+The real serialization guarantee is the combination of PostgreSQL's
+`REPEATABLE READ` snapshot + tuple locks + the TM's first-committer
+validation — not `SERIALIZABLE` alone.
+
+### `pgx.Tx` single-owner property
+
+A `pgx.Tx` is held by exactly one goroutine on exactly one node.
+There is no mechanism for two nodes to share a PostgreSQL transaction
+handle: the handle is a pointer into a `pgxpool.Conn` that only exists
+in the process that acquired it.
+
+Consequences:
+
+- No distributed locking is needed for transaction access.
+- No fencing tokens are needed to prevent stale writes from a revoked
+  owner — if the owning node dies, PostgreSQL rolls back the
+  transaction on connection loss / idle timeout.
+- cyoda's multi-node dispatch routes every subsequent operation on a
+  `txID` back to the node that began it. The gossip-backed cluster
+  registry advertises which node owns which transaction; any peer
+  that receives a request for someone else's txID proxies the
+  request rather than trying to rehydrate the handle locally.
+- The `txRegistry` (`sync.RWMutex`-protected `map[string]pgx.Tx`) is
+  the single source of truth for active transactions on a node.
+
+## Data model and schema
+
+The postgres plugin uses a normalized relational schema with JSONB
+columns for flexible document storage and GIN indexes on the JSONB
+columns where search requires it.
+
+**Bi-temporal versioning:** `entity_versions` is the append-only
+history table:
+
+```sql
+CREATE TABLE entity_versions (
+    tenant_id        TEXT        NOT NULL,
+    entity_id        TEXT        NOT NULL,
+    model_name       TEXT        NOT NULL,
+    model_version    TEXT        NOT NULL,
+    version          BIGINT      NOT NULL,
+    valid_time       TIMESTAMPTZ NOT NULL,
+    transaction_time TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    wall_clock_time  TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    doc              JSONB       NOT NULL,
+    PRIMARY KEY (tenant_id, entity_id, version)
+);
+```
+
+- `valid_time` — application-supplied timestamp (entity's logical
+  time).
+- `transaction_time` — database `CURRENT_TIMESTAMP` (when PG recorded
+  the row).
+- `wall_clock_time` — `clock_timestamp()` (actual wall-clock,
+  independent of transaction).
+
+As-at queries filter by `valid_time`:
+
+```sql
+SELECT doc FROM entity_versions
+WHERE tenant_id = $1 AND entity_id = $2 AND valid_time <= $3
+ORDER BY valid_time DESC, transaction_time DESC
+LIMIT 1;
+```
+
+**Row-level security (RLS):** every table has RLS enabled with a
+policy that compares `tenant_id` against the session variable
+`app.current_tenant`, set via `set_config(..., true)` at transaction
+start:
+
+```sql
+ALTER TABLE entities ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_entities ON entities
+    USING (tenant_id = current_setting('app.current_tenant', true));
+```
+
+This is defense-in-depth: even a tenant-scoping bug in application
+code cannot leak data, because PostgreSQL enforces the isolation at
+the row level.
+
+**Schema (all tables):**
+
+| Table | Purpose | Primary key |
+|-------|---------|-------------|
+| `entities` | Current entity state (one row per entity) | `(tenant_id, entity_id)` |
+| `entity_versions` | Append-only bi-temporal history | `(tenant_id, entity_id, version)` |
+| `models` | Model descriptors (JSON) | `(tenant_id, model_name, model_version)` |
+| `kv_store` | Generic key-value (workflows, configs) | `(tenant_id, namespace, key)` |
+| `messages` | Edge messages with binary payload | `(tenant_id, message_id)` |
+| `sm_audit_events` | State-machine audit trail | `(tenant_id, entity_id, event_id)` |
+| `search_jobs` | Async search job metadata | `id` (with `tenant_id` indexed) |
+| `search_job_results` | Entity ID results per job | `(job_id, seq)`, FK to `search_jobs` |
+
+Workflows live in `kv_store` under a dedicated namespace.
+
+**Migrations:** SQL migrations ship embedded in the binary via
+`//go:embed migrations/*.sql` and are applied on startup by
+`golang-migrate` when `CYODA_POSTGRES_AUTO_MIGRATE=true` (the
+default). Schema compatibility is verified at startup before any
+migration runs: if the database schema is newer than the binary's
+embedded migrations, the binary refuses to start rather than risk
+running against an incompatible schema. Dirty migration state is
+surfaced as a fatal error requiring manual intervention. A dedicated
+`cyoda migrate` subcommand (`RunMigrateWithDSN`) is available for
+operators who prefer to apply migrations out-of-band.
+
+## Configuration (env vars)
+
+The plugin advertises its env vars via
+`DescribablePlugin.ConfigVars()` (`plugins/postgres/plugin.go`); they
+are rendered in the binary's `--help`.
+
+| Var | Default | Purpose |
+|---|---|---|
+| `CYODA_POSTGRES_URL` (or `CYODA_POSTGRES_URL_FILE`) | *(required)* | PostgreSQL connection string. The `_FILE` variant reads the value from a file path and takes precedence if both are set (trailing whitespace trimmed). Implemented in `resolveSecretWith`. |
+| `CYODA_POSTGRES_MAX_CONNS` | `25` | `pgxpool.Pool` maximum connections. |
+| `CYODA_POSTGRES_MIN_CONNS` | `5` | `pgxpool.Pool` minimum (warm) connections. |
+| `CYODA_POSTGRES_MAX_CONN_IDLE_TIME` | `5m` | Idle connection reap threshold (Go duration syntax). |
+| `CYODA_POSTGRES_AUTO_MIGRATE` | `true` | Run embedded SQL migrations on startup. When `false`, the binary refuses to start if the database schema is older than the code. |
+
+### Managed-platform notes
+
+Platforms that front PostgreSQL with **PgBouncer in transaction
+pooling mode** (Supabase port 6543, Neon pooled endpoint) strip
+prepared-statement caching mid-session. `pgx`'s default extended-query
+protocol uses prepared statements.
+
+Options:
+
+- Use the platform's **direct-connection endpoint** (Supabase 5432,
+  Neon direct) — recommended for cyoda.
+- Set `default_query_exec_mode=exec` on the `pgx` pool to force
+  simple-query mode — accepts a small per-query overhead in exchange
+  for pooler compatibility.
+
+cyoda uses transaction-scoped `set_config(..., true)` for RLS
+(tenant isolation) only — no session-level state fights PgBouncer
+transaction mode beyond the prepared-statement cache.
+
+## Operational notes and limits
+
+- Requires PostgreSQL 14+.
+- Recommended HA mode: primary + streaming replica with automatic
+  failover.
+- Cluster-mode cyoda uses Postgres for durable storage and cyoda's
+  own gossip registry for node discovery and transaction-owner
+  routing — the two are orthogonal.
+- Scale-out is bounded by the PostgreSQL primary's write capacity.
+  Read-replicas are not yet wired in to cyoda.
+- Schema-compatibility contract: the binary refuses to start if the
+  database schema is newer than the code, and (with
+  `CYODA_POSTGRES_AUTO_MIGRATE=false`) if it is older. Dirty
+  migration state is fatal.
+
+## When to use / when not to use
+
+**Use:** clustered production, high consistency requirements,
+audit/compliance workloads, any deployment where a managed PostgreSQL
+platform is the infrastructure baseline.
+
+**Don't use:** single-process desktop deployments (use `sqlite`),
+workloads whose write volume exceeds what a single Postgres primary
+can sustain (consider the commercial `cassandra` plugin).

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,0 +1,38 @@
+# Storage plugins
+
+cyoda-go's storage layer is a plugin system defined by the stable
+[`cyoda-go-spi`](https://github.com/cyoda-platform/cyoda-go-spi) module
+(stdlib-only Go interfaces and value types). A running binary has
+exactly one active plugin, selected at startup via `CYODA_STORAGE_BACKEND`.
+
+## Open-source plugins shipped with the stock binary
+
+- **[`memory`](IN_MEMORY.md)** (default) — ephemeral, microsecond-latency
+  SSI for tests and high-throughput digital-twin workloads.
+- **[`sqlite`](SQLITE.md)** — persistent, zero-ops single-node storage for
+  desktop, edge, and containerised single-node production.
+- **[`postgres`](POSTGRES.md)** — durable multi-node storage with SSI via
+  PostgreSQL `SERIALIZABLE`; works against any managed PostgreSQL 14+
+  platform.
+
+## Commercial plugin
+
+A **`cassandra`** plugin is available as a commercial offering from Cyoda
+for deployments that need horizontal write scalability beyond a
+single-primary PostgreSQL. See [cyoda.com](https://www.cyoda.com) and use
+its contact page.
+
+## Authoring your own plugin
+
+Third-party plugins (Redis, ScyllaDB, FoundationDB, etc.) can be authored
+against `cyoda-go-spi` and compiled into a custom binary via a blank
+import in a local `main.go`. The stock plugins serve as reference
+implementations:
+
+- [`plugins/memory/doc.go`](../../plugins/memory/doc.go) — simplest reference
+  implementation; start here.
+- [`plugins/postgres/doc.go`](../../plugins/postgres/doc.go) — fully-featured
+  reference implementation with migrations, connection pooling, and
+  multi-node wiring.
+
+See [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §2 for the plugin contract.

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -8,12 +8,13 @@ exactly one active plugin, selected at startup via `CYODA_STORAGE_BACKEND`.
 ## Open-source plugins shipped with the stock binary
 
 - **[`memory`](IN_MEMORY.md)** (default) — ephemeral, microsecond-latency
-  SSI for tests and high-throughput digital-twin workloads.
+  SI+FCW for tests and high-throughput digital-twin workloads.
 - **[`sqlite`](SQLITE.md)** — persistent, zero-ops single-node storage for
   desktop, edge, and containerised single-node production.
-- **[`postgres`](POSTGRES.md)** — durable multi-node storage with SSI via
-  PostgreSQL `SERIALIZABLE`; works against any managed PostgreSQL 14+
-  platform.
+- **[`postgres`](POSTGRES.md)** — durable multi-node storage. PostgreSQL
+  `REPEATABLE READ` plus application-layer first-committer-wins delivers
+  the same SI+FCW contract as the other plugins; works against any
+  managed PostgreSQL 14+ platform.
 
 ## Commercial plugin
 

--- a/docs/plugins/SQLITE.md
+++ b/docs/plugins/SQLITE.md
@@ -15,9 +15,9 @@ matching the PostgreSQL plugin's search shape.
 ## Concurrency model
 
 Application-layer Snapshot Isolation with First-Committer-Wins
-(SI+FCW), **ported from the memory plugin**. SQLite provides only
-database-level write locking (zero write concurrency); cyoda's SI+FCW
-layer gives entity-level conflict detection on top.
+(SI+FCW). SQLite provides only database-level write locking (zero
+write concurrency); cyoda's SI+FCW layer gives entity-level conflict
+detection on top.
 
 An exclusive `flock` on the database file is acquired at startup and
 held for the process lifetime. A second cyoda process against the
@@ -31,9 +31,9 @@ so the restriction is implicit in choosing SQLite at all.
 
 ## Transaction manager
 
-Same SI+FCW engine as the memory plugin (`TransactionManager` ported
-verbatim; SQLite is the durability layer, not the concurrency
-controller). Reference: `plugins/sqlite/txmanager.go`.
+Application-layer SI+FCW `TransactionManager`; SQLite is the
+durability layer, not the concurrency controller. Reference:
+`plugins/sqlite/txmanager.go`.
 
 ## Data model and schema
 

--- a/docs/plugins/SQLITE.md
+++ b/docs/plugins/SQLITE.md
@@ -1,0 +1,85 @@
+# `sqlite` storage plugin
+
+## Capabilities
+
+Persistent, zero-ops single-node storage. Embedded in-process via a
+pure-Go (WASM) SQLite driver — no CGO, clean cross-compilation,
+future [sqlite-vec](https://github.com/asg017/sqlite-vec) support. The
+ideal backend for desktop binary users, edge deployments, and
+containerised single-node production.
+
+Search predicate pushdown to SQL — the majority of entity search
+predicates resolve in the SQL engine rather than post-filter in Go,
+matching the PostgreSQL plugin's search shape.
+
+## Concurrency model
+
+Application-layer Serializable Snapshot Isolation (SSI), **ported
+from the memory plugin**. SQLite provides only database-level write
+locking (zero write concurrency); cyoda's SSI gives first-committer-wins
+entity-level conflict detection on top.
+
+An exclusive `flock` on the database file is acquired at startup and
+held for the process lifetime. A second cyoda process against the
+same file fails fast with a clear error. The flock is required
+because the SSI state (committed-log, active-transaction set) is
+per-process — two processes sharing a file would have independent SSI
+and silently corrupt each other's conflict detection.
+
+`flock` does not work on NFS, but SQLite itself is unreliable on NFS,
+so the restriction is implicit in choosing SQLite at all.
+
+## Transaction manager
+
+Same SSI engine as the memory plugin (`TransactionManager` ported
+verbatim; SQLite is the durability layer, not the concurrency
+controller). Reference: `plugins/sqlite/txmanager.go`.
+
+## Data model and schema
+
+Mirrors the PostgreSQL logical schema with SQLite optimisations:
+
+- JSONB columns stored as `BLOB` with `jsonb()` / `json()` functions —
+  2-5× faster `json_extract()` than TEXT JSON. Plugin asserts
+  `sqlite_version() >= 3.45.0` at startup.
+- `STRICT` tables + `WITHOUT ROWID` on append-only tables (e.g.
+  `entity_versions`). The `entities` table keeps its rowid because it
+  is UPSERT-heavy and `WITHOUT ROWID` would rewrite the clustered row
+  on every update.
+- INTEGER timestamps (Unix nanoseconds) — 15-25% smaller, 15-30% faster
+  point lookups than TEXT timestamps.
+
+Migrations via `golang-migrate` with embedded SQL files — same pattern
+as the postgres plugin. Runs automatically on startup when
+`CYODA_SQLITE_AUTO_MIGRATE=true` (the default).
+
+## Configuration (env vars)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `CYODA_SQLITE_PATH` | `$XDG_DATA_HOME/cyoda/cyoda.db` on Linux/macOS (fallback `~/.local/share/cyoda/cyoda.db`); `%LocalAppData%\cyoda\cyoda.db` on Windows | Database file path |
+| `CYODA_SQLITE_AUTO_MIGRATE` | `true` | Run embedded SQL migrations on startup |
+| `CYODA_SQLITE_BUSY_TIMEOUT` | `5s` | Wait time for write lock before returning `SQLITE_BUSY` |
+| `CYODA_SQLITE_CACHE_SIZE` | `64000` (KiB) | Page cache size in KiB |
+| `CYODA_SQLITE_SEARCH_SCAN_LIMIT` | `100000` | Max rows examined per search when a residual filter applies |
+
+## Operational notes and limits
+
+- **No CGO.** Uses [`ncruces/go-sqlite3`](https://github.com/ncruces/go-sqlite3)
+  (WASM-based); ~2-3× slower on micro-benchmarks than native C SQLite.
+  Accepted for clean cross-compile and the sqlite-vec roadmap.
+- **Tenant isolation is application-layer only.** No RLS (SQLite has no
+  native row-level security). Same trust model as the memory plugin.
+- **Single-process, single-node.** See concurrency model for the flock
+  requirement.
+- **NFS unsupported.**
+
+## When to use / when not to use
+
+**Use:** desktop binary users, containerised single-node production,
+embedded deployments, edge devices, any scenario where "memory plugin
+but must survive restart" is the requirement.
+
+**Don't use:** multi-node deployments, multi-process deployments,
+NFS-mounted storage, workloads that need horizontal write scale (go to
+postgres or the commercial cassandra plugin).

--- a/docs/plugins/SQLITE.md
+++ b/docs/plugins/SQLITE.md
@@ -14,24 +14,24 @@ matching the PostgreSQL plugin's search shape.
 
 ## Concurrency model
 
-Application-layer Serializable Snapshot Isolation (SSI), **ported
-from the memory plugin**. SQLite provides only database-level write
-locking (zero write concurrency); cyoda's SSI gives first-committer-wins
-entity-level conflict detection on top.
+Application-layer Snapshot Isolation with First-Committer-Wins
+(SI+FCW), **ported from the memory plugin**. SQLite provides only
+database-level write locking (zero write concurrency); cyoda's SI+FCW
+layer gives entity-level conflict detection on top.
 
 An exclusive `flock` on the database file is acquired at startup and
 held for the process lifetime. A second cyoda process against the
 same file fails fast with a clear error. The flock is required
-because the SSI state (committed-log, active-transaction set) is
-per-process — two processes sharing a file would have independent SSI
-and silently corrupt each other's conflict detection.
+because the SI+FCW state (committed-log, active-transaction set) is
+per-process — two processes sharing a file would have independent
+conflict-detection state and silently corrupt each other.
 
 `flock` does not work on NFS, but SQLite itself is unreliable on NFS,
 so the restriction is implicit in choosing SQLite at all.
 
 ## Transaction manager
 
-Same SSI engine as the memory plugin (`TransactionManager` ported
+Same SI+FCW engine as the memory plugin (`TransactionManager` ported
 verbatim; SQLite is the durability layer, not the concurrency
 controller). Reference: `plugins/sqlite/txmanager.go`.
 

--- a/docs/superpowers/plans/2026-04-18-architecture-prd-sync.md
+++ b/docs/superpowers/plans/2026-04-18-architecture-prd-sync.md
@@ -1,0 +1,1375 @@
+# Architecture + PRD documentation sync — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring `docs/ARCHITECTURE.md` and `docs/PRD.md` into perfect sync with the codebase at HEAD, restructure storage content into `docs/ARCHITECTURE.md` + per-plugin `docs/plugins/*.md`, and sanitize Cassandra plugin references to capability-only framing.
+
+**Architecture:** Three phases. Phase A runs eight parallel reconciliation subagents, one per section scope, each returning a structured discrepancies list. Phase B applies the structural split and all reconciliation findings. Phase C verifies via six deterministic checks (mechanism grep-zero, rename-residue grep-zero, per-plugin template conformance, cross-link resolution, env-var cross-reference, frozen-section intactness).
+
+**Tech Stack:** Markdown docs only (no code changes). Edits via `Edit`/`Write` tools. Verification via `grep`/`rg`. Parallel agent dispatch via the `Agent` tool with `Explore` subagent type.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-architecture-prd-sync-design.md`.
+
+---
+
+## Prerequisites
+
+Before starting Task 1, verify:
+
+- [ ] Working tree at repo root is clean: `git status` shows only untracked `.claude/scheduled_tasks.lock`, `cyoda-go` (stray binary), or similar harness/build artefacts — not the three target files.
+- [ ] `docs/ARCHITECTURE.md` SHA matches the one referenced in the spec: `git log -1 --format=%H -- docs/ARCHITECTURE.md` returns a SHA whose content has the "Version: 2.0 / Date: 2026-04-14" header.
+- [ ] `docs/PRD.md` is the 712-line version with the same header.
+- [ ] `docs/plugins/` directory does not yet exist.
+
+If any is off, stop and realign with the spec.
+
+---
+
+## File structure
+
+### Docs touched
+
+```
+docs/
+  ARCHITECTURE.md              (MODIFY — trim §2 to index+§2.4, apply reconciliation findings, update header)
+  PRD.md                       (MODIFY — rewrite §1 storage callout, apply reconciliation findings, update header)
+  plugins/
+    README.md                  (CREATE — one-page index)
+    IN_MEMORY.md               (CREATE — from current §2.1 + §3.2 + §9 memory content + reconciliation)
+    SQLITE.md                  (CREATE — new; draws on plugins/sqlite/ and the sqlite design spec)
+    POSTGRES.md                (CREATE — from current §2.2 + §3.3 + §3.5 + §9 postgres content + reconciliation)
+```
+
+### Code references
+
+No code changes. All edits are in `docs/`. The reconciliation agents read code (`cmd/`, `app/`, `internal/`, `plugins/`, `api/`) but do not modify it.
+
+---
+
+## Phase A — Reconciliation (Tasks 1–8)
+
+Eight parallel subagents. Each returns a **structured discrepancies list** in a single agent response. Dispatch in parallel — no cross-dependencies between agents.
+
+Before dispatching, set shared baseline context that every agent gets:
+
+- Spec: `docs/superpowers/specs/2026-04-18-architecture-prd-sync-design.md`
+- Commit SHA of the source of truth: `git rev-parse HEAD` (capture this value; pass it to every agent)
+- Output format required from each agent: Critical / Significant / Minor, each with `file:line`, what the doc says, what the code does, recommended fix.
+
+### Task 1: Reconcile ARCHITECTURE.md §1 System Overview + §3 Transaction Model (storage-agnostic parts)
+
+**Files:**
+- Read: `docs/ARCHITECTURE.md` §1 (lines 32–210) and §3 excluding §3.2 and §3.3 (lines 369–473)
+- Read: `cyoda-go-spi/` module (fetched via `go env GOMODCACHE` or local clone if available; otherwise from `go.mod` + `go.sum` to locate it in the module cache)
+- Read: `internal/contract/` (all files)
+- Read: `app/app.go`, `app/config.go`
+- Read: `internal/cluster/lifecycle/`
+
+- [ ] **Step 1: Dispatch Agent 1**
+
+Use Agent tool with `subagent_type: Explore`. Description: "Reconcile ARCH §1+§3 vs code". Prompt includes:
+
+```
+Thorough reconciliation task against the cyoda-go codebase at commit <SHA>.
+
+Read these sections of docs/ARCHITECTURE.md:
+- §1 System Overview (lines 32–210)
+- §3 Transaction Model, excluding §3.2 (In-Memory SSI) and §3.3 (PostgreSQL SERIALIZABLE)
+  which are out of scope — they're being extracted to per-plugin files.
+  §3.1 (TransactionManager SPI), §3.4 (TX Lifecycle Manager), §3.5 (pgx.Tx property),
+  §3.6 (Plugin-Specific TMs) are in scope.
+
+Cross-check against:
+- The cyoda-go-spi module (located at the module cache path reported by `go list -m -f '{{.Dir}}' github.com/cyoda-platform/cyoda-go-spi`).
+- internal/contract/ (every *.go file)
+- app/app.go (startup sequence, plugin resolution)
+- app/config.go (config types referenced in narrative)
+- internal/cluster/lifecycle/ (Manager type referenced by TX Lifecycle narrative)
+
+Verify every concrete claim — interface names, method signatures, file paths, package paths,
+module paths, the blank-import pattern for custom binaries. Flag every drift.
+
+Output format:
+- Critical: doc claim contradicted by code.
+- Significant: doc omits material change or describes since-refactored impl.
+- Minor: stylistic drift, stale cross-reference, outdated example.
+Each item: file:line, what doc says, what code does, recommended fix.
+Return findings as text; do not edit files.
+```
+
+- [ ] **Step 2: Capture findings**
+
+Save the agent's response verbatim to `/tmp/arch-sync-agent1.md`. No synthesis yet — raw agent output.
+
+- [ ] **Step 3: Verify coverage**
+
+Confirm the agent did not refuse or error. Re-dispatch if empty response.
+
+### Task 2: Reconcile ARCHITECTURE.md §4 Multi-Node Routing
+
+**Files:**
+- Read: `docs/ARCHITECTURE.md` §4 (lines 475–875)
+- Read: `internal/cluster/registry/gossip.go`
+- Read: `internal/cluster/dispatch/` (all files)
+- Read: `internal/cluster/proxy/` (all files)
+- Read: `internal/cluster/token/` (all files)
+- Read: `internal/domain/search/` (focus on persistent-snapshot claims in §4.6)
+
+- [ ] **Step 1: Dispatch Agent 2**
+
+```
+Thorough reconciliation against cyoda-go codebase at commit <SHA>.
+
+Read docs/ARCHITECTURE.md §4 (Multi-Node Routing, lines 475–875):
+- §4.1 Cluster Discovery (SWIM gossip)
+- §4.2 Transaction Routing
+- §4.3 Compute Dispatch Routing
+- §4.4 Transaction Flow Swimlane
+- §4.5 Network Partition Analysis
+- §4.6 Persistent Search Snapshots
+
+Cross-check against:
+- internal/cluster/registry/gossip.go (memberlist wiring, seed list, filterSelf)
+- internal/cluster/dispatch/ (forwarder, dispatch handler, HMAC authn)
+- internal/cluster/proxy/ (transaction routing proxy)
+- internal/cluster/token/ (token-claim-based member affinity)
+- internal/domain/search/ (snapshot TTL, reap interval, cross-cluster coherence)
+
+Specifically verify:
+- The seed-list + filterSelf behavior against the chart-side seed-list change (the ConfigMap
+  now emits every pod DNS, not just pod-0).
+- HMAC secret shape expected by dispatch handler against what the chart generates
+  (the hex-over-b64 HMAC generation chain in templates/secret-hmac.yaml).
+- Swimlane diagram accuracy against actual request flow.
+- §4.6 search-snapshot claims against current search-snapshot code.
+
+Output format as in Agent 1. Return findings as text.
+```
+
+- [ ] **Step 2: Capture findings to `/tmp/arch-sync-agent2.md`.**
+
+### Task 3: Reconcile ARCHITECTURE.md §5 Workflow + §6 gRPC / Externalized Processing
+
+**Files:**
+- Read: `docs/ARCHITECTURE.md` §5 (lines 877–939) and §6 (lines 941–999)
+- Read: `internal/domain/workflow/` (all files)
+- Read: `api/grpc/events/` (all files)
+- Read: `internal/grpc/` (all files)
+- Read: `internal/domain/messaging/`
+
+- [ ] **Step 1: Dispatch Agent 3**
+
+```
+Thorough reconciliation against cyoda-go codebase at commit <SHA>.
+
+Read docs/ARCHITECTURE.md:
+- §5 Workflow Engine (lines 877–939): FSM model, execution modes, cascade logic,
+  processor execution, audit trail.
+- §6 gRPC & Externalized Processing (lines 941–999): CloudEventsService,
+  member lifecycle, tag-based selection, response correlation, CloudEvent types.
+
+Cross-check against:
+- internal/domain/workflow/ (Engine, State, Transition, Processor, Criteria)
+- api/grpc/events/ (proto + generated CloudEventsService stubs)
+- internal/grpc/ (server, member registry, dispatch)
+- internal/domain/messaging/ (any messaging contracts surfaced)
+
+Verify every FSM concept name, every CloudEvent type name, every gRPC method
+signature, every lifecycle event name, every tag-selection rule.
+
+Output format as in Agent 1.
+```
+
+- [ ] **Step 2: Capture findings to `/tmp/arch-sync-agent3.md`.**
+
+### Task 4: Reconcile ARCHITECTURE.md §7 Auth + §8 Error Model
+
+**Files:**
+- Read: `docs/ARCHITECTURE.md` §7 (lines 1001–1047) and §8 (lines 1048–1133)
+- Read: `internal/auth/` (all files)
+- Read: `internal/admin/auth.go`, `internal/admin/admin.go`
+- Read: `app/app.go` (validateBootstrapConfig, validateMetricsAuth)
+- Read: `internal/common/error_codes.go`
+- Read: `internal/api/middleware/`
+- Read: `internal/common/apperror.go` or equivalent error type
+
+- [ ] **Step 1: Dispatch Agent 4**
+
+```
+Thorough reconciliation against cyoda-go codebase at commit <SHA>.
+
+Read docs/ARCHITECTURE.md:
+- §7 Authentication & Authorization: §7.1 Mock Mode, §7.2 JWT Mode, §7.3 Authorization.
+- §8 Error Model: §8.1 Three-Tier Classification, §8.2 RFC 9457 Problem Details,
+  §8.3 Error Code Taxonomy, §8.4 Warning/Error Accumulation.
+
+Cross-check against:
+- internal/auth/service.go (adminMux, OAuth endpoints, JWT mint/verify)
+- internal/admin/admin.go + internal/admin/auth.go (probe endpoints, metrics bearer
+  middleware — this is NEW since the doc was written; flag as missing if §7 doesn't cover it)
+- app/app.go (validateBootstrapConfig coupled-predicate, validateMetricsAuth coupled-predicate —
+  both are recent additions)
+- internal/common/error_codes.go (verify the error code taxonomy enumerated in §8.3 matches;
+  flag additions/removals)
+- internal/api/middleware/ (Problem Details middleware, Auth middleware)
+
+Specifically flag:
+- /metrics bearer auth mechanism (CYODA_METRICS_BEARER, CYODA_METRICS_REQUIRE_AUTH) —
+  confirm §7 covers it or flag as missing.
+- Bootstrap coupled-predicate (both CYODA_BOOTSTRAP_CLIENT_ID and CLIENT_SECRET
+  must be set-or-both-empty in jwt mode) — confirm §7 covers it or flag as missing.
+- _FILE suffix support for credential env vars — confirm §7/§9 covers it or flag.
+
+Output format as in Agent 1.
+```
+
+- [ ] **Step 2: Capture findings to `/tmp/arch-sync-agent4.md`.**
+
+### Task 5: Reconcile ARCHITECTURE.md §9 Configuration Reference
+
+**Files:**
+- Read: `docs/ARCHITECTURE.md` §9 (lines 1135–1240)
+- Read: `app/config.go` (entire file, focus on `DefaultConfig`)
+- Read: `cmd/cyoda/main.go` (focus on `printHelp`)
+- Read: `README.md` (config sections)
+- Read: each plugin's `ConfigVars()`: `plugins/memory/plugin.go`, `plugins/sqlite/plugin.go`, `plugins/postgres/plugin.go`
+
+- [ ] **Step 1: Dispatch Agent 5 (highest-drift agent)**
+
+```
+Thorough reconciliation against cyoda-go codebase at commit <SHA>.
+
+Read docs/ARCHITECTURE.md §9 Configuration Reference (lines 1135–1240):
+- Server (ports, bind, context path, error mode, log level, etc.)
+- Storage — plugin selection
+- PostgreSQL plugin subsection (lines 1157–1168)
+- Cassandra plugin subsection (lines 1169–1186) — will be REMOVED in Phase B;
+  flag this to confirm the removal is correct, but don't evaluate content accuracy.
+- IAM
+- Bootstrap
+- gRPC
+- Cluster
+- Search
+
+Cross-check every CYODA_* env var mentioned in §9 against:
+- app/config.go DefaultConfig (every env var has a call site there for non-plugin vars)
+- cmd/cyoda/main.go printHelp (every env var should appear in help text)
+- README.md (env vars are documented in the Configuration section)
+- plugins/memory/plugin.go ConfigVars(), plugins/sqlite/plugin.go ConfigVars(),
+  plugins/postgres/plugin.go ConfigVars() — the plugin-local env vars.
+
+Flag:
+- Env vars mentioned in §9 that do not exist in code (orphans in doc).
+- Env vars in code that do not appear in §9 (orphans in code, missed in doc).
+  Highest risk: CYODA_METRICS_REQUIRE_AUTH, CYODA_METRICS_BEARER (+ _FILE variant),
+  CYODA_ADMIN_BIND_ADDRESS, CYODA_SUPPRESS_BANNER, CYODA_REQUIRE_JWT,
+  _FILE variants for credentials, CYODA_SEED_NODES, CYODA_NODE_ADDR, CYODA_GOSSIP_ADDR,
+  CYODA_PROFILES, CYODA_SQLITE_*.
+- Default-value drift: §9 says default X, code says default Y.
+- Env vars in §9 that are plugin-scoped (should move to the per-plugin files during
+  Phase B restructuring). Tag these with "EXTRACT TO plugins/<plugin>.md".
+
+Output format as in Agent 1. This agent's output drives the largest volume of edits
+in Phase B; be exhaustive.
+```
+
+- [ ] **Step 2: Capture findings to `/tmp/arch-sync-agent5.md`.**
+
+### Task 6: Reconcile ARCHITECTURE.md §10 Deployment + §11 Observability + §14 Limits
+
+**Files:**
+- Read: `docs/ARCHITECTURE.md` §10 (lines 1242–1298), §11 (lines 1300–1320), §14 (if present, else skip)
+- Read: `deploy/helm/cyoda/` (chart overview)
+- Read: `deploy/docker/` (Dockerfile, compose.yaml)
+- Read: `internal/observability/` (metrics, tracing)
+- Read: `internal/admin/admin.go` (probe endpoints)
+
+- [ ] **Step 1: Dispatch Agent 6**
+
+```
+Thorough reconciliation against cyoda-go codebase at commit <SHA>.
+
+Read docs/ARCHITECTURE.md:
+- §10 Deployment Architecture: §10.1 Single-Node, §10.2 Multi-Node Cluster
+- §11 Observability
+- §14 Non-Functional Limits and Design Boundaries (if present)
+
+Cross-check against:
+- deploy/helm/cyoda/Chart.yaml, values.yaml, templates/ (shipping shape — the Helm spec
+  at docs/superpowers/specs/2026-04-17-provisioning-helm-design.md is authoritative for
+  the chart's current state)
+- deploy/docker/Dockerfile, deploy/docker/compose.yaml (canonical compose)
+- internal/observability/ (metrics registry, tracing setup, sampler, OTel exporters)
+- internal/admin/admin.go (probe endpoints, bearer-gated /metrics)
+- .goreleaser.yaml (release artifacts — desktop, Docker)
+
+Specifically flag:
+- §11 observability: any Cassandra-specific span/metric name (cyoda.cassandra.*) — MUST
+  be removed; generalise to plugin-namespaced bullet.
+- §11 mention of "trace context propagation through the cassandra plugin's broker messages" —
+  MUST be removed.
+- §10 single-node / multi-node shapes — confirm against the current helm + compose.
+- §14 limits — confirm numeric limits still hold (search snapshot TTL, tx TTL, stability
+  window, etc.) against app/config.go defaults.
+
+Output format as in Agent 1.
+```
+
+- [ ] **Step 2: Capture findings to `/tmp/arch-sync-agent6.md`.**
+
+### Task 7: Reconcile PRD.md §1–§4
+
+**Files:**
+- Read: `docs/PRD.md` §1 (Vision, lines 9–42), §2 (EDBMS Core, lines 44–105), §3 (Workflow Engine, lines 106–169), §4 (Transaction Model, lines 170–221)
+- Read: `internal/domain/entity/` (entity type, lifecycle, soft delete)
+- Read: `internal/domain/model/` (model discovery, change levels, lock lifecycle)
+- Read: `internal/domain/workflow/` (FSM, transition types, criteria, processor modes, cascade, audit)
+- Read: `app/app.go` + transaction-related code (ACID guarantees, lifecycle, read-your-own-writes, conflict detection, tx timeout/reaper, multi-node affinity)
+
+- [ ] **Step 1: Dispatch Agent 7**
+
+```
+Thorough reconciliation of docs/PRD.md §1–§4 against cyoda-go codebase at commit <SHA>.
+
+Read PRD sections:
+- §1 Product Vision and Target Use Case (lines 9–42) — will have storage callout rewritten
+  in Phase B per the spec, so focus on the rest: target apps, scale profile, cost model.
+- §2 EDBMS Core (lines 44–105): entities as state machines, entity models, temporal integrity.
+- §3 Workflow Engine (lines 106–169): FSM, transition types, criteria types, processor
+  execution modes, cascade behaviour, workflow management, audit trail.
+- §4 Transaction Model (lines 170–221): ACID guarantees, tx lifecycle, read-your-own-writes,
+  conflict detection, tx timeout and reaper, multi-node tx affinity.
+
+Cross-check against:
+- internal/domain/entity/ (UUID, Model, State, Data, Temporal History, Soft Delete,
+  Physical Delete — the PRD mentions planned issues #65 and #66; verify if they are
+  still planned or landed)
+- internal/domain/model/ (discovery via import, lock lifecycle UNLOCKED↔LOCKED, change levels)
+- internal/domain/workflow/ (finite state machine, transition types, criteria types,
+  processor execution modes sync/async, cascade, audit trail)
+- app/app.go and lifecycle.Manager (ACID guarantees, tx timeout, reaper)
+
+Flag:
+- Planned feature references (#65, #66, etc.) that have since landed and should move
+  out of "planned" context.
+- Processor mode names that drifted.
+- Transition type names that drifted.
+- Criteria operator names (PRD lists 23 search predicates — verify count against
+  internal/match/).
+- ACID claim specificity (spec-level, not implementation-specific).
+
+Output format as in Agent 1.
+```
+
+- [ ] **Step 2: Capture findings to `/tmp/arch-sync-agent7.md`.**
+
+### Task 8: Reconcile PRD.md §5–§12 (excluding frozen sections)
+
+**Files:**
+- Read: `docs/PRD.md` §5 onward (lines 222 through end, stopping at the first frozen version-history/decision-log block)
+- Read: `internal/domain/account/` (tenants, tenant hierarchy)
+- Read: `internal/match/` (search predicates)
+- Read: `internal/domain/search/` (snapshot mechanics referenced in §6 Search)
+- Read: `api/grpc/events/` (gRPC CloudEvents for §7 Externalized Processing)
+
+- [ ] **Step 1: Dispatch Agent 8**
+
+```
+Thorough reconciliation of docs/PRD.md §5 through last non-frozen section against
+cyoda-go codebase at commit <SHA>.
+
+Read PRD sections (stop at any version history / change log / frozen block):
+- §5 Multi-Tenancy (lines 222–247): design principles, tenant hierarchy, gRPC member isolation.
+- §6 Search (lines 248–294): synchronous search, asynchronous (snapshot) search,
+  predicate operators (23 listed), condition types.
+- §7 Externalized Processing (lines 295–347): protocol gRPC CloudEvents, connection lifecycle,
+  CloudEvent types, tag-based routing, computation member lifecycle, transaction context propagation.
+- §8 onward (if present, until frozen content).
+
+Cross-check against:
+- internal/domain/account/ (tenant model, hierarchy if any)
+- internal/match/ (predicate operators — enumerate what exists; compare to the 23 listed in §6)
+- internal/domain/search/ (synchronous direct search, async snapshot search, snapshot TTL)
+- api/grpc/events/ (CloudEvent type names, correlation, routing tags)
+- internal/grpc/ (member lifecycle, tag-based selection)
+
+Flag:
+- Count mismatches (e.g. "23 predicate operators" — is it still 23? List actual count).
+- Predicate operator name drift (PRD says X, code says Y).
+- CloudEvent type name drift.
+- Connection-lifecycle state names.
+- Tenant hierarchy claims vs actual account model.
+
+Output format as in Agent 1. Do NOT evaluate content inside any "version history",
+"decision log", or similarly-labelled frozen block.
+```
+
+- [ ] **Step 2: Capture findings to `/tmp/arch-sync-agent8.md`.**
+
+### Task 9: Synthesize all reconciliation findings
+
+**Files:**
+- Read: `/tmp/arch-sync-agent1.md` through `/tmp/arch-sync-agent8.md`
+- Create: `/tmp/arch-sync-findings.md` (consolidated fix list)
+
+- [ ] **Step 1: Read all eight agent outputs.**
+
+- [ ] **Step 2: Consolidate into a single fix-list structured as follows:**
+
+```markdown
+# Reconciliation findings — consolidated
+
+## A. Critical (must-fix, doc contradicts code)
+### A.1 ARCHITECTURE.md
+- line XX: [claim] → [code truth at file:line] → [fix]
+...
+### A.2 PRD.md
+...
+
+## B. Significant (material omissions or since-refactored)
+...
+
+## C. Minor (stylistic drift)
+...
+
+## D. Content extracted to per-plugin files (from Agent 5)
+### D.1 memory plugin
+- env vars: ...
+- §3.2 content extracted verbatim
+### D.2 sqlite plugin
+- env vars: ...
+### D.3 postgres plugin
+- env vars: ...
+- §3.3 content extracted verbatim
+- §3.5 pgx.Tx single-owner extracted verbatim
+```
+
+- [ ] **Step 3: Commit the findings to the repo for audit trail (not a permanent doc, but useful for review).**
+
+```bash
+# Don't commit /tmp files. Instead, copy the synthesis to a working location:
+mkdir -p .worktree-scratch
+cp /tmp/arch-sync-findings.md .worktree-scratch/reconciliation-findings.md
+# Add .worktree-scratch/ to .gitignore if not already
+echo ".worktree-scratch/" >> .gitignore
+```
+
+(This keeps the findings accessible during Phase B without polluting main. Delete after Phase C passes.)
+
+---
+
+## Phase B — Apply fixes and restructure (Tasks 10–18)
+
+### Task 10: Create `docs/plugins/` directory with README.md
+
+**Files:**
+- Create: `docs/plugins/README.md`
+
+- [ ] **Step 1: Create the directory and index file.**
+
+```bash
+mkdir -p docs/plugins
+```
+
+- [ ] **Step 2: Write `docs/plugins/README.md`:**
+
+```markdown
+# Storage plugins
+
+cyoda-go's storage layer is a plugin system defined by the stable
+[`cyoda-go-spi`](https://github.com/cyoda-platform/cyoda-go-spi) module (stdlib-only
+Go interfaces and value types). A running binary has exactly one active plugin,
+selected at startup via `CYODA_STORAGE_BACKEND`.
+
+## Open-source plugins shipped with the stock binary
+
+- **[`memory`](IN_MEMORY.md)** (default) — ephemeral, microsecond-latency SSI for
+  tests and high-throughput digital-twin workloads.
+- **[`sqlite`](SQLITE.md)** — persistent, zero-ops single-node storage for desktop,
+  edge, and containerised single-node production.
+- **[`postgres`](POSTGRES.md)** — durable multi-node storage with SSI via PostgreSQL
+  `SERIALIZABLE`; works against any managed PostgreSQL 14+ platform.
+
+## Commercial plugin
+
+A **`cassandra`** plugin is available as a commercial offering from Cyoda for
+deployments that need horizontal write scalability beyond a single-primary
+PostgreSQL. See [cyoda.com](https://www.cyoda.com) and use its contact page.
+
+## Authoring your own plugin
+
+Third-party plugins (Redis, ScyllaDB, FoundationDB, etc.) can be authored against
+`cyoda-go-spi` and compiled into a custom binary via a blank import in a local
+`main.go`. The stock plugins serve as reference implementations:
+
+- [`plugins/memory/doc.go`](../../plugins/memory/doc.go) — the simplest possible
+  reference implementation; start here.
+- [`plugins/postgres/doc.go`](../../plugins/postgres/doc.go) — the fully-featured
+  reference implementation with migrations, connection pooling, and multi-node
+  wiring.
+
+See [`../ARCHITECTURE.md`](../ARCHITECTURE.md) §2 for the plugin contract.
+```
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add docs/plugins/README.md
+git commit -m "docs(plugins): create plugins/ directory with index README"
+```
+
+### Task 11: Create `docs/plugins/IN_MEMORY.md`
+
+**Files:**
+- Create: `docs/plugins/IN_MEMORY.md`
+
+- [ ] **Step 1: Extract content from the current ARCHITECTURE.md §2.1 and §3.2.**
+
+Read `docs/ARCHITECTURE.md` around lines 244–284 (current §2.1) and lines 389–412 (current §3.2).
+
+- [ ] **Step 2: Apply reconciliation-findings items tagged for the memory plugin from `/tmp/arch-sync-findings.md` §D.1.**
+
+- [ ] **Step 3: Write `docs/plugins/IN_MEMORY.md` with the seven-section template:**
+
+```markdown
+# `memory` storage plugin
+
+## Capabilities
+
+Ephemeral, in-process state — no disk I/O, no network round-trips, no query
+planner on the hot path. The memory plugin's latency profile sits an order of
+magnitude ahead of any persistent backend: a full SSI transaction (begin →
+read-modify-write → commit) completes in the low microseconds rather than the
+milliseconds a Postgres round-trip takes.
+
+That performance envelope makes the memory plugin particularly effective as
+the **state-backing for high-throughput digital-twin workloads** — an agentic
+software factory where an agent swarm drives thousands of scenario executions
+per second against a behavioural twin of a production entity, or a simulation
+that replays weeks of production state-machine behaviour in seconds. Same
+workflow semantics, same FSM engine, same SSI guarantees as the persistent
+backends — without the durability trade-off.
+
+## Concurrency model
+
+<!--
+IMPLEMENTER NOTE: This section is extracted verbatim from the current
+docs/ARCHITECTURE.md §3.2 (In-Memory SSI Conflict Detection, approximately
+lines 389–412). Read that section, copy its content here, and apply any
+reconciliation-finding deltas tagged §D.1 in /tmp/arch-sync-findings.md.
+The final content describes: the committedLog structure, active-transaction
+tracking, read-set and write-set recording, and first-committer-wins
+conflict detection at commit time.
+-->
+
+## Transaction manager
+
+<!--
+IMPLEMENTER NOTE: Extract from current §3.2 tail + §3.6 memory bullet.
+Reference plugins/memory/txmanager.go for the concrete type names.
+-->
+See `plugins/memory/txmanager.go` for the `TransactionManager` implementation.
+The manager owns the per-transaction read/write sets and the committed-log
+window used for conflict detection.
+
+## Data model and schema
+
+No persistence. All state lives in Go data structures inside the process.
+Restart loses everything. Data structures mirror the entity/model/workflow/KV/
+message/audit/search boundaries defined by the SPI — see
+`plugins/memory/<type>_store.go` for each.
+
+## Configuration (env vars)
+
+The memory plugin has no plugin-specific env vars. It is the default backend when
+`CYODA_STORAGE_BACKEND` is unset or set to `memory`.
+
+## Operational notes and limits
+
+- Process-local; data lost on restart.
+- Single-process only — multiple cyoda processes against the "same" memory plugin
+  would have independent state (there is no shared store).
+- No persistence snapshots. Pair with periodic exports to a durable backend if
+  agent/simulation results matter beyond the session.
+- No tenant isolation beyond application-layer.
+
+## When to use / when not to use
+
+**Use:** tests, short-lived local dev, parity baselines, high-throughput digital-twin
+simulations where durability is delegated to an external snapshot mechanism.
+
+**Don't use:** production where any restart would lose data; multi-process
+deployments; anywhere durable storage is a functional requirement.
+```
+
+- [ ] **Step 4: Run the verification grep for this file (Cassandra mechanism leak):**
+
+```bash
+grep -rEi 'HLC|hybrid logical clock|Redpanda|shard.epoch|ClusterBroadcaster|USING TIMESTAMP|transaction_log_idx|2PC|two.phase commit|LWT|last.writer.wins|cyoda-go-cassandra|CASSANDRA_BACKEND_DESIGN' docs/plugins/IN_MEMORY.md
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add docs/plugins/IN_MEMORY.md
+git commit -m "docs(plugins): extract memory plugin docs to IN_MEMORY.md"
+```
+
+### Task 12: Create `docs/plugins/SQLITE.md`
+
+**Files:**
+- Create: `docs/plugins/SQLITE.md`
+
+- [ ] **Step 1: Gather source material.**
+
+Read:
+- `docs/superpowers/specs/2026-04-15-sqlite-storage-plugin-design.md` (the plugin's own design spec)
+- `plugins/sqlite/plugin.go` (ConfigVars)
+- `plugins/sqlite/config.go` (OS-aware default DB path)
+- `plugins/sqlite/store_factory.go` (flock, WASM driver)
+- Agent 7/8 findings for any drift
+
+- [ ] **Step 2: Write the file following the seven-section template.**
+
+```markdown
+# `sqlite` storage plugin
+
+## Capabilities
+
+Persistent, zero-ops single-node storage. Embedded in-process via a pure-Go
+(WASM) SQLite driver — no CGO, clean cross-compilation, future
+[sqlite-vec](https://github.com/asg017/sqlite-vec) support. The ideal backend
+for desktop binary users, edge deployments, and containerised single-node
+production.
+
+Search predicate pushdown to SQL — the majority of entity search predicates
+resolve in the SQL engine rather than post-filter in Go, matching the
+PostgreSQL plugin's search shape.
+
+## Concurrency model
+
+Application-layer Serializable Snapshot Isolation (SSI), **ported from the
+memory plugin**. SQLite provides only database-level write locking (zero write
+concurrency); cyoda's SSI gives first-committer-wins entity-level conflict
+detection on top.
+
+An exclusive `flock` on the database file is acquired at startup and held for
+the process lifetime. A second cyoda process against the same file fails fast
+with a clear error. The flock is required because the SSI state (committed-log,
+active-transaction set) is per-process — two processes sharing a file would
+have independent SSI and silently corrupt each other's conflict detection.
+
+`flock` does not work on NFS, but SQLite itself is unreliable on NFS, so the
+restriction is implicit in choosing SQLite at all.
+
+## Transaction manager
+
+Same SSI engine as the memory plugin (`TransactionManager` ported verbatim;
+SQLite is the durability layer, not the concurrency controller). Reference:
+`plugins/sqlite/txmanager.go`.
+
+## Data model and schema
+
+Mirrors the PostgreSQL logical schema with SQLite optimisations:
+- JSONB columns stored as `BLOB` with `jsonb()` / `json()` functions — 2-5×
+  faster `json_extract()` than TEXT JSON. Plugin asserts
+  `sqlite_version() >= 3.45.0` at startup.
+- `STRICT` tables + `WITHOUT ROWID` on append-only tables (e.g. `entity_versions`).
+- INTEGER timestamps (Unix nanoseconds) — 15-25% smaller, 15-30% faster point
+  lookups than TEXT timestamps.
+
+Migrations via `golang-migrate` with embedded SQL files — same pattern as the
+postgres plugin. Runs automatically on startup when
+`CYODA_SQLITE_AUTO_MIGRATE=true` (the default).
+
+## Configuration (env vars)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `CYODA_SQLITE_PATH` | `$XDG_DATA_HOME/cyoda/cyoda.db` on Linux/macOS (fallback `~/.local/share/cyoda/cyoda.db`); `%LocalAppData%\cyoda\cyoda.db` on Windows | Database file path |
+| `CYODA_SQLITE_AUTO_MIGRATE` | `true` | Run embedded SQL migrations on startup |
+| `CYODA_SQLITE_BUSY_TIMEOUT` | `5s` | Wait time for write lock before returning `SQLITE_BUSY` |
+| `CYODA_SQLITE_CACHE_SIZE` | `64000` (KiB) | Page cache size in KiB |
+| `CYODA_SQLITE_SEARCH_SCAN_LIMIT` | `100000` | Max rows examined per search when a residual filter applies |
+
+## Operational notes and limits
+
+- **No CGO.** Uses [`ncruces/go-sqlite3`](https://github.com/ncruces/go-sqlite3)
+  (WASM-based); ~2-3× slower on micro-benchmarks than native C SQLite. Accepted
+  for clean cross-compile and the sqlite-vec roadmap.
+- **Tenant isolation is application-layer only.** No RLS (SQLite has no native
+  row-level security).
+- **Single-process, single-node.** See concurrency model for the flock requirement.
+- **NFS unsupported.**
+
+## When to use / when not to use
+
+**Use:** desktop binary users, containerised single-node production, embedded
+deployments, edge devices, any scenario where "memory plugin but must survive
+restart" is the requirement.
+
+**Don't use:** multi-node deployments, multi-process deployments, NFS-mounted
+storage, workloads that need horizontal write scale (go to postgres or cassandra).
+```
+
+- [ ] **Step 3: Apply any Agent 5/7/8 findings tagged for SQLite.**
+
+- [ ] **Step 4: Run verification grep.**
+
+```bash
+grep -rEi 'HLC|hybrid logical clock|Redpanda|shard.epoch|ClusterBroadcaster|USING TIMESTAMP|transaction_log_idx|2PC|two.phase commit|LWT|last.writer.wins|cyoda-go-cassandra|CASSANDRA_BACKEND_DESIGN' docs/plugins/SQLITE.md
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add docs/plugins/SQLITE.md
+git commit -m "docs(plugins): add SQLITE.md — first-class sqlite plugin documentation"
+```
+
+### Task 13: Create `docs/plugins/POSTGRES.md`
+
+**Files:**
+- Create: `docs/plugins/POSTGRES.md`
+
+- [ ] **Step 1: Extract content from current ARCHITECTURE.md §2.2, §3.3, §3.5, §9 postgres subsection.**
+
+Read:
+- `docs/ARCHITECTURE.md` lines 285–350 (current §2.2)
+- `docs/ARCHITECTURE.md` lines 413–462 (current §3.3, §3.5)
+- `docs/ARCHITECTURE.md` lines 1157–1168 (current §9 postgres subsection)
+- Agent 1/5 findings tagged §D.3
+
+- [ ] **Step 2: Write the file following the seven-section template.**
+
+```markdown
+# `postgres` storage plugin
+
+## Capabilities
+
+Durable multi-node storage using PostgreSQL as the single source of truth for
+transaction isolation. Each transaction holds a `pgx.Tx` handle in one cyoda
+node's process memory, executing under PostgreSQL's `SERIALIZABLE` isolation —
+cyoda's multi-node architecture pins each transaction to its owning node via
+`txID → pgx.Tx` affinity, giving active-active HA without distributed-transaction
+overhead.
+
+**Works against any managed PostgreSQL 14+ platform:** AWS RDS, Google Cloud SQL,
+Azure Database for PostgreSQL, Supabase, Neon, Aiven, Crunchy Bridge, Render,
+Fly.io Postgres, DigitalOcean Managed Databases, and self-hosted.
+
+## Concurrency model
+
+<!--
+IMPLEMENTER NOTE: Extract verbatim from current docs/ARCHITECTURE.md §3.3
+(PostgreSQL SERIALIZABLE + Error Code 40001, approximately lines 413–434).
+Apply reconciliation-finding deltas tagged §D.3 in /tmp/arch-sync-findings.md.
+Content covers: SERIALIZABLE isolation mode set per-transaction, the 40001
+"could not serialize access due to concurrent update" retry semantics, and
+cyoda's retry-bounded handling of the error class.
+-->
+
+## Transaction manager
+
+Lightweight in-process lifecycle tracker. The real serialization guarantee comes
+from PostgreSQL's `SERIALIZABLE` isolation inside the stores. The TM assigns IDs,
+tracks active/committed sets with timestamps, and supports savepoints as a local
+stack. See `plugins/postgres/txmanager.go`.
+
+### `pgx.Tx` single-owner property
+
+<!--
+IMPLEMENTER NOTE: Extract verbatim from current docs/ARCHITECTURE.md §3.5
+(pgx.Tx Single-Owner Property, approximately lines 452–462). Apply any
+reconciliation-finding deltas tagged §D.3.
+-->
+
+## Data model and schema
+
+<!--
+IMPLEMENTER NOTE: Extract the postgres data-model description and migration
+infrastructure from current docs/ARCHITECTURE.md §2.2 (approximately lines
+285–350). Apply reconciliation-finding deltas tagged §D.3.
+-->
+
+Schema lives under `plugins/postgres/migrations/` (embedded via `embed.FS`).
+Applied on startup via `golang-migrate` when `CYODA_POSTGRES_AUTO_MIGRATE=true`
+(the default). Entities, models, KV, messages, workflows, and audit each have
+their dedicated tables with appropriate JSONB columns and GIN indexes.
+
+## Configuration (env vars)
+
+<!--
+IMPLEMENTER NOTE: The complete list of postgres env vars comes from
+plugins/postgres/plugin.go ConfigVars(). Enumerate every entry from that
+method into the table below. Cross-check against current §9 postgres
+subsection of docs/ARCHITECTURE.md (approximately lines 1157–1168) and
+apply Agent 5 findings tagged §D.3 for any default-value drift or
+missing entries. The _FILE-suffix variant of CYODA_POSTGRES_URL is
+implemented in plugins/postgres/config.go via resolveSecretWith.
+-->
+
+| Var | Default | Purpose |
+|---|---|---|
+| `CYODA_POSTGRES_URL` (or `_FILE`) | *(required)* | PostgreSQL connection string |
+| `CYODA_POSTGRES_AUTO_MIGRATE` | `true` | Run embedded SQL migrations on startup |
+| *(remaining rows enumerated from ConfigVars() during implementation)* | | |
+
+### Managed-platform notes
+
+Platforms that front PostgreSQL with **PgBouncer in transaction pooling mode**
+(Supabase port 6543, Neon pooled endpoint) strip prepared-statement caching
+mid-session. `pgx`'s default extended-query protocol uses prepared statements.
+
+Options:
+- Use the platform's **direct-connection endpoint** (Supabase 5432, Neon direct)
+  — recommended for cyoda.
+- Set `default_query_exec_mode=exec` on the `pgx` pool to force simple-query
+  mode — accepts a small per-query overhead in exchange for pooler compatibility.
+
+cyoda uses transaction-scoped `SET LOCAL` for RLS (tenant isolation) only — no
+session-level state fights PgBouncer transaction mode beyond the prepared-statement
+cache.
+
+## Operational notes and limits
+
+- Requires PostgreSQL 14+.
+- Recommended HA mode: primary + streaming replica with automatic failover.
+- Cluster-mode cyoda uses Postgres for transaction isolation and cyoda's own
+  gossip registry for node discovery — the two are orthogonal.
+- Scale-out is bounded by the PostgreSQL primary's write capacity. Read-replicas
+  are not yet wired in to cyoda.
+
+## When to use / when not to use
+
+**Use:** clustered production, high consistency requirements, audit/compliance
+workloads, any deployment where a managed PostgreSQL platform is the infrastructure
+baseline.
+
+**Don't use:** single-process desktop deployments (use sqlite), workloads whose
+write volume exceeds what a single Postgres primary can sustain (consider the
+commercial cassandra plugin).
+```
+
+- [ ] **Step 3: Apply Agent 1/5 reconciliation findings.**
+
+- [ ] **Step 4: Run verification grep.**
+
+```bash
+grep -rEi 'HLC|hybrid logical clock|Redpanda|shard.epoch|ClusterBroadcaster|USING TIMESTAMP|transaction_log_idx|2PC|two.phase commit|LWT|last.writer.wins|cyoda-go-cassandra|CASSANDRA_BACKEND_DESIGN' docs/plugins/POSTGRES.md
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add docs/plugins/POSTGRES.md
+git commit -m "docs(plugins): extract postgres plugin docs to POSTGRES.md"
+```
+
+### Task 14: Restructure ARCHITECTURE.md §2 — trim to index + §2.4 Cassandra capabilities
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md` §2 (lines 211–366)
+
+- [ ] **Step 1: Read current §2 (lines 211–366).**
+
+- [ ] **Step 2: Replace §2 body with the target shape from the spec:**
+
+<!--
+IMPLEMENTER NOTE: The opening storage-agnostic paragraphs of §2 (approximately
+lines 211–243 of the current docs/ARCHITECTURE.md — SPI contract, blank-import
+binary pattern, plugin resolution at startup) are kept verbatim. Only the
+per-plugin subsections (§2.1 through §2.3) are replaced with the abbreviated
+forms shown below, and §2.4 is added.
+-->
+
+```markdown
+## 2. Storage Architecture
+
+<!-- keep existing opening paragraphs here -->
+
+### 2.1 The `memory` plugin (`plugins/memory/`)
+
+Ephemeral, in-process state with microsecond-latency SSI. Default for tests,
+local development, and high-throughput digital-twin workloads where durability
+is delegated elsewhere. Full detail in
+[docs/plugins/IN_MEMORY.md](plugins/IN_MEMORY.md).
+
+### 2.2 The `sqlite` plugin (`plugins/sqlite/`)
+
+Persistent, zero-ops single-node storage. Embedded in-process via a pure-Go
+(WASM) SQLite driver, exclusive file lock, application-layer SSI ported from
+the memory plugin, search predicate pushdown to SQL. Default for desktop
+binary, edge deployments, and containerised single-node production. Full
+detail in [docs/plugins/SQLITE.md](plugins/SQLITE.md).
+
+### 2.3 The `postgres` plugin (`plugins/postgres/`)
+
+Durable multi-node storage with SSI via PostgreSQL `SERIALIZABLE`. Works
+against any managed PostgreSQL 14+ platform (RDS, Cloud SQL, Azure, Supabase,
+Neon, Aiven, Crunchy Bridge, self-hosted, etc.). Full detail in
+[docs/plugins/POSTGRES.md](plugins/POSTGRES.md).
+
+### 2.4 The `cassandra` plugin (commercial)
+
+A Cassandra-backed storage plugin is available as a commercial offering from
+Cyoda. It slots into cyoda-go through the same `spi.Plugin` contract as the
+open-source plugins — operators select it at runtime via
+`CYODA_STORAGE_BACKEND=cassandra`.
+
+**Capability envelope:**
+
+- Horizontal write scalability across a Cassandra cluster
+- Snapshot isolation with first-committer-wins semantics
+- Append-only point-in-time storage with full historical reads
+- No single points of failure
+- Multi-node consistency
+
+**When it fits:** workloads whose write volume or availability requirements
+outgrow a single-primary PostgreSQL deployment — while keeping the same EDBMS
+semantics (entities, workflows, temporal history, SSI) that the open-source
+binary provides on top of the in-memory / sqlite / postgres plugins.
+
+**Interested?** Get in touch with Cyoda at [cyoda.com](https://www.cyoda.com)
+and use its contact page.
+```
+
+- [ ] **Step 3: Run the Cassandra mechanism grep.**
+
+```bash
+grep -nEi 'HLC|hybrid logical clock|Redpanda|shard.epoch|ClusterBroadcaster|USING TIMESTAMP|transaction_log_idx|2PC|two.phase commit|LWT|last.writer.wins|cyoda-go-cassandra|CASSANDRA_BACKEND_DESIGN' docs/ARCHITECTURE.md
+```
+
+Expected: no output in §2 range (may still have hits elsewhere — those are cleaned in Task 15).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add docs/ARCHITECTURE.md
+git commit -m "docs(architecture): trim §2 to plugins index + §2.4 Cassandra capabilities"
+```
+
+### Task 15: Sweep remaining Cassandra mechanism leaks from ARCHITECTURE.md
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md` — lines 44 (repositories table), ~231 (SPI lifecycle note), ~469 (§3.6 TM bullet), ~1169–1186 (§9 Cassandra subsection), ~1310–1316 (§11 observability), ~1322 (§12 cyoda-go-cassandra reference)
+
+- [ ] **Step 1: Remove row from repositories table at line 44.**
+
+Find: `| \`cyoda-go-cassandra\` | github.com/cyoda-platform/cyoda-go-cassandra | Proprietary Cassandra storage plugin + full binary | Proprietary |`
+
+Delete that row.
+
+- [ ] **Step 2: Remove parenthetical in SPI lifecycle note (~line 231).**
+
+Find: `(e.g. cassandra's shard-rebalance wait)` and remove the parenthetical. Keep the generic SPI point.
+
+- [ ] **Step 3: Replace §3.6 cassandra bullet.**
+
+Find:
+```
+- **cassandra plugin** — a coordinator-managed 2PC over a message broker, with HLC fencing, per-shard epoch ownership, and committed-log replay for recovery (see Section 2.3). Owns its own TM because Cassandra has neither `SERIALIZABLE` nor native multi-partition transactions.
+```
+
+Replace with:
+```
+- **Commercial plugins** (e.g. the Cassandra plugin from Cyoda) implement their
+  own `TransactionManager` against their underlying store's primitives. See
+  §2.4 for the capability envelope of the commercial Cassandra plugin.
+```
+
+- [ ] **Step 4: Remove §9 Cassandra subsection entirely.**
+
+Delete lines ~1169–1186 (the `### Cassandra plugin (CYODA_STORAGE_BACKEND=cassandra, available only in the cyoda-go-cassandra binary)` heading through the last env-var bullet of that subsection).
+
+- [ ] **Step 5: Generalise §11 Observability.**
+
+Find the paragraph with "cyoda.cassandra.cql.duration, cyoda.cassandra.batch.duration..." and rewrite:
+
+```
+**Plugin-level instrumentation:** plugins are free to add their own spans and
+metrics under a plugin-specific namespace. The `memory` and `postgres` plugins
+emit minimal plugin-level telemetry (their behaviour is well-captured by the
+core transaction/workflow/dispatch spans); other plugins may add detailed
+instrumentation scoped to their own namespace as their hot-path semantics warrant.
+```
+
+Also remove the paragraph that mentions "trace context propagation through the cassandra plugin's broker messages, search pipeline, and external-processor gRPC/CloudEvents is incomplete" — replace with a more generic known-gap note if §11 still has a Known-Gaps block, otherwise just delete.
+
+- [ ] **Step 6: Remove cyoda-go-cassandra reference in §12.**
+
+Find: `cyoda-go-cassandra for cassandra plugin` and remove. If the sentence becomes nonsensical after removal, rewrite it to reference only open-source repositories.
+
+- [ ] **Step 7: Run the Cassandra mechanism grep across the whole file.**
+
+```bash
+grep -nEi 'HLC|hybrid logical clock|Redpanda|shard.epoch|ClusterBroadcaster|USING TIMESTAMP|transaction_log_idx|2PC|two.phase commit|LWT|last.writer.wins|cyoda-go-cassandra|CASSANDRA_BACKEND_DESIGN' docs/ARCHITECTURE.md
+```
+
+Expected: no output.
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add docs/ARCHITECTURE.md
+git commit -m "docs(architecture): sweep Cassandra mechanism leaks to capability-only"
+```
+
+### Task 16: Apply reconciliation findings to ARCHITECTURE.md non-storage sections
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md` — any non-§2 sections with findings in `/tmp/arch-sync-findings.md` §A, §B, §C
+
+- [ ] **Step 1: Walk through `/tmp/arch-sync-findings.md` §A (Critical) for ARCHITECTURE.md items, applying each fix.**
+
+For each item:
+- Use `Read` to load the surrounding context.
+- Use `Edit` to make the fix.
+- Verify the edit landed.
+
+- [ ] **Step 2: Walk through §B (Significant) for ARCHITECTURE.md items, applying each.**
+
+- [ ] **Step 3: Walk through §C (Minor) for ARCHITECTURE.md items, applying each.**
+
+- [ ] **Step 4: Fix the cross-references at lines 467–468** (flagged during spec self-review):
+
+Find (current text):
+```
+- **memory plugin** — in-process SSI with entity-level read/write sets and a committed-transaction log (Section 3.2).
+- **postgres plugin** — lightweight in-process lifecycle tracker. The real serialization guarantee comes from PostgreSQL's `SERIALIZABLE` isolation inside the stores (Section 3.3). ...
+```
+
+Replace with:
+```
+- **memory plugin** — in-process SSI with entity-level read/write sets and a committed-transaction log (see [docs/plugins/IN_MEMORY.md](plugins/IN_MEMORY.md) for the full implementation).
+- **postgres plugin** — lightweight in-process lifecycle tracker. The real serialization guarantee comes from PostgreSQL's `SERIALIZABLE` isolation inside the stores (see [docs/plugins/POSTGRES.md](plugins/POSTGRES.md)). ...
+```
+
+- [ ] **Step 5: Fix the package-layout diagram** — `cmd/cyoda-go/main.go` → `cmd/cyoda/main.go`.
+
+- [ ] **Step 6: Update the header metadata.**
+
+Find:
+```
+**Version:** 2.0
+**Date:** 2026-04-14
+**Status:** Target state after the storage-plugin architecture refactor (Plans 1–5). See `docs/superpowers/specs/2026-04-13-storage-plugin-architecture-design.md` for the refactor plan.
+```
+
+Replace with:
+```
+**Version:** 2.1
+**Date:** 2026-04-18
+**Status:** Current as of the Helm provisioning drop (PR #60, commit 31435d2).
+```
+
+- [ ] **Step 7: Remove §3.2 and §3.3 from ARCHITECTURE.md (content extracted to plugin files).**
+
+In their place, add a one-line pointer:
+
+```
+### 3.2 Memory plugin SSI
+
+See [docs/plugins/IN_MEMORY.md](plugins/IN_MEMORY.md).
+
+### 3.3 Postgres `SERIALIZABLE` + retry
+
+See [docs/plugins/POSTGRES.md](plugins/POSTGRES.md).
+```
+
+(Keep the section numbers intact to avoid breaking any intra-document references.)
+
+- [ ] **Step 8: Similarly, §3.5 pgx.Tx content — extract to POSTGRES.md, replace with pointer.**
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add docs/ARCHITECTURE.md
+git commit -m "docs(architecture): apply reconciliation findings; link out to plugin docs"
+```
+
+### Task 17: Rewrite PRD.md §1 storage callout + apply reconciliation findings
+
+**Files:**
+- Modify: `docs/PRD.md`
+
+- [ ] **Step 1: Rewrite the §1 storage-plugin blockquote (currently lines 23–26).**
+
+Find: the blockquote starting `> **Storage plugin architecture.** Cyoda-Go's storage layer is a plugin system...`
+
+Replace with the spec-approved version (from `docs/superpowers/specs/2026-04-18-architecture-prd-sync-design.md` §5.1):
+
+```markdown
+> **Storage plugin architecture.** Cyoda-Go's storage layer is a plugin system
+> defined by the stable `cyoda-go-spi` module (stdlib-only Go interfaces and
+> value types). A running binary has exactly one active plugin, selected at
+> startup via `CYODA_STORAGE_BACKEND`. The stock `cyoda-go` binary ships with
+> three open-source plugins:
+>
+> - **`memory`** (default) — ephemeral, microsecond-latency SSI for tests and
+>   high-throughput digital-twin workloads.
+> - **`sqlite`** — persistent, zero-ops single-node storage for desktop, edge,
+>   and containerised single-node production.
+> - **`postgres`** — durable multi-node storage with SSI via PostgreSQL
+>   `SERIALIZABLE`; works against any managed PostgreSQL platform.
+>
+> A commercial `cassandra` plugin is also available from Cyoda for deployments
+> that need horizontal write scalability beyond what a single-primary
+> PostgreSQL can provide — see [cyoda.com](https://www.cyoda.com) and use its
+> contact page.
+>
+> Third-party plugins (Redis, ScyllaDB, FoundationDB, etc.) can be authored
+> against `cyoda-go-spi` and compiled into a custom binary via a blank import.
+> See `docs/ARCHITECTURE.md` for the plugin contract and `docs/plugins/` for
+> per-plugin specifics.
+```
+
+- [ ] **Step 2: Generalise §1 Scale Profile** (currently line 25 area).
+
+Find: `Small compute clusters (3-10 stateless Go nodes) with a shared PostgreSQL instance.`
+
+Replace with:
+
+```markdown
+Scale envelope depends on storage plugin:
+
+- **`memory`** — single process, bounded by host RAM.
+- **`sqlite`** — single node, persistent; write throughput bounded by local disk.
+- **`postgres`** — small compute clusters (3–10 stateless Go nodes) behind a
+  load balancer, sharing a primary PostgreSQL. Active-active HA; any node
+  serves any request.
+- **`cassandra`** (commercial) — multi-cluster, horizontal write scale-out
+  without a single-primary bottleneck.
+```
+
+- [ ] **Step 3: Generalise §1 Cost Model** similarly — acknowledge all four backends.
+
+- [ ] **Step 4: Add one sentence to §4 Transaction Model:**
+
+Find a place near the ACID discussion and add:
+
+```
+SQLite plugin uses application-layer SSI ported from the memory plugin; the
+commercial Cassandra plugin implements SSI against its own primitives.
+```
+
+- [ ] **Step 5: Walk through `/tmp/arch-sync-findings.md` §A/§B/§C for PRD.md items, applying each fix.**
+
+Follow the same walk-through pattern as Task 16.
+
+- [ ] **Step 6: Update the PRD.md header metadata.**
+
+Find:
+```
+**Version:** 2.0
+**Date:** 2026-04-14
+**Status:** Target state after the storage-plugin architecture refactor (Plans 1–5). See `docs/superpowers/specs/2026-04-13-storage-plugin-architecture-design.md` for the refactor plan.
+```
+
+Replace with:
+```
+**Version:** 2.1
+**Date:** 2026-04-18
+**Status:** Current as of the Helm provisioning drop (PR #60, commit 31435d2).
+```
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add docs/PRD.md
+git commit -m "docs(prd): rewrite storage callout; apply reconciliation findings; refresh header"
+```
+
+### Task 18: Clean up working-scratch and spec artefacts
+
+**Files:**
+- Modify: `.gitignore` (if `.worktree-scratch/` was added in Task 9)
+- Delete: `.worktree-scratch/reconciliation-findings.md`
+
+- [ ] **Step 1: Delete the scratch directory.**
+
+```bash
+rm -rf .worktree-scratch/
+```
+
+- [ ] **Step 2: If `.gitignore` was modified to include `.worktree-scratch/`, leave that line in place** (future runs may use the same pattern).
+
+- [ ] **Step 3: No commit needed unless `.gitignore` changed; if it did, commit the gitignore update:**
+
+```bash
+# Only if .gitignore was modified in Task 9:
+git add .gitignore
+git commit -m "chore(gitignore): add .worktree-scratch/ for temporary agent findings"
+```
+
+---
+
+## Phase C — Verification (Tasks 19–20)
+
+### Task 19: Run the six verification checks
+
+**Files:**
+- Read-only: `docs/ARCHITECTURE.md`, `docs/PRD.md`, `docs/plugins/*.md`
+
+- [ ] **Step 1: Cassandra mechanism grep across all docs files.**
+
+```bash
+grep -rEi 'HLC|hybrid logical clock|Redpanda|shard.epoch|ClusterBroadcaster|USING TIMESTAMP|transaction_log_idx|2PC|two.phase commit|LWT|last.writer.wins|cyoda-go-cassandra|CASSANDRA_BACKEND_DESIGN' docs/ARCHITECTURE.md docs/PRD.md docs/plugins/
+```
+
+Expected: **no output**. Any hit is a leak — fix it before proceeding.
+
+- [ ] **Step 2: Rename-residue grep.**
+
+```bash
+grep -rE 'cmd/cyoda-go|deploy/helm/cyoda-go|cyoda-go-0\.' docs/ARCHITECTURE.md docs/PRD.md docs/plugins/
+```
+
+Expected: **no output**.
+
+- [ ] **Step 3: Per-plugin template conformance.**
+
+Each of `docs/plugins/IN_MEMORY.md`, `docs/plugins/SQLITE.md`, `docs/plugins/POSTGRES.md` should have these seven section headings in order:
+
+```
+## Capabilities
+## Concurrency model
+## Transaction manager
+## Data model and schema
+## Configuration (env vars)
+## Operational notes and limits
+## When to use / when not to use
+```
+
+Check:
+```bash
+for f in docs/plugins/IN_MEMORY.md docs/plugins/SQLITE.md docs/plugins/POSTGRES.md; do
+  echo "=== $f ==="
+  grep -nE '^## ' "$f"
+done
+```
+
+Expected: each file shows all seven headings in order.
+
+- [ ] **Step 4: Cross-link resolution.**
+
+```bash
+grep -nE '\]\(plugins/' docs/ARCHITECTURE.md | while IFS=: read -r line_num line; do
+  # Extract the link path
+  path=$(echo "$line" | grep -oE '\]\(plugins/[^)]+\)' | sed 's/^](\(.*\))$/\1/')
+  if [ -n "$path" ]; then
+    full_path="docs/$path"
+    if [ ! -f "$full_path" ]; then
+      echo "BROKEN LINK at line $line_num: $path"
+    fi
+  fi
+done
+```
+
+Expected: **no "BROKEN LINK" lines**.
+
+- [ ] **Step 5: Env-var cross-reference.**
+
+```bash
+# Collect every CYODA_* env var documented in the docs tree
+grep -rhoE 'CYODA_[A-Z0-9_]+' docs/ARCHITECTURE.md docs/plugins/ | sort -u > /tmp/env-docs.txt
+
+# Collect every CYODA_* env var referenced in code
+grep -rhoE 'CYODA_[A-Z0-9_]+' app/ cmd/ plugins/ internal/ | sort -u > /tmp/env-code.txt
+
+# Orphans in doc (documented but not in code)
+echo "=== Documented but not in code ==="
+comm -23 /tmp/env-docs.txt /tmp/env-code.txt
+
+# Orphans in code (in code but not documented)
+echo "=== In code but not documented ==="
+comm -13 /tmp/env-docs.txt /tmp/env-code.txt
+```
+
+Expected: both lists empty. Any orphan is a drift — fix or flag for the next reconciliation pass.
+
+Some acceptable exceptions (if any remain): `_FILE` variants may only appear in READMEs, not in the plugin docs — that's intentional and can be excluded.
+
+- [ ] **Step 6: Frozen-sections intactness.**
+
+```bash
+# Confirm §13 of ARCHITECTURE.md was not edited by us (should only have header-line drift)
+git log --oneline -p HEAD~10..HEAD -- docs/ARCHITECTURE.md | grep -A 200 "Section 13" | head -50
+```
+
+Manual scan: the only change in the §13 range should be any version/date header drift from Task 16, not content.
+
+- [ ] **Step 7: If any check fails, loop back to the relevant task. If all six pass, proceed to Task 20.**
+
+### Task 20: Request code review + user review gate
+
+**Files:**
+- Read-only: all new and modified docs.
+
+- [ ] **Step 1: Invoke the requesting-code-review skill** to dispatch a code-reviewer subagent over the commit range.
+
+Prompt notes: this is a docs-only change; the reviewer should focus on clarity, consistency, completeness against the spec, and any Cassandra mechanism residue not caught by grep (e.g., rephrased but still revealing content).
+
+- [ ] **Step 2: Apply any reviewer-flagged fixes.**
+
+- [ ] **Step 3: Commit the fixes** (one commit per category of fix — Critical / Important / Minor — per the receiving-code-review pattern).
+
+- [ ] **Step 4: Create a PR.**
+
+```bash
+# Use a feature branch if main is reserved
+git checkout -b docs/architecture-prd-sync
+git push -u origin docs/architecture-prd-sync
+gh pr create --title "docs: sync ARCHITECTURE.md and PRD.md with codebase; split storage content to plugins/*" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Brings docs/ARCHITECTURE.md and docs/PRD.md into perfect sync with the codebase
+at HEAD. Restructures storage-plugin content: ARCHITECTURE.md becomes
+storage-agnostic, per-plugin depth moves to docs/plugins/{IN_MEMORY,SQLITE,POSTGRES}.md.
+Sanitises Cassandra plugin references to capability-only framing.
+
+## Changes
+
+- NEW: docs/plugins/README.md, IN_MEMORY.md, SQLITE.md, POSTGRES.md
+- MODIFIED: docs/ARCHITECTURE.md — §2 restructured, Cassandra mechanism leaks
+  removed, per-plugin content extracted, reconciliation findings applied,
+  header bumped to Version 2.1.
+- MODIFIED: docs/PRD.md — §1 storage callout rewritten, scale/cost sections
+  generalised, reconciliation findings applied, header bumped to Version 2.1.
+
+## Spec
+
+docs/superpowers/specs/2026-04-18-architecture-prd-sync-design.md
+
+## Test plan
+
+- [x] Cassandra mechanism grep returns zero hits
+- [x] Rename-residue grep returns zero hits
+- [x] Per-plugin template conformance
+- [x] Cross-link resolution
+- [x] Env-var cross-reference (documented ↔ code)
+- [x] Frozen-sections intactness
+EOF
+)"
+```
+
+- [ ] **Step 5: User review gate.**
+
+Ping the user: "PR open at <URL>. Please review and merge when ready."
+
+---
+
+## Rollback plan
+
+If any task fails irrecoverably:
+- Phase B tasks are small, single-commit units. Revert the offending commit with `git revert <sha>` and redo.
+- Phase A agent outputs (`/tmp/arch-sync-agentN.md`) are write-only; re-running an agent simply overwrites.
+- Phase C is non-destructive (grep-based checks).
+- Spec (`docs/superpowers/specs/2026-04-18-architecture-prd-sync-design.md`) is the source of truth — if a design decision is in dispute, re-read the spec.

--- a/docs/superpowers/specs/2026-04-16-provisioning-shared-design.md
+++ b/docs/superpowers/specs/2026-04-16-provisioning-shared-design.md
@@ -55,8 +55,8 @@ Helm bundles `bitnami/postgresql` as a subchart with `postgresql.enabled: true` 
 
 The Go binary's compiled-in default stays `memory` (unchanged). Desktop users who install via:
 
-- `go install github.com/Cyoda-platform/cyoda-go/cmd/cyoda-go@latest` — get the raw binary with memory default. Power-user path; they're expected to set env.
-- **Homebrew formula, `.deb`/`.rpm`, or the `curl|sh` installer script** — get a thin wrapper (or systemd unit, or launchd plist, or shell script on PATH) that sets `CYODA_STORAGE_BACKEND=sqlite` and `CYODA_SQLITE_PATH=$XDG_DATA_HOME/cyoda-go/cyoda.db` before invoking the binary.
+- `go install github.com/Cyoda-platform/cyoda-go/cmd/cyoda@latest` — get the raw binary with memory default. Power-user path; they're expected to set env.
+- **Homebrew formula, `.deb`/`.rpm`, or the `curl|sh` installer script** — get a thin wrapper (or systemd unit, or launchd plist, or shell script on PATH) that sets `CYODA_STORAGE_BACKEND=sqlite` and `CYODA_SQLITE_PATH=$XDG_DATA_HOME/cyoda/cyoda.db` before invoking the binary.
 
 The packaging layer owns the opinion. The desktop per-target spec picks which packaging paths ship in the first release.
 
@@ -159,7 +159,7 @@ A dedicated migration entrypoint (e.g., a `cyoda-go migrate` subcommand) is **no
 **Decoupled versioning** — two independent tag streams. Both reset to `0.1.0`:
 
 - App tags at the repo root: `v0.1.0` onward. The only existing root-level tag stream is pre-public; no consumers depend on it.
-- Chart tags: `cyoda-go-0.1.0` onward. No prior chart has shipped.
+- Chart tags: `cyoda-0.1.0` onward (per the rename supersession at the top of this document). No prior chart has shipped.
 
 **Plugin module tags** (`plugins/memory/v0.1.0`, `plugins/postgres/v0.1.0`, and future `plugins/sqlite/v0.1.0`) are a separate stream governed by Go module semantics and the SPI's own versioning policy — they are **not reset** and **not controlled by this spec**. See the Out-of-Scope section.
 
@@ -174,15 +174,15 @@ Triggered by pushing a semver tag matching `v*`. Produces:
 
 Windows binaries ship from day one. Windows-specific packaging paths (MSI, Chocolatey, Scoop, Winget, service install) are deferred to the desktop per-target spec — a `.exe` in a `.zip` on the GH Release is the initial coverage.
 
-### Chart tags (`cyoda-go-0.1.0`, `cyoda-go-0.2.0`, …) — Helm chart
+### Chart tags (`cyoda-0.1.0`, `cyoda-0.2.0`, …) — Helm chart
 
-Triggered by pushing a tag matching `cyoda-go-*`. Uses [`helm/chart-releaser-action`](https://github.com/helm/chart-releaser-action) — the Helm org's canonical chart-release workflow:
+Triggered by pushing a tag matching `cyoda-*`. Uses [`helm/chart-releaser-action`](https://github.com/helm/chart-releaser-action) — the Helm org's canonical chart-release workflow:
 
-- Packages the chart from `deploy/helm/cyoda-go/`.
+- Packages the chart from `deploy/helm/cyoda/`.
 - Chart's `appVersion` field pins a tested app version (e.g., `appVersion: "0.1.0"`).
-- The exact publishing target — GitHub Pages (chart-releaser's original mode, `gh-pages` branch with `index.yaml`) versus OCI at `ghcr.io/cyoda-platform/charts/cyoda-go` — is a mechanical choice for the Helm per-target spec. Both are supported by current tooling; this shared spec only commits to the tag scheme and packaging action.
+- The exact publishing target — GitHub Pages (chart-releaser's original mode, `gh-pages` branch with `index.yaml`) versus OCI at `ghcr.io/cyoda-platform/charts/cyoda` — is a mechanical choice for the Helm per-target spec. Both are supported by current tooling; this shared spec only commits to the tag scheme and packaging action.
 
-The `cyoda-go-<version>` tag form is the convention `chart-releaser-action` expects. Diverging from it would mean writing a custom workflow — not worth it.
+The `cyoda-<version>` tag form is the convention `chart-releaser-action` expects. Diverging from it would mean writing a custom workflow — not worth it.
 
 ### Private Nexus publishing
 
@@ -219,7 +219,7 @@ deploy/
     compose.yaml
     README.md
   helm/
-    cyoda-go/                    # chart skeleton created here; filled in per-target spec
+    cyoda/                       # chart skeleton created here; filled in per-target spec
       values-production.yaml     # production preset: postgresql.enabled=false, external URL required
 examples/
   compose-with-observability/
@@ -231,7 +231,7 @@ scripts/
 .github/workflows/
   ci.yml                         # unchanged
   release.yml                    # NEW: GoReleaser + multi-arch image + keyless cosign on v* tags
-  release-chart.yml              # NEW: helm/chart-releaser-action on cyoda-go-* tags
+  release-chart.yml              # NEW: helm/chart-releaser-action on cyoda-* tags
   bump-chart-appversion.yml      # NEW: opens PR bumping Chart.yaml appVersion on stable v* tags
 ```
 
@@ -275,9 +275,9 @@ The implementation plan generated from this spec covers the shared-layer work:
 
    **Pre-flight check.** The release workflow runs `GOWORK=off go mod download` and `GOWORK=off go mod verify` before invoking GoReleaser. If any plugin dependency resolves to a pseudo-version, a `replace` directive, or a non-tagged SHA, the workflow fails fast with a clear error naming the offending module. This prevents an accidental root-repo tag from producing a release built against unreleased or stale plugin code.
 7. Add `.github/workflows/release-chart.yml` using `helm/chart-releaser-action`, gated on the chart's existence.
-8. Add `.github/workflows/bump-chart-appversion.yml` — triggered when a stable (non-prerelease) `v*` tag is pushed, this workflow opens a PR updating `deploy/helm/cyoda-go/Chart.yaml`'s `appVersion` to the new app version. Keeps the decoupled tag streams in sync without manual edits. A human reviews and merges the PR (which becomes the trigger for the next chart tag when desired).
+8. Add `.github/workflows/bump-chart-appversion.yml` — triggered when a stable (non-prerelease) `v*` tag is pushed, this workflow opens a PR updating `deploy/helm/cyoda/Chart.yaml`'s `appVersion` to the new app version. Keeps the decoupled tag streams in sync without manual edits. A human reviews and merges the PR (which becomes the trigger for the next chart tag when desired).
 9. Delete `.github/workflows/docker-publish.yml`.
-10. Update `README.md`, `CONTRIBUTING.md`, `cmd/cyoda-go/main.go` `printHelp()` for new endpoints, new env vars (`CYODA_ADMIN_PORT`, `CYODA_ADMIN_BIND_ADDRESS`, `CYODA_SUPPRESS_BANNER`, `CYODA_REQUIRE_JWT`), new port convention, and new layout. Additionally, close existing SQLite documentation gaps now that sqlite is elevated to a default:
+10. Update `README.md`, `CONTRIBUTING.md`, `cmd/cyoda/main.go` `printHelp()` for new endpoints, new env vars (`CYODA_ADMIN_PORT`, `CYODA_ADMIN_BIND_ADDRESS`, `CYODA_SUPPRESS_BANNER`, `CYODA_REQUIRE_JWT`), new port convention, and new layout. Additionally, close existing SQLite documentation gaps now that sqlite is elevated to a default:
     - Add **sqlite** as a first-class row in the README "Storage backends" table alongside memory and postgres.
     - Add a **Configuration > SQLite** subsection in the README documenting `CYODA_SQLITE_PATH`, `CYODA_SQLITE_AUTO_MIGRATE`, `CYODA_SQLITE_BUSY_TIMEOUT`, `CYODA_SQLITE_CACHE_SIZE`, `CYODA_SQLITE_SEARCH_SCAN_LIMIT`.
     - Add a **`.env.sqlite.example`** alongside the existing `.env.local.example` / `.env.postgres.example` / `.env.jwt.example` / `.env.otel.example` so "copy the example for your backend" works for sqlite too.

--- a/docs/superpowers/specs/2026-04-18-architecture-prd-sync-design.md
+++ b/docs/superpowers/specs/2026-04-18-architecture-prd-sync-design.md
@@ -1,0 +1,259 @@
+# Architecture + PRD documentation sync — Design Specification
+
+**Status:** draft · **Date:** 2026-04-18 · **Target:** perfect alignment between `docs/ARCHITECTURE.md` + `docs/PRD.md` and the current codebase at HEAD (commit `31435d2` at spec-write time)
+
+---
+
+## 1. Scope and goals
+
+`docs/ARCHITECTURE.md` (1555 lines) and `docs/PRD.md` (712 lines) are the canonical technical and product references for cyoda-go. Both documents are stamped **Version 2.0, Date 2026-04-14** with a status line claiming "Target state after the storage-plugin architecture refactor (Plans 1–5)". Since that stamp the storage-plugin refactor shipped, the SQLite plugin landed as a first-class stock plugin, the desktop/Docker/Helm provisioning track shipped (PR #45, #54, #60), and many env-var defaults / endpoints have evolved.
+
+### Goals
+
+1. **Every statement in `ARCHITECTURE.md` and `PRD.md` is grounded in a verifiable code reference** at spec-write commit. Drift is the exception that gets flagged and fixed, not the baseline.
+2. **Structural split:** `ARCHITECTURE.md` becomes storage-agnostic. Per-plugin depth moves to `docs/plugins/IN_MEMORY.md`, `docs/plugins/SQLITE.md` (new), `docs/plugins/POSTGRES.md`.
+3. **SQLite gets first-class treatment** parallel to the other stock plugins — currently missing entirely from both documents.
+4. **Cassandra plugin is presented as a commercial capability**, not a technical design. No mechanism leakage, no repository reference, no design-doc pointer — just capability envelope, value proposition, and a "contact Cyoda" call to action.
+5. **Legacy rename residue** (`cmd/cyoda-go/`, pre-rename chart tags, etc.) swept from both documents.
+
+### Frozen — not touched in this pass
+
+- `ARCHITECTURE.md §13 Design Decisions Log` — historical record, immutable by convention.
+- `PRD.md` version history / version-2.0 status line content prior to the Version bump. The version bump itself is allowed; prior version entries are not re-edited.
+- Any `docs/adr/` file.
+- Any `docs/superpowers/` file other than this spec and its downstream plan.
+
+### Non-goals
+
+- Rewriting git history to scrub pre-sanitization commits. Considered and rejected (see §6).
+- Expanding `PRD.md` scope into new product domains.
+- Adding feature sections that are planned-but-not-implemented — those stay in `§12 Planned Features`.
+- Revising the `cyoda-go-spi` module documentation.
+- Touching the per-plugin `doc.go` files (they're reference implementations for plugin authors; they can drift with the code).
+
+---
+
+## 2. Target file structure
+
+```
+docs/
+  ARCHITECTURE.md              # storage-agnostic core — see §3 for content
+  PRD.md                       # single file; updated per §5
+  plugins/
+    README.md                  # one-page index + "authoring a plugin" pointer
+    IN_MEMORY.md               # memory plugin
+    SQLITE.md                  # NEW — sqlite plugin
+    POSTGRES.md                # postgres plugin
+  superpowers/
+    specs/
+      2026-04-18-architecture-prd-sync-design.md   # this spec
+      ...
+```
+
+The `cassandra` plugin is not represented as a file — it surfaces only as a capability paragraph in `ARCHITECTURE.md §2.4` and a mention in `PRD.md §1`.
+
+---
+
+## 3. `ARCHITECTURE.md` — target shape
+
+After the split, the storage-agnostic core retains the same top-level section numbering as today (so cross-references from other docs still hold), but the contents of §2 shrink dramatically.
+
+### §2. Storage Architecture (≈30 lines, down from ≈155)
+
+- Opening storage-agnostic paragraphs (SPI contract, blank-import binary pattern, plugin-resolution at startup) — **kept**.
+- **§2.1 The `memory` plugin** — capability one-liner + link to `docs/plugins/IN_MEMORY.md`.
+- **§2.2 The `sqlite` plugin** — capability one-liner + link to `docs/plugins/SQLITE.md`.
+- **§2.3 The `postgres` plugin** — capability one-liner + link to `docs/plugins/POSTGRES.md`.
+- **§2.4 The `cassandra` plugin (commercial)** — three-paragraph block:
+  1. One-sentence framing ("A Cassandra-backed storage plugin is available as a commercial offering from Cyoda. It slots into cyoda-go through the same `spi.Plugin` contract as the open-source plugins — operators select it at runtime via `CYODA_STORAGE_BACKEND=cassandra`.")
+  2. Capability envelope bullet list: horizontal write scalability · snapshot isolation with first-committer-wins · append-only point-in-time storage with full historical reads · no single points of failure · multi-node consistency.
+  3. Value-proposition sentence plus contact CTA pointing to `https://www.cyoda.com` with direction to use its contact page.
+
+No mention of: the proprietary repository, the `CASSANDRA_BACKEND_DESIGN.md` document, HLC, shard epochs, 2PC phases, transaction reaper, `ClusterBroadcaster` adapter, message-broker specifics (Kafka / Redpanda), consistency-clock details, LWT, `USING TIMESTAMP`, any table name, any env-var prefix specific to the plugin.
+
+### Other §§: reconciliation only
+
+All other sections (§1, §3–§14) stay in `ARCHITECTURE.md` at their current section numbers. Content changes come from the Phase A reconciliation pass (§7 of this spec), not from structural edits.
+
+Plugin-specific subsections currently embedded in general sections (e.g., `§3.2 In-Memory SSI Conflict Detection`, `§3.3 PostgreSQL SERIALIZABLE + Error Code 40001`) are **excised and moved** to their respective `docs/plugins/*.md` files. Their place in `ARCHITECTURE.md` is taken by one-sentence summaries linking out.
+
+Specific Cassandra leakage points to sanitize across the full document (beyond §2.3):
+
+| Current location | Current content | Action |
+|---|---|---|
+| Repositories table (§1) | `cyoda-go-cassandra` row | Remove row |
+| §1 SPI lifecycle note | "(e.g. cassandra's shard-rebalance wait)" parenthetical | Remove parenthetical; generic point stays |
+| §3.6 Plugin-Specific Transaction Managers | "cassandra plugin — a coordinator-managed 2PC over a message broker, with HLC fencing, per-shard epoch ownership..." | Replace with neutral bullet: "Commercial plugins implement their own `TransactionManager` against their underlying store's primitives." |
+| §9 Cassandra config subsection | Full `CYODA_CASSANDRA_*` + `CYODA_REDPANDA_*` env-var listing | Remove entirely. §9 is storage-agnostic after the split; per-plugin config lives with each plugin. |
+| §11 Observability | Cassandra-specific span/metric examples and broker-propagation known-gap | Generalised; plugin-namespaced instrumentation point kept without naming |
+| §12 Planned Features | "cyoda-go-cassandra for cassandra plugin" | Remove. |
+
+---
+
+## 4. `docs/plugins/*.md` — per-plugin file template
+
+Every per-plugin file follows the same seven-section shape so readers can compare plugins quickly:
+
+```
+# <plugin name> storage plugin
+
+## Capabilities                          — one paragraph, headline first
+## Concurrency model                     — how SSI is achieved; who owns isolation
+## Transaction manager                   — plugin-specific TM details
+## Data model and schema                 — persistence layout + migrations
+## Configuration (env vars)              — exhaustive per-plugin env-var reference
+## Operational notes and limits          — what to watch out for in prod
+## When to use / when not to use         — one sentence each, targeted
+```
+
+### 4.1 `docs/plugins/IN_MEMORY.md`
+
+**Capabilities framing** (this is the money-shot positioning; worth writing carefully):
+
+> Ephemeral, in-process state — no disk I/O, no network round-trips, no query planner on the hot path. The memory plugin's latency profile sits an order of magnitude ahead of any persistent backend: a full SSI transaction (begin → read-modify-write → commit) completes in the low microseconds rather than the milliseconds a Postgres round-trip takes. That performance envelope makes the memory plugin particularly effective as the **state-backing for high-throughput digital-twin workloads** — an agentic software factory where an agent swarm drives thousands of scenario executions per second against a behavioural twin of a production entity, or a simulation that replays weeks of production state-machine behaviour in seconds. Same workflow semantics, same FSM engine, same SSI guarantees as the persistent backends — without the durability trade-off.
+
+Other sections extracted from current `§2.1` + `§3.2` + `§9` memory content, updated for any drift found during reconciliation.
+
+### 4.2 `docs/plugins/SQLITE.md` (new)
+
+Pulled from `docs/superpowers/specs/2026-04-15-sqlite-storage-plugin-design.md` (the plugin's own design spec) and verified against `plugins/sqlite/` code:
+
+- **Capabilities:** persistent, zero-ops single-node storage; embedded in-process via a pure-Go (WASM) SQLite driver; ideal for desktop binary, edge deployments, containerised single-node production; search predicate pushdown to SQL.
+- **Concurrency:** application-layer SSI ported from memory plugin (SQLite's database-level write lock doesn't provide the semantics cyoda needs). Exclusive `flock` at startup — second process against the same file fails fast.
+- **Transaction manager:** same SSI engine as memory; SQLite is the durability layer, not the concurrency controller.
+- **Data model:** mirrors PostgreSQL logical schema with SQLite optimisations (JSONB via BLOB, `STRICT` + `WITHOUT ROWID` where beneficial, INTEGER timestamps). Migrations via `golang-migrate` embedded SQL files.
+- **Config:** `CYODA_SQLITE_PATH` (default `$XDG_DATA_HOME/cyoda/cyoda.db`, Windows `%LocalAppData%\cyoda\cyoda.db`), `CYODA_SQLITE_AUTO_MIGRATE`, `CYODA_SQLITE_BUSY_TIMEOUT`, `CYODA_SQLITE_CACHE_SIZE`, `CYODA_SQLITE_SEARCH_SCAN_LIMIT`.
+- **Operational notes:** no CGO (WASM driver `ncruces/go-sqlite3`, ≈2-3× slower than native C; traded for clean cross-compile + sqlite-vec roadmap); NFS unsupported; tenant isolation application-layer only (no RLS).
+- **Limits:** single-process, single-node, no horizontal scale.
+- **When to use:** desktop binary users, containerised single-node production, embedded deployments.
+- **When not to use:** multi-node, multi-process, NFS-mounted storage.
+
+### 4.3 `docs/plugins/POSTGRES.md`
+
+Pulled from current `§2.2` + `§3.3` + `§3.5` (pgx.Tx single-owner) + `§9` postgres content, updated for any drift found during reconciliation.
+
+**Capabilities framing** (with managed-platform story):
+
+> Durable multi-node storage using PostgreSQL as the single source of truth for transaction isolation. Each transaction holds a `pgx.Tx` handle in one cyoda node's process memory, executing under PostgreSQL's `SERIALIZABLE` isolation — cyoda's multi-node architecture pins each transaction to its owning node via `txID → pgx.Tx` affinity, giving active-active HA without distributed-transaction overhead. **Works against any managed PostgreSQL 14+ platform:** AWS RDS, Google Cloud SQL, Azure Database for PostgreSQL, Supabase, Neon, Aiven, Crunchy Bridge, Render, Fly.io Postgres, and self-hosted.
+
+**Managed-platform operational note:** platforms that front PostgreSQL with **PgBouncer in transaction pooling mode** (Supabase port 6543, Neon pooled endpoint) strip prepared-statement caching mid-session. `pgx`'s default extended-query protocol uses prepared statements. Options: (a) use the platform's direct-connection endpoint (Supabase 5432, Neon direct), or (b) set `default_query_exec_mode=exec` on the pgx pool to force simple-query mode. cyoda uses transaction-scoped `SET LOCAL` only for RLS — no session-level state fights the pool.
+
+### 4.4 `docs/plugins/README.md`
+
+One-page index. Bullet list linking to each of the three open-source plugin docs with their one-line capability summaries. Pointer to `plugins/memory/doc.go` + `plugins/postgres/doc.go` + `plugins/sqlite/doc.go` (if present) as reference implementations for plugin authors, and to the `cyoda-go-spi` module for the contract. Note that the `cassandra` plugin is a commercial Cyoda offering documented by Cyoda elsewhere.
+
+---
+
+## 5. `PRD.md` — target shape
+
+Stays a single file. Changes are narrative, not structural.
+
+### 5.1 Storage-plugin callout in §1
+
+Replaces the current blockquote (lines 23–26):
+
+> **Storage plugin architecture.** Cyoda-Go's storage layer is a plugin system defined by the stable `cyoda-go-spi` module (stdlib-only Go interfaces and value types). A running binary has exactly one active plugin, selected at startup via `CYODA_STORAGE_BACKEND`. The stock `cyoda-go` binary ships with three open-source plugins:
+>
+> - **`memory`** (default) — ephemeral, microsecond-latency SSI for tests and high-throughput digital-twin workloads.
+> - **`sqlite`** — persistent, zero-ops single-node storage for desktop, edge, and containerised single-node production.
+> - **`postgres`** — durable multi-node storage with SSI via PostgreSQL `SERIALIZABLE`; works against any managed PostgreSQL platform.
+>
+> A commercial `cassandra` plugin is also available from Cyoda for deployments that need horizontal write scalability beyond what a single-primary PostgreSQL can provide — see [cyoda.com](https://www.cyoda.com) and use its contact page.
+>
+> Third-party plugins (Redis, ScyllaDB, FoundationDB, etc.) can be authored against `cyoda-go-spi` and compiled into a custom binary via a blank import. See `docs/ARCHITECTURE.md` for the plugin contract and `docs/plugins/` for per-plugin specifics.
+
+### 5.2 Other sections
+
+- **§1 Scale Profile:** rewritten so it acknowledges all four backends and their scale envelopes without mechanism leak.
+- **§1 Cost Model:** generalised so it doesn't imply Postgres is the only production path.
+- **§4 Transaction Model:** one sentence added: "SQLite plugin uses application-layer SSI; the commercial Cassandra plugin implements SSI against its own primitives."
+- **All other §§:** reconciled section-by-section against the code (see §7 below). No new structural content — just drift correction.
+
+---
+
+## 6. Git-history rewrite — considered and rejected
+
+Rewriting commit history to scrub the pre-sanitization §2.3 content was considered. Decision: not worth the disruption.
+
+Rationale:
+- The content has already been on the public `Cyoda-platform/cyoda-go` repository since commit `31435d2` (my recent merge) and earlier. Forks, archive.org / Software Heritage / Common Crawl snapshots, and potential LLM training corpora retain the unredacted version. A force-push cleans the canonical remote but does not restore exclusivity.
+- The leaked content names **publicly-known distributed-systems primitives** (HLC, Cassandra LWT, 2PC phases, transaction reapers, SWIM gossip) applied to Cassandra. The proprietary synthesis is "how they compose into a coordinator protocol", and even that is recoverable from the Cassandra design doc's publicly-stated Goals.
+- A history rewrite invalidates every contributor's local clone, breaks open PRs, and requires a GitHub Support ticket to purge dangling-commit access — significant coordination cost for a best-effort partial cleanup.
+
+**Fix-forward policy:** the sanitised docs become the canonical reference. No rewrite.
+
+---
+
+## 7. Reconciliation methodology — Phase A
+
+The structural split (§3–§5 of this spec) covers **known** drift. The reconciliation pass covers **unknown** drift — the sections of `ARCHITECTURE.md` and `PRD.md` that haven't been explicitly flagged but may have silently diverged from the code over the months since the 2.0 stamp.
+
+### 7.1 Parallel Explore-agent dispatch
+
+Eight agents, one per scope cluster. Each agent reads its section(s), cross-checks against the code, returns a structured discrepancies list (Critical / Significant / Minor) using the same format as the recent provisioning-spec reconciliation.
+
+| Agent | Scope | Primary code references |
+|---|---|---|
+| 1 | `ARCHITECTURE §1` (System Overview) + `§3` (Transaction Model, storage-agnostic parts) | `cyoda-go-spi` module, `internal/contract/`, `app/app.go`, `internal/cluster/lifecycle/` |
+| 2 | `ARCHITECTURE §4` (Multi-Node Routing) | `internal/cluster/registry/gossip.go`, `internal/cluster/dispatch/`, `internal/cluster/proxy/`, `internal/cluster/token/`, `internal/domain/search/` |
+| 3 | `ARCHITECTURE §5` (Workflow) + `§6` (gRPC & Externalized Processing) | `internal/domain/workflow/`, `api/grpc/events/`, `internal/grpc/`, `internal/domain/messaging/` |
+| 4 | `ARCHITECTURE §7` (Auth) + `§8` (Error Model) | `internal/auth/`, `internal/admin/` (metrics bearer), `app/app.go validateBootstrapConfig` + `validateMetricsAuth`, `internal/common/error_codes.go`, `internal/api/middleware/` |
+| 5 | `ARCHITECTURE §9` (Configuration Reference) — **highest drift risk** | `app/config.go DefaultConfig`, `cmd/cyoda/main.go printHelp`, `README.md`, each plugin's `ConfigVars()` |
+| 6 | `ARCHITECTURE §10` (Deployment) + `§11` (Observability) + `§14` (Limits) | `deploy/helm/cyoda/`, `deploy/docker/`, `internal/observability/`, `internal/admin/` |
+| 7 | `PRD §1–§4` (Vision / EDBMS Core / Workflow / Transaction Model) | `internal/domain/entity/`, `internal/domain/model/`, `internal/domain/workflow/`, `app/app.go`, migration plugin |
+| 8 | `PRD §5–§12` (Multi-Tenancy / Search / Externalized Processing / rest, **excluding** version history and frozen sections) | `internal/domain/account/`, `internal/match/`, `internal/domain/search/`, `api/grpc/events/` |
+
+Frozen sections (§13 Design Decisions Log on ARCHITECTURE, and version-history blocks on PRD) are **excluded from the reconciliation pass** and untouched.
+
+### 7.2 Synthesis
+
+Discrepancies from all eight agents are collated into a single fix-list. Each item is categorised:
+
+- **Critical:** doc claims something contradicted by code (mislead readers into wrong behaviour expectations).
+- **Significant:** doc omits a material change or describes an implementation that has since been refactored.
+- **Minor:** stylistic drift, stale cross-reference, outdated example.
+
+All three categories get fixed in this pass — "perfectly in sync" is strict.
+
+---
+
+## 8. Incidental cleanup
+
+Bundled into the restructuring commit:
+
+| File | Stale content | Fix |
+|---|---|---|
+| `ARCHITECTURE.md` package-layout diagram | `cmd/cyoda-go/main.go` | → `cmd/cyoda/main.go` |
+| `ARCHITECTURE.md` status line | "Target state after the storage-plugin architecture refactor (Plans 1–5)" | → "Current as of 2026-04-18 (Helm provisioning shipped in PR #60)" |
+| `ARCHITECTURE.md` + `PRD.md` version | `2.0`, dated `2026-04-14` | → `2.1`, dated `2026-04-18` |
+
+---
+
+## 9. Verification — Phase C
+
+Before claiming done:
+
+1. **Cassandra mechanism grep:** `grep -rEi 'HLC|hybrid logical clock|Redpanda|shard.epoch|ClusterBroadcaster|USING TIMESTAMP|transaction_log_idx|2PC|two.phase commit|LWT|last.writer.wins|cyoda-go-cassandra|CASSANDRA_BACKEND_DESIGN' docs/ARCHITECTURE.md docs/PRD.md docs/plugins/` — expected hits: zero. Any hit is a leak.
+2. **Rename-residue grep:** `grep -rE 'cmd/cyoda-go|deploy/helm/cyoda-go|cyoda-go-0\.' docs/ARCHITECTURE.md docs/PRD.md docs/plugins/` — expected hits: zero.
+3. **Per-plugin template conformance:** each of `docs/plugins/IN_MEMORY.md`, `SQLITE.md`, `POSTGRES.md` has all seven template sections in the prescribed order.
+4. **Cross-link resolution:** every `[text](path)` link from `ARCHITECTURE.md` to a `plugins/*.md` file resolves to an existing file. Script-checkable.
+5. **Env-var cross-reference:** every `CYODA_*` env var documented in `ARCHITECTURE.md §9` or a plugin file appears in `app/config.go` + `cmd/cyoda/main.go printHelp` + `README.md`, and vice-versa. Orphans flagged.
+6. **Frozen sections intact:** `git diff` on `ARCHITECTURE.md §13` range and `PRD.md` version-history block shows only the version-line bump, no content edits.
+
+---
+
+## 10. Out of scope
+
+- Rewriting git history.
+- Revising `cyoda-go-spi` module documentation.
+- Revising per-plugin `doc.go` files.
+- Expanding `PRD.md` scope into new product domains.
+- Adding content for planned-but-unimplemented features (they stay in `§12 Planned Features`).
+- Touching `docs/adr/` or any other `docs/superpowers/` spec.
+- Any code change to `cyoda-go` proper. This is a documentation-only deliverable.
+
+---
+
+## 11. Open questions
+
+None remaining at spec-writing time. The reconciliation pass may surface items that warrant human judgement (e.g., "spec claims X but code does Y — which is the canonical behaviour?"); those are handled inline during Phase B synthesis with a decision log kept in the implementation plan.


### PR DESCRIPTION
## Summary

Brings `docs/ARCHITECTURE.md` and `docs/PRD.md` into perfect sync with the codebase at origin/main tip `31435d2`. Restructures storage-plugin content so ARCH becomes storage-agnostic; per-plugin depth moves to `docs/plugins/{IN_MEMORY,SQLITE,POSTGRES}.md`. Adds a new canonical `docs/CONSISTENCY.md` as the source of truth for cyoda's isolation and consistency semantics. Sanitises all Cassandra plugin references to capability-only framing — no mechanism leakage in the open-source repo.

## Major corrections

- **SI+FCW, not SSI or SERIALIZABLE.** Pre-branch docs claimed "PostgreSQL's `SERIALIZABLE` isolation" as the core value proposition. Code reality: postgres plugin uses `pgx.TxOptions{IsoLevel: pgx.RepeatableRead}` and layers application-level, row-granular first-committer-wins validation at commit time (see `plugins/postgres/transaction_manager.go:68` and the `2026-04-15-postgres-si-first-committer-wins-design.md` spec). All four plugins (memory, sqlite, postgres, commercial cassandra) deliver the same semantic: **Snapshot Isolation with First-Committer-Wins on entity-level conflicts (SI+FCW)** — weaker than Cahill SSI on predicate phantoms; mitigated by an operational rule captured in `CONSISTENCY.md §5`.
- **Cassandra plugin sanitisation.** `§2.4` now capability-only (horizontal write scalability, SI+FCW, append-only PIT storage, no SPOF, multi-node consistency) with a "contact cyoda.com" CTA. Every mechanism-level mention (HLC, shard epochs, 2PC phases, transaction reaper, ClusterBroadcaster adapter description, broker topology, CQL table names, `USING TIMESTAMP`, LWT) swept from ARCH, PRD, and all plugin docs.
- **SQLite plugin documented.** New `docs/plugins/SQLITE.md` captures concurrency model (application-layer SI+FCW ported from memory + exclusive flock), data model (PostgreSQL-schema mirror with SQLite optimisations), and all five `CYODA_SQLITE_*` env vars. PRD and ARCH storage-callouts now include sqlite as a first-class plugin.
- **Missing env vars documented.** `CYODA_ADMIN_PORT`, `CYODA_ADMIN_BIND_ADDRESS`, `CYODA_METRICS_REQUIRE_AUTH`, `CYODA_METRICS_BEARER`, `CYODA_STARTUP_TIMEOUT`, `CYODA_OTEL_ENABLED`, `CYODA_REQUIRE_JWT`, `CYODA_IAM_MOCK_ROLES`, `CYODA_PROFILES`, `CYODA_SUPPRESS_BANNER`, all five `_FILE` suffixes. Admin listener auth subsection `§7.4` added.
- **SPI interface corrections.** ARCH `§3.1` code blocks now match `cyoda-go-spi` exactly (`Plugin.NewFactory` takes `ctx context.Context`; `TransactionManager` includes the three savepoint methods with real signatures).
- **gRPC RPC methods in `§6.1`** were fabricated (SendCloudEvent, ReceiveCloudEventStream, etc.). Replaced with the actual proto service: `startStreaming` bidi + `entityModelManage`, `entityManage`, `entitySearch` unary + `entityManageCollection`, `entitySearchCollection` server-streaming.
- **Transition `type: AUTOMATIC/MANUAL`** claim corrected. Code uses `Manual: bool` + `Disabled: bool` booleans. Loopback moved from "transition type" enumeration into its own paragraph as a re-evaluation operation.
- **Bootstrap auto-generation claim removed.** Code fails startup on half-configured state; no stdout print ever existed. Replaced with accurate coupled-predicate description.
- **Transaction TTL default.** PRD said 30s; code default is 60s.
- **Predicate operator count.** PRD said 23; code has 26 functional + 2 planned (`IS_CHANGED`, `IS_UNCHANGED`).

## New canonical document — `docs/CONSISTENCY.md`

Eleven sections, ~400 lines. First-class peer of ARCH and PRD. Contents:

1. The contract at a glance
2. What this contract catches (dirty/non-repeatable/lost-update + entity-level write conflicts)
3. What it does NOT catch (phantom anomalies from predicate reads — explained with worked example)
4. Why the transactional-umbrella pattern doesn't close the gap
5. The operational rule for workflow authors + three robust alternatives (counter entity, FSM precondition, post-commit reconciliation)
6. Per-plugin implementation matrix
7. Five worked scenarios covering where FCW catches and where the rule applies
8. Multi-node routing preserves the contract
9. Isolation-level taxonomy (READ COMMITTED → SI → cyoda SI+FCW → Cahill SSI)
10. Practical checklist for workflow authors
11. References (spec pointers only; proprietary plugin's design acknowledged without link)

Both ARCH `§3` and PRD `§4` now defer to `CONSISTENCY.md` for depth.

## Branch shape

10 commits, +1354 / -296 lines net across 8 files:

| File | Action |
|---|---|
| `docs/ARCHITECTURE.md` | modified — §2 restructured to index+§2.4, §3 extracted to per-plugin stubs with a new §3.7 cross-plugin contract table, §7.4 admin auth subsection added, §8.3 error taxonomy expanded (11 missing codes added), §9 rewritten with Profiles/Admin/Observability subsections + SQLite env-var table, Cassandra mechanism leaks swept throughout |
| `docs/PRD.md` | modified — §1 storage callout rewritten (three open-source plugins + commercial cassandra pointer), scale/cost profiles generalised across backends, §1 core value proposition rewritten as SI+FCW, §3 Loopback extracted from transition-types, §4 transaction-model table rewritten with plugin-row capability framing, §6 predicate count 23→26, §12 sqlite plugin row added, §13 Cassandra-specific OTel span list swept |
| `docs/plugins/README.md` | new — plugin index |
| `docs/plugins/IN_MEMORY.md` | new — seven-section template |
| `docs/plugins/SQLITE.md` | new — seven-section template |
| `docs/plugins/POSTGRES.md` | new — seven-section template; managed-platform operational notes on PgBouncer transaction-mode caveat |
| `docs/CONSISTENCY.md` | new — canonical consistency reference (see above) |
| `.gitignore` | modified — `.worktree-scratch/` added |

## Process

- Spec: `docs/superpowers/specs/2026-04-18-architecture-prd-sync-design.md`
- Plan: `docs/superpowers/plans/2026-04-18-architecture-prd-sync.md`
- Methodology: three phases — Phase A dispatched eight parallel `Explore` subagents across non-frozen sections returning structured Critical/Significant/Minor discrepancy lists; Phase B applied fixes via per-task implementer subagents; Phase C ran six verification checks. Full synthesis + individual agent reports were stored under `.worktree-scratch/` (gitignored).
- Frozen sections (`ARCHITECTURE.md §13 Design Decisions Log`, version-history blocks) are byte-identical to origin/main; verified via `diff`.
- Code review by `superpowers:code-reviewer` subagent identified 4 findings (1 Critical + 2 Important + 1 Minor); all applied.

## Note on commit history

Commit `98cf0fa docs(maintain): add ARCHITECTURE+PRD reconciliation prompt and cadence` has a misleading subject — it actually only adds `.worktree-scratch/` to `.gitignore`. The "reconciliation prompt" artefact that the subject references was staged for a separate effort and not included in this branch. Since Cyoda main merges PRs via squash, this will be absorbed into the squash-merge commit and not visible in main's history.

## Verification

All six Phase C checks pass:

1. Cassandra mechanism grep: zero hits across all docs (only public SPI name `ClusterBroadcaster` remains).
2. Rename-residue grep: zero hits.
3. Per-plugin template conformance: IN_MEMORY.md / SQLITE.md / POSTGRES.md each have the seven-section template in order.
4. Cross-link resolution: every in-repo markdown link resolves.
5. Env-var cross-reference: zero orphans in docs; nine acceptable orphans in code (`_FILE` variants + test/client-only vars).
6. `§13 Design Decisions Log` byte-identical to `31435d2`.

## Test plan

- [ ] Visual review of `docs/CONSISTENCY.md` — the canonical story; check the phantom scenario in §3 and §7.3 tell the same story.
- [ ] Visual review of `docs/plugins/POSTGRES.md` managed-platform notes — Supabase/Neon PgBouncer caveat.
- [ ] Confirm `§2.4` Cassandra section is the shape Cyoda wants as its public framing.
- [ ] Spot-check one or two `[plugins/*.md](...)` cross-links render correctly on GitHub preview.