### PR TITLE
build(ci): aggregator for plugin submodule tests (#46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,22 @@ jobs:
       - name: Run tests with race detector
         run: go test -race ./...
 
+      # Plugin submodules each have their own go.mod, so `./...` from the root
+      # does not recurse into them. Run tests inside each module so CI does
+      # not miss regressions (issue #46). Postgres plugin uses testcontainers-go;
+      # ubuntu-latest provides the Docker socket.
+      - name: Run plugins/memory tests
+        working-directory: plugins/memory
+        run: go test -v ./...
+
+      - name: Run plugins/sqlite tests
+        working-directory: plugins/sqlite
+        run: go test -v ./...
+
+      - name: Run plugins/postgres tests
+        working-directory: plugins/postgres
+        run: go test -v ./...
+
       - name: Build
         run: go build -o bin/cyoda ./cmd/cyoda
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,8 @@ aggregator targets below when you want coverage across the whole repo.
 - Test (root + every plugin submodule): `make test-all` — covers root + `plugins/memory|sqlite|postgres`; Docker required for postgres testcontainers
 - Test (root + plugins, short): `make test-short-all`
 - Test (E2E only): `go test ./internal/e2e/... -v`
-- Coverage: `go test -coverprofile=coverage.out ./...`
-- Race detector: `go test -race ./...`
+- Coverage (root module): `go test -coverprofile=coverage.out ./...` — run inside each `plugins/*` for per-plugin coverage
+- Race detector (root module): `go test -race ./...`
 - Build: `go build -o bin/cyoda ./cmd/cyoda`
 - Tidy: `go mod tidy`
-- Vet: `go vet ./...`
+- Vet (root module): `go vet ./...` — the `per-module-hygiene` CI job vets each plugin separately

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,8 +97,15 @@ Review and security audit prevent defects reaching main.
 
 ## Common Commands
 
-- Test (all): `go test ./... -v` (includes E2E — requires Docker)
-- Test (unit only): `go test -short ./... -v`
+Plugin submodules (`plugins/memory`, `plugins/sqlite`, `plugins/postgres`)
+each have their own `go.mod`; Go's `./...` recursion does **not** cross
+module boundaries, so root-module commands miss them. Use the `-all`
+aggregator targets below when you want coverage across the whole repo.
+
+- Test (root module): `go test ./... -v` — root incl. internal/e2e (requires Docker)
+- Test (root module, unit only): `go test -short ./... -v`
+- Test (root + every plugin submodule): `make test-all` — covers root + `plugins/memory|sqlite|postgres`; Docker required for postgres testcontainers
+- Test (root + plugins, short): `make test-short-all`
 - Test (E2E only): `go test ./internal/e2e/... -v`
 - Coverage: `go test -coverprofile=coverage.out ./...`
 - Race detector: `go test -race ./...`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: dev-up dev-down dev-ps dev-logs dev-run dev-test build test clean docker-build docker-push todos
+.PHONY: dev-up dev-down dev-ps dev-logs dev-run dev-test build test test-all test-short-all clean docker-build docker-push todos
+
+# Plugin submodules: each has its own go.mod, so `go test ./...` from the
+# repo root does not recurse into them. The aggregator targets below close
+# that coverage gap (issue #46).
+PLUGIN_MODULES := plugins/memory plugins/sqlite plugins/postgres
 
 # --- Docker services ---
 
@@ -48,8 +53,22 @@ endif
 
 # --- Testing ---
 
-test:                  ## Run all tests (postgres tests skipped without DB)
+test:                  ## Run root-module tests only (plugin submodules skipped — see test-all)
 	go test ./... -v
+
+test-all:              ## Run root + every plugin submodule (requires Docker for postgres)
+	go test ./... -v
+	@for m in $(PLUGIN_MODULES); do \
+	  echo "==> go test ./... in $$m"; \
+	  (cd $$m && go test ./... -v) || exit $$?; \
+	done
+
+test-short-all:        ## Run root + every plugin submodule with -short (quick coverage check)
+	go test -short ./... -v
+	@for m in $(PLUGIN_MODULES); do \
+	  echo "==> go test -short ./... in $$m"; \
+	  (cd $$m && go test -short ./... -v) || exit $$?; \
+	done
 
 dev-test: dev-up       ## Run all tests against local postgres
 	set -a && . .env.dev && set +a && go test ./... -v -count=1


### PR DESCRIPTION
## Summary
- Plugin submodules (`plugins/memory`, `plugins/sqlite`, `plugins/postgres`) each have their own `go.mod`. Go's `./...` recursion does **not** cross module boundaries, so `go test ./...` from the repo root never touches them. This caused one regression escape already (PR #44 → #45 post-hoc fix).
- Added `make test-all` + `make test-short-all` aggregator targets that invoke `go test` in the root and every plugin submodule.
- Extended CI's `test` job with explicit `go test -v ./...` steps per plugin module — submodule regressions now block PRs.
- Updated `CLAUDE.md` Common Commands so the module-boundary quirk is documented and future contributors know to use `make test-all` for whole-repo coverage.

Closes #46.

## Test plan
- [x] `make -n test-short-all` prints the expected command set (root + 3 plugins)
- [x] `make test-short-all` runs locally: root + memory + sqlite + postgres, all green
- [x] CI `test` job extended with 3 new steps — plugin regressions will now fail CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)