### PR TITLE
chore(helm): bump chart version and appVersion to 0.6.2

### DIFF
--- a/deploy/helm/cyoda/Chart.yaml
+++ b/deploy/helm/cyoda/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   Postgres, fronted by Gateway API (default) or a still-maintained Ingress
   controller (transitional).
 type: application
-version: 0.1.0
-appVersion: "0.1.0"  # bump-chart-appversion.yml syncs this to the binary
+version: 0.6.2
+appVersion: "0.6.2"  # bump-chart-appversion.yml syncs this to the binary
 kubeVersion: ">=1.31.0"
 keywords:
   - cyoda
@@ -21,4 +21,4 @@ maintainers:
     url: https://github.com/cyoda-platform
 annotations:
   artifacthub.io/changes: |
-    - Initial chart release
+    - Chart and appVersion synced to the v0.6.x binary series


### PR DESCRIPTION
## Summary
- `Chart.yaml` was stuck at `version/appVersion: 0.1.0` since initial chart release, despite the chart shipping as part of the v0.6.x binary series.
- Two automated `chore(helm)` PRs had accumulated in the backlog:
  - #88 (`chore(helm): bump chart appVersion to v0.6.0`)
  - #95 (`chore(helm): bump chart appVersion to v0.6.1`)
- Instead of merging them incrementally, bump both `version` and `appVersion` directly to `0.6.2` to align the chart's own semver with the binary.
- `artifacthub.io/changes` annotation updated from the stale "Initial chart release" text.

The `bump-chart-appversion.yml` workflow stays in place — post-v0.6.2 tag it will propose another appVersion bump (which will be a no-op diff since the value is already correct) for human review.

## Follow-up in this PR
After merge I'll close #88 and #95 as superseded with a pointer back to this PR.

## Notes
- Pre-existing `helm lint` errors (values.yaml requires `postgres.existingSecret` / `jwt.existingSecret` to be supplied by the caller) exist independent of the version fields; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)