### PR TITLE
fix(security): JWKS hardening — in-process key source + TLS 1.3 pin (#66 finding 8)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -183,9 +183,10 @@ func New(cfg Config) *App {
 		if err != nil {
 			panic(fmt.Sprintf("failed to create auth service: %v", err))
 		}
-		contextPath := strings.TrimRight(cfg.ContextPath, "/")
-		jwksURL := fmt.Sprintf("http://localhost:%d%s/.well-known/jwks.json", cfg.HTTPPort, contextPath)
-		validator := auth.NewJWKSValidator(jwksURL, authSvc.Issuer(), 5*time.Minute)
+		// The built-in IAM holds its signing keys in-process, so the validator
+		// reads public keys directly from the local key store. No loopback JWKS
+		// fetch, no HTTP client, no attack surface on that path.
+		validator := auth.NewValidatorFromSource(auth.NewLocalKeySource(authSvc.KeyStore()), authSvc.Issuer())
 		if cfg.IAM.JWTAudience != "" {
 			validator.SetExpectedAudience(cfg.IAM.JWTAudience)
 		}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -998,7 +998,7 @@ Full RS256 JWT authentication with JWKS discovery and M2M client support.
 | `InMemoryM2MClientStore` | Machine-to-machine client credentials |
 | `JWKSHandler` | `GET /.well-known/jwks.json` -- standard JWKS endpoint |
 | `TokenHandler` | `POST /oauth/token` -- issues JWTs (client_credentials, OBO exchange) |
-| `JWKSValidator` | Validates JWTs against the JWKS endpoint (with caching) |
+| `JWKSValidator` | Validates JWTs against a `KeySource`: in-process `LocalKeySource` by default (no HTTP fetch), or `HTTPJWKSSource` (TLS 1.3 pinned, JSON content-type validated) for future external-IdP wiring |
 | `DelegatingAuthenticator` | Implements `spi.AuthenticationService`, delegates to validator |
 
 **Deterministic KID derivation:**

--- a/internal/auth/http_jwks_source.go
+++ b/internal/auth/http_jwks_source.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/rsa"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -41,6 +42,18 @@ func NewHTTPJWKSSourceWithTransportForTesting(jwksURL string, cacheTTL time.Dura
 	return newHTTPJWKSSource(jwksURL, cacheTTL, transport)
 }
 
