### PR TITLE
fix(security): admin ROLE_ADMIN check + SQLite JSON-path injection guard (#64)

### DIFF
--- a/internal/auth/admin_authz_test.go
+++ b/internal/auth/admin_authz_test.go
@@ -1,0 +1,182 @@
+package auth
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// adminReq builds an httptest request with a ROLE_ADMIN UserContext attached.
+// Admin handlers are gated by requireAdmin, so tests exercising positive
+// paths must use this helper (or otherwise inject an admin context).
+func adminReq(method, target string, body io.Reader) *http.Request {
+	return withAdminCtx(httptest.NewRequest(method, target, body))
+}
+
+// withAdminCtx attaches a UserContext holding ROLE_ADMIN to the request.
+// The admin handlers (M2M, key pair, trusted keys) are wrapped by the auth
+// middleware in production, which guarantees a UserContext is present; the
+// role-check guard then inspects that context. Tests that want to exercise
+// authorised behaviour must attach an equivalent context.
+func withAdminCtx(req *http.Request) *http.Request {
+	return req.WithContext(spi.WithUserContext(req.Context(), &spi.UserContext{
+		UserID: "test-admin",
+		Roles:  []string{"ROLE_ADMIN"},
+	}))
+}
+
+// withNonAdminCtx attaches a UserContext holding only ROLE_USER.
+func withNonAdminCtx(req *http.Request) *http.Request {
+	return req.WithContext(spi.WithUserContext(req.Context(), &spi.UserContext{
+		UserID: "test-user",
+		Roles:  []string{"ROLE_USER"},
+	}))
+}
+
+// assertForbidden runs the handler and expects 403 Forbidden.
+func assertForbidden(t *testing.T, h http.Handler, req *http.Request, desc string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("%s: expected 403, got %d (body=%q)", desc, rec.Code, rec.Body.String())
+	}
+}
+
+// assertUnauthorized runs the handler and expects 401 Unauthorized.
+func assertUnauthorized(t *testing.T, h http.Handler, req *http.Request, desc string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("%s: expected 401, got %d (body=%q)", desc, rec.Code, rec.Body.String())
+	}
+}
+
+// --- M2M handler ---
+
+func TestM2MHandler_NonAdminForbidden(t *testing.T) {
+	handler := NewM2MHandler(NewInMemoryM2MClientStore())
+
+	body := `{"tenantId":"t1","userId":"u1","roles":["ROLE_USER"]}`
+	cases := []struct {
+		name string
+		req  *http.Request
+	}{
+		{"create", httptest.NewRequest(http.MethodPost, "/account/m2m", bytes.NewBufferString(body))},
+		{"list", httptest.NewRequest(http.MethodGet, "/account/m2m", nil)},
+		{"delete", httptest.NewRequest(http.MethodDelete, "/account/m2m/some-id", nil)},
+		{"reset-secret", httptest.NewRequest(http.MethodPost, "/account/m2m/some-id/secret/reset", nil)},
+	}
+	for _, tc := range cases {
+		tc.req.Header.Set("Content-Type", "application/json")
+		assertForbidden(t, handler, withNonAdminCtx(tc.req), "non-admin "+tc.name)
+	}
+}
+
+func TestM2MHandler_NoUserContextUnauthorized(t *testing.T) {
+	handler := NewM2MHandler(NewInMemoryM2MClientStore())
+
+	req := httptest.NewRequest(http.MethodGet, "/account/m2m", nil)
+	// Intentionally no user context — mirrors what would happen if auth
+	// middleware were ever bypassed or misconfigured.
+	assertUnauthorized(t, handler, req, "no-ctx list")
+}
+
+// --- Keys handler ---
+
+func TestKeysHandler_NonAdminForbidden(t *testing.T) {
+	handler := NewKeysHandler(NewInMemoryKeyStore())
+
+	cases := []struct {
+		name string
+		req  *http.Request
+	}{
+		{"issue", httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair", nil)},
+		{"current", httptest.NewRequest(http.MethodGet, "/oauth/keys/keypair/current", nil)},
+		{"delete", httptest.NewRequest(http.MethodDelete, "/oauth/keys/keypair/some-kid", nil)},
+		{"invalidate", httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair/some-kid/invalidate", nil)},
+		{"reactivate", httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair/some-kid/reactivate", nil)},
+	}
+	for _, tc := range cases {
+		assertForbidden(t, handler, withNonAdminCtx(tc.req), "non-admin "+tc.name)
+	}
+}
+
+func TestKeysHandler_NoUserContextUnauthorized(t *testing.T) {
+	handler := NewKeysHandler(NewInMemoryKeyStore())
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair", nil)
+	assertUnauthorized(t, handler, req, "no-ctx issue")
+}
+
+// --- Trusted keys handler ---
+
+func TestTrustedKeysHandler_NonAdminForbidden(t *testing.T) {
+	handler := NewTrustedKeysHandler(NewInMemoryTrustedKeyStore())
+
+	cases := []struct {
+		name string
+		req  *http.Request
+	}{
+		{"list", httptest.NewRequest(http.MethodGet, "/oauth/keys/trusted", nil)},
+		{"register", httptest.NewRequest(http.MethodPost, "/oauth/keys/trusted", bytes.NewBufferString(`{}`))},
+		{"delete", httptest.NewRequest(http.MethodDelete, "/oauth/keys/trusted/some-kid", nil)},
+		{"invalidate", httptest.NewRequest(http.MethodPost, "/oauth/keys/trusted/some-kid/invalidate", nil)},
+		{"reactivate", httptest.NewRequest(http.MethodPost, "/oauth/keys/trusted/some-kid/reactivate", nil)},
+	}
+	for _, tc := range cases {
+		tc.req.Header.Set("Content-Type", "application/json")
+		assertForbidden(t, handler, withNonAdminCtx(tc.req), "non-admin "+tc.name)
+	}
+}
+
+func TestTrustedKeysHandler_NoUserContextUnauthorized(t *testing.T) {
+	handler := NewTrustedKeysHandler(NewInMemoryTrustedKeyStore())
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/keys/trusted", nil)
+	assertUnauthorized(t, handler, req, "no-ctx list")
+}
+
+// --- Positive case: admin context allows through ---
+// These guard against a future mistake where the guard rejects admins.
+
+func TestM2MHandler_AdminCanList(t *testing.T) {
+	handler := NewM2MHandler(NewInMemoryM2MClientStore())
+
+	req := withAdminCtx(httptest.NewRequest(http.MethodGet, "/account/m2m", nil))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin list: expected 200, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestKeysHandler_AdminCanIssue(t *testing.T) {
+	handler := NewKeysHandler(NewInMemoryKeyStore())
+
+	req := withAdminCtx(httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair", nil))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("admin issue: expected 201, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTrustedKeysHandler_AdminCanList(t *testing.T) {
+	handler := NewTrustedKeysHandler(NewInMemoryTrustedKeyStore())
+
+	req := withAdminCtx(httptest.NewRequest(http.MethodGet, "/oauth/keys/trusted", nil))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin list: expected 200, got %d (body=%q)", rec.Code, rec.Body.String())
+	}
+}

--- a/internal/auth/admin_guard.go
+++ b/internal/auth/admin_guard.go
@@ -1,0 +1,28 @@
+package auth
+
+import (
+	"net/http"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// requireAdmin gates administrative endpoints: the key pair handler, the
+// trusted-key handler, and the M2M client handler. These routes are wrapped
+// by the auth middleware, so a missing UserContext here means the middleware
+// was bypassed or misconfigured — respond 401. A present UserContext lacking
+// ROLE_ADMIN is a genuine authorization failure — respond 403.
+//
+// Returns true when the caller may proceed; otherwise writes the response
+// and returns false.
+func requireAdmin(w http.ResponseWriter, r *http.Request) bool {
+	uc := spi.GetUserContext(r.Context())
+	if uc == nil {
+		http.Error(w, `{"error":"not authenticated"}`, http.StatusUnauthorized)
+		return false
+	}
+	if !spi.HasRole(uc.Roles, "ROLE_ADMIN") {
+		http.Error(w, `{"error":"forbidden: requires ROLE_ADMIN"}`, http.StatusForbidden)
+		return false
+	}
+	return true
+}

--- a/internal/auth/integration_test.go
+++ b/internal/auth/integration_test.go
@@ -13,8 +13,24 @@ import (
 	"testing"
 	"time"
 
+	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/auth"
 )
+
+// testAdminMW wraps an admin handler with a UserContext carrying ROLE_ADMIN.
+// In production this context is established by the real auth middleware;
+// body-size integration tests that hit the handler over real HTTP need an
+// equivalent stand-in so the requireAdmin guard lets the request reach the
+// MaxBytesReader under test.
+func testAdminMW(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := spi.WithUserContext(r.Context(), &spi.UserContext{
+			UserID: "test-admin",
+			Roles:  []string{"ROLE_ADMIN"},
+		})
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
 
 func generateTestPEM(t *testing.T) string {
 	t.Helper()
@@ -246,8 +262,10 @@ func TestIntegration_RequestBodySizeLimit(t *testing.T) {
 		}
 	})
 
-	// Admin endpoints are served on a separate handler.
-	adminSrv := httptest.NewServer(svc.AdminHandler())
+	// Admin endpoints are served on a separate handler; wrap with a test
+	// middleware that supplies an admin UserContext so requireAdmin admits
+	// the request and the body-size limit is the observable behaviour.
+	adminSrv := httptest.NewServer(testAdminMW(svc.AdminHandler()))
 	defer adminSrv.Close()
 
 	t.Run("m2m create endpoint rejects oversized body", func(t *testing.T) {

--- a/internal/auth/keys.go
+++ b/internal/auth/keys.go
@@ -28,8 +28,11 @@ type keysInfoResponse struct {
 	CreatedAt string `json:"createdAt"`
 }
 
-// ServeHTTP routes key pair management requests.
+// ServeHTTP routes key pair management requests. Requires ROLE_ADMIN.
 func (h *KeysHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	const basePath = "/oauth/keys/keypair"
 
 	path := r.URL.Path

--- a/internal/auth/keys_test.go
+++ b/internal/auth/keys_test.go
@@ -17,7 +17,7 @@ func TestKeysHandler_IssueKeyPair(t *testing.T) {
 	store := NewInMemoryKeyStore()
 	handler := NewKeysHandler(store)
 
-	req := httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair", nil)
+	req := adminReq(http.MethodPost, "/oauth/keys/keypair", nil)
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
@@ -58,7 +58,7 @@ func TestKeysHandler_GetCurrent(t *testing.T) {
 	handler := NewKeysHandler(store)
 
 	// Issue a key pair first
-	issueReq := httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair", nil)
+	issueReq := adminReq(http.MethodPost, "/oauth/keys/keypair", nil)
 	issueRec := httptest.NewRecorder()
 	handler.ServeHTTP(issueRec, issueReq)
 
@@ -68,7 +68,7 @@ func TestKeysHandler_GetCurrent(t *testing.T) {
 	}
 
 	// Get current
-	req := httptest.NewRequest(http.MethodGet, "/oauth/keys/keypair/current", nil)
+	req := adminReq(http.MethodGet, "/oauth/keys/keypair/current", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -102,7 +102,7 @@ func TestKeysHandler_Invalidate(t *testing.T) {
 	handler := NewKeysHandler(store)
 
 	// Issue a key pair
-	issueReq := httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair", nil)
+	issueReq := adminReq(http.MethodPost, "/oauth/keys/keypair", nil)
 	issueRec := httptest.NewRecorder()
 	handler.ServeHTTP(issueRec, issueReq)
 
@@ -112,7 +112,7 @@ func TestKeysHandler_Invalidate(t *testing.T) {
 	}
 
 	// Invalidate
-	req := httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair/"+issued.KID+"/invalidate", nil)
+	req := adminReq(http.MethodPost, "/oauth/keys/keypair/"+issued.KID+"/invalidate", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -135,7 +135,7 @@ func TestKeysHandler_Reactivate(t *testing.T) {
 	handler := NewKeysHandler(store)
 
 	// Issue a key pair
-	issueReq := httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair", nil)
+	issueReq := adminReq(http.MethodPost, "/oauth/keys/keypair", nil)
 	issueRec := httptest.NewRecorder()
 	handler.ServeHTTP(issueRec, issueReq)
 
@@ -145,12 +145,12 @@ func TestKeysHandler_Reactivate(t *testing.T) {
 	}
 
 	// Invalidate first
-	invReq := httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair/"+issued.KID+"/invalidate", nil)
+	invReq := adminReq(http.MethodPost, "/oauth/keys/keypair/"+issued.KID+"/invalidate", nil)
 	invRec := httptest.NewRecorder()
 	handler.ServeHTTP(invRec, invReq)
 
 	// Reactivate
-	req := httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair/"+issued.KID+"/reactivate", nil)
+	req := adminReq(http.MethodPost, "/oauth/keys/keypair/"+issued.KID+"/reactivate", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -173,7 +173,7 @@ func TestKeysHandler_Delete(t *testing.T) {
 	handler := NewKeysHandler(store)
 
 	// Issue a key pair
-	issueReq := httptest.NewRequest(http.MethodPost, "/oauth/keys/keypair", nil)
+	issueReq := adminReq(http.MethodPost, "/oauth/keys/keypair", nil)
 	issueRec := httptest.NewRecorder()
 	handler.ServeHTTP(issueRec, issueReq)
 
@@ -183,7 +183,7 @@ func TestKeysHandler_Delete(t *testing.T) {
 	}
 
 	// Delete
-	req := httptest.NewRequest(http.MethodDelete, "/oauth/keys/keypair/"+issued.KID, nil)
+	req := adminReq(http.MethodDelete, "/oauth/keys/keypair/"+issued.KID, nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -202,7 +202,7 @@ func TestKeysHandler_GetCurrent_NoActiveKey(t *testing.T) {
 	store := NewInMemoryKeyStore()
 	handler := NewKeysHandler(store)
 
-	req := httptest.NewRequest(http.MethodGet, "/oauth/keys/keypair/current", nil)
+	req := adminReq(http.MethodGet, "/oauth/keys/keypair/current", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 

--- a/internal/auth/m2m.go
+++ b/internal/auth/m2m.go
@@ -40,8 +40,11 @@ func NewM2MHandler(store M2MClientStore) *M2MHandler {
 	return &M2MHandler{m2mStore: store}
 }
 
-// ServeHTTP routes M2M client management requests.
+// ServeHTTP routes M2M client management requests. Requires ROLE_ADMIN.
 func (h *M2MHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	path := strings.TrimSuffix(r.URL.Path, "/")
 
 	// POST /account/m2m/{clientId}/secret/reset

--- a/internal/auth/m2m_test.go
+++ b/internal/auth/m2m_test.go
@@ -13,7 +13,7 @@ func TestM2M_CreateClient(t *testing.T) {
 	handler := NewM2MHandler(store)
 
 	body := `{"tenantId":"tenant-1","userId":"user-1","roles":["ROLE_ADMIN"]}`
-	req := httptest.NewRequest(http.MethodPost, "/account/m2m", bytes.NewBufferString(body))
+	req := adminReq(http.MethodPost, "/account/m2m", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 
@@ -42,7 +42,7 @@ func TestM2M_ListClients(t *testing.T) {
 
 	// Create a client first.
 	body := `{"tenantId":"tenant-1","userId":"user-1","roles":["ROLE_ADMIN","ROLE_USER"]}`
-	createReq := httptest.NewRequest(http.MethodPost, "/account/m2m", bytes.NewBufferString(body))
+	createReq := adminReq(http.MethodPost, "/account/m2m", bytes.NewBufferString(body))
 	createReq.Header.Set("Content-Type", "application/json")
 	createRec := httptest.NewRecorder()
 	handler.ServeHTTP(createRec, createReq)
@@ -55,7 +55,7 @@ func TestM2M_ListClients(t *testing.T) {
 	json.NewDecoder(createRec.Body).Decode(&created)
 
 	// List clients.
-	listReq := httptest.NewRequest(http.MethodGet, "/account/m2m", nil)
+	listReq := adminReq(http.MethodGet, "/account/m2m", nil)
 	listRec := httptest.NewRecorder()
 	handler.ServeHTTP(listRec, listReq)
 
@@ -92,7 +92,7 @@ func TestM2M_VerifySecret(t *testing.T) {
 	handler := NewM2MHandler(store)
 
 	body := `{"tenantId":"tenant-1","userId":"user-1","roles":["ROLE_ADMIN"]}`
-	req := httptest.NewRequest(http.MethodPost, "/account/m2m", bytes.NewBufferString(body))
+	req := adminReq(http.MethodPost, "/account/m2m", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
@@ -125,7 +125,7 @@ func TestM2M_ResetSecret(t *testing.T) {
 
 	// Create a client.
 	body := `{"tenantId":"tenant-1","userId":"user-1","roles":["ROLE_ADMIN"]}`
-	createReq := httptest.NewRequest(http.MethodPost, "/account/m2m", bytes.NewBufferString(body))
+	createReq := adminReq(http.MethodPost, "/account/m2m", bytes.NewBufferString(body))
 	createReq.Header.Set("Content-Type", "application/json")
 	createRec := httptest.NewRecorder()
 	handler.ServeHTTP(createRec, createReq)
@@ -135,7 +135,7 @@ func TestM2M_ResetSecret(t *testing.T) {
 	oldSecret := created.ClientSecret
 
 	// Reset secret.
-	resetReq := httptest.NewRequest(http.MethodPost, "/account/m2m/"+created.ClientID+"/secret/reset", nil)
+	resetReq := adminReq(http.MethodPost, "/account/m2m/"+created.ClientID+"/secret/reset", nil)
 	resetRec := httptest.NewRecorder()
 	handler.ServeHTTP(resetRec, resetReq)
 
@@ -181,7 +181,7 @@ func TestM2M_DeleteClient(t *testing.T) {
 
 	// Create a client.
 	body := `{"tenantId":"tenant-1","userId":"user-1","roles":["ROLE_ADMIN"]}`
-	createReq := httptest.NewRequest(http.MethodPost, "/account/m2m", bytes.NewBufferString(body))
+	createReq := adminReq(http.MethodPost, "/account/m2m", bytes.NewBufferString(body))
 	createReq.Header.Set("Content-Type", "application/json")
 	createRec := httptest.NewRecorder()
 	handler.ServeHTTP(createRec, createReq)
@@ -190,7 +190,7 @@ func TestM2M_DeleteClient(t *testing.T) {
 	json.NewDecoder(createRec.Body).Decode(&created)
 
 	// Delete the client.
-	deleteReq := httptest.NewRequest(http.MethodDelete, "/account/m2m/"+created.ClientID, nil)
+	deleteReq := adminReq(http.MethodDelete, "/account/m2m/"+created.ClientID, nil)
 	deleteRec := httptest.NewRecorder()
 	handler.ServeHTTP(deleteRec, deleteReq)
 
@@ -199,7 +199,7 @@ func TestM2M_DeleteClient(t *testing.T) {
 	}
 
 	// List should be empty.
-	listReq := httptest.NewRequest(http.MethodGet, "/account/m2m", nil)
+	listReq := adminReq(http.MethodGet, "/account/m2m", nil)
 	listRec := httptest.NewRecorder()
 	handler.ServeHTTP(listRec, listReq)
 
@@ -215,7 +215,7 @@ func TestM2M_DeleteNonExistent(t *testing.T) {
 	store := NewInMemoryM2MClientStore()
 	handler := NewM2MHandler(store)
 
-	req := httptest.NewRequest(http.MethodDelete, "/account/m2m/non-existent-id", nil)
+	req := adminReq(http.MethodDelete, "/account/m2m/non-existent-id", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 

--- a/internal/auth/trusted.go
+++ b/internal/auth/trusted.go
@@ -42,8 +42,11 @@ func NewTrustedKeysHandler(store TrustedKeyStore) *TrustedKeysHandler {
 	return &TrustedKeysHandler{trustedKeyStore: store}
 }
 
-// ServeHTTP routes requests based on method and path.
+// ServeHTTP routes requests based on method and path. Requires ROLE_ADMIN.
 func (h *TrustedKeysHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
 	path := strings.TrimSuffix(r.URL.Path, "/")
 
 	// POST /oauth/keys/trusted/{keyId}/invalidate

--- a/internal/auth/trusted_test.go
+++ b/internal/auth/trusted_test.go
@@ -50,7 +50,7 @@ func TestTrustedKeysHandler_RegisterAndList(t *testing.T) {
 	bodyBytes, _ := json.Marshal(body)
 
 	// POST register
-	req := httptest.NewRequest(http.MethodPost, "/oauth/keys/trusted", bytes.NewReader(bodyBytes))
+	req := adminReq(http.MethodPost, "/oauth/keys/trusted", bytes.NewReader(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
@@ -80,7 +80,7 @@ func TestTrustedKeysHandler_RegisterAndList(t *testing.T) {
 	}
 
 	// GET list
-	req = httptest.NewRequest(http.MethodGet, "/oauth/keys/trusted", nil)
+	req = adminReq(http.MethodGet, "/oauth/keys/trusted", nil)
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -114,7 +114,7 @@ func TestTrustedKeysHandler_Invalidate(t *testing.T) {
 	bodyBytes, _ := json.Marshal(body)
 
 	// Register
-	req := httptest.NewRequest(http.MethodPost, "/oauth/keys/trusted", bytes.NewReader(bodyBytes))
+	req := adminReq(http.MethodPost, "/oauth/keys/trusted", bytes.NewReader(bodyBytes))
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusCreated {
@@ -122,7 +122,7 @@ func TestTrustedKeysHandler_Invalidate(t *testing.T) {
 	}
 
 	// Invalidate
-	req = httptest.NewRequest(http.MethodPost, "/oauth/keys/trusted/ext-key-2/invalidate", nil)
+	req = adminReq(http.MethodPost, "/oauth/keys/trusted/ext-key-2/invalidate", nil)
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -153,7 +153,7 @@ func TestTrustedKeysHandler_Reactivate(t *testing.T) {
 	bodyBytes, _ := json.Marshal(body)
 
 	// Register
-	req := httptest.NewRequest(http.MethodPost, "/oauth/keys/trusted", bytes.NewReader(bodyBytes))
+	req := adminReq(http.MethodPost, "/oauth/keys/trusted", bytes.NewReader(bodyBytes))
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusCreated {
@@ -161,7 +161,7 @@ func TestTrustedKeysHandler_Reactivate(t *testing.T) {
 	}
 
 	// Invalidate first
-	req = httptest.NewRequest(http.MethodPost, "/oauth/keys/trusted/ext-key-3/invalidate", nil)
+	req = adminReq(http.MethodPost, "/oauth/keys/trusted/ext-key-3/invalidate", nil)
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -169,7 +169,7 @@ func TestTrustedKeysHandler_Reactivate(t *testing.T) {
 	}
 
 	// Reactivate
-	req = httptest.NewRequest(http.MethodPost, "/oauth/keys/trusted/ext-key-3/reactivate", nil)
+	req = adminReq(http.MethodPost, "/oauth/keys/trusted/ext-key-3/reactivate", nil)
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -200,7 +200,7 @@ func TestTrustedKeysHandler_Delete(t *testing.T) {
 	bodyBytes, _ := json.Marshal(body)
 
 	// Register
-	req := httptest.NewRequest(http.MethodPost, "/oauth/keys/trusted", bytes.NewReader(bodyBytes))
+	req := adminReq(http.MethodPost, "/oauth/keys/trusted", bytes.NewReader(bodyBytes))
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusCreated {
@@ -208,7 +208,7 @@ func TestTrustedKeysHandler_Delete(t *testing.T) {
 	}
 
 	// Delete
-	req = httptest.NewRequest(http.MethodDelete, "/oauth/keys/trusted/ext-key-4", nil)
+	req = adminReq(http.MethodDelete, "/oauth/keys/trusted/ext-key-4", nil)
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusNoContent {
@@ -216,7 +216,7 @@ func TestTrustedKeysHandler_Delete(t *testing.T) {
 	}
 
 	// Verify list is empty
-	req = httptest.NewRequest(http.MethodGet, "/oauth/keys/trusted", nil)
+	req = adminReq(http.MethodGet, "/oauth/keys/trusted", nil)
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -241,7 +241,7 @@ func TestTrustedKeysHandler_RegisterInvalidJWK(t *testing.T) {
 	}
 	bodyBytes, _ := json.Marshal(body)
 
-	req := httptest.NewRequest(http.MethodPost, "/oauth/keys/trusted", bytes.NewReader(bodyBytes))
+	req := adminReq(http.MethodPost, "/oauth/keys/trusted", bytes.NewReader(bodyBytes))
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 
@@ -254,7 +254,7 @@ func TestTrustedKeysHandler_DeleteNotFound(t *testing.T) {
 	store := NewInMemoryTrustedKeyStore()
 	handler := NewTrustedKeysHandler(store)
 
-	req := httptest.NewRequest(http.MethodDelete, "/oauth/keys/trusted/nonexistent", nil)
+	req := adminReq(http.MethodDelete, "/oauth/keys/trusted/nonexistent", nil)
 	rec := httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 

--- a/plugins/sqlite/path_validation.go
+++ b/plugins/sqlite/path_validation.go
@@ -1,0 +1,97 @@
+package sqlite
+
+import (
+	"errors"
+	"fmt"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// ErrInvalidFilterPath is returned when a Filter.Path or OrderSpec.Path
+// contains characters that could break out of a JSON-path literal in a
+// json_extract expression. Sentinel for callers that want to distinguish
+// input validation errors from storage errors.
+var ErrInvalidFilterPath = errors.New("invalid filter path")
+
+// validateJSONPath enforces a strict dotted-identifier grammar on paths that
+// are interpolated into json_extract(..., '$.<path>') expressions.
+//
+// Allowed: segments of ASCII letters, digits, and underscore, separated by
+// single '.' characters. At least one segment, no empty segments, no
+// leading/trailing dots. This rejects every character that could terminate
+// the surrounding single-quoted SQL literal or otherwise inject SQL —
+// notably ', ", \, ;, -, /, *, whitespace, and control bytes.
+//
+// The grammar is intentionally narrower than the full SQLite JSON path
+// grammar (which accepts bracketed indices and Unicode identifiers). If a
+// genuine use case ever needs those forms, extend this validator rather
+// than bypassing it.
+func validateJSONPath(path string) error {
+	if path == "" {
+		return fmt.Errorf("%w: empty", ErrInvalidFilterPath)
+	}
+	segmentStart := 0
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if c == '.' {
+			if i == segmentStart {
+				return fmt.Errorf("%w: empty segment", ErrInvalidFilterPath)
+			}
+			segmentStart = i + 1
+			continue
+		}
+		if !isIdentByte(c) {
+			return fmt.Errorf("%w: disallowed character %q at offset %d", ErrInvalidFilterPath, c, i)
+		}
+	}
+	if segmentStart == len(path) {
+		return fmt.Errorf("%w: trailing dot", ErrInvalidFilterPath)
+	}
+	return nil
+}
+
+func isIdentByte(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	case c == '_':
+		return true
+	}
+	return false
+}
+
+// validateFilterPaths walks a Filter tree and returns the first invalid path
+// it encounters. Leaf nodes without a Path (IsNull tree operators etc.) are
+// skipped; only nodes whose Path will be interpolated into SQL are checked.
+func validateFilterPaths(f spi.Filter) error {
+	switch f.Op {
+	case spi.FilterAnd, spi.FilterOr:
+		for _, c := range f.Children {
+			if err := validateFilterPaths(c); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if f.Path == "" {
+		return nil
+	}
+	return validateJSONPath(f.Path)
+}
+
+// validateOrderSpecs checks every OrderSpec.Path.
+func validateOrderSpecs(specs []spi.OrderSpec) error {
+	for _, s := range specs {
+		if s.Path == "" {
+			continue
+		}
+		if err := validateJSONPath(s.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/plugins/sqlite/path_validation_test.go
+++ b/plugins/sqlite/path_validation_test.go
@@ -1,0 +1,66 @@
+package sqlite
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestValidateJSONPath_Accepts ensures well-formed dotted-identifier paths pass.
+func TestValidateJSONPath_Accepts(t *testing.T) {
+	valid := []string{
+		"state",
+		"city",
+		"name",
+		"nested.field",
+		"a.b.c",
+		"field_1",
+		"UserID",
+		"order42",
+		"_private",
+	}
+	for _, p := range valid {
+		if err := validateJSONPath(p); err != nil {
+			t.Errorf("validateJSONPath(%q) returned unexpected error: %v", p, err)
+		}
+	}
+}
+
+// TestValidateJSONPath_RejectsInjection ensures classic SQL-injection
+// payloads are rejected before they can reach json_extract(...,'$.<path>').
+func TestValidateJSONPath_RejectsInjection(t *testing.T) {
+	malicious := []string{
+		// Single-quote escape — the core injection vector.
+		"state')--",
+		"state') UNION SELECT 1 --",
+		"a'b",
+		// Line-comment / block-comment sequences.
+		"a--b",
+		"a/*b*/c",
+		// SQL statement terminators.
+		"a;b",
+		";DROP TABLE entities",
+		// Whitespace and control characters.
+		"a b",
+		"a\nb",
+		"a\tb",
+		// Empty segments / malformed dotting.
+		"",
+		".",
+		".foo",
+		"foo.",
+		"a..b",
+		// Backslash / quote characters outright.
+		`a"b`,
+		`a\b`,
+	}
+	for _, p := range malicious {
+		err := validateJSONPath(p)
+		if err == nil {
+			t.Errorf("validateJSONPath(%q) = nil, want non-nil (injection payload accepted)", p)
+			continue
+		}
+		if !errors.Is(err, ErrInvalidFilterPath) {
+			t.Errorf("validateJSONPath(%q) = %v, want wraps ErrInvalidFilterPath", p, err)
+		}
+	}
+}

--- a/plugins/sqlite/query_planner.go
+++ b/plugins/sqlite/query_planner.go
@@ -166,6 +166,12 @@ var directMetaColumns = map[string]bool{
 // SourceMeta fields without direct columns (e.g., "state") use
 // json_extract on the meta JSONB column.
 // SourceData fields use json_extract on the data BLOB column.
+//
+// Safety invariant: f.Path is interpolated into a JSON-path literal and
+// therefore MUST have been validated by validateFilterPaths at the
+// Search() boundary (see path_validation.go). Adding a new caller that
+// bypasses Search() re-introduces SQL injection — call validateJSONPath
+// or validateFilterPaths before invoking this function.
 func fieldExpr(f spi.Filter) string {
 	if f.Source == spi.SourceMeta {
 		if directMetaColumns[f.Path] {

--- a/plugins/sqlite/search_injection_test.go
+++ b/plugins/sqlite/search_injection_test.go
@@ -1,0 +1,78 @@
+package sqlite_test
+
+import (
+	"errors"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/sqlite"
+)
+
+// TestSearcher_RejectsMaliciousFilterPath confirms that user-supplied Filter
+// paths containing SQL-injection payloads are rejected at the Search()
+// boundary — before they can be interpolated into a json_extract expression.
+//
+// Regression test for issue #64 (SQLite JSON-path SQL injection via
+// Filter/OrderSpec Path). Pre-fix, these payloads reached
+// fmt.Sprintf("json_extract(json(meta), '$.%s')", path) and broke out of
+// the single-quoted JSON-path literal, injecting arbitrary SQL.
+func TestSearcher_RejectsMaliciousFilterPath(t *testing.T) {
+	factory, ctx := setupSearcherTest(t)
+	store, _ := factory.EntityStore(ctx)
+	searcher := store.(spi.Searcher)
+
+	payloads := []string{
+		"state')--",
+		"state') UNION SELECT 1 --",
+		"a'b",
+		"a;DROP TABLE entities",
+		"a--b",
+	}
+
+	for _, payload := range payloads {
+		_, err := searcher.Search(ctx, spi.Filter{
+			Op:     spi.FilterEq,
+			Path:   payload,
+			Source: spi.SourceData,
+			Value:  "x",
+		}, spi.SearchOptions{
+			ModelName:    "person",
+			ModelVersion: "1",
+		})
+		if err == nil {
+			t.Errorf("Search with malicious Filter.Path %q returned nil error (injection not blocked)", payload)
+			continue
+		}
+		if !errors.Is(err, sqlite.ErrInvalidFilterPath) {
+			t.Errorf("Search with malicious Filter.Path %q returned err=%v, want wraps ErrInvalidFilterPath", payload, err)
+		}
+	}
+}
+
+// TestSearcher_RejectsMaliciousOrderByPath mirrors the above for OrderSpec.Path,
+// which reached orderByFieldExpr unvalidated pre-fix.
+func TestSearcher_RejectsMaliciousOrderByPath(t *testing.T) {
+	factory, ctx := setupSearcherTest(t)
+	store, _ := factory.EntityStore(ctx)
+	searcher := store.(spi.Searcher)
+
+	_, err := searcher.Search(ctx, spi.Filter{
+		Op:     spi.FilterEq,
+		Path:   "city",
+		Source: spi.SourceData,
+		Value:  "Berlin",
+	}, spi.SearchOptions{
+		ModelName:    "person",
+		ModelVersion: "1",
+		OrderBy: []spi.OrderSpec{{
+			Path:   "name') --",
+			Source: spi.SourceData,
+		}},
+	})
+	if err == nil {
+		t.Fatalf("Search with malicious OrderBy.Path returned nil error (injection not blocked)")
+	}
+	if !errors.Is(err, sqlite.ErrInvalidFilterPath) {
+		t.Fatalf("Search with malicious OrderBy.Path returned err=%v, want wraps ErrInvalidFilterPath", err)
+	}
+}

--- a/plugins/sqlite/searcher.go
+++ b/plugins/sqlite/searcher.go
@@ -22,6 +22,12 @@ var ErrScanBudgetExhausted = errors.New("scan budget exhausted")
 // post-filters the residual in Go. Pagination is applied in SQL when no
 // residual exists, or in Go after post-filtering.
 func (s *entityStore) Search(ctx context.Context, filter spi.Filter, opts spi.SearchOptions) ([]*spi.Entity, error) {
+	if err := validateFilterPaths(filter); err != nil {
+		return nil, err
+	}
+	if err := validateOrderSpecs(opts.OrderBy); err != nil {
+		return nil, err
+	}
 	plan := planQuery(filter)
 
 	var baseQuery string

--- a/plugins/sqlite/searcher.go
+++ b/plugins/sqlite/searcher.go
@@ -178,6 +178,11 @@ func orderByClause(opts spi.SearchOptions, tablePrefix string) string {
 }
 
 // orderByFieldExpr returns the SQL expression for an OrderSpec field.
+//
+// Safety invariant: spec.Path is interpolated into a JSON-path literal
+// and therefore MUST have been validated by validateOrderSpecs at the
+// Search() boundary (see path_validation.go). Adding a new caller that
+// bypasses Search() re-introduces SQL injection.
 func orderByFieldExpr(spec spi.OrderSpec, tablePrefix string) string {
 	qualify := func(col string) string {
 		if tablePrefix != "" {


### PR DESCRIPTION
Closes #64.

## Summary

Two critical findings from the systematic security audit, grouped because they are small orthogonal fixes.

- **SQLite JSON-path SQL injection.** `Filter.Path` / `OrderSpec.Path` were `fmt.Sprintf`'d into `json_extract(..., '\$.<path>')` expressions. A single quote in the path broke out of the JSON-path literal and injected arbitrary SQL. Added a strict dotted-identifier validator (`plugins/sqlite/path_validation.go`) applied at the `Search()` boundary; malformed paths now return `sqlite.ErrInvalidFilterPath` before any SQL is constructed.
- **Admin handlers missing `ROLE_ADMIN` check.** `M2MHandler`, `KeysHandler`, `TrustedKeysHandler` were wrapped by auth middleware but never verified the caller's role themselves; any authenticated principal from any tenant could manage OAuth key pairs, trusted JWKS, and M2M clients. Added a shared `requireAdmin` guard (`internal/auth/admin_guard.go`) — 401 on missing `UserContext`, 403 on non-admin — and wired it into each `ServeHTTP`.

## Tests

- `plugins/sqlite/path_validation_test.go` — unit tests of the validator against classic injection payloads (`state')--`, `UNION SELECT`, embedded quotes, statement terminators, control characters, malformed dotting).
- `plugins/sqlite/search_injection_test.go` — integration tests showing `Search()` rejects malicious `Filter.Path` and `OrderSpec.Path` with `ErrInvalidFilterPath`.
- `internal/auth/admin_authz_test.go` — per-handler tests: non-admin context → 403, no UserContext → 401, admin context → expected success. Existing tests migrated to an `adminReq` helper that attaches a ROLE_ADMIN context.
- `internal/auth/integration_test.go` — body-size integration tests wrapped with a `testAdminMW` stand-in so the guard admits the request and the `MaxBytesReader` behaviour is the observable assertion.

## Test plan

- [x] `go test ./... -v` — root module green (incl. E2E against Postgres)
- [x] `go test -count=1 ./internal/auth/... ./plugins/sqlite/...` — green on changed packages
- [x] `go test ./...` in each plugin submodule (`memory`, `postgres`, `sqlite`) — green
- [x] `go test -race ./internal/auth/... ./plugins/sqlite/...` — green
- [x] `go vet ./...` — clean across root and plugin submodules
- [x] RED → GREEN cycle verified for every new test (they fail without the fix, pass with it)

## Not in this PR

- Other findings from issue #64's siblings (#65 auth hardening, #66 transport, #67 CI gates, #68 hardening sweep) — separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)