### PR TITLE
ci: continuous security gates (govulncheck, dependency-review, Trivy, CodeQL) (#67)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,47 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run shellcheck
         run: shellcheck scripts/install.sh scripts/dev/run-docker-dev.sh
+
+  # Continuous security gates (issue #67):
+  #   - govulncheck scans the call graph for exploitable stdlib and third-party CVEs,
+  #     covering the root module and each plugin submodule (they have their own go.mod
+  #     and are independently consumable, so each must be scanned separately).
+  #   - dependency-review-action blocks PRs that introduce known-vulnerable deps
+  #     before they land.
+  # Both gates are blocking: merging past a vulnerability finding is not allowed.
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Pinned binary for CI reproducibility. The vulnerability database itself is
+      # fetched at scan time, so pinning the tool does not pin the findings.
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
+      - name: govulncheck (root)
+        run: govulncheck ./...
+
+      - name: govulncheck (plugins/memory)
+        working-directory: plugins/memory
+        run: govulncheck ./...
+
+      - name: govulncheck (plugins/postgres)
+        working-directory: plugins/postgres
+        run: govulncheck ./...
+
+      - name: govulncheck (plugins/sqlite)
+        working-directory: plugins/sqlite
+        run: govulncheck ./...
+
+      # dependency-review is only meaningful on PR events (it compares base↔head).
+      # Push events to main/develop skip this step — the govulncheck above still runs.
+      - name: Dependency review
+        if: github.event_name == 'pull_request'
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: CodeQL
+
+# CodeQL static analysis (issue #67). Complements the `security` job in ci.yml:
+#   - govulncheck asks "does the call graph reach a known-CVE function?"
+#   - dependency-review asks "is this PR adding a vulnerable dep?"
+#   - CodeQL asks "does the code we wrote itself contain a bug pattern?"
+# Uses GitHub's security-and-quality query pack — broader than security-extended;
+# includes code-quality queries that catch logic bugs alongside security findings.
+#
+# Free for public repositories on GitHub.com — no GHAS license required.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly cron catches newly-published queries against stable code that
+    # isn't actively being modified. Monday 06:00 UTC keeps results fresh
+    # for the workweek without clashing with release-day traffic.
+    - cron: '0 6 * * 1'
+
+permissions:
+  security-events: write   # upload SARIF to Security tab
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          queries: security-and-quality
+
+      # Explicit build across the workspace (root + plugins/memory|postgres|sqlite
+      # via go.work). CodeQL's autobuild would normally handle this, but being
+      # explicit surfaces build failures cleanly and guarantees every module in
+      # the workspace is observed.
+      - name: Build workspace
+        run: go build ./...
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,3 +101,39 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOWORK: "off"
           HOMEBREW_TAP_TOKEN: ${{ steps.homebrew-tap-token.outputs.token }}
+
+      # Post-build image scan (issue #67). Scans the GHCR image goreleaser
+      # just pushed for OS-package and third-party CVEs. Advisory at release
+      # time: we do not gate the already-pushed tag on findings, but the
+      # report is surfaced to the job summary so maintainers can triage.
+      # Gating lives in CI (govulncheck) which runs pre-merge.
+      #
+      # goreleaser's `{{ .Version }}` strips the leading `v`, so tag `v1.2.3`
+      # produces image `ghcr.io/cyoda-platform/cyoda:1.2.3`. Derive the image
+      # ref accordingly.
+      - name: Compute image ref for scan
+        id: image-ref
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          echo "ref=ghcr.io/cyoda-platform/cyoda:${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Scan release image (Trivy)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ steps.image-ref.outputs.ref }}
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "0"
+          ignore-unfixed: true
+          output: trivy-report.txt
+
+      - name: Publish Trivy report to job summary
+        if: always()
+        run: |
+          {
+            echo "## Trivy image scan — \`${{ steps.image-ref.outputs.ref }}\`"
+            echo ""
+            echo '```'
+            cat trivy-report.txt 2>/dev/null || echo "(no report produced)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,9 @@ jobs:
           echo "ref=ghcr.io/cyoda-platform/cyoda:${version}" >> "$GITHUB_OUTPUT"
 
       - name: Scan release image (Trivy)
-        uses: aquasecurity/trivy-action@0.28.0
+        # Pin to >= v0.35.0; earlier versions are covered by
+        # GHSA-69fq-xp46-6x23 (briefly-compromised supply chain).
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ steps.image-ref.outputs.ref }}
           format: table

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,14 +56,15 @@ go test -tags cyoda_recon ./test/recon/   # reconciliation (optional, needs Clou
 
 ## CI checks
 
-Every PR must pass the following gates before it can be merged (see `.github/workflows/ci.yml`):
+Every PR must pass the following gates before it can be merged:
 