+// NewHTTPJWKSSourceWithRootCAsForTesting returns a KeySource built via the
+// production transport assembly (TLS 1.3 pinned, no InsecureSkipVerify) with
+// the given CertPool substituted as RootCAs. Tests use this to verify that
+// the **production** MinVersion is TLS 1.3 end-to-end against an httptest
+// TLS server — not just the test-transport variant. Production code MUST
+// use NewHTTPJWKSSource; grep-enforced.
+func NewHTTPJWKSSourceWithRootCAsForTesting(jwksURL string, cacheTTL time.Duration, rootCAs *x509.CertPool) KeySource {
+	transport := defaultJWKSTransport()
+	transport.TLSClientConfig.RootCAs = rootCAs
+	return newHTTPJWKSSource(jwksURL, cacheTTL, transport)
+}
+
 func newHTTPJWKSSource(jwksURL string, cacheTTL time.Duration, transport *http.Transport) *httpJWKSSource {
 	return &httpJWKSSource{
 		jwksURL:  jwksURL,
@@ -73,6 +86,10 @@ func (s *httpJWKSSource) GetKey(kid string) (*rsa.PublicKey, error) {
 		return key, nil
 	}
 
+	// Stale cache is treated as no cache: a refresh failure returns an error
+	// even if a previously-cached key for this kid is still in memory. This
+	// is fail-closed — better to reject a token than to validate against a
+	// key we can no longer confirm is current. Matches pre-refactor behaviour.
 	if err := s.refreshCache(); err != nil {
 		return nil, fmt.Errorf("failed to refresh JWKS cache: %w", err)
 	}

--- a/internal/auth/http_jwks_source.go
+++ b/internal/auth/http_jwks_source.go
@@ -1,0 +1,181 @@
+package auth
+
+import (
+	"crypto/rsa"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"mime"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// httpJWKSSource fetches RSA public keys from a JWKS HTTP endpoint, caching
+// the result for cacheTTL. Its http.Transport pins TLS 1.3 as the minimum
+// version and the response must carry a JSON content-type — any deviation is
+// treated as a potentially hostile substitution and rejected.
+type httpJWKSSource struct {
+	jwksURL   string
+	cacheTTL  time.Duration
+	client    *http.Client
+	mu        sync.RWMutex
+	cache     map[string]*rsa.PublicKey
+	lastFetch time.Time
+}
+
+// NewHTTPJWKSSource returns a KeySource that fetches JWKS from the given URL.
+// The client pins TLS 1.3 and validates Content-Type on each response.
+func NewHTTPJWKSSource(jwksURL string, cacheTTL time.Duration) KeySource {
+	return newHTTPJWKSSource(jwksURL, cacheTTL, defaultJWKSTransport())
+}
+
+// NewHTTPJWKSSourceWithTransportForTesting returns a KeySource with a
+// caller-supplied transport. Reserved for tests that need to trust an
+// httptest.Server's self-signed certificate. Production code MUST use
+// NewHTTPJWKSSource; grep-enforced.
+func NewHTTPJWKSSourceWithTransportForTesting(jwksURL string, cacheTTL time.Duration, transport *http.Transport) KeySource {
+	return newHTTPJWKSSource(jwksURL, cacheTTL, transport)
+}
+
+func newHTTPJWKSSource(jwksURL string, cacheTTL time.Duration, transport *http.Transport) *httpJWKSSource {
+	return &httpJWKSSource{
+		jwksURL:  jwksURL,
+		cacheTTL: cacheTTL,
+		cache:    make(map[string]*rsa.PublicKey),
+		client: &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: transport,
+		},
+	}
+}
+
+// defaultJWKSTransport returns the production JWKS transport: TLS 1.3 minimum,
+// system root CAs, no InsecureSkipVerify.
+func defaultJWKSTransport() *http.Transport {
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
+		},
+	}
+}
+
+func (s *httpJWKSSource) GetKey(kid string) (*rsa.PublicKey, error) {
+	s.mu.RLock()
+	key, found := s.cache[kid]
+	stale := time.Since(s.lastFetch) > s.cacheTTL
+	s.mu.RUnlock()
+
+	if found && !stale {
+		return key, nil
+	}
+
+	if err := s.refreshCache(); err != nil {
+		return nil, fmt.Errorf("failed to refresh JWKS cache: %w", err)
+	}
+
+	s.mu.RLock()
+	key, found = s.cache[kid]
+	s.mu.RUnlock()
+
+	if !found {
+		return nil, fmt.Errorf("%w: %q", ErrKeyNotFound, kid)
+	}
+	return key, nil
+}
+
+// refreshCache fetches the JWKS endpoint and refreshes the key cache. It
+// rejects any response whose Content-Type is not JSON-shaped.
+func (s *httpJWKSSource) refreshCache() error {
+	resp, err := s.client.Get(s.jwksURL)
+	if err != nil {
+		return fmt.Errorf("JWKS fetch failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("JWKS endpoint returned status %d", resp.StatusCode)
+	}
+
+	if err := validateJWKSContentType(resp.Header.Get("Content-Type")); err != nil {
+		return err
+	}
+
+	// Limit response body to 1 MB to prevent OOM from misconfigured/compromised endpoints.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("failed to read JWKS response: %w", err)
+	}
+
+	keys, err := parseJWKSResponse(body)
+	if err != nil {
+		return fmt.Errorf("failed to parse JWKS response: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cache = keys
+	s.lastFetch = time.Now()
+	return nil
+}
+
+// parseJWKSResponse parses a JWKS JSON response into a map of kid to RSA public keys.
+func parseJWKSResponse(body []byte) (map[string]*rsa.PublicKey, error) {
+	var jwks struct {
+		Keys []struct {
+			Kty string `json:"kty"`
+			KID string `json:"kid"`
+			N   string `json:"n"`
+			E   string `json:"e"`
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(body, &jwks); err != nil {
+		return nil, fmt.Errorf("invalid JWKS JSON: %w", err)
+	}
+
+	result := make(map[string]*rsa.PublicKey, len(jwks.Keys))
+	for _, k := range jwks.Keys {
+		if k.KID == "" || k.Kty != "RSA" {
+			continue
+		}
+		nBytes, err := decodeBase64URL(k.N)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base64url for n (kid=%s): %w", k.KID, err)
+		}
+		eBytes, err := decodeBase64URL(k.E)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base64url for e (kid=%s): %w", k.KID, err)
+		}
+
+		n := new(big.Int).SetBytes(nBytes)
+		e := int(new(big.Int).SetBytes(eBytes).Int64())
+
+		result[k.KID] = &rsa.PublicKey{N: n, E: e}
+	}
+
+	return result, nil
+}
+
+// validateJWKSContentType accepts application/json and application/jwk-set+json
+// (RFC 7517 §8.5.1), with or without parameters like charset. Anything else —
+// text/html, empty, application/xml — is rejected as a potentially hostile
+// substitution of the JWKS response.
+func validateJWKSContentType(header string) error {
+	if header == "" {
+		return fmt.Errorf("JWKS response missing Content-Type header")
+	}
+	mediaType, _, err := mime.ParseMediaType(header)
+	if err != nil {
+		return fmt.Errorf("JWKS response has malformed Content-Type %q: %w", header, err)
+	}
+	mediaType = strings.ToLower(mediaType)
+	switch mediaType {
+	case "application/json", "application/jwk-set+json":
+		return nil
+	default:
+		return fmt.Errorf("JWKS response has unexpected Content-Type %q (want application/json or application/jwk-set+json)", mediaType)
+	}
+}

--- a/internal/auth/http_jwks_source_test.go
+++ b/internal/auth/http_jwks_source_test.go
@@ -1,0 +1,134 @@
+package auth_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/internal/auth"
+)
+
+// testTransportTrusting builds an http.Transport whose TLS config trusts the
+// given httptest.Server's self-signed cert AND pins MinVersion to TLS 1.3
+// (mirroring production). Tests use this to exercise the real TLS hardening
+// against httptest servers.
+func testTransportTrusting(srv *httptest.Server) *http.Transport {
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	return &http.Transport{
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS13,
+			RootCAs:    pool,
+		},
+	}
+}
+
+// jwksJSONBody returns a minimal but well-formed JWKS body for tests that
+// don't care about the keys themselves — only the HTTP-layer behavior.
+func jwksJSONBody(t *testing.T) []byte {
+	t.Helper()
+	b, err := json.Marshal(struct {
+		Keys []any `json:"keys"`
+	}{Keys: []any{}})
+	if err != nil {
+		t.Fatalf("marshal jwks body: %v", err)
+	}
+	return b
+}
+
+func TestHTTPJWKSSource_RejectsTLS12OnlyEndpoint(t *testing.T) {
+	body := jwksJSONBody(t)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	srv.TLS = &tls.Config{MaxVersion: tls.VersionTLS12}
+	srv.StartTLS()
+	defer srv.Close()
+
+	src := auth.NewHTTPJWKSSourceWithTransportForTesting(srv.URL, 5*time.Minute, testTransportTrusting(srv))
+	_, err := src.GetKey("any")
+	if err == nil {
+		t.Fatal("expected handshake failure against TLS 1.2-only endpoint, got nil")
+	}
+	// Should be a TLS handshake / protocol version failure. Don't overfit on
+	// the exact message, but require it to NOT look like a 404 or body error.
+	msg := err.Error()
+	if strings.Contains(msg, "status") || strings.Contains(msg, "invalid JWKS JSON") {
+		t.Fatalf("expected TLS/handshake error, got HTTP-level error: %v", err)
+	}
+}
+
+func TestHTTPJWKSSource_RejectsHTMLContentType(t *testing.T) {
+	body := jwksJSONBody(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	src := auth.NewHTTPJWKSSourceWithTransportForTesting(srv.URL, 5*time.Minute, testTransportTrusting(srv))
+	_, err := src.GetKey("any")
+	if err == nil {
+		t.Fatal("expected content-type rejection, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "content-type") {
+		t.Fatalf("expected error to mention content-type, got: %v", err)
+	}
+}
+
+func TestHTTPJWKSSource_AcceptsApplicationJSON(t *testing.T) {
+	body := jwksJSONBody(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	src := auth.NewHTTPJWKSSourceWithTransportForTesting(srv.URL, 5*time.Minute, testTransportTrusting(srv))
+	// Empty key set → GetKey returns ErrKeyNotFound, NOT a transport/content-type
+	// error. Confirms the fetch succeeded.
+	_, err := src.GetKey("any-kid")
+	if err == nil {
+		t.Fatal("expected ErrKeyNotFound for empty JWKS, got nil")
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "content-type") {
+		t.Fatalf("unexpected content-type error for valid application/json: %v", err)
+	}
+}
+
+func TestHTTPJWKSSource_AcceptsJWKSetJSONWithCharset(t *testing.T) {
+	body := jwksJSONBody(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/jwk-set+json; charset=utf-8")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	src := auth.NewHTTPJWKSSourceWithTransportForTesting(srv.URL, 5*time.Minute, testTransportTrusting(srv))
+	_, err := src.GetKey("any-kid")
+	if err == nil {
+		t.Fatal("expected ErrKeyNotFound for empty JWKS, got nil")
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "content-type") {
+		t.Fatalf("unexpected content-type error for application/jwk-set+json: %v", err)
+	}
+}
+
+func TestHTTPJWKSSource_RejectsNon200Status(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	src := auth.NewHTTPJWKSSourceWithTransportForTesting(srv.URL, 5*time.Minute, testTransportTrusting(srv))
+	_, err := src.GetKey("any")
+	if err == nil {
+		t.Fatal("expected status-code rejection, got nil")
+	}
+}

--- a/internal/auth/http_jwks_source_test.go
+++ b/internal/auth/http_jwks_source_test.go
@@ -56,11 +56,40 @@ func TestHTTPJWKSSource_RejectsTLS12OnlyEndpoint(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected handshake failure against TLS 1.2-only endpoint, got nil")
 	}
-	// Should be a TLS handshake / protocol version failure. Don't overfit on
-	// the exact message, but require it to NOT look like a 404 or body error.
-	msg := err.Error()
-	if strings.Contains(msg, "status") || strings.Contains(msg, "invalid JWKS JSON") {
-		t.Fatalf("expected TLS/handshake error, got HTTP-level error: %v", err)
+	// Positively confirm it's a TLS protocol-version failure, not an
+	// incidental DNS/timeout that would also pass this test.
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "protocol version") && !strings.Contains(msg, "handshake") && !strings.Contains(msg, "tls") {
+		t.Fatalf("expected TLS/handshake error, got: %v", err)
+	}
+}
+
+// TestHTTPJWKSSource_ProductionTransportPinsTLS13 exercises the **production**
+// constructor NewHTTPJWKSSource via the RootCAs-injection testing variant.
+// This closes the coverage gap that the WithTransportForTesting variant
+// leaves: without this test, defaultJWKSTransport()'s MinVersion pin is
+// trusted by inspection rather than proven end-to-end.
+func TestHTTPJWKSSource_ProductionTransportPinsTLS13(t *testing.T) {
+	body := jwksJSONBody(t)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	srv.TLS = &tls.Config{MaxVersion: tls.VersionTLS12}
+	srv.StartTLS()
+	defer srv.Close()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+
+	src := auth.NewHTTPJWKSSourceWithRootCAsForTesting(srv.URL, 5*time.Minute, pool)
+	_, err := src.GetKey("any")
+	if err == nil {
+		t.Fatal("production transport accepted TLS 1.2 handshake — MinVersion pin is broken")
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "protocol version") && !strings.Contains(msg, "handshake") && !strings.Contains(msg, "tls") {
+		t.Fatalf("expected TLS/handshake error from production transport, got: %v", err)
 	}
 }
 

--- a/internal/auth/key_source.go
+++ b/internal/auth/key_source.go
@@ -35,7 +35,9 @@ func NewLocalKeySource(ks KeyStore) KeySource {
 func (s *localKeySource) GetKey(kid string) (*rsa.PublicKey, error) {
 	kp, err := s.ks.Get(kid)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %q: %v", ErrKeyNotFound, kid, err)
+		// Double %w so callers can errors.Is against both ErrKeyNotFound
+		// (semantic) and the underlying KeyStore error (diagnostic).
+		return nil, fmt.Errorf("%w (kid=%q): %w", ErrKeyNotFound, kid, err)
 	}
 	return kp.PublicKey, nil
 }

--- a/internal/auth/key_source.go
+++ b/internal/auth/key_source.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"crypto/rsa"
+	"errors"
+	"fmt"
+)
+
+// KeySource retrieves RSA public keys by KID for JWT signature verification.
+// Implementations may fetch from a JWKS HTTP endpoint, from a local in-process
+// key store, or from any other source. The validator depends only on this
+// interface so the transport story can evolve without touching validation logic.
+type KeySource interface {
+	GetKey(kid string) (*rsa.PublicKey, error)
+}
+
+// ErrKeyNotFound is returned by KeySource implementations when the requested
+// KID is not known. Callers that need to distinguish "unknown key" from
+// "transport failure" can use errors.Is.
+var ErrKeyNotFound = errors.New("kid not found")
+
+// localKeySource returns public keys directly from the in-process KeyStore,
+// with no HTTP round-trip.
+type localKeySource struct {
+	ks KeyStore
+}
+
+// NewLocalKeySource returns a KeySource that reads directly from the given
+// in-process KeyStore. This is the default for the built-in IAM: no JWKS
+// HTTP fetch is needed when the signing keys are already in the same process.
+func NewLocalKeySource(ks KeyStore) KeySource {
+	return &localKeySource{ks: ks}
+}
+
+func (s *localKeySource) GetKey(kid string) (*rsa.PublicKey, error) {
+	kp, err := s.ks.Get(kid)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %q: %v", ErrKeyNotFound, kid, err)
+	}
+	return kp.PublicKey, nil
+}

--- a/internal/auth/local_key_source_test.go
+++ b/internal/auth/local_key_source_test.go
@@ -1,0 +1,71 @@
+package auth_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/internal/auth"
+)
+
+func TestLocalKeySource_ReturnsPublicKeyForRegisteredKID(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate test key: %v", err)
+	}
+
+	ks := auth.NewInMemoryKeyStore()
+	kid := "test-kid-123"
+	if err := ks.Save(&auth.KeyPair{
+		KID:        kid,
+		PublicKey:  &priv.PublicKey,
+		PrivateKey: priv,
+		Active:     true,
+		CreatedAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("failed to save keypair: %v", err)
+	}
+
+	src := auth.NewLocalKeySource(ks)
+	got, err := src.GetKey(kid)
+	if err != nil {
+		t.Fatalf("GetKey returned unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetKey returned nil public key")
+	}
+	if got.N.Cmp(priv.PublicKey.N) != 0 || got.E != priv.PublicKey.E {
+		t.Fatal("GetKey returned a different public key than registered")
+	}
+}
+
+func TestLocalKeySource_ReturnsErrorForUnknownKID(t *testing.T) {
+	ks := auth.NewInMemoryKeyStore()
+	src := auth.NewLocalKeySource(ks)
+
+	got, err := src.GetKey("nonexistent-kid")
+	if err == nil {
+		t.Fatal("expected error for unknown kid, got nil")
+	}
+	if got != nil {
+		t.Fatalf("expected nil key on error, got %v", got)
+	}
+}
+
+func TestLocalKeySource_ErrorIsUnwrappable(t *testing.T) {
+	// The returned error should unwrap to something meaningful — not just
+	// a string. Keeps callers able to check for ErrKeyNotFound semantically.
+	ks := auth.NewInMemoryKeyStore()
+	src := auth.NewLocalKeySource(ks)
+
+	_, err := src.GetKey("nope")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Don't overspecify the sentinel; just confirm it wraps something.
+	if errors.Unwrap(err) == nil {
+		t.Log("note: error does not wrap inner error; acceptable but less helpful for callers")
+	}
+}

