### PR TITLE
fix(cluster): gossip.Register honors ctx / CYODA_STARTUP_TIMEOUT (#9)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -304,7 +304,9 @@ func New(cfg Config) *App {
 		// gossipReg was created above (before plugin.NewFactory) so the plugin
 		// could subscribe to broadcast topics. Join the cluster now; subscribers
 		// are already registered, so no messages are dropped.
-		if err := gossipReg.Register(context.Background(), cfg.Cluster.NodeID, cfg.Cluster.NodeAddr); err != nil {
+		// Use startupCtx so the gossip join honors CYODA_STARTUP_TIMEOUT
+		// (issue #9) instead of the legacy hard-coded 2-minute deadline.
+		if err := gossipReg.Register(startupCtx, cfg.Cluster.NodeID, cfg.Cluster.NodeAddr); err != nil {
 			slog.Error("failed to register with gossip cluster", "pkg", "cluster", "err", err)
 			os.Exit(1)
 		}

--- a/cmd/cyoda/help/content/config.md
+++ b/cmd/cyoda/help/content/config.md
@@ -62,7 +62,7 @@ loads `cyoda.postgres.env` and `cyoda.otel.env` from the working directory.
 - `CYODA_ERROR_RESPONSE_MODE` (string, default: `sanitized`) — error detail level: `sanitized` (generic message + ticket UUID for 5xx) or `verbose` (internal error detail included in responses; development use only).
 - `CYODA_LOG_LEVEL` (string, default: `info`) — accepted: `debug|info|warn|error`.
 - `CYODA_SUPPRESS_BANNER` (bool, default: `false`) — silence startup and mock-auth banners.
-- `CYODA_STARTUP_TIMEOUT` (duration, default: `30s`) — deadline for plugin and TM init.
+- `CYODA_STARTUP_TIMEOUT` (duration, default: `30s`) — deadline for plugin init, TM init, and (cluster mode) the gossip seed-join retry loop.
 - `CYODA_DEBUG` — reserved; not currently read by the server.
 - `CYODA_MAX_STATE_VISITS` (int, default: `10`) — max visits per state in workflow cascade.
 - `CYODA_MODEL_CACHE_LEASE` (duration, default: `5m`) — model cache lease duration; actual expiry is jittered ±10%.

--- a/internal/cluster/registry/gossip.go
+++ b/internal/cluster/registry/gossip.go
@@ -95,7 +95,11 @@ func NewGossip(cfg GossipConfig) (*Gossip, error) {
 
 // Register joins the cluster seeds. If no seeds are configured, the node
 // proceeds as a cluster of one. Self-addresses are filtered from the seed list.
-func (g *Gossip) Register(_ context.Context, _ string, _ string) error {
+//
+// The retry loop and stability-window wait are bounded by ctx — callers set
+// the join deadline via context.WithTimeout (typically cfg.StartupTimeout).
+// A nil/background context makes the retry loop unbounded; pass a deadline.
+func (g *Gossip) Register(ctx context.Context, _ string, _ string) error {
 	seeds := g.filterSelf(g.cfg.Seeds)
 	if len(seeds) == 0 {
 		slog.Info("no seeds configured, proceeding as cluster of one",
@@ -105,24 +109,21 @@ func (g *Gossip) Register(_ context.Context, _ string, _ string) error {
 		return nil
 	}
 
-	// Exponential backoff: 500ms initial, 10s max, 2min deadline.
 	const (
 		initialBackoff = 500 * time.Millisecond
 		maxBackoff     = 10 * time.Second
-		deadline       = 2 * time.Minute
 	)
 
 	start := time.Now()
 	backoff := initialBackoff
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("join seeds after %v: %w", time.Since(start), err)
+		}
 		_, err := g.list.Join(seeds)
 		if err == nil {
 			break
-		}
-		elapsed := time.Since(start)
-		if elapsed+backoff > deadline {
-			return fmt.Errorf("join seeds after %v: %w", elapsed, err)
 		}
 		slog.Warn("failed to join seeds, retrying",
 			"pkg", "cluster/registry",
@@ -130,19 +131,31 @@ func (g *Gossip) Register(_ context.Context, _ string, _ string) error {
 			"err", err,
 			"backoff", backoff,
 		)
-		time.Sleep(backoff)
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("join seeds after %v: %w", time.Since(start), ctx.Err())
+		case <-timer.C:
+		}
 		backoff = time.Duration(math.Min(float64(backoff*2), float64(maxBackoff)))
 	}
 
 	// Wait for the stability window to allow gossip convergence.
 	// Poll every 200ms; only proceed when the member count is stable for the
-	// full window duration.
+	// full window duration. Cancel early if ctx expires.
 	if g.cfg.StabilityWindow > 0 {
 		const pollInterval = 200 * time.Millisecond
 		lastCount := g.list.NumMembers()
 		stableSince := time.Now()
 		for time.Since(stableSince) < g.cfg.StabilityWindow {
-			time.Sleep(pollInterval)
+			timer := time.NewTimer(pollInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return fmt.Errorf("stability-window wait aborted after %v: %w", time.Since(start), ctx.Err())
+			case <-timer.C:
+			}
 			current := g.list.NumMembers()
 			if current != lastCount {
 				lastCount = current

--- a/internal/cluster/registry/gossip_ctx_test.go
+++ b/internal/cluster/registry/gossip_ctx_test.go
@@ -1,0 +1,93 @@
+package registry_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/internal/cluster/registry"
+)
+
+// TestGossipRegistry_RegisterHonorsContextDeadline is the regression test for
+// issue #9. Previously Register hardcoded a 2-minute retry deadline and
+// ignored the context entirely, so operators who set CYODA_STARTUP_TIMEOUT
+// could still hang for up to 2 minutes when seeds were unreachable.
+//
+// Register must abort with a context error once the caller's deadline elapses.
+func TestGossipRegistry_RegisterHonorsContextDeadline(t *testing.T) {
+	// 127.0.0.1:1 is a privileged port nothing is listening on — Join will
+	// fail with ECONNREFUSED on every attempt.
+	r, err := registry.NewGossip(registry.GossipConfig{
+		NodeID:          "ctx-deadline-node",
+		NodeAddr:        "127.0.0.1:28000",
+		BindAddr:        "127.0.0.1",
+		BindPort:        28946,
+		Seeds:           []string{"127.0.0.1:1"},
+		StabilityWindow: 0,
+	})
+	if err != nil {
+		t.Fatalf("NewGossip: %v", err)
+	}
+	defer r.Deregister(context.Background(), "ctx-deadline-node")
+
+	const deadline = 1500 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	start := time.Now()
+	err = r.Register(ctx, "ctx-deadline-node", "127.0.0.1:28000")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("Register: expected error, got nil after %v", elapsed)
+	}
+	// Allow one extra backoff cycle for the in-flight attempt to unwind.
+	if elapsed > deadline+2*time.Second {
+		t.Errorf("Register took %v; expected to return within ~%v of ctx deadline — does it still ignore the context?", elapsed, deadline)
+	}
+	// The error must reflect the context cancellation, not some unrelated
+	// memberlist failure.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Register err = %v; want wrapped context.DeadlineExceeded", err)
+	}
+}
+
+// TestGossipRegistry_RegisterHonorsCanceledContext verifies that a context
+// canceled before or during Register causes the call to return promptly
+// with context.Canceled.
+func TestGossipRegistry_RegisterHonorsCanceledContext(t *testing.T) {
+	r, err := registry.NewGossip(registry.GossipConfig{
+		NodeID:          "ctx-cancel-node",
+		NodeAddr:        "127.0.0.1:28010",
+		BindAddr:        "127.0.0.1",
+		BindPort:        28947,
+		Seeds:           []string{"127.0.0.1:1"},
+		StabilityWindow: 0,
+	})
+	if err != nil {
+		t.Fatalf("NewGossip: %v", err)
+	}
+	defer r.Deregister(context.Background(), "ctx-cancel-node")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after Register begins so we can observe the abort path.
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err = r.Register(ctx, "ctx-cancel-node", "127.0.0.1:28010")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("Register: expected error, got nil after %v", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("Register took %v after cancel; expected prompt return", elapsed)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Register err = %v; want wrapped context.Canceled", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `gossip.Register` ignored the context and hard-coded a 2-minute retry deadline, so `CYODA_STARTUP_TIMEOUT` did not apply to the seed-join phase.
- Register now drives its retry-loop and stability-window waits off `ctx`: `ctx.Err()` check before each Join, `select` on `ctx.Done()` for the backoff sleep and the stability poll. The hard-coded 2-minute deadline is removed — ctx is the sole authority.
- `app.New` now passes the existing `startupCtx` (bounded by `cfg.StartupTimeout`) into `Register` instead of `context.Background()`.
- Help topic updated: `CYODA_STARTUP_TIMEOUT` now documents coverage of the gossip join.

Closes #9.

## Test plan
- [x] `go test ./internal/cluster/registry/ -v` — new ctx tests PASS; existing TwoNodes/TagPropagation/LookupUnknown still pass
- [x] `go test -race ./internal/cluster/registry/` clean
- [x] `go test -short ./...` clean
- [x] `go vet ./...` clean
- [x] Behavioral: unreachable seed + 1.5s ctx deadline → Register returns in ~1.5s with `context.DeadlineExceeded` (previously hung ~2 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)