-| Job | Purpose |
-|-----|---------|
-| `test` | Unit + integration tests, race detector, `go build`. |
-| `per-module-hygiene` | Each plugin module builds and vets independently with `GOWORK=off` (protects downstream consumers). |
-| `security` | `govulncheck` against the root module and each plugin submodule; `actions/dependency-review-action` on PR diffs. |
-| `shellcheck` | Lint for shell scripts. |
+| Job | Workflow | Purpose |
+|-----|----------|---------|
+| `test` | `ci.yml` | Unit + integration tests, race detector, `go build`. |
+| `per-module-hygiene` | `ci.yml` | Each plugin module builds and vets independently with `GOWORK=off` (protects downstream consumers). |
+| `security` | `ci.yml` | `govulncheck` against the root module and each plugin submodule; `actions/dependency-review-action` on PR diffs. |
+| `Analyze Go` | `codeql.yml` | CodeQL static analysis (`security-and-quality` pack). Findings surface in the Security tab and as PR annotations. Also runs on a weekly cron. |
+| `shellcheck` | `ci.yml` | Lint for shell scripts. |
 
 The `security` job is blocking: any vulnerability finding in the call graph, or any new dependency at `moderate` severity or above, fails the PR. To reproduce locally:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,29 @@ go test -tags cyoda_recon ./test/recon/   # reconciliation (optional, needs Clou
 | `go test -coverprofile=coverage.out ./...` | Test coverage |
 | `./scripts/dev/run-docker-dev.sh` | Start with Docker + PostgreSQL |
 
+## CI checks
+
+Every PR must pass the following gates before it can be merged (see `.github/workflows/ci.yml`):
+
+| Job | Purpose |
+|-----|---------|
+| `test` | Unit + integration tests, race detector, `go build`. |
+| `per-module-hygiene` | Each plugin module builds and vets independently with `GOWORK=off` (protects downstream consumers). |
+| `security` | `govulncheck` against the root module and each plugin submodule; `actions/dependency-review-action` on PR diffs. |
+| `shellcheck` | Lint for shell scripts. |
+
+The `security` job is blocking: any vulnerability finding in the call graph, or any new dependency at `moderate` severity or above, fails the PR. To reproduce locally:
+
+```bash
+go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+govulncheck ./...
+(cd plugins/memory && govulncheck ./...)
+(cd plugins/postgres && govulncheck ./...)
+(cd plugins/sqlite && govulncheck ./...)
+```
+
+Release builds additionally run a Trivy scan against the published GHCR image (`.github/workflows/release.yml`). Results are surfaced in the release run's job summary. This is advisory — the tag is already published by the time Trivy runs; pre-merge gating is the `security` job's responsibility.
+
 ## Dependencies
 
 No external web frameworks. No DI frameworks. No ORM.


### PR DESCRIPTION
## Summary

Adds the four continuous security gates from #67:

### Pre-merge (blocking) — `ci.yml` `security` job
- `govulncheck` against the root module and each plugin submodule (`plugins/memory`, `plugins/postgres`, `plugins/sqlite` — own `go.mod`, independently consumable, must be scanned separately).
- `actions/dependency-review-action@v4` on PR diffs, `fail-on-severity: moderate`.
- Govulncheck binary pinned at `v1.1.4`; the vulnerability DB is still fetched fresh at scan time.

### Pre-merge (findings surfaced) — `codeql.yml`
- GitHub-hosted CodeQL, `security-and-quality` query pack (broader than security-extended — includes code-quality queries).
- Runs on PR, push to main, and Monday 06:00 UTC cron.
- Findings appear in the Security tab and as PR annotations.
- Explicit `go build ./...` so every module in the `go.work` workspace is observed.
- Free for public repos — no GHAS license.

### Post-release (advisory) — `release.yml` Trivy scan
- Scans `ghcr.io/cyoda-platform/cyoda:<version>` after goreleaser publishes it.
- `severity: CRITICAL,HIGH`, `ignore-unfixed: true`, rendered into the run's job summary.
- Advisory by design: the tag is already in GHCR when Trivy runs; pre-merge gating is `security`'s job.
- Image ref strips the leading `v` to match goreleaser's `{{ .Version }}` template.

### Docs
`CONTRIBUTING.md` **CI checks** section enumerates every gate (now including CodeQL) with workflow location and local reproduction commands.

## Verification

- `govulncheck ./...` locally at root and in all three plugin submodules: no findings.
- `actionlint` on all three workflow files: clean.
- YAML parse check on all three: clean.

End-to-end verification happens when this PR runs through CI — the new jobs execute against their own diff.

## Test plan

- [ ] `security` job passes on this PR.
- [ ] `dependency-review` step runs (no `go.mod` changes — should pass trivially).
- [ ] `CodeQL / Analyze Go` job runs and uploads results.
- [ ] Existing jobs (`test`, `per-module-hygiene`, `shellcheck`) unaffected.
- [ ] On the next release, Trivy step runs and posts to the job summary.

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)