### PR TITLE
fix(release): stamp version on help-JSON goreleaser hook (#101)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,10 @@ before:
     - env GOWORK=off go mod download
     - env GOWORK=off go mod verify
     - bash -c 'mkdir -p .release-extras && tar -czf ".release-extras/cyoda_help_{{ .Version }}.tar.gz" -C cmd/cyoda/help content'
-    - bash -c 'go run ./cmd/cyoda help --format=json > ".release-extras/cyoda_help_{{ .Version }}.json"'
+    # `go run` does not apply the `builds:` ldflags, so stamp main.version
+    # explicitly — otherwise the emitted JSON ships with main.version="dev"
+    # instead of the tagged version (issue #101).
+    - bash -c 'go run -ldflags="-X main.version={{ .Version }}" ./cmd/cyoda help --format=json > ".release-extras/cyoda_help_{{ .Version }}.json"'
 
 builds:
   - id: cyoda

--- a/cmd/release-preflight/goreleaser_test.go
+++ b/cmd/release-preflight/goreleaser_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestGoreleaserHelpJSONHasVersionLdflags is a regression test for issue #101.
+//
+// The .goreleaser.yaml before-hooks generate cyoda_help_<version>.json by
+// invoking `go run ./cmd/cyoda help --format=json`. `go run` does not apply
+// the `builds:` ldflags, so without an explicit -ldflags flag on the hook
+// itself, main.version keeps its source default ("dev") and the JSON asset
+// ships with `"version": "dev"` instead of the tagged release version.
+//
+// This test fails if the hook is missing -ldflags '-X main.version=...'.
+func TestGoreleaserHelpJSONHasVersionLdflags(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", ".goreleaser.yaml"))
+	if err != nil {
+		t.Fatalf("read .goreleaser.yaml: %v", err)
+	}
+	helpHookRe := regexp.MustCompile(`(?m)^.*go run .*\./cmd/cyoda.*help.*--format=json.*$`)
+	matches := helpHookRe.FindAllString(string(data), -1)
+	if len(matches) == 0 {
+		t.Fatalf("no help-JSON generation hook found in .goreleaser.yaml — did it move?")
+	}
+	for _, hook := range matches {
+		if !strings.Contains(hook, "-ldflags") || !strings.Contains(hook, "-X main.version=") {
+			t.Errorf("help-JSON hook missing -ldflags with -X main.version=...:\n  %s", hook)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `.goreleaser.yaml` before-hook `go run ./cmd/cyoda help --format=json` did not inherit `builds:` ldflags, so the emitted `cyoda_help_<ver>.json` shipped with `"version": "dev"`.
- Pass `-ldflags="-X main.version={{ .Version }}"` explicitly on the hook's `go run`.
- Regression test in `cmd/release-preflight/goreleaser_test.go` parses `.goreleaser.yaml` and asserts the help-JSON hook carries the ldflags stamp.

Closes #101.

## Test plan
- [x] `go test ./cmd/release-preflight/ -v` — new test fails before fix, passes after
- [x] `goreleaser check` — config still valid
- [x] Behavioral: `go run -ldflags="-X main.version=v9.9.9-test" ./cmd/cyoda help --format=json` emits `"version": "v9.9.9-test"`
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)