### PR TITLE
docs: update CONSISTENCY.md to reflect AEAD dispatch auth (#66 follow-up)

### DIFF
--- a/docs/CONSISTENCY.md
+++ b/docs/CONSISTENCY.md
@@ -303,7 +303,8 @@ per-node `TransactionManager` holds per-transaction state (read-set,
 write-set, postgres `pgx.Tx` handle) in the process memory of the node
 that called `Begin`. Subsequent requests inside the same transaction
 must route back to that node — enforced by the cluster-mode dispatch
-layer (signed transaction tokens + HMAC-authenticated forwarding).
+layer (HMAC-signed transaction tokens + AEAD-encrypted inter-node
+forwarding via the `PeerAuth` seam).
 
 The isolation contract is therefore preserved end-to-end: an API caller
 interacting with transaction `T` always lands on the same node for the


### PR DESCRIPTION
Follow-up to #72 and #73 (issue #66 transport hardening). One line in `docs/CONSISTENCY.md` §8 still described inter-node forwarding as \"HMAC-authenticated\" — accurate pre-refactor, stale post-AEAD.

## Summary

- Update the parenthetical describing cluster-mode dispatch authentication to name the current primitive (AEAD encryption via the `PeerAuth` seam).
- Transaction routing tokens remain HMAC-SHA256-signed; the distinction is preserved in the new wording.

## Context

Checked all living docs (`ARCHITECTURE.md`, `PRD.md`, `CONSISTENCY.md`, `README.md`, `deploy/helm/cyoda/README.md`, `MAINTAINING.md`, `OVERVIEW.md`) for stale references to the old HMAC-on-body dispatch auth or loopback JWKS fetch. Historical records under `docs/superpowers/` and `docs/plans/` are intentionally not touched per project convention. Only this one line was stale.

## Test plan

- [x] No code changes; existing CI validates docs don't break anything
- [x] Grep for `HMAC.*forward`, `X-Dispatch`, `JWKSValidator`, `loopback.*jwks` across living docs — no remaining hits that describe a stale state

🤖 Generated with [Claude Code](https://claude.com/claude-code)