### PR TITLE
fix(security): AEAD inter-node dispatch with PeerAuth seam (#66 finding 7)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -304,6 +304,18 @@ func New(cfg Config) *App {
 
 	// Wire external processing dispatcher
 	var extProc contract.ExternalProcessingService
+	// Peer-auth for inter-node dispatch. AES-256-GCM + HKDF-derived key over
+	// the shared cluster secret. 30-second timestamp skew window. Constructed
+	// once and shared by forwarder and handler so rotation is atomic.
+	var peerAuth clusterdispatch.PeerAuth
+	if cfg.Cluster.Enabled {
+		auth, err := clusterdispatch.NewAEADPeerAuth(cfg.Cluster.HMACSecret, 30*time.Second)
+		if err != nil {
+			slog.Error("failed to construct dispatch peer auth", "pkg", "cluster", "err", err)
+			os.Exit(1)
+		}
+		peerAuth = auth
+	}
 	if cfg.ExternalProcessing != nil {
 		extProc = cfg.ExternalProcessing
 	} else if cfg.Cluster.Enabled {
@@ -312,7 +324,7 @@ func New(cfg Config) *App {
 			a.nodeRegistry,
 			cfg.Cluster.NodeID,
 			clusterdispatch.NewRandomSelector(),
-			clusterdispatch.NewHTTPForwarder(cfg.Cluster.HMACSecret, cfg.Cluster.DispatchForwardTimeout),
+			clusterdispatch.NewHTTPForwarder(peerAuth, cfg.Cluster.DispatchForwardTimeout),
 			cfg.Cluster.DispatchWaitTimeout,
 		)
 	} else {
@@ -398,26 +410,18 @@ func New(cfg Config) *App {
 		outerMux.Handle(contextPath+"/", http.StripPrefix(contextPath, mux))
 		// Discovery routes at root (no auth, no context path)
 		internalapi.RegisterDiscoveryRoutes(outerMux, contextPath)
-		// Internal dispatch routes at root (HMAC-authenticated, not under context path)
+		// Internal dispatch routes at root (AEAD-authenticated, not under context path)
 		if cfg.Cluster.Enabled {
-			dispatchHandler, dhErr := clusterdispatch.NewDispatchHandler(localDispatcher, cfg.Cluster.HMACSecret)
-			if dhErr != nil {
-				slog.Error("failed to create dispatch handler", "pkg", "cluster", "err", dhErr)
-				os.Exit(1)
-			}
+			dispatchHandler := clusterdispatch.NewDispatchHandler(localDispatcher, peerAuth)
 			dispatchHandler.Register(outerMux)
 		}
 		a.handler = outerMux
 	} else {
 		// No context path — discovery routes on the main mux
 		internalapi.RegisterDiscoveryRoutes(mux, "")
-		// Internal dispatch routes (HMAC-authenticated)
+		// Internal dispatch routes (AEAD-authenticated)
 		if cfg.Cluster.Enabled {
-			dispatchHandler, dhErr := clusterdispatch.NewDispatchHandler(localDispatcher, cfg.Cluster.HMACSecret)
-			if dhErr != nil {
-				slog.Error("failed to create dispatch handler", "pkg", "cluster", "err", dhErr)
-				os.Exit(1)
-			}
+			dispatchHandler := clusterdispatch.NewDispatchHandler(localDispatcher, peerAuth)
 			dispatchHandler.Register(mux)
 		}
 		a.handler = mux

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -479,10 +479,16 @@ bytes); the binary's `envHexFromSecret` decodes hex if valid,
 falling back to raw bytes otherwise. Transaction tokens use
 base64url for both the JSON payload and the HMAC signature:
 `base64url(json_payload).base64url(hmac_sha256(json_payload, secret))`.
-Inter-node dispatch authentication uses a hex-encoded HMAC in the
-`X-Dispatch-HMAC` header — *not* base64. The distinction matters: a
-client or peer-forwarding handler that encodes the dispatch HMAC
-as base64url will be rejected.
+
+Inter-node dispatch authentication uses AEAD (AES-256-GCM) over an
+HKDF-SHA256-derived key (info string `"cyoda-dispatch-v1"`), which
+separates the dispatch key from the raw gossip-encryption secret
+despite both being derived from the same `CYODA_HMAC_SECRET`. Wire
+format is `[nonce(12) || ciphertext||tag]` with Content-Type
+`application/cyoda-dispatch-v1`; `X-Dispatch-Timestamp` is bound as
+associated data along with HTTP method and path, preventing
+cross-endpoint and timestamp-strip replays. A bounded, TTL-evicted
+nonce cache rejects replays within the 30s skew window.
 
 The token is opaque to the client. The router decodes it to extract `nodeID` without any network call -- address resolution is a local scan over `list.Members()`.
 
@@ -554,8 +560,9 @@ Three strategy interfaces, each with a default implementation:
 3. Forward to selected peer:
    HTTPForwarder.ForwardProcessor(ctx, peer.Addr, request)
    - POST to http://peer/internal/dispatch/processor
-   - HMAC-SHA256 signed body (X-Dispatch-HMAC header)
-   - Peer deserializes, calls its own local dispatch, returns result
+   - AES-256-GCM AEAD envelope over the request body
+     (Content-Type: application/cyoda-dispatch-v1)
+   - Peer verifies envelope, decrypts, calls local dispatch, returns result
 ```
 
 Dispatch forwarding reuses a shared `http.Transport` (`MaxIdleConns: 20`,
@@ -1489,9 +1496,9 @@ Items carried forward from the `cyoda-light-go` predecessor repository. Issues w
 
 **Context:** What protocol to use for cross-node dispatch forwarding.
 
-**Decision:** HTTP POST to `/internal/dispatch/processor` and `/internal/dispatch/criteria`, authenticated with HMAC-SHA256.
+**Decision:** HTTP POST to `/internal/dispatch/processor` and `/internal/dispatch/criteria`, authenticated and encrypted with AES-256-GCM AEAD (PeerAuth interface, AEADPeerAuth impl). The AEAD key is HKDF-derived from `CYODA_HMAC_SECRET`; the forwarder and handler share a `PeerAuth` seam so a future mTLS-based transport can be swapped in without changing the dispatch logic.
 
-**Rationale:** Reuses the existing HTTP infrastructure. The dispatch payload is a single request-response pair (not a stream), making HTTP a natural fit. HMAC authentication reuses the cluster secret without adding TLS complexity for internal traffic.
+**Rationale:** Reuses the existing HTTP infrastructure. The dispatch payload is a single request-response pair (not a stream), making HTTP a natural fit. AEAD gives integrity + confidentiality + replay resistance (via timestamp skew + nonce cache) in one primitive, closing the plaintext-and-replayable gap the earlier HMAC-on-body design left open. Per-node identity remains cluster-scoped; adding it is a future transport change, not a protocol change.
 
 ### DD-9: Poll-Based Wait for Missing Compute Members
 

--- a/internal/cluster/dispatch/aead_peer_auth.go
+++ b/internal/cluster/dispatch/aead_peer_auth.go
@@ -1,0 +1,204 @@
+package dispatch
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// Wire-level constants. Versioned in the Content-Type so a future envelope
+// format can coexist with this one if a migration is ever required.
+const (
+	DispatchContentType  = "application/cyoda-dispatch-v1"
+	DispatchTimestampHdr = "X-Dispatch-Timestamp"
+
+	// dispatchMaxBodySize caps how much an attacker can force the handler
+	// to buffer before we reject the envelope.
+	dispatchMaxBodySize = 10 * 1024 * 1024
+
+	// nonceCacheCapacity is the replay-cache ceiling — see nonceCache.
+	nonceCacheCapacity = 100_000
+
+	// hkdfInfo separates the dispatch key from memberlist's gossip key
+	// derived from the same shared secret. Do not change: it's the binding
+	// between key material versions.
+	hkdfInfo = "cyoda-dispatch-v1"
+
+	authMethodAEADv1 = "aead-v1"
+)
+
+// ErrSharedSecretTooShort is returned by NewAEADPeerAuth when the provided
+// shared secret is under the 32-byte minimum.
+var ErrSharedSecretTooShort = errors.New("shared secret must be at least 32 bytes")
+
+// AEADPeerAuth implements PeerAuth using AES-256-GCM with an HKDF-derived key.
+//
+// On the wire, the request body is [nonce(12) || ciphertext||tag]. The
+// associated data binds HTTP method, path, and timestamp — preventing
+// cross-endpoint replays without re-encrypting on each route. A sliding
+// nonce cache rejects repeated envelopes within the skew window.
+type AEADPeerAuth struct {
+	gcm     cipher.AEAD
+	nonces  *nonceCache
+	skew    time.Duration
+	clockFn func() time.Time
+}
+
+// NewAEADPeerAuth returns an AEADPeerAuth keyed by HKDF-SHA256 over the
+// given shared secret. The secret is the same cluster-wide value as
+// CYODA_HMAC_SECRET; HKDF separates the dispatch key from the memberlist
+// gossip key so a compromise of one primitive does not extend to the other.
+func NewAEADPeerAuth(sharedSecret []byte, skew time.Duration) (*AEADPeerAuth, error) {
+	return newAEADPeerAuth(sharedSecret, skew, time.Now)
+}
+
+// NewAEADPeerAuthWithClockForTesting is an AEADPeerAuth whose notion of "now"
+// is controlled by the caller. Reserved for tests that exercise timestamp
+// skew and replay-TTL behaviour. Production code MUST use NewAEADPeerAuth.
+func NewAEADPeerAuthWithClockForTesting(sharedSecret []byte, skew time.Duration, clockFn func() time.Time) (*AEADPeerAuth, error) {
+	return newAEADPeerAuth(sharedSecret, skew, clockFn)
+}
+
+func newAEADPeerAuth(sharedSecret []byte, skew time.Duration, clockFn func() time.Time) (*AEADPeerAuth, error) {
+	if len(sharedSecret) < 32 {
+		return nil, ErrSharedSecretTooShort
+	}
+	key := deriveDispatchKey(sharedSecret)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("build AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("build AES-GCM: %w", err)
+	}
+	return &AEADPeerAuth{
+		gcm:     gcm,
+		nonces:  newNonceCache(skew*2, nonceCacheCapacity, clockFn),
+		skew:    skew,
+		clockFn: clockFn,
+	}, nil
+}
+
+// SetClockForTesting swaps the clock function for both the AEAD and its
+// nonce cache. Reserved for tests that need to manipulate observed time.
+// Production code MUST NOT call this.
+func (a *AEADPeerAuth) SetClockForTesting(clockFn func() time.Time) {
+	a.clockFn = clockFn
+	a.nonces.nowFn = clockFn
+}
+
+// DeriveDispatchKeyForTesting exposes the HKDF key derivation for a single
+// test that proves derivation actually runs. Production code uses it
+// internally only.
+func DeriveDispatchKeyForTesting(sharedSecret []byte) []byte {
+	return deriveDispatchKey(sharedSecret)
+}
+
+func deriveDispatchKey(sharedSecret []byte) []byte {
+	r := hkdf.New(sha256.New, sharedSecret, nil, []byte(hkdfInfo))
+	out := make([]byte, 32)
+	if _, err := io.ReadFull(r, out); err != nil {
+		// hkdf.New's Reader cannot fail to produce 32 bytes from any
+		// non-empty secret; guard is belt-and-suspenders.
+		panic(fmt.Sprintf("hkdf derivation failed: %v", err))
+	}
+	return out
+}
+
+// Sign wraps body in an AEAD envelope, sets the Content-Type and timestamp
+// headers, and returns the wire bytes. The caller replaces the request body
+// with the returned slice.
+func (a *AEADPeerAuth) Sign(req *http.Request, body []byte) ([]byte, error) {
+	ts := strconv.FormatInt(a.clockFn().Unix(), 10)
+
+	nonce := make([]byte, a.gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
+	ad := buildAD(req.Method, req.URL.Path, ts)
+	ct := a.gcm.Seal(nil, nonce, body, ad)
+
+	wire := make([]byte, 0, len(nonce)+len(ct))
+	wire = append(wire, nonce...)
+	wire = append(wire, ct...)
+
+	req.Header.Set("Content-Type", DispatchContentType)
+	req.Header.Set(DispatchTimestampHdr, ts)
+	return wire, nil
+}
+
+// Verify validates the request's timestamp skew, AEAD envelope, and nonce
+// freshness. On success it returns the decrypted plaintext and a PeerIdentity
+// describing the authenticated peer.
+func (a *AEADPeerAuth) Verify(r *http.Request) ([]byte, PeerIdentity, error) {
+	tsStr := r.Header.Get(DispatchTimestampHdr)
+	if tsStr == "" {
+		return nil, PeerIdentity{}, errors.New("missing X-Dispatch-Timestamp header")
+	}
+	tsUnix, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		return nil, PeerIdentity{}, fmt.Errorf("malformed timestamp: %w", err)
+	}
+	tsTime := time.Unix(tsUnix, 0)
+
+	// Skew check happens first — cheap rejection of stale/future envelopes
+	// before we touch the body.
+	now := a.clockFn()
+	diff := now.Sub(tsTime)
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > a.skew {
+		return nil, PeerIdentity{}, fmt.Errorf("timestamp outside skew window: %v > %v", diff, a.skew)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, dispatchMaxBodySize))
+	if err != nil {
+		return nil, PeerIdentity{}, fmt.Errorf("read body: %w", err)
+	}
+
+	nonceSize := a.gcm.NonceSize()
+	if len(body) < nonceSize+a.gcm.Overhead() {
+		return nil, PeerIdentity{}, errors.New("body too short for AEAD envelope")
+	}
+	nonce := body[:nonceSize]
+	ct := body[nonceSize:]
+
+	ad := buildAD(r.Method, r.URL.Path, tsStr)
+	pt, err := a.gcm.Open(nil, nonce, ct, ad)
+	if err != nil {
+		return nil, PeerIdentity{}, fmt.Errorf("AEAD open failed: %w", err)
+	}
+
+	// Record the nonce only after successful decrypt. A flood of bogus
+	// nonces that fail AEAD.Open never enters the cache.
+	if a.nonces.checkAndRecord(nonce, tsTime) {
+		return nil, PeerIdentity{}, errors.New("duplicate nonce — replay rejected")
+	}
+
+	return pt, PeerIdentity{authMethod: authMethodAEADv1}, nil
+}
+
+// buildAD constructs the Associated Data for AES-GCM. Binding method, path,
+// and timestamp to ciphertext prevents cross-endpoint and timestamp-strip
+// replays without adding an outer signature.
+func buildAD(method, path, ts string) []byte {
+	ad := make([]byte, 0, len(method)+1+len(path)+1+len(ts))
+	ad = append(ad, method...)
+	ad = append(ad, '\n')
+	ad = append(ad, path...)
+	ad = append(ad, '\n')
+	ad = append(ad, ts...)
+	return ad
+}

--- a/internal/cluster/dispatch/aead_peer_auth_test.go
+++ b/internal/cluster/dispatch/aead_peer_auth_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -204,6 +205,131 @@ func TestAEADPeerAuth_DerivedKeyDiffersFromRawSecret(t *testing.T) {
 	}
 	if len(derived) != 32 {
 		t.Fatalf("derived key length = %d, want 32", len(derived))
+	}
+}
+
+// TestAEADPeerAuth_SkewBoundaryReplayStillRejected pins the relationship
+// between the skew window (30s) and the nonce-cache TTL (skew*2 = 60s) with
+// observed=tsTime indexing: an envelope stamped at T and first verified
+// anywhere within [T-skew, T+skew], then replayed anywhere else within the
+// same window, MUST be rejected. Code review flagged a suspected eviction
+// window where the cache would evict before skew could reject; this test
+// locks in the invariant that that window does not exist.
+func TestAEADPeerAuth_SkewBoundaryReplayStillRejected(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	clock := base
+	clockFn := func() time.Time { return clock }
+
+	a, err := dispatch.NewAEADPeerAuthWithClockForTesting(testSecret, 30*time.Second, clockFn)
+	if err != nil {
+		t.Fatalf("NewAEADPeerAuth: %v", err)
+	}
+
+	// Sign at T.
+	req := httptest.NewRequest("POST", "/internal/dispatch/processor", nil)
+	wire, err := a.Sign(req, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	ts := req.Header.Get(dispatch.DispatchTimestampHdr)
+
+	build := func() *http.Request {
+		r := httptest.NewRequest("POST", "/internal/dispatch/processor", bytes.NewReader(wire))
+		r.Header.Set(dispatch.DispatchTimestampHdr, ts)
+		r.Header.Set("Content-Type", dispatch.DispatchContentType)
+		return r
+	}
+
+	// First verify at T+25s (inside skew). Must succeed.
+	clock = base.Add(25 * time.Second)
+	if _, _, err := a.Verify(build()); err != nil {
+		t.Fatalf("first verify at T+25s should succeed: %v", err)
+	}
+
+	// Replay at T+30s (skew boundary). Must be rejected as replay, not
+	// accepted due to premature eviction.
+	clock = base.Add(30 * time.Second)
+	if _, _, err := a.Verify(build()); err == nil {
+		t.Fatal("replay at skew boundary was accepted — nonce cache evicted too aggressively")
+	}
+
+	// Replay at T+31s (just past skew boundary). Must be rejected — now by
+	// the skew check, not the nonce cache. Either rejection is correct;
+	// the invariant is that it's NOT accepted.
+	clock = base.Add(31 * time.Second)
+	if _, _, err := a.Verify(build()); err == nil {
+		t.Fatal("replay just past skew boundary was accepted")
+	}
+}
+
+func TestAEADPeerAuth_ZeroTimestampRejected(t *testing.T) {
+	a, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	req := httptest.NewRequest("POST", "/internal/dispatch/processor", bytes.NewReader([]byte{}))
+	req.Header.Set(dispatch.DispatchTimestampHdr, "0")
+	req.Header.Set("Content-Type", dispatch.DispatchContentType)
+	if _, _, err := a.Verify(req); err == nil {
+		t.Fatal("ts=0 (1970-01-01) was accepted")
+	}
+}
+
+func TestAEADPeerAuth_NegativeTimestampRejected(t *testing.T) {
+	a, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	req := httptest.NewRequest("POST", "/internal/dispatch/processor", bytes.NewReader([]byte{}))
+	req.Header.Set(dispatch.DispatchTimestampHdr, "-1")
+	req.Header.Set("Content-Type", dispatch.DispatchContentType)
+	if _, _, err := a.Verify(req); err == nil {
+		t.Fatal("negative ts was accepted")
+	}
+}
+
+func TestAEADPeerAuth_FarFutureTimestampRejected(t *testing.T) {
+	a, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	req := httptest.NewRequest("POST", "/internal/dispatch/processor", bytes.NewReader([]byte{}))
+	// Year 4000 or so.
+	req.Header.Set(dispatch.DispatchTimestampHdr, "64060588800")
+	req.Header.Set("Content-Type", dispatch.DispatchContentType)
+	if _, _, err := a.Verify(req); err == nil {
+		t.Fatal("year-4000 ts was accepted")
+	}
+}
+
+func TestAEADPeerAuth_EmptyPlaintextRoundTrips(t *testing.T) {
+	// Body at the envelope minimum: empty plaintext seals to
+	// nonceSize(12) + overhead(16) = 28 bytes on the wire. Confirms the
+	// len() >= nonceSize + overhead guard accepts the boundary case.
+	a, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	req := httptest.NewRequest("POST", "/internal/dispatch/processor", nil)
+	wire, err := a.Sign(req, []byte{})
+	if err != nil {
+		t.Fatalf("Sign empty body: %v", err)
+	}
+	if len(wire) != 12+16 {
+		t.Fatalf("expected 28-byte envelope, got %d", len(wire))
+	}
+
+	req2 := httptest.NewRequest("POST", "/internal/dispatch/processor", bytes.NewReader(wire))
+	req2.Header.Set(dispatch.DispatchTimestampHdr, req.Header.Get(dispatch.DispatchTimestampHdr))
+	req2.Header.Set("Content-Type", dispatch.DispatchContentType)
+
+	pt, _, err := a.Verify(req2)
+	if err != nil {
+		t.Fatalf("Verify at envelope minimum: %v", err)
+	}
+	if len(pt) != 0 {
+		t.Fatalf("expected empty plaintext, got %d bytes", len(pt))
+	}
+}
+
+func TestAEADPeerAuth_ShortBodyRejected(t *testing.T) {
+	// One byte below the envelope minimum must be rejected before any
+	// decrypt attempt.
+	a, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	tooShort := make([]byte, 12+16-1)
+	req := httptest.NewRequest("POST", "/internal/dispatch/processor", bytes.NewReader(tooShort))
+	req.Header.Set(dispatch.DispatchTimestampHdr, strconv.FormatInt(time.Now().Unix(), 10))
+	req.Header.Set("Content-Type", dispatch.DispatchContentType)
+	if _, _, err := a.Verify(req); err == nil {
+		t.Fatal("short body (below envelope min) was accepted")
 	}
 }
 

--- a/internal/cluster/dispatch/aead_peer_auth_test.go
+++ b/internal/cluster/dispatch/aead_peer_auth_test.go
@@ -1,0 +1,228 @@
+package dispatch_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/internal/cluster/dispatch"
+)
+
+// testSecret is a 32-byte shared secret used across AEAD tests. Not the
+// real production key — purely for deterministic test construction.
+var testSecret = bytes.Repeat([]byte{0xAB}, 32)
+
+// aeadFixedClock returns a stable time function for tests that manipulate time.
+func aeadFixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+// signAndBuildRequest signs body and returns an http.Request ready to Verify.
+// Mirrors the real forwarder.forward path without needing a server.
+func signAndBuildRequest(t *testing.T, auth dispatch.PeerAuth, method, path string, body []byte) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	wire, err := auth.Sign(req, body)
+	if err != nil {
+		t.Fatalf("Sign failed: %v", err)
+	}
+	// Install the wire body as the request body (Sign doesn't attach it —
+	// that's the caller's responsibility, matching forwarder.forward).
+	req.Body = io.NopCloser(bytes.NewReader(wire))
+	req.ContentLength = int64(len(wire))
+	return req
+}
+
+func TestAEADPeerAuth_RoundTrip(t *testing.T) {
+	a, err := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	if err != nil {
+		t.Fatalf("NewAEADPeerAuth: %v", err)
+	}
+
+	plaintext := []byte(`{"hello":"world"}`)
+	req := signAndBuildRequest(t, a, "POST", "/internal/dispatch/processor", plaintext)
+
+	got, id, err := a.Verify(req)
+	if err != nil {
+		t.Fatalf("Verify failed: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Fatalf("plaintext mismatch: got %q want %q", got, plaintext)
+	}
+	if id.AuthMethod() != "aead-v1" {
+		t.Fatalf("identity auth method = %q, want aead-v1", id.AuthMethod())
+	}
+	if id.NodeID() != "" {
+		t.Fatalf("shared-key identity should have empty NodeID, got %q", id.NodeID())
+	}
+}
+
+func TestAEADPeerAuth_RejectsShortSecret(t *testing.T) {
+	short := bytes.Repeat([]byte{0xAB}, 31)
+	if _, err := dispatch.NewAEADPeerAuth(short, 30*time.Second); err == nil {
+		t.Fatal("expected error for secret < 32 bytes")
+	}
+}
+
+func TestAEADPeerAuth_TamperedCiphertextFails(t *testing.T) {
+	a, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	req := signAndBuildRequest(t, a, "POST", "/internal/dispatch/processor", []byte(`{"a":1}`))
+
+	wire, _ := io.ReadAll(req.Body)
+	// Flip a byte in the ciphertext region (past the 12-byte nonce prefix).
+	wire[len(wire)-1] ^= 0x01
+	req.Body = io.NopCloser(bytes.NewReader(wire))
+
+	if _, _, err := a.Verify(req); err == nil {
+		t.Fatal("tampered ciphertext was accepted")
+	}
+}
+
+func TestAEADPeerAuth_TamperedNonceFails(t *testing.T) {
+	a, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	req := signAndBuildRequest(t, a, "POST", "/internal/dispatch/processor", []byte(`{"a":1}`))
+	wire, _ := io.ReadAll(req.Body)
+	wire[0] ^= 0xFF
+	req.Body = io.NopCloser(bytes.NewReader(wire))
+
+	if _, _, err := a.Verify(req); err == nil {
+		t.Fatal("tampered nonce was accepted")
+	}
+}
+
+func TestAEADPeerAuth_CrossEndpointReplayRejected(t *testing.T) {
+	a, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	// Sign for processor, try to verify as criteria.
+	req := signAndBuildRequest(t, a, "POST", "/internal/dispatch/processor", []byte(`{"a":1}`))
+	wire, _ := io.ReadAll(req.Body)
+
+	replay := httptest.NewRequest("POST", "/internal/dispatch/criteria", bytes.NewReader(wire))
+	replay.Header.Set("X-Dispatch-Timestamp", req.Header.Get("X-Dispatch-Timestamp"))
+	replay.Header.Set("Content-Type", req.Header.Get("Content-Type"))
+
+	if _, _, err := a.Verify(replay); err == nil {
+		t.Fatal("cross-endpoint replay (processor → criteria) was accepted")
+	}
+}
+
+func TestAEADPeerAuth_MethodChangeRejected(t *testing.T) {
+	a, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	req := signAndBuildRequest(t, a, "POST", "/internal/dispatch/processor", []byte(`{"a":1}`))
+	wire, _ := io.ReadAll(req.Body)
+
+	replay := httptest.NewRequest("PUT", "/internal/dispatch/processor", bytes.NewReader(wire))
+	replay.Header.Set("X-Dispatch-Timestamp", req.Header.Get("X-Dispatch-Timestamp"))
+	replay.Header.Set("Content-Type", req.Header.Get("Content-Type"))
+
+	if _, _, err := a.Verify(replay); err == nil {
+		t.Fatal("method change (POST → PUT) was accepted")
+	}
+}
+
+func TestAEADPeerAuth_StaleTimestampRejected(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	a, _ := dispatch.NewAEADPeerAuthWithClockForTesting(testSecret, 30*time.Second, aeadFixedClock(base))
+
+	// Sign at T.
+	req := httptest.NewRequest("POST", "/internal/dispatch/processor", nil)
+	wire, err := a.Sign(req, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	ts := req.Header.Get("X-Dispatch-Timestamp")
+
+	// Advance clock past skew window (60s > 30s).
+	a.SetClockForTesting(aeadFixedClock(base.Add(60 * time.Second)))
+
+	// Verify at T+60s — outside 30s skew.
+	req2 := httptest.NewRequest("POST", "/internal/dispatch/processor", bytes.NewReader(wire))
+	req2.Header.Set("X-Dispatch-Timestamp", ts)
+	req2.Header.Set("Content-Type", "application/cyoda-dispatch-v1")
+
+	_, _, err = a.Verify(req2)
+	if err == nil {
+		t.Fatal("expected stale-timestamp rejection, got nil")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "timestamp") {
+		t.Fatalf("expected timestamp error, got: %v", err)
+	}
+}
+
+func TestAEADPeerAuth_ReplayWithinWindowRejected(t *testing.T) {
+	a, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+
+	req := httptest.NewRequest("POST", "/internal/dispatch/processor", nil)
+	wire, err := a.Sign(req, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	ts := req.Header.Get("X-Dispatch-Timestamp")
+
+	buildReq := func() *http.Request {
+		r := httptest.NewRequest("POST", "/internal/dispatch/processor", bytes.NewReader(wire))
+		r.Header.Set("X-Dispatch-Timestamp", ts)
+		r.Header.Set("Content-Type", "application/cyoda-dispatch-v1")
+		return r
+	}
+
+	if _, _, err := a.Verify(buildReq()); err != nil {
+		t.Fatalf("first verify should succeed: %v", err)
+	}
+	if _, _, err := a.Verify(buildReq()); err == nil {
+		t.Fatal("replay within window should be rejected, got nil error")
+	}
+}
+
+func TestAEADPeerAuth_DifferentSecretsIncompatible(t *testing.T) {
+	a1, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	otherSecret := bytes.Repeat([]byte{0xCD}, 32)
+	a2, _ := dispatch.NewAEADPeerAuth(otherSecret, 30*time.Second)
+
+	req := httptest.NewRequest("POST", "/internal/dispatch/processor", nil)
+	wire, _ := a1.Sign(req, []byte(`{"a":1}`))
+	ts := req.Header.Get("X-Dispatch-Timestamp")
+
+	recv := httptest.NewRequest("POST", "/internal/dispatch/processor", bytes.NewReader(wire))
+	recv.Header.Set("X-Dispatch-Timestamp", ts)
+	recv.Header.Set("Content-Type", "application/cyoda-dispatch-v1")
+
+	if _, _, err := a2.Verify(recv); err == nil {
+		t.Fatal("a2 accepted an envelope sealed by a1 with a different secret")
+	}
+}
+
+func TestAEADPeerAuth_DerivedKeyDiffersFromRawSecret(t *testing.T) {
+	// Ensures HKDF is actually running. If the impl ever regresses to using
+	// the raw secret directly, this test fails.
+	derived := dispatch.DeriveDispatchKeyForTesting(testSecret)
+	if bytes.Equal(derived, testSecret) {
+		t.Fatal("derived dispatch key equals raw secret — HKDF not applied")
+	}
+	if len(derived) != 32 {
+		t.Fatalf("derived key length = %d, want 32", len(derived))
+	}
+}
+
+func TestAEADPeerAuth_WireBodyIsNotPlaintextJSON(t *testing.T) {
+	// Confidentiality smoke test: the wire body does not contain the
+	// plaintext JSON secret, proving the envelope encrypts rather than
+	// merely authenticates.
+	a, _ := dispatch.NewAEADPeerAuth(testSecret, 30*time.Second)
+	secret := `{"secret_marker":"SENSITIVE_PAYLOAD_7f3a9b"}`
+
+	req := httptest.NewRequest("POST", "/internal/dispatch/processor", nil)
+	wire, err := a.Sign(req, []byte(secret))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if strings.Contains(string(wire), "SENSITIVE_PAYLOAD_7f3a9b") {
+		t.Fatal("wire body contains plaintext marker — payload is not encrypted")
+	}
+	if strings.Contains(string(wire), "secret_marker") {
+		t.Fatal("wire body contains plaintext JSON key — payload is not encrypted")
+	}
+}

--- a/internal/cluster/dispatch/cluster_dispatcher_test.go
+++ b/internal/cluster/dispatch/cluster_dispatcher_test.go
@@ -114,7 +114,8 @@ func TestClusterDispatcher_LocalFirst(t *testing.T) {
 	}
 	registry := &stubNodeRegistry{}
 	selector := NewRandomSelector()
-	forwarder := NewHTTPForwarder([]byte("secret"), 5*time.Second).AllowLoopbackForTesting()
+	auth, _ := NewAEADPeerAuth(testSecret32, 30*time.Second)
+	forwarder := NewHTTPForwarder(auth, 5*time.Second).AllowLoopbackForTesting()
 
 	d := NewClusterDispatcher(local, registry, "self-node", selector, forwarder, 1*time.Second)
 
@@ -158,7 +159,7 @@ func TestClusterDispatcher_LocalFirst(t *testing.T) {
 }
 
 func TestClusterDispatcher_ForwardsToPeer(t *testing.T) {
-	hmacSecret := []byte("test-hmac-secret")
+	auth, _ := NewAEADPeerAuth(testSecret32, 30*time.Second)
 
 	t.Run("processor_forwarded_to_peer", func(t *testing.T) {
 		// Set up a peer httptest server that acts as a dispatch handler.
@@ -168,7 +169,7 @@ func TestClusterDispatcher_ForwardsToPeer(t *testing.T) {
 				Data: []byte(`{"key":"peer-processed"}`),
 			},
 		}
-		handler := &DispatchHandler{local: peerLocal, hmacSecret: hmacSecret}
+		handler := NewDispatchHandler(peerLocal, auth)
 		mux := http.NewServeMux()
 		handler.Register(mux)
 		peer := httptest.NewServer(mux)
@@ -183,7 +184,7 @@ func TestClusterDispatcher_ForwardsToPeer(t *testing.T) {
 			},
 		}
 		selector := NewRandomSelector()
-		forwarder := NewHTTPForwarder(hmacSecret, 5*time.Second).AllowLoopbackForTesting()
+		forwarder := NewHTTPForwarder(auth, 5*time.Second).AllowLoopbackForTesting()
 
 		d := NewClusterDispatcher(local, registry, "self-node", selector, forwarder, 1*time.Second)
 
@@ -201,7 +202,7 @@ func TestClusterDispatcher_ForwardsToPeer(t *testing.T) {
 		peerLocal := &stubDispatcher{
 			criteriaResult: true,
 		}
-		handler := &DispatchHandler{local: peerLocal, hmacSecret: hmacSecret}
+		handler := NewDispatchHandler(peerLocal, auth)
 		mux := http.NewServeMux()
 		handler.Register(mux)
 		peer := httptest.NewServer(mux)
@@ -215,7 +216,7 @@ func TestClusterDispatcher_ForwardsToPeer(t *testing.T) {
 			},
 		}
 		selector := NewRandomSelector()
-		forwarder := NewHTTPForwarder(hmacSecret, 5*time.Second).AllowLoopbackForTesting()
+		forwarder := NewHTTPForwarder(auth, 5*time.Second).AllowLoopbackForTesting()
 
 		d := NewClusterDispatcher(local, registry, "self-node", selector, forwarder, 1*time.Second)
 
@@ -240,7 +241,8 @@ func TestClusterDispatcher_NoMemberAnywhere(t *testing.T) {
 		},
 	}
 	selector := NewRandomSelector()
-	forwarder := NewHTTPForwarder([]byte("secret"), 5*time.Second).AllowLoopbackForTesting()
+	auth, _ := NewAEADPeerAuth(testSecret32, 30*time.Second)
+	forwarder := NewHTTPForwarder(auth, 5*time.Second).AllowLoopbackForTesting()
 
 	// Use a very short wait timeout so the test completes quickly.
 	d := NewClusterDispatcher(local, registry, "self-node", selector, forwarder, 500*time.Millisecond)

--- a/internal/cluster/dispatch/forwarder.go
+++ b/internal/cluster/dispatch/forwarder.go
@@ -3,9 +3,6 @@ package dispatch
 import (
 	"bytes"
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,18 +17,21 @@ type DispatchForwarder interface {
 	ForwardCriteria(ctx context.Context, addr string, req *DispatchCriteriaRequest) (*DispatchCriteriaResponse, error)
 }
 
-// HTTPForwarder implements DispatchForwarder over HTTP with HMAC-SHA256 authentication.
+// HTTPForwarder implements DispatchForwarder over HTTP with a PeerAuth
+// message-authentication wrapper. The auth impl — today AEADPeerAuth over
+// a shared secret, tomorrow potentially an mTLS variant — owns signing and
+// verification; the forwarder itself is transport plumbing.
 type HTTPForwarder struct {
-	hmacSecret    []byte
+	auth          PeerAuth
 	client        *http.Client
 	allowLoopback bool
 }
 
-// NewHTTPForwarder constructs an HTTPForwarder with the given HMAC secret and request timeout.
-// Loopback peer addresses are rejected by default; see AllowLoopbackForTesting.
-func NewHTTPForwarder(hmacSecret []byte, timeout time.Duration) *HTTPForwarder {
+// NewHTTPForwarder constructs an HTTPForwarder. Loopback peer addresses
+// are rejected by default; see AllowLoopbackForTesting.
+func NewHTTPForwarder(auth PeerAuth, timeout time.Duration) *HTTPForwarder {
 	return &HTTPForwarder{
-		hmacSecret: hmacSecret,
+		auth: auth,
 		client: &http.Client{
 			Timeout: timeout,
 			Transport: &http.Transport{
@@ -86,19 +86,28 @@ func ensureScheme(addr string) string {
 	return addr
 }
 
-// forward marshals reqBody, signs it, POSTs to url, and decodes the response into respBody.
+// forward marshals reqBody as JSON, hands it to the PeerAuth for wire
+// encoding, POSTs the resulting bytes, and decodes the (plaintext) JSON
+// response. Response bodies are not AEAD-wrapped — integrity of the
+// peer's reply relies on TLS (future) or the trust boundary that auth
+// established for the request.
 func (f *HTTPForwarder) forward(ctx context.Context, url string, reqBody any, respBody any) error {
-	body, err := json.Marshal(reqBody)
+	plain, err := json.Marshal(reqBody)
 	if err != nil {
 		return fmt.Errorf("dispatch forward: marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	if err != nil {
 		return fmt.Errorf("dispatch forward: build request: %w", err)
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("X-Dispatch-HMAC", f.sign(body))
+
+	wire, err := f.auth.Sign(httpReq, plain)
+	if err != nil {
+		return fmt.Errorf("dispatch forward: sign body: %w", err)
+	}
+	httpReq.Body = io.NopCloser(bytes.NewReader(wire))
+	httpReq.ContentLength = int64(len(wire))
 
 	httpResp, err := f.client.Do(httpReq)
 	if err != nil {
@@ -115,11 +124,4 @@ func (f *HTTPForwarder) forward(ctx context.Context, url string, reqBody any, re
 		return fmt.Errorf("dispatch forward: decode response from %s: %w", url, err)
 	}
 	return nil
-}
-
-// sign returns the hex-encoded HMAC-SHA256 of body using the configured secret.
-func (f *HTTPForwarder) sign(body []byte) string {
-	mac := hmac.New(sha256.New, f.hmacSecret)
-	mac.Write(body)
-	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/internal/cluster/dispatch/forwarder.go
+++ b/internal/cluster/dispatch/forwarder.go
@@ -102,6 +102,13 @@ func (f *HTTPForwarder) forward(ctx context.Context, url string, reqBody any, re
 		return fmt.Errorf("dispatch forward: build request: %w", err)
 	}
 
+	// Default Content-Type is application/json — the plaintext format the
+	// handler parses after Verify. PeerAuth impls MAY override this in Sign
+	// if they use a wire format that supersedes JSON (e.g. AEADPeerAuth sets
+	// application/cyoda-dispatch-v1); a pure-transport-auth impl like future
+	// mTLS can leave it alone.
+	httpReq.Header.Set("Content-Type", "application/json")
+
 	wire, err := f.auth.Sign(httpReq, plain)
 	if err != nil {
 		return fmt.Errorf("dispatch forward: sign body: %w", err)

--- a/internal/cluster/dispatch/forwarder_ssrf_test.go
+++ b/internal/cluster/dispatch/forwarder_ssrf_test.go
@@ -21,7 +21,7 @@ import (
 // The guard is enforced at address validation time; the HTTP call must
 // never be dialled.
 func TestHTTPForwarder_RejectsLoopbackAddresses(t *testing.T) {
-	fw := dispatch.NewHTTPForwarder([]byte("test-secret-long-enough-for-constructor-checks"), time.Second)
+	fw := dispatch.NewHTTPForwarder(newTestPeerAuth(t), time.Second)
 
 	cases := []string{
 		"127.0.0.1:8080",
@@ -51,7 +51,7 @@ func TestHTTPForwarder_RejectsLoopbackAddresses(t *testing.T) {
 // a link-local reason — not a DNS-lookup failure that happens to reject
 // the address by accident.
 func TestHTTPForwarder_RejectsIPv6LinkLocalWithZoneID(t *testing.T) {
-	fw := dispatch.NewHTTPForwarder([]byte("test-secret-long-enough-for-constructor-checks"), time.Second)
+	fw := dispatch.NewHTTPForwarder(newTestPeerAuth(t), time.Second)
 
 	_, err := fw.ForwardProcessor(context.Background(), "[fe80::1%eth0]:8080", makeProcessorReq())
 	if err == nil {
@@ -77,7 +77,7 @@ func TestHTTPForwarder_RejectsIPv6LinkLocalWithZoneID(t *testing.T) {
 // metadata-service SSRF vector. 169.254.169.254 is the canonical target;
 // the broader 169.254.0.0/16 range and IPv6 fe80::/10 are equally unsafe.
 func TestHTTPForwarder_RejectsLinkLocalAddresses(t *testing.T) {
-	fw := dispatch.NewHTTPForwarder([]byte("test-secret-long-enough-for-constructor-checks"), time.Second)
+	fw := dispatch.NewHTTPForwarder(newTestPeerAuth(t), time.Second)
 
 	cases := []string{
 		"169.254.169.254:80",                // AWS / Azure metadata
@@ -105,7 +105,7 @@ func TestHTTPForwarder_AcceptsRoutableAddress(t *testing.T) {
 	// address known to be unreachable (TEST-NET-1) with a tiny timeout;
 	// the guard must let it through and the call must fail with a
 	// *network* error, not ErrForbiddenPeerAddress.
-	fw := dispatch.NewHTTPForwarder([]byte("test-secret-long-enough-for-constructor-checks"), 50*time.Millisecond)
+	fw := dispatch.NewHTTPForwarder(newTestPeerAuth(t), 50*time.Millisecond)
 	_, err := fw.ForwardProcessor(context.Background(), "192.0.2.1:8080", makeProcessorReq())
 	if err == nil {
 		t.Fatal("expected network error for unreachable TEST-NET-1 address")

--- a/internal/cluster/dispatch/forwarder_test.go
+++ b/internal/cluster/dispatch/forwarder_test.go
@@ -2,21 +2,17 @@ package dispatch_test
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/cluster/dispatch"
 )
-
-const testHMACSecret = "test-secret-key"
 
 func makeProcessorReq() *dispatch.DispatchProcessorRequest {
 	return &dispatch.DispatchProcessorRequest{
@@ -46,17 +42,19 @@ func makeCriteriaReq() *dispatch.DispatchCriteriaRequest {
 	}
 }
 
-// verifyHMAC checks that the X-Dispatch-HMAC header matches the body.
-func verifyHMAC(t *testing.T, r *http.Request, secret string) {
+// verifyAEADHeaders confirms the forwarder set the expected AEAD envelope
+// headers. Replaces the pre-AEAD verifyHMAC helper.
+func verifyAEADHeaders(t *testing.T, r *http.Request) {
 	t.Helper()
-	sig := r.Header.Get("X-Dispatch-HMAC")
-	if sig == "" {
-		t.Fatal("X-Dispatch-HMAC header missing")
+	if got := r.Header.Get("Content-Type"); got != dispatch.DispatchContentType {
+		t.Errorf("Content-Type = %q, want %q", got, dispatch.DispatchContentType)
 	}
-	// body already read by handler; verify against what was signed
-	// We'll verify in a separate read of the body by the test server handler,
-	// so we accept any non-empty value here. More thorough check done in
-	// TestHTTPForwarder_HMACSignature below.
+	if r.Header.Get(dispatch.DispatchTimestampHdr) == "" {
+		t.Errorf("%s header missing", dispatch.DispatchTimestampHdr)
+	}
+	if r.Header.Get("X-Dispatch-HMAC") != "" {
+		t.Errorf("legacy X-Dispatch-HMAC header still set; should have been removed with AEAD migration")
+	}
 }
 
 func TestHTTPForwarder_ProcessorSuccess(t *testing.T) {
@@ -73,14 +71,14 @@ func TestHTTPForwarder_ProcessorSuccess(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("unexpected method %q", r.Method)
 		}
-		verifyHMAC(t, r, testHMACSecret)
+		verifyAEADHeaders(t, r)
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(wantResp)
+		_ = json.NewEncoder(w).Encode(wantResp)
 	}))
 	defer srv.Close()
 
-	f := dispatch.NewHTTPForwarder([]byte(testHMACSecret), 5*time.Second).AllowLoopbackForTesting()
+	f := dispatch.NewHTTPForwarder(newTestPeerAuth(t), 5*time.Second).AllowLoopbackForTesting()
 	resp, err := f.ForwardProcessor(context.Background(), srv.URL, makeProcessorReq())
 	if err != nil {
 		t.Fatalf("ForwardProcessor: %v", err)
@@ -106,14 +104,14 @@ func TestHTTPForwarder_CriteriaSuccess(t *testing.T) {
 		if r.URL.Path != "/internal/dispatch/criteria" {
 			t.Errorf("unexpected path %q", r.URL.Path)
 		}
-		verifyHMAC(t, r, testHMACSecret)
+		verifyAEADHeaders(t, r)
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(wantResp)
+		_ = json.NewEncoder(w).Encode(wantResp)
 	}))
 	defer srv.Close()
 
-	f := dispatch.NewHTTPForwarder([]byte(testHMACSecret), 5*time.Second).AllowLoopbackForTesting()
+	f := dispatch.NewHTTPForwarder(newTestPeerAuth(t), 5*time.Second).AllowLoopbackForTesting()
 	resp, err := f.ForwardCriteria(context.Background(), srv.URL, makeCriteriaReq())
 	if err != nil {
 		t.Fatalf("ForwardCriteria: %v", err)
@@ -128,7 +126,7 @@ func TestHTTPForwarder_CriteriaSuccess(t *testing.T) {
 
 func TestHTTPForwarder_PeerUnreachable(t *testing.T) {
 	// localhost:1 is guaranteed unreachable (privileged port, never listening)
-	f := dispatch.NewHTTPForwarder([]byte(testHMACSecret), 2*time.Second).AllowLoopbackForTesting()
+	f := dispatch.NewHTTPForwarder(newTestPeerAuth(t), 2*time.Second).AllowLoopbackForTesting()
 
 	_, err := f.ForwardProcessor(context.Background(), "http://localhost:1", makeProcessorReq())
 	if err == nil {
@@ -141,35 +139,33 @@ func TestHTTPForwarder_PeerUnreachable(t *testing.T) {
 	}
 }
 
-func TestHTTPForwarder_HMACSignature(t *testing.T) {
-	secret := []byte("verify-me")
-
-	var capturedSig string
+// TestHTTPForwarder_WireBodyIsEncrypted proves the forwarder ships an AEAD
+// envelope — not plaintext JSON. Replaces the pre-AEAD HMAC-signature test.
+func TestHTTPForwarder_WireBodyIsEncrypted(t *testing.T) {
 	var capturedBody []byte
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		capturedSig = r.Header.Get("X-Dispatch-HMAC")
 		capturedBody, _ = io.ReadAll(r.Body)
-
-		resp := dispatch.DispatchProcessorResponse{Success: true}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(dispatch.DispatchProcessorResponse{Success: true})
 	}))
 	defer srv.Close()
 
-	f := dispatch.NewHTTPForwarder(secret, 5*time.Second).AllowLoopbackForTesting()
-	_, err := f.ForwardProcessor(context.Background(), srv.URL, makeProcessorReq())
-	if err != nil {
+	f := dispatch.NewHTTPForwarder(newTestPeerAuth(t), 5*time.Second).AllowLoopbackForTesting()
+	if _, err := f.ForwardProcessor(context.Background(), srv.URL, makeProcessorReq()); err != nil {
 		t.Fatalf("ForwardProcessor: %v", err)
 	}
 
-	// Compute expected HMAC over the captured body
-	mac := hmac.New(sha256.New, secret)
-	mac.Write(capturedBody)
-	expected := hex.EncodeToString(mac.Sum(nil))
-
-	if capturedSig != expected {
-		t.Errorf("X-Dispatch-HMAC = %q, want %q", capturedSig, expected)
+	// Plaintext markers from makeProcessorReq() must not appear on the wire.
+	wire := string(capturedBody)
+	for _, marker := range []string{`"amount":100`, `"calc"`, `"wf"`, `"t1"`, `"tx-1"`} {
+		if strings.Contains(wire, marker) {
+			t.Errorf("wire body contains plaintext marker %q — payload is not encrypted", marker)
+		}
+	}
+	// And it must be non-empty (sanity — proves we captured something).
+	if len(capturedBody) == 0 {
+		t.Fatal("no body captured")
 	}
 }
 
@@ -178,14 +174,14 @@ func TestHTTPForwarder_HMACSignature(t *testing.T) {
 // "cyoda-go-node-2:8123"). Regression test for unsupported protocol error.
 func TestHTTPForwarder_AddrWithoutScheme(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(dispatch.DispatchProcessorResponse{Success: true})
+		_ = json.NewEncoder(w).Encode(dispatch.DispatchProcessorResponse{Success: true})
 	}))
 	defer srv.Close()
 
 	// Strip the "http://" from the test server URL to simulate gossip NODE_ADDR
 	addrWithoutScheme := srv.Listener.Addr().String() // e.g., "127.0.0.1:PORT"
 
-	f := dispatch.NewHTTPForwarder([]byte(testHMACSecret), 5*time.Second).AllowLoopbackForTesting()
+	f := dispatch.NewHTTPForwarder(newTestPeerAuth(t), 5*time.Second).AllowLoopbackForTesting()
 	resp, err := f.ForwardProcessor(context.Background(), addrWithoutScheme, makeProcessorReq())
 	if err != nil {
 		t.Fatalf("ForwardProcessor with schemeless addr should work: %v", err)
@@ -201,7 +197,7 @@ func TestHTTPForwarder_PeerReturnsError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := dispatch.NewHTTPForwarder([]byte(testHMACSecret), 5*time.Second).AllowLoopbackForTesting()
+	f := dispatch.NewHTTPForwarder(newTestPeerAuth(t), 5*time.Second).AllowLoopbackForTesting()
 	_, err := f.ForwardProcessor(context.Background(), srv.URL, makeProcessorReq())
 	if err == nil {
 		t.Fatal("expected error for 500 response, got nil")

--- a/internal/cluster/dispatch/handler.go
+++ b/internal/cluster/dispatch/handler.go
@@ -2,12 +2,7 @@ package dispatch
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
-	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 
@@ -15,27 +10,22 @@ import (
 	"github.com/cyoda-platform/cyoda-go/internal/contract"
 )
 
-var ErrHMACSecretTooShort = errors.New("HMAC secret must be at least 32 bytes")
-
-const maxDispatchBodySize = 10 * 1024 * 1024 // 10MB
-
-// DispatchHandler serves the internal dispatch endpoints for processor and criteria
-// execution. Requests are authenticated with HMAC-SHA256.
+// DispatchHandler serves the internal dispatch endpoints for processor and
+// criteria execution. Authenticates each request via PeerAuth — today AEAD
+// over a shared secret, tomorrow potentially mTLS — and annotates the
+// request context with the authenticated PeerIdentity so downstream code
+// can audit origin regardless of the transport.
 type DispatchHandler struct {
-	local      contract.ExternalProcessingService
-	hmacSecret []byte
+	local contract.ExternalProcessingService
+	auth  PeerAuth
 }
 
 // NewDispatchHandler constructs a DispatchHandler backed by the given local
-// ExternalProcessingService and HMAC secret. The secret must be at least 32 bytes.
-func NewDispatchHandler(local contract.ExternalProcessingService, hmacSecret []byte) (*DispatchHandler, error) {
-	if len(hmacSecret) < 32 {
-		return nil, ErrHMACSecretTooShort
-	}
-	return &DispatchHandler{
-		local:      local,
-		hmacSecret: hmacSecret,
-	}, nil
+// ExternalProcessingService and peer-authentication impl. Auth is already
+// validated at construction time (NewAEADPeerAuth etc. check secret length),
+// so this constructor does not return an error.
+func NewDispatchHandler(local contract.ExternalProcessingService, auth PeerAuth) *DispatchHandler {
+	return &DispatchHandler{local: local, auth: auth}
 }
 
 // Register registers the dispatch routes on the provided ServeMux.
@@ -46,7 +36,7 @@ func (h *DispatchHandler) Register(mux *http.ServeMux) {
 
 // handleProcessor handles POST /internal/dispatch/processor.
 func (h *DispatchHandler) handleProcessor(w http.ResponseWriter, r *http.Request) {
-	body, ok := h.readAndVerify(w, r)
+	body, identity, ok := h.verifyRequest(w, r)
 	if !ok {
 		return
 	}
@@ -57,7 +47,7 @@ func (h *DispatchHandler) handleProcessor(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	ctx := h.buildContext(r, req.TenantID, req.UserID, req.Roles)
+	ctx := h.buildContext(r, identity, req.TenantID, req.UserID, req.Roles)
 
 	entity := &spi.Entity{
 		Meta: req.EntityMeta,
@@ -82,7 +72,7 @@ func (h *DispatchHandler) handleProcessor(w http.ResponseWriter, r *http.Request
 
 // handleCriteria handles POST /internal/dispatch/criteria.
 func (h *DispatchHandler) handleCriteria(w http.ResponseWriter, r *http.Request) {
-	body, ok := h.readAndVerify(w, r)
+	body, identity, ok := h.verifyRequest(w, r)
 	if !ok {
 		return
 	}
@@ -93,7 +83,7 @@ func (h *DispatchHandler) handleCriteria(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	ctx := h.buildContext(r, req.TenantID, req.UserID, req.Roles)
+	ctx := h.buildContext(r, identity, req.TenantID, req.UserID, req.Roles)
 
 	entity := &spi.Entity{
 		Meta: req.EntityMeta,
@@ -116,44 +106,29 @@ func (h *DispatchHandler) handleCriteria(w http.ResponseWriter, r *http.Request)
 	})
 }
 
-// readAndVerify reads the full request body, verifies the HMAC-SHA256 signature
-// from the X-Dispatch-HMAC header, and returns the body bytes. On failure it
-// writes an error response and returns false.
-func (h *DispatchHandler) readAndVerify(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
-	sig := r.Header.Get("X-Dispatch-HMAC")
-	if sig == "" {
-		slog.Warn("dispatch request missing HMAC header", "pkg", "dispatch", "remoteAddr", r.RemoteAddr)
-		http.Error(w, "forbidden", http.StatusForbidden)
-		return nil, false
-	}
-
-	r.Body = http.MaxBytesReader(w, r.Body, maxDispatchBodySize)
-	body, err := io.ReadAll(r.Body)
+// verifyRequest runs peer authentication over the incoming request. On
+// failure it writes 403 and returns ok=false; on success it returns the
+// authenticated plaintext body and the peer's identity. Error messages
+// are deliberately generic to avoid leaking which step failed.
+func (h *DispatchHandler) verifyRequest(w http.ResponseWriter, r *http.Request) ([]byte, PeerIdentity, bool) {
+	body, identity, err := h.auth.Verify(r)
 	if err != nil {
-		http.Error(w, "failed to read body", http.StatusInternalServerError)
-		return nil, false
-	}
-
-	expected := h.sign(body)
-	if !hmac.Equal([]byte(sig), []byte(expected)) {
-		slog.Warn("dispatch request HMAC mismatch", "pkg", "dispatch", "remoteAddr", r.RemoteAddr)
+		slog.Warn("dispatch request auth failed",
+			"pkg", "dispatch",
+			"remoteAddr", r.RemoteAddr,
+			"err", err)
 		http.Error(w, "forbidden", http.StatusForbidden)
-		return nil, false
+		return nil, PeerIdentity{}, false
 	}
-
-	return body, true
+	return body, identity, true
 }
 
-// sign returns the hex-encoded HMAC-SHA256 of body — identical to HTTPForwarder.sign().
-func (h *DispatchHandler) sign(body []byte) string {
-	mac := hmac.New(sha256.New, h.hmacSecret)
-	mac.Write(body)
-	return hex.EncodeToString(mac.Sum(nil))
-}
-
-// buildContext constructs a context.Context carrying the UserContext from the
-// dispatch request fields.
-func (h *DispatchHandler) buildContext(r *http.Request, tenantID, userID string, roles []string) context.Context {
+// buildContext constructs a context.Context carrying the UserContext from
+// the dispatch request fields and the authenticated PeerIdentity. Even in
+// the shared-key regime where PeerIdentity is degenerate, propagating it
+// through context means downstream audit / tracing can read origin without
+// being rewritten when transport evolves.
+func (h *DispatchHandler) buildContext(r *http.Request, identity PeerIdentity, tenantID, userID string, roles []string) context.Context {
 	uc := &spi.UserContext{
 		UserID: userID,
 		Tenant: spi.Tenant{
@@ -161,7 +136,9 @@ func (h *DispatchHandler) buildContext(r *http.Request, tenantID, userID string,
 		},
 		Roles: roles,
 	}
-	return spi.WithUserContext(r.Context(), uc)
+	ctx := spi.WithUserContext(r.Context(), uc)
+	ctx = WithPeerIdentity(ctx, identity)
+	return ctx
 }
 
 // writeJSON encodes v as JSON and writes it with the given status code.

--- a/internal/cluster/dispatch/handler_test.go
+++ b/internal/cluster/dispatch/handler_test.go
@@ -3,62 +3,78 @@ package dispatch
 import (
 	"bytes"
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 )
 
 // fakeLocalDispatcher implements contract.ExternalProcessingService for testing.
+// capturedCtx records the ctx from the most recent dispatch call so tests can
+// assert identity propagation.
 type fakeLocalDispatcher struct {
 	processorResult *spi.Entity
 	processorErr    error
 	criteriaResult  bool
 	criteriaErr     error
+	capturedCtx     context.Context
 }
 
 func (f *fakeLocalDispatcher) DispatchProcessor(
-	_ context.Context,
+	ctx context.Context,
 	_ *spi.Entity,
 	_ spi.ProcessorDefinition,
 	_, _, _ string,
 ) (*spi.Entity, error) {
+	f.capturedCtx = ctx
 	return f.processorResult, f.processorErr
 }
 
 func (f *fakeLocalDispatcher) DispatchCriteria(
-	_ context.Context,
+	ctx context.Context,
 	_ *spi.Entity,
 	_ json.RawMessage,
 	_, _, _, _, _ string,
 ) (bool, error) {
+	f.capturedCtx = ctx
 	return f.criteriaResult, f.criteriaErr
 }
 
-// newTestDispatchHandler creates a DispatchHandler without secret length validation,
-// for use in tests that predate the minimum-length requirement.
-func newTestDispatchHandler(local *fakeLocalDispatcher, secret []byte) *DispatchHandler {
-	return &DispatchHandler{local: local, hmacSecret: secret}
+var testSecret32 = bytes.Repeat([]byte{0xAB}, 32)
+
+// newAEAD builds an AEADPeerAuth keyed by testSecret32. Internal test helper.
+func newAEAD(t *testing.T) *AEADPeerAuth {
+	t.Helper()
+	a, err := NewAEADPeerAuth(testSecret32, 30*time.Second)
+	if err != nil {
+		t.Fatalf("NewAEADPeerAuth: %v", err)
+	}
+	return a
 }
 
-// sign computes the HMAC-SHA256 of body using secret — mirrors HTTPForwarder.sign().
-func sign(secret, body []byte) string {
-	mac := hmac.New(sha256.New, secret)
-	mac.Write(body)
-	return hex.EncodeToString(mac.Sum(nil))
+// signedRequest builds an AEAD-wrapped POST request ready for the handler
+// to verify. Convenience for tests that need an authenticated request body.
+func signedRequest(t *testing.T, auth *AEADPeerAuth, method, path string, plain []byte) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	wire, err := auth.Sign(req, plain)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	req.Body = io.NopCloser(bytes.NewReader(wire))
+	req.ContentLength = int64(len(wire))
+	return req
 }
 
 func TestHandler_ProcessorSuccess(t *testing.T) {
-	secret := []byte("test-secret")
-	resultData := json.RawMessage(`{"output":42}`)
+	auth := newAEAD(t)
 	fake := &fakeLocalDispatcher{
 		processorResult: &spi.Entity{
 			Meta: spi.EntityMeta{ID: "ent-1"},
@@ -66,7 +82,7 @@ func TestHandler_ProcessorSuccess(t *testing.T) {
 		},
 	}
 
-	handler := newTestDispatchHandler(fake, secret)
+	handler := NewDispatchHandler(fake, auth)
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
@@ -81,11 +97,8 @@ func TestHandler_ProcessorSuccess(t *testing.T) {
 		UserID:         "user-1",
 		Roles:          []string{"ROLE_USER"},
 	}
-	body, _ := json.Marshal(req)
-
-	httpReq := httptest.NewRequest(http.MethodPost, "/internal/dispatch/processor", bytes.NewReader(body))
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("X-Dispatch-HMAC", sign(secret, body))
+	plain, _ := json.Marshal(req)
+	httpReq := signedRequest(t, auth, http.MethodPost, "/internal/dispatch/processor", plain)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httpReq)
@@ -101,16 +114,16 @@ func TestHandler_ProcessorSuccess(t *testing.T) {
 	if !resp.Success {
 		t.Errorf("expected success=true, got false (error: %s)", resp.Error)
 	}
-	if string(resp.EntityData) != string(resultData) {
-		t.Errorf("expected entity data %s, got %s", resultData, resp.EntityData)
+	if string(resp.EntityData) != `{"output":42}` {
+		t.Errorf("unexpected entity data: %s", resp.EntityData)
 	}
 }
 
 func TestHandler_CriteriaSuccess(t *testing.T) {
-	secret := []byte("test-secret")
+	auth := newAEAD(t)
 	fake := &fakeLocalDispatcher{criteriaResult: true}
 
-	handler := newTestDispatchHandler(fake, secret)
+	handler := NewDispatchHandler(fake, auth)
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
@@ -127,11 +140,8 @@ func TestHandler_CriteriaSuccess(t *testing.T) {
 		UserID:         "user-1",
 		Roles:          []string{"ROLE_USER"},
 	}
-	body, _ := json.Marshal(req)
-
-	httpReq := httptest.NewRequest(http.MethodPost, "/internal/dispatch/criteria", bytes.NewReader(body))
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("X-Dispatch-HMAC", sign(secret, body))
+	plain, _ := json.Marshal(req)
+	httpReq := signedRequest(t, auth, http.MethodPost, "/internal/dispatch/criteria", plain)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httpReq)
@@ -152,17 +162,15 @@ func TestHandler_CriteriaSuccess(t *testing.T) {
 	}
 }
 
-func TestHandler_MissingHMAC(t *testing.T) {
-	secret := []byte("test-secret")
-	fake := &fakeLocalDispatcher{}
-	handler := newTestDispatchHandler(fake, secret)
+func TestHandler_MissingAEADHeaders(t *testing.T) {
+	handler := NewDispatchHandler(&fakeLocalDispatcher{}, newAEAD(t))
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
 	body := []byte(`{}`)
 	httpReq := httptest.NewRequest(http.MethodPost, "/internal/dispatch/processor", bytes.NewReader(body))
 	httpReq.Header.Set("Content-Type", "application/json")
-	// No X-Dispatch-HMAC header
+	// No X-Dispatch-Timestamp header, plain JSON body — rejected by AEAD Verify.
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httpReq)
@@ -172,56 +180,118 @@ func TestHandler_MissingHMAC(t *testing.T) {
 	}
 }
 
-func TestHandler_InvalidHMAC(t *testing.T) {
-	secret := []byte("test-secret")
-	fake := &fakeLocalDispatcher{}
-	handler := newTestDispatchHandler(fake, secret)
+func TestHandler_RejectsPlainJSONWithoutAEAD(t *testing.T) {
+	// Even if someone sets the timestamp header, a plain JSON body fails AEAD.Open.
+	handler := NewDispatchHandler(&fakeLocalDispatcher{}, newAEAD(t))
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	body := []byte(`{"entityMeta":{"ID":"x"}}`)
-	httpReq := httptest.NewRequest(http.MethodPost, "/internal/dispatch/processor", bytes.NewReader(body))
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("X-Dispatch-HMAC", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	httpReq := httptest.NewRequest(http.MethodPost, "/internal/dispatch/processor",
+		bytes.NewReader([]byte(`{"not":"encrypted"}`)))
+	httpReq.Header.Set("Content-Type", DispatchContentType)
+	httpReq.Header.Set(DispatchTimestampHdr, fmt.Sprintf("%d", time.Now().Unix()))
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httpReq)
 
 	if rec.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d", rec.Code)
+		t.Fatalf("expected 403 for plain JSON, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 
-func TestNewDispatchHandler_SecretTooShort(t *testing.T) {
-	_, err := NewDispatchHandler(&fakeLocalDispatcher{}, []byte("short"))
+func TestHandler_RejectsReplayedRequest(t *testing.T) {
+	auth := newAEAD(t)
+	handler := NewDispatchHandler(&fakeLocalDispatcher{
+		processorResult: &spi.Entity{Meta: spi.EntityMeta{ID: "e"}, Data: []byte(`{}`)},
+	}, auth)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	// Sign once, then submit the same wire body twice.
+	plain, _ := json.Marshal(DispatchProcessorRequest{
+		TenantID: "t", UserID: "u",
+		Processor:    spi.ProcessorDefinition{Name: "p", Type: "SCRIPT"},
+		WorkflowName: "w", TransitionName: "t", TxID: "x",
+		EntityMeta: spi.EntityMeta{ID: "e"},
+		Entity:     json.RawMessage(`{}`),
+	})
+	first := signedRequest(t, auth, http.MethodPost, "/internal/dispatch/processor", plain)
+	wire, _ := io.ReadAll(first.Body)
+	ts := first.Header.Get(DispatchTimestampHdr)
+
+	build := func() *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/internal/dispatch/processor", bytes.NewReader(wire))
+		r.Header.Set("Content-Type", DispatchContentType)
+		r.Header.Set(DispatchTimestampHdr, ts)
+		return r
+	}
+
+	rec1 := httptest.NewRecorder()
+	mux.ServeHTTP(rec1, build())
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first request should succeed, got %d: %s", rec1.Code, rec1.Body.String())
+	}
+
+	rec2 := httptest.NewRecorder()
+	mux.ServeHTTP(rec2, build())
+	if rec2.Code != http.StatusForbidden {
+		t.Fatalf("replay should be rejected with 403, got %d", rec2.Code)
+	}
+}
+
+func TestHandler_PopulatesPeerIdentityInContext(t *testing.T) {
+	auth := newAEAD(t)
+	fake := &fakeLocalDispatcher{
+		processorResult: &spi.Entity{Meta: spi.EntityMeta{ID: "e"}, Data: []byte(`{}`)},
+	}
+	handler := NewDispatchHandler(fake, auth)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	plain, _ := json.Marshal(DispatchProcessorRequest{
+		TenantID: "t", UserID: "u", TxID: "tx",
+		Processor:    spi.ProcessorDefinition{Name: "p", Type: "SCRIPT"},
+		WorkflowName: "w", TransitionName: "t",
+		EntityMeta: spi.EntityMeta{ID: "e"},
+		Entity:     json.RawMessage(`{}`),
+	})
+	httpReq := signedRequest(t, auth, http.MethodPost, "/internal/dispatch/processor", plain)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httpReq)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	id, ok := PeerIdentityFromContext(fake.capturedCtx)
+	if !ok {
+		t.Fatal("PeerIdentity not found in dispatcher ctx — handler failed to propagate")
+	}
+	if id.AuthMethod() != "aead-v1" {
+		t.Errorf("AuthMethod = %q, want aead-v1", id.AuthMethod())
+	}
+}
+
+func TestNewAEADPeerAuth_SecretTooShort(t *testing.T) {
+	_, err := NewAEADPeerAuth([]byte("short"), 30*time.Second)
 	if err == nil {
 		t.Fatal("expected error for short secret")
 	}
-	if !errors.Is(err, ErrHMACSecretTooShort) {
-		t.Errorf("expected ErrHMACSecretTooShort, got %v", err)
-	}
-}
-
-func TestNewDispatchHandler_SecretValid(t *testing.T) {
-	h, err := NewDispatchHandler(&fakeLocalDispatcher{}, []byte("at-least-32-bytes-long-secret!!!"))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if h == nil {
-		t.Fatal("expected non-nil handler")
+	if !errors.Is(err, ErrSharedSecretTooShort) {
+		t.Errorf("expected ErrSharedSecretTooShort, got %v", err)
 	}
 }
 
 func TestHandler_ProcessorError_SanitizedResponse(t *testing.T) {
-	secret := []byte("at-least-32-bytes-long-secret!!!")
+	auth := newAEAD(t)
 	fake := &fakeLocalDispatcher{
 		processorErr: fmt.Errorf("connection refused: dial tcp 10.0.0.1:5432"),
 	}
-	handler, _ := NewDispatchHandler(fake, secret)
+	handler := NewDispatchHandler(fake, auth)
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	req := DispatchProcessorRequest{
+	plain, _ := json.Marshal(DispatchProcessorRequest{
 		Entity:         json.RawMessage(`{"foo":"bar"}`),
 		EntityMeta:     spi.EntityMeta{ID: "ent-1"},
 		Processor:      spi.ProcessorDefinition{Name: "proc1", Type: "SCRIPT"},
@@ -231,18 +301,14 @@ func TestHandler_ProcessorError_SanitizedResponse(t *testing.T) {
 		TenantID:       "tenant-a",
 		UserID:         "user-1",
 		Roles:          []string{"ROLE_USER"},
-	}
-	body, _ := json.Marshal(req)
-
-	httpReq := httptest.NewRequest(http.MethodPost, "/internal/dispatch/processor", bytes.NewReader(body))
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("X-Dispatch-HMAC", sign(secret, body))
+	})
+	httpReq := signedRequest(t, auth, http.MethodPost, "/internal/dispatch/processor", plain)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httpReq)
 
 	var resp DispatchProcessorResponse
-	json.NewDecoder(rec.Body).Decode(&resp)
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
 	if resp.Success {
 		t.Fatal("expected success=false")
 	}
@@ -255,15 +321,15 @@ func TestHandler_ProcessorError_SanitizedResponse(t *testing.T) {
 }
 
 func TestHandler_CriteriaError_SanitizedResponse(t *testing.T) {
-	secret := []byte("at-least-32-bytes-long-secret!!!")
+	auth := newAEAD(t)
 	fake := &fakeLocalDispatcher{
 		criteriaErr: fmt.Errorf("pq: password authentication failed for user admin"),
 	}
-	handler, _ := NewDispatchHandler(fake, secret)
+	handler := NewDispatchHandler(fake, auth)
 	mux := http.NewServeMux()
 	handler.Register(mux)
 
-	req := DispatchCriteriaRequest{
+	plain, _ := json.Marshal(DispatchCriteriaRequest{
 		Entity:         json.RawMessage(`{"foo":"bar"}`),
 		EntityMeta:     spi.EntityMeta{ID: "ent-2"},
 		Criterion:      json.RawMessage(`{"type":"eq"}`),
@@ -275,18 +341,14 @@ func TestHandler_CriteriaError_SanitizedResponse(t *testing.T) {
 		TenantID:       "tenant-a",
 		UserID:         "user-1",
 		Roles:          []string{"ROLE_USER"},
-	}
-	body, _ := json.Marshal(req)
-
-	httpReq := httptest.NewRequest(http.MethodPost, "/internal/dispatch/criteria", bytes.NewReader(body))
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("X-Dispatch-HMAC", sign(secret, body))
+	})
+	httpReq := signedRequest(t, auth, http.MethodPost, "/internal/dispatch/criteria", plain)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httpReq)
 
 	var resp DispatchCriteriaResponse
-	json.NewDecoder(rec.Body).Decode(&resp)
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
 	if resp.Success {
 		t.Fatal("expected success=false")
 	}

--- a/internal/cluster/dispatch/integration_test.go
+++ b/internal/cluster/dispatch/integration_test.go
@@ -19,7 +19,7 @@ import (
 //  4. Call DispatchProcessor on Node A's ClusterDispatcher.
 //  5. Verify the result comes from the peer (forwarded successfully).
 func TestIntegration_ClusterDispatch_FullFlow(t *testing.T) {
-	hmacSecret := []byte("integration-hmac-secret")
+	auth, _ := NewAEADPeerAuth(testSecret32, 30*time.Second)
 
 	t.Run("processor_full_flow", func(t *testing.T) {
 		// Node B: local dispatcher returns peer-processed result.
@@ -29,7 +29,7 @@ func TestIntegration_ClusterDispatch_FullFlow(t *testing.T) {
 				Data: []byte(`{"result":"from-peer-processor"}`),
 			},
 		}
-		handler := &DispatchHandler{local: nodeBLocal, hmacSecret: hmacSecret}
+		handler := NewDispatchHandler(nodeBLocal, auth)
 		mux := http.NewServeMux()
 		handler.Register(mux)
 		nodeBServer := httptest.NewServer(mux)
@@ -44,7 +44,7 @@ func TestIntegration_ClusterDispatch_FullFlow(t *testing.T) {
 			},
 		}
 		selector := NewRandomSelector()
-		forwarder := NewHTTPForwarder(hmacSecret, 5*time.Second).AllowLoopbackForTesting()
+		forwarder := NewHTTPForwarder(auth, 5*time.Second).AllowLoopbackForTesting()
 		d := NewClusterDispatcher(nodeALocal, registry, "node-a", selector, forwarder, 2*time.Second)
 
 		ctx := testContext()
@@ -62,7 +62,7 @@ func TestIntegration_ClusterDispatch_FullFlow(t *testing.T) {
 		nodeBLocal := &stubDispatcher{
 			criteriaResult: true,
 		}
-		handler := &DispatchHandler{local: nodeBLocal, hmacSecret: hmacSecret}
+		handler := NewDispatchHandler(nodeBLocal, auth)
 		mux := http.NewServeMux()
 		handler.Register(mux)
 		nodeBServer := httptest.NewServer(mux)
@@ -77,7 +77,7 @@ func TestIntegration_ClusterDispatch_FullFlow(t *testing.T) {
 			},
 		}
 		selector := NewRandomSelector()
-		forwarder := NewHTTPForwarder(hmacSecret, 5*time.Second).AllowLoopbackForTesting()
+		forwarder := NewHTTPForwarder(auth, 5*time.Second).AllowLoopbackForTesting()
 		d := NewClusterDispatcher(nodeALocal, registry, "node-a", selector, forwarder, 2*time.Second)
 
 		ctx := testContext()
@@ -109,7 +109,8 @@ func TestIntegration_ClusterDispatch_NoMemberTimeout(t *testing.T) {
 		},
 	}
 	selector := NewRandomSelector()
-	forwarder := NewHTTPForwarder([]byte("secret"), 5*time.Second).AllowLoopbackForTesting()
+	timeoutAuth, _ := NewAEADPeerAuth(testSecret32, 30*time.Second)
+	forwarder := NewHTTPForwarder(timeoutAuth, 5*time.Second).AllowLoopbackForTesting()
 
 	const waitTimeout = 300 * time.Millisecond
 	d := NewClusterDispatcher(local, registry, "node-a", selector, forwarder, waitTimeout)

--- a/internal/cluster/dispatch/nonce_cache.go
+++ b/internal/cluster/dispatch/nonce_cache.go
@@ -1,0 +1,68 @@
+package dispatch
+
+import (
+	"sync"
+	"time"
+)
+
+// nonceCache is a bounded, TTL-expiring set used to reject replayed AEAD
+// envelopes. Nonces are AES-GCM IVs — one per encryption — so a duplicate
+// over the wire within the skew window is an attacker replaying a captured
+// request.
+//
+// Fail-closed on capacity: when the cache is full, checkAndRecord reports
+// *seen* for any new nonce. The caller surfaces this as a replay rejection.
+// At realistic cluster rates (max ~10k dispatch/s) and a 60s TTL, a 100k
+// ceiling leaves a 10x headroom over sustained load; an attacker flood fails
+// closed rather than letting stale entries linger.
+type nonceCache struct {
+	ttl    time.Duration
+	cap    int
+	nowFn  func() time.Time
+	mu     sync.Mutex
+	entries map[string]time.Time
+}
+
+func newNonceCache(ttl time.Duration, capacity int, nowFn func() time.Time) *nonceCache {
+	return &nonceCache{
+		ttl:     ttl,
+		cap:     capacity,
+		nowFn:   nowFn,
+		entries: make(map[string]time.Time, capacity),
+	}
+}
+
+// checkAndRecord reports whether the nonce has been seen within the TTL
+// window. If not, it records the nonce with the given observation time.
+// Returns true only if the nonce is considered a replay (either a genuine
+// duplicate, or a fail-closed capacity rejection).
+func (c *nonceCache) checkAndRecord(nonce []byte, observed time.Time) bool {
+	key := string(nonce)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.evictLocked()
+
+	if _, exists := c.entries[key]; exists {
+		return true
+	}
+
+	if len(c.entries) >= c.cap {
+		// Fail-closed: cache is full after eviction; treat as replay.
+		return true
+	}
+
+	c.entries[key] = observed
+	return false
+}
+
+// evictLocked removes entries older than the TTL. Caller holds c.mu.
+func (c *nonceCache) evictLocked() {
+	cutoff := c.nowFn().Add(-c.ttl)
+	for k, ts := range c.entries {
+		if ts.Before(cutoff) {
+			delete(c.entries, k)
+		}
+	}
+}

--- a/internal/cluster/dispatch/nonce_cache_test.go
+++ b/internal/cluster/dispatch/nonce_cache_test.go
@@ -1,0 +1,110 @@
+package dispatch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNonceCache_FirstObservationNotSeen(t *testing.T) {
+	c := newNonceCache(60*time.Second, 100, time.Now)
+	nonce := []byte("abcdefghijkl")
+	if c.checkAndRecord(nonce, time.Now()) {
+		t.Fatal("first observation reported as seen")
+	}
+}
+
+func TestNonceCache_DuplicateIsSeen(t *testing.T) {
+	c := newNonceCache(60*time.Second, 100, time.Now)
+	nonce := []byte("abcdefghijkl")
+	now := time.Now()
+	if c.checkAndRecord(nonce, now) {
+		t.Fatal("first observation reported as seen")
+	}
+	if !c.checkAndRecord(nonce, now) {
+		t.Fatal("duplicate observation not detected")
+	}
+}
+
+func TestNonceCache_EvictsAfterTTL(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	nowFn := func() time.Time { return base }
+	c := newNonceCache(60*time.Second, 100, nowFn)
+	nonce := []byte("abcdefghijkl")
+
+	c.checkAndRecord(nonce, base)
+
+	// Advance clock past TTL.
+	base = base.Add(120 * time.Second)
+
+	// After TTL has elapsed, the same nonce is no longer considered seen.
+	if c.checkAndRecord(nonce, base) {
+		t.Fatal("nonce still seen after TTL expired")
+	}
+}
+
+func TestNonceCache_BoundedSize_RejectsWhenFull(t *testing.T) {
+	c := newNonceCache(60*time.Second, 3, time.Now)
+
+	now := time.Now()
+	n1 := []byte("aaaaaaaaaaaa")
+	n2 := []byte("bbbbbbbbbbbb")
+	n3 := []byte("cccccccccccc")
+	n4 := []byte("dddddddddddd")
+
+	if c.checkAndRecord(n1, now) {
+		t.Fatal("n1 seen on first observation")
+	}
+	if c.checkAndRecord(n2, now) {
+		t.Fatal("n2 seen on first observation")
+	}
+	if c.checkAndRecord(n3, now) {
+		t.Fatal("n3 seen on first observation")
+	}
+
+	// Cache is at capacity. A new nonce should be rejected (fail-closed).
+	// Returning "seen" is the conservative signal: the caller treats it as
+	// a replay-reject and surfaces an error.
+	if !c.checkAndRecord(n4, now) {
+		t.Fatal("expected capacity-exceeded to fail closed (report seen), got not-seen")
+	}
+}
+
+func TestNonceCache_CapacityRecoversAfterEviction(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	nowFn := func() time.Time { return base }
+	c := newNonceCache(60*time.Second, 2, nowFn)
+
+	n1 := []byte("aaaaaaaaaaaa")
+	n2 := []byte("bbbbbbbbbbbb")
+	n3 := []byte("cccccccccccc")
+
+	c.checkAndRecord(n1, base)
+	c.checkAndRecord(n2, base)
+
+	// Capacity full; n3 rejected.
+	if !c.checkAndRecord(n3, base) {
+		t.Fatal("expected n3 to be fail-closed rejected at capacity")
+	}
+
+	// Advance past TTL — both n1 and n2 should evict.
+	base = base.Add(120 * time.Second)
+
+	// Now there's room; n3 is fresh.
+	if c.checkAndRecord(n3, base) {
+		t.Fatal("n3 reported seen even after eviction freed space")
+	}
+}
+
+func TestNonceCache_DifferentNonceLengthsDistinct(t *testing.T) {
+	c := newNonceCache(60*time.Second, 100, time.Now)
+	now := time.Now()
+
+	a := []byte("aaaaaaaaaaaa")
+	b := []byte("aaaaaaaaaaab")
+	if c.checkAndRecord(a, now) {
+		t.Fatal("a seen on first observation")
+	}
+	if c.checkAndRecord(b, now) {
+		t.Fatal("b treated as seen; cache is not byte-distinct")
+	}
+}

--- a/internal/cluster/dispatch/peer_auth.go
+++ b/internal/cluster/dispatch/peer_auth.go
@@ -1,0 +1,74 @@
+package dispatch
+
+import (
+	"context"
+	"net/http"
+)
+
+// PeerAuth authenticates inter-node dispatch HTTP requests at the message
+// layer. Implementations wrap outbound bodies on the client and verify them
+// on the server, returning the authenticated plaintext plus a PeerIdentity.
+//
+// The interface is deliberately split so future transports (e.g. mTLS, where
+// authentication is transport-layer) can implement Sign as a no-op and derive
+// identity from tls.ConnectionState in Verify — without disturbing the
+// forwarder or handler call sites.
+type PeerAuth interface {
+	// Sign transforms the plaintext body into an on-the-wire body, setting
+	// any required headers on req. The returned slice replaces req.Body at
+	// the call site. Implementations MAY write to req.Header but MUST NOT
+	// capture or retain req past the call.
+	Sign(req *http.Request, body []byte) (wireBody []byte, err error)
+
+	// Verify reads the request body, validates it, and returns the
+	// authenticated plaintext plus the peer's identity. A non-nil error
+	// means authentication failed and the caller must respond with 403.
+	// The returned identity MUST be populated (even if degenerate) so
+	// handlers can attach it to the request context unconditionally.
+	Verify(r *http.Request) (body []byte, identity PeerIdentity, err error)
+}
+
+// PeerIdentity describes an authenticated cluster peer. Today (shared-key
+// AEAD) identity is degenerate — the sender held the derived dispatch key,
+// nothing more. In a future mTLS transport, NodeID carries the specific
+// node identifier from the peer certificate's CommonName. The abstraction
+// is stable across both so callers that care about origin can start reading
+// it today without having to be rewritten when transport changes.
+type PeerIdentity struct {
+	authMethod string
+	nodeID     string
+}
+
+// AuthMethod returns the auth-mechanism tag (e.g. "aead-v1", "mtls").
+// Used primarily for diagnostics and audit trails.
+func (i PeerIdentity) AuthMethod() string { return i.authMethod }
+
+// NodeID returns the specific peer node ID if the auth mechanism proves it,
+// or the empty string otherwise. Callers MUST treat empty NodeID as
+// "authenticated cluster member, identity unknown" rather than "anonymous".
+func (i PeerIdentity) NodeID() string { return i.nodeID }
+
+// NewPeerIdentityForTesting constructs a PeerIdentity with the given fields.
+// Production PeerAuth implementations have their own internal constructors
+// so the zero-value invariant stays meaningful; tests use this helper.
+func NewPeerIdentityForTesting(authMethod, nodeID string) PeerIdentity {
+	return PeerIdentity{authMethod: authMethod, nodeID: nodeID}
+}
+
+type peerIdentityCtxKey struct{}
+
+// WithPeerIdentity returns ctx annotated with the authenticated peer identity.
+// Handlers call this after Verify succeeds so downstream code can audit the
+// origin without re-running authentication.
+func WithPeerIdentity(ctx context.Context, id PeerIdentity) context.Context {
+	return context.WithValue(ctx, peerIdentityCtxKey{}, id)
+}
+
+// PeerIdentityFromContext retrieves the peer identity placed by
+// WithPeerIdentity. The boolean is false if no identity was set — callers
+// that expect one (i.e. inside a dispatch handler) should treat absence
+// as a bug rather than as "anonymous caller".
+func PeerIdentityFromContext(ctx context.Context) (PeerIdentity, bool) {
+	id, ok := ctx.Value(peerIdentityCtxKey{}).(PeerIdentity)
+	return id, ok
+}

--- a/internal/cluster/dispatch/peer_auth.go
+++ b/internal/cluster/dispatch/peer_auth.go
@@ -13,11 +13,21 @@ import (
 // authentication is transport-layer) can implement Sign as a no-op and derive
 // identity from tls.ConnectionState in Verify — without disturbing the
 // forwarder or handler call sites.
+//
+// Contract between PeerAuth and HTTPForwarder.forward:
+//   - forward sets Content-Type: application/json as the default BEFORE
+//     calling Sign. Impls using a different wire format (e.g. AEAD) override
+//     it inside Sign. Transport-auth-only impls (e.g. mTLS carrying plain
+//     JSON) can leave it alone.
+//   - forward replaces req.Body with the returned wireBody after Sign.
+//     Impls may return body unchanged if authentication is fully transport
+//     layer.
 type PeerAuth interface {
 	// Sign transforms the plaintext body into an on-the-wire body, setting
 	// any required headers on req. The returned slice replaces req.Body at
-	// the call site. Implementations MAY write to req.Header but MUST NOT
-	// capture or retain req past the call.
+	// the call site. Implementations MAY write to req.Header (including
+	// overriding Content-Type) but MUST NOT capture or retain req past the
+	// call. A no-op impl may return body unchanged.
 	Sign(req *http.Request, body []byte) (wireBody []byte, err error)
 
 	// Verify reads the request body, validates it, and returns the

--- a/internal/cluster/dispatch/peer_auth_test.go
+++ b/internal/cluster/dispatch/peer_auth_test.go
@@ -1,0 +1,43 @@
+package dispatch_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/cluster/dispatch"
+)
+
+func TestPeerIdentity_MissingFromEmptyContext(t *testing.T) {
+	_, ok := dispatch.PeerIdentityFromContext(context.Background())
+	if ok {
+		t.Fatal("expected PeerIdentity absent from bare context")
+	}
+}
+
+func TestPeerIdentity_RoundTripThroughContext(t *testing.T) {
+	id := dispatch.NewPeerIdentityForTesting("aead-v1", "")
+	ctx := dispatch.WithPeerIdentity(context.Background(), id)
+
+	got, ok := dispatch.PeerIdentityFromContext(ctx)
+	if !ok {
+		t.Fatal("expected PeerIdentity present after WithPeerIdentity")
+	}
+	if got.AuthMethod() != "aead-v1" {
+		t.Fatalf("auth method = %q, want aead-v1", got.AuthMethod())
+	}
+	if got.NodeID() != "" {
+		t.Fatalf("unexpected node id on shared-key identity: %q", got.NodeID())
+	}
+}
+
+func TestPeerIdentity_FutureMTLSIdentityCarriesNodeID(t *testing.T) {
+	// This test codifies the Option-2 (mTLS) contract: the same abstraction
+	// must be able to carry a node-specific identity. If this test stays
+	// green after future refactors, Option 2 stays additive.
+	id := dispatch.NewPeerIdentityForTesting("mtls", "node-b")
+	ctx := dispatch.WithPeerIdentity(context.Background(), id)
+	got, _ := dispatch.PeerIdentityFromContext(ctx)
+	if got.AuthMethod() != "mtls" || got.NodeID() != "node-b" {
+		t.Fatalf("mTLS identity not preserved: auth=%q node=%q", got.AuthMethod(), got.NodeID())
+	}
+}

--- a/internal/cluster/dispatch/test_helpers_test.go
+++ b/internal/cluster/dispatch/test_helpers_test.go
@@ -1,0 +1,24 @@
+package dispatch_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/internal/cluster/dispatch"
+)
+
+// testSharedSecret is a 32-byte shared secret used across tests that need to
+// construct a PeerAuth. Not the real production key.
+var testSharedSecret = bytes.Repeat([]byte{0xAB}, 32)
+
+// newTestPeerAuth builds a default PeerAuth (AEAD, 30s skew) from
+// testSharedSecret. Test helper; production uses NewAEADPeerAuth in app.go.
+func newTestPeerAuth(t *testing.T) dispatch.PeerAuth {
+	t.Helper()
+	auth, err := dispatch.NewAEADPeerAuth(testSharedSecret, 30*time.Second)
+	if err != nil {
+		t.Fatalf("newTestPeerAuth: %v", err)
+	}
+	return auth
+}


### PR DESCRIPTION
Closes the second half of #66 (transport hardening). PR1 (#72) already landed the JWKS work.

## Summary

- **AES-256-GCM replaces HMAC-on-body** for inter-node dispatch. Wire format: `[nonce(12) || ciphertext||tag]`. Associated Data binds HTTP method + path + timestamp so cross-endpoint and timestamp-strip replays are rejected by the primitive itself, not by auxiliary checks.
- **Replay resistance**: 30-second timestamp skew window (reject before decrypt), bounded TTL-evicted nonce cache (100k entries / 60s TTL). Nonces are recorded only after successful decrypt, so a flood of bogus envelopes can't pollute the cache.
- **Key derivation**: HKDF-SHA256 over `CYODA_HMAC_SECRET` with info `"cyoda-dispatch-v1"` — separates the dispatch key from memberlist's raw-secret gossip key. One shared secret, two independent derived primitives.
- **`PeerAuth` seam** designed for future mTLS. `Sign`/`Verify` interface + opaque `PeerIdentity` propagated through request context via `WithPeerIdentity`. Today's shared-key identity is degenerate; tomorrow's mTLS impl would populate `NodeID` from the peer cert CN without changing any call sites.

## Greenfield — no back-compat

No feature flag, no v1 fallback, no dual-stack handler. `X-Dispatch-HMAC` header is gone. `ErrHMACSecretTooShort` becomes `ErrSharedSecretTooShort` on the AEAD constructor.

## Test plan

- [x] `go test -short ./...` green
- [x] `go test ./internal/e2e/...` green
- [x] `go test -race ./internal/cluster/dispatch/ ./app/` clean
- [x] `go vet ./...` clean
- [x] Plugin submodules (memory, postgres, sqlite) green
- [x] Unit: 17 AEAD tests covering round-trip, tamper (ct/nonce/method/path/ts), stale ts, replay, skew-boundary, short-secret, key-derivation-actually-runs, wire-body-not-plaintext, timestamp edge cases (neg/zero/future), envelope-minimum body, short-body-rejected
- [x] Nonce cache: seen/not-seen, TTL eviction, bounded-size fail-closed, capacity-recovers-after-eviction
- [x] Forwarder: AEAD headers set, wire body encrypted (no plaintext markers)
- [x] Handler: plain JSON rejected, replay rejected, `PeerIdentity` propagated to dispatcher ctx, error sanitization preserved
- [x] Code review completed (superpowers:code-reviewer): I2 applied (Content-Type defaulting moved to forwarder); I1 analyzed and pushed back — invariant now pinned by `TestAEADPeerAuth_SkewBoundaryReplayStillRejected`; M2 and M7 (timestamp edge cases + envelope minimum) added

## Future Option 2 (mTLS)

When it's time: write `MTLSPeerAuth`. `Sign` is no-op (returns body unchanged; forwarder's default `Content-Type: application/json` is correct). `Verify` reads `r.TLS.PeerCertificates[0]` and populates `PeerIdentity` with `authMethod="mtls"` and `NodeID=<cert CN>`. Swap the impl in `app/app.go`. Nothing in the dispatch business logic, forwarder, or handler moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)