--- a/internal/auth/local_validator_integration_test.go
+++ b/internal/auth/local_validator_integration_test.go
@@ -1,0 +1,81 @@
+package auth_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/auth"
+)
+
+// TestIntegration_JWTMode_LocalKeySource_NoHTTPFetch proves the hardened
+// default wiring: validator built via NewValidatorFromSource + LocalKeySource
+// validates tokens minted by the same authSvc without making any HTTP call,
+// even if a JWKS endpoint is also exposed. This is the invariant #66 locks
+// in — there is no loopback fetch to MITM because there is no fetch at all.
+func TestIntegration_JWTMode_LocalKeySource_NoHTTPFetch(t *testing.T) {
+	svc, err := auth.NewAuthService(auth.AuthConfig{
+		SigningKeyPEM: generateTestPEM(t),
+		Issuer:        "cyoda",
+		ExpirySeconds: 3600,
+	})
+	if err != nil {
+		t.Fatalf("NewAuthService: %v", err)
+	}
+
+	if err := svc.M2MClientStore().CreateWithSecret(
+		"client-1", "tenant-1", "user-1", "secret-1", []string{"ROLE_USER"},
+	); err != nil {
+		t.Fatalf("CreateWithSecret: %v", err)
+	}
+
+	// Serve only the token endpoint. Crucially, no JWKS endpoint is exposed —
+	// if the validator tried to fetch one, this test would fail.
+	tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		svc.Handler().ServeHTTP(w, r)
+	}))
+	defer tokenSrv.Close()
+
+	// Mint a token via the normal token endpoint. Client credentials are
+	// conveyed via HTTP Basic, matching the existing integration pattern.
+	req, _ := http.NewRequest("POST", tokenSrv.URL+"/oauth/token",
+		strings.NewReader("grant_type=client_credentials"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Basic "+
+		base64.StdEncoding.EncodeToString([]byte("client-1:secret-1")))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("token request failed: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("token endpoint returned %d: %s", resp.StatusCode, body)
+	}
+
+	var tokenResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		t.Fatalf("decode token: %v", err)
+	}
+	if tokenResp.AccessToken == "" {
+		t.Fatal("empty access token")
+	}
+
+	// Build the validator the same way app.go does: LocalKeySource wrapping
+	// the in-process KeyStore. No JWKS URL, no http.Client.
+	validator := auth.NewValidatorFromSource(auth.NewLocalKeySource(svc.KeyStore()), svc.Issuer())
+
+	uc, err := validator.Validate(tokenResp.AccessToken)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if uc == nil || uc.UserID != "user-1" {
+		t.Fatalf("unexpected user context: %+v", uc)
+	}
+}

--- a/internal/auth/validator.go
+++ b/internal/auth/validator.go
@@ -1,28 +1,22 @@
 package auth
 
 import (
-	"crypto/rsa"
-	"encoding/json"
 	"fmt"
-	"io"
-	"math/big"
-	"net/http"
 	"sync"
 	"time"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 )
 
-// JWKSValidator validates JWT tokens by fetching public keys from a JWKS endpoint.
+// JWKSValidator validates JWT tokens against a KeySource. The transport —
+// in-process lookup, HTTPS JWKS fetch, or any future alternative — is pluggable
+// behind KeySource; the validator itself only owns issuer, audience, and claims
+// validation.
 type JWKSValidator struct {
-	jwksURL   string
-	issuer    string
-	audience  string
-	cache     map[string]*rsa.PublicKey
-	lastFetch time.Time
-	cacheTTL  time.Duration
-	mu        sync.RWMutex
-	client    *http.Client
+	source   KeySource
+	issuer   string
+	mu       sync.RWMutex
+	audience string
 }
 
 // SetExpectedAudience configures the audience value that tokens must
@@ -40,15 +34,19 @@ func (v *JWKSValidator) SetExpectedAudience(aud string) {
 	v.audience = aud
 }
 
-// NewJWKSValidator creates a new JWKSValidator that fetches keys from jwksURL.
+// NewValidatorFromSource returns a JWKSValidator that resolves keys via the
+// given KeySource. This is the preferred constructor — callers decide where
+// keys come from (in-process, external JWKS, etc).
+func NewValidatorFromSource(src KeySource, issuer string) *JWKSValidator {
+	return &JWKSValidator{source: src, issuer: issuer}
+}
+
+// NewJWKSValidator creates a validator backed by an HTTPS JWKS endpoint with
+// TLS 1.3 pinned, 10s request timeout, and the given cache TTL. Preserved as
+// a convenience for tests and for future external-IdP wiring; in-process
+// callers should use NewValidatorFromSource with NewLocalKeySource.
 func NewJWKSValidator(jwksURL, issuer string, cacheTTL time.Duration) *JWKSValidator {
-	return &JWKSValidator{
-		jwksURL:  jwksURL,
-		issuer:   issuer,
-		cache:    make(map[string]*rsa.PublicKey),
-		cacheTTL: cacheTTL,
-		client:   &http.Client{Timeout: 10 * time.Second},
-	}
+	return NewValidatorFromSource(NewHTTPJWKSSource(jwksURL, cacheTTL), issuer)
 }
 
 // Validate parses and validates a JWT token string, returning a UserContext on success.
@@ -67,9 +65,9 @@ func (v *JWKSValidator) Validate(tokenString string) (*spi.UserContext, error) {
 		return nil, fmt.Errorf("missing kid in token header")
 	}
 
-	publicKey, err := v.getKey(kid)
+	publicKey, err := v.source.GetKey(kid)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to resolve key for kid %q: %w", kid, err)
 	}
 
 	if err := Verify(parsed.SigningInput, parsed.Signature, publicKey); err != nil {
@@ -100,101 +98,6 @@ func (v *JWKSValidator) Validate(tokenString string) (*spi.UserContext, error) {
 	}
 
 	return uc, nil
-}
-
-// getKey retrieves the public key for the given kid, refreshing the cache if needed.
-func (v *JWKSValidator) getKey(kid string) (*rsa.PublicKey, error) {
-	v.mu.RLock()
-	key, found := v.cache[kid]
-	stale := time.Since(v.lastFetch) > v.cacheTTL
-	v.mu.RUnlock()
-
-	if found && !stale {
-		return key, nil
-	}
-
-	// Cache miss or stale — refresh
-	if err := v.refreshCache(); err != nil {
-		return nil, fmt.Errorf("failed to refresh JWKS cache: %w", err)
-	}
-
-	v.mu.RLock()
-	key, found = v.cache[kid]
-	v.mu.RUnlock()
-
-	if !found {
-		return nil, fmt.Errorf("kid %q not found in JWKS", kid)
-	}
-
-	return key, nil
-}
-
-// refreshCache fetches the JWKS endpoint and updates the key cache.
-func (v *JWKSValidator) refreshCache() error {
-	resp, err := v.client.Get(v.jwksURL)
-	if err != nil {
-		return fmt.Errorf("JWKS fetch failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("JWKS endpoint returned status %d", resp.StatusCode)
-	}
-
-	// Limit response body to 1 MB to prevent OOM from misconfigured/compromised endpoints.
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return fmt.Errorf("failed to read JWKS response: %w", err)
-	}
-
-	keys, err := parseJWKSResponse(body)
-	if err != nil {
-		return fmt.Errorf("failed to parse JWKS response: %w", err)
-	}
-
-	v.mu.Lock()
-	v.cache = keys
-	v.lastFetch = time.Now()
-	v.mu.Unlock()
-
-	return nil
-}
-
-// parseJWKSResponse parses a JWKS JSON response into a map of kid to RSA public keys.
-func parseJWKSResponse(body []byte) (map[string]*rsa.PublicKey, error) {
-	var jwks struct {
-		Keys []struct {
-			Kty string `json:"kty"`
-			KID string `json:"kid"`
-			N   string `json:"n"`
-			E   string `json:"e"`
-		} `json:"keys"`
-	}
-	if err := json.Unmarshal(body, &jwks); err != nil {
-		return nil, fmt.Errorf("invalid JWKS JSON: %w", err)
-	}
-
-	result := make(map[string]*rsa.PublicKey, len(jwks.Keys))
-	for _, k := range jwks.Keys {
-		if k.KID == "" || k.Kty != "RSA" {
-			continue
-		}
-		nBytes, err := decodeBase64URL(k.N)
-		if err != nil {
-			return nil, fmt.Errorf("invalid base64url for n (kid=%s): %w", k.KID, err)
-		}
-		eBytes, err := decodeBase64URL(k.E)
-		if err != nil {
-			return nil, fmt.Errorf("invalid base64url for e (kid=%s): %w", k.KID, err)
-		}
-
-		n := new(big.Int).SetBytes(nBytes)
-		e := int(new(big.Int).SetBytes(eBytes).Int64())
-
-		result[k.KID] = &rsa.PublicKey{N: n, E: e}
-	}
-
-	return result, nil
 }
 
 // buildUserContext extracts user information from JWT claims.

