### PR TITLE
ci: run CI workflow on pull requests (not only push to develop/main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` was previously gated to \`push\` events on \`develop\` and \`main\` only. That meant PRs against those branches ran **zero** status checks — surfaced when PR #69 reported no rollup after push.

Add \`pull_request: { branches: [develop, main] }\` so the test, build, race, and per-module hygiene jobs run on every PR.

## Why this isn't folded into #67

Issue #67 (\"add continuous security gates to CI\") is broader — govulncheck, CodeQL, Trivy, dependency-review. This PR is just the one-liner that gets the existing checks to actually run on PRs. Merging it first unblocks verification on any in-flight security PRs (#69, #70 and follow-ups).

## Test plan

- [x] File parses as YAML (pre-commit hook OK).
- [ ] After merge: re-push any branch to confirm CI fires on PR event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)