### PR TITLE
fix(release): drop brew post_install; revise caveats (#96)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -82,18 +82,22 @@ brews:
       bin.install "cyoda"
     test: |
       system bin/"cyoda", "--help"
-    post_install: |
-      system bin/"cyoda", "init"
+    # No post_install: Homebrew sandboxes post_install and denies writes to
+    # $HOME, so `cyoda init` always failed on macOS and emitted a warning on
+    # every install. The caveats block below already tells users how to run
+    # init when they want to (issue #96).
     caveats: |
       ==============================================================
-      cyoda is configured to use sqlite with data stored in
-      #{Dir.home}/.local/share/cyoda/cyoda.db
+      cyoda is installed but not yet initialised. Run:
 
-      If you want to reconfigure, run:
-        cyoda init --force
+        cyoda init
 
-      Or set CYODA_STORAGE_BACKEND in your shell environment to
-      override the packaged default.
+      to write the default sqlite configuration to
+      #{Dir.home}/.config/cyoda/ with data stored in
+      #{Dir.home}/.local/share/cyoda/cyoda.db.
+
+      Alternatively, set CYODA_STORAGE_BACKEND and related env vars
+      in your shell environment to run without an on-disk config.
       ==============================================================
 
 checksum:

--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ brew tap cyoda-platform/cyoda-go
 brew install cyoda
 ```
 
-The formula automatically runs `cyoda init` after install, enabling
-sqlite persistence with data stored in `~/.local/share/cyoda/cyoda.db`.
+After install, run `cyoda init` to write the default sqlite config to
+`~/.config/cyoda/cyoda.env` (data file at `~/.local/share/cyoda/cyoda.db`),
+or set `CYODA_STORAGE_BACKEND` and related env vars in your shell to run
+without an on-disk config. Homebrew does not auto-init because its
+`post_install` sandbox denies writes to `$HOME` (see issue #96).
 
 ### Any Unix via curl
 

--- a/cmd/release-preflight/brew_post_install_test.go
+++ b/cmd/release-preflight/brew_post_install_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// TestGoreleaserBrewHasNoPostInstall is the regression test for issue #96.
+//
+// Homebrew sandboxes the post_install hook and denies writes to $HOME.
+// Our previous formula tried to invoke `cyoda init` from post_install,
+// which always failed on macOS and emitted a warning on every install.
+// The generated Caveats block already tells users how to run init when
+// they want to — no auto-init at install time is needed.
+//
+// This test fails if `.goreleaser.yaml` regrows a `post_install:` stanza
+// under `brews:`.
+func TestGoreleaserBrewHasNoPostInstall(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", ".goreleaser.yaml"))
+	if err != nil {
+		t.Fatalf("read .goreleaser.yaml: %v", err)
+	}
+	// Match a `post_install:` YAML key indented under any block. The
+	// goreleaser `brews:` schema only places post_install under a brew
+	// entry, so any occurrence is the regression we're guarding.
+	postInstallRe := regexp.MustCompile(`(?m)^\s*post_install\s*:`)
+	if postInstallRe.MatchString(string(data)) {
+		t.Errorf("`.goreleaser.yaml` contains a post_install stanza — the Homebrew formula must not auto-invoke `cyoda init` (issue #96).")
+	}
+}


### PR DESCRIPTION
## Summary
- Homebrew sandboxes `post_install` and denies writes to `\$HOME`, so the formula's `cyoda init` always failed on macOS and emitted a warning on every install / upgrade.
- Remove the `post_install:` stanza from `.goreleaser.yaml`'s `brews:` block. Users run `cyoda init` themselves when they want sqlite config on disk.
- Caveats rewritten — previously it claimed "cyoda is configured to use sqlite..." which was false when the sandboxed init had failed. Now it directs the user to run init or to use env vars.
- Regression test in `cmd/release-preflight/brew_post_install_test.go` fails if any `post_install:` stanza regrows under `brews:`.

Closes #96.

## Test plan
- [x] `go test ./cmd/release-preflight/ -v` — new test fails before fix, passes after
- [x] `goreleaser check` — config still valid
- [x] Manual inspection: caveats block no longer claims auto-configured state
- [ ] Post-merge: tagged release produces a formula without `def post_install`; `brew install` / `brew upgrade` emit no post-install warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)