--- a/internal/auth/validator_keysource_test.go
+++ b/internal/auth/validator_keysource_test.go
@@ -1,0 +1,60 @@
+package auth_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/internal/auth"
+)
+
+// fakeKeySource records calls and returns a fixed key. Proves the validator
+// goes through the KeySource interface rather than any HTTP client.
+type fakeKeySource struct {
+	key      *rsa.PublicKey
+	kid      string
+	getCalls int
+}
+
+func (f *fakeKeySource) GetKey(kid string) (*rsa.PublicKey, error) {
+	f.getCalls++
+	if kid != f.kid {
+		return nil, auth.ErrKeyNotFound
+	}
+	return f.key, nil
+}
+
+func TestValidator_RoutesKeyLookupThroughInjectedSource(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+
+	kid := "keysource-kid"
+	fake := &fakeKeySource{key: &priv.PublicKey, kid: kid}
+
+	v := auth.NewValidatorFromSource(fake, "test-issuer")
+
+	now := time.Now().Unix()
+	claims := map[string]any{
+		"iss":          "test-issuer",
+		"sub":          "u1",
+		"caas_user_id": "u1",
+		"caas_org_id":  "org1",
+		"exp":          float64(now + 300),
+		"iat":          float64(now),
+	}
+	token := signTestToken(t, priv, kid, claims)
+
+	uc, err := v.Validate(token)
+	if err != nil {
+		t.Fatalf("Validate failed: %v", err)
+	}
+	if uc == nil || uc.UserID != "u1" {
+		t.Fatalf("unexpected user context: %+v", uc)
+	}
+	if fake.getCalls == 0 {
+		t.Fatal("KeySource.GetKey was never invoked; validator bypassed the injected source")
+	}
+}


### PR DESCRIPTION
Closes part 1 of #66 (transport hardening). PR2 will tackle inter-node AEAD dispatch separately.

## Summary

- **Kills the loopback JWKS fetch entirely.** `app/app.go` previously built `http://localhost:<port>/.well-known/jwks.json` and let the validator round-trip to itself on every cache miss — plaintext HTTP, no TLS config, wasted indirection. Signing keys are already in process via `authSvc.KeyStore()`. New `LocalKeySource` pulls the public key directly. Default deployment no longer crosses the process boundary for JWKS validation.
- **Hardens the residual HTTP path** for tests and future external-IdP wiring. `HTTPJWKSSource` pins `tls.VersionTLS13` minimum on a custom `http.Transport` and validates response `Content-Type` is JSON-shaped (`application/json` or `application/jwk-set+json`, params tolerated) before parsing. A dedicated production-transport test proves the MinVersion pin end-to-end, not just the test variant.
- **Introduces `KeySource` interface** as the pluggable seam. The validator now owns only issuer/audience/claims validation. Future external-IdP or mTLS-to-IdP support plugs in as a new `KeySource` implementation without touching validation logic.

## Compatibility

No env var changes. No config surface change. `NewJWKSValidator(url, issuer, ttl)` preserved as a convenience (wraps `HTTPJWKSSource` internally) so all existing tests and any future external-JWKS wiring work unchanged.

## Test plan

- [x] `go test -short ./...` green
- [x] `go test ./internal/e2e/...` green
- [x] `go test -race ./internal/auth/ ./app/` clean
- [x] `go vet ./...` clean
- [x] Plugin submodules (memory, postgres, sqlite) green
- [x] New tests: `TestLocalKeySource_*`, `TestHTTPJWKSSource_*` (incl. production-transport TLS 1.3 pin test), `TestValidator_RoutesKeyLookupThroughInjectedSource`, `TestIntegration_JWTMode_LocalKeySource_NoHTTPFetch`
- [x] All pre-existing auth tests pass unchanged (validator, jwt_audience, jwt_alg_pinning, delegating, integration)
- [x] Code review completed (superpowers:code-reviewer): Important #1 and #2 addressed, #3 annotated; Minor error-wrapping fix applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)