### PR TITLE
fix(common): make Conflict() non-retryable; add RetryableConflict() for TX aborts

### DIFF
--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -57,8 +57,34 @@ func Operational(status int, code string, message string) *AppError {
 	}
 }
 
-// Conflict creates a 409 Conflict error with retryable=true.
+// Conflict creates a 409 Conflict error for a permanent, non-retryable
+// business-logic conflict (e.g. "model already locked", ETag mismatch on
+// If-Match, "cannot delete: entities exist"). Retrying the same request
+// without a state change will never succeed, so retryable defaults to false.
+//
+// For transient conflicts that ARE expected to succeed on retry (e.g.
+// SERIALIZABLE 40001/40P01 transaction aborts) use RetryableConflict.
 func Conflict(message string) *AppError {
+	return &AppError{
+		Level:     LevelOperational,
+		Status:    http.StatusConflict,
+		Code:      ErrCodeConflict,
+		Message:   fmt.Sprintf("%s: %s", ErrCodeConflict, message),
+		Retryable: false,
+	}
+}
+
+// RetryableConflict creates a 409 Conflict error that the parity HTTP client
+// (e2e/parity/client/http.go isRetryableConflict) is allowed to retry. Use it
+// only for transient conflicts that depend on concurrent state and may
+// succeed on a fresh attempt — typically SERIALIZABLE transaction aborts and
+// optimistic-lock failures triggered by concurrent writers.
+//
+// Permanent business conflicts (locked-state mismatches, ETag mismatches,
+// cardinality precondition failures) MUST use Conflict — calling those
+// retryable causes pointless backoff and 5x request amplification on the
+// client side.
+func RetryableConflict(message string) *AppError {
 	return &AppError{
 		Level:     LevelOperational,
 		Status:    http.StatusConflict,
@@ -71,12 +97,12 @@ func Conflict(message string) *AppError {
 // Internal creates a 500 error with internal detail from the wrapped error.
 //
 // If the wrapped error is (or wraps) spi.ErrConflict, the result is routed to
-// Conflict() instead — a serialization abort (40001/40P01) that fully rolled
-// back is retryable, not a server error. This keeps every call site honest
-// without forcing each to reason about pgx error codes.
+// RetryableConflict instead — a serialization abort (40001/40P01) that fully
+// rolled back is retryable, not a server error. This keeps every call site
+// honest without forcing each to reason about pgx error codes.
 func Internal(message string, err error) *AppError {
 	if err != nil && errors.Is(err, spi.ErrConflict) {
-		return Conflict("transaction conflict — retry")
+		return RetryableConflict("transaction conflict — retry")
 	}
 	detail := ""
 	if err != nil {

--- a/internal/common/errors_test.go
+++ b/internal/common/errors_test.go
@@ -293,3 +293,89 @@ func TestErrCodeSearchResultLimit(t *testing.T) {
 		t.Errorf("got %q", common.ErrCodeSearchResultLimit)
 	}
 }
+
+// TestConflict_NotRetryableByDefault pins the behavior change for #126:
+// a plain Conflict represents a permanent business-logic conflict (e.g.
+// "model already locked", ETag mismatch on If-Match). The parity HTTP
+// client retries on properties.retryable=true; if Conflict were retryable
+// every permanent conflict would burn 5 attempts × 30+ms backoff before
+// surfacing to the caller.
+func TestConflict_NotRetryableByDefault(t *testing.T) {
+	err := common.Conflict("model already locked")
+	if err.Status != http.StatusConflict {
+		t.Errorf("status = %d, want 409", err.Status)
+	}
+	if err.Retryable {
+		t.Error("Conflict() must default to retryable=false (permanent business conflict)")
+	}
+	if err.Level != common.LevelOperational {
+		t.Errorf("level = %v, want Operational", err.Level)
+	}
+}
+
+// TestRetryableConflict_RetryableTrue pins the new constructor's contract:
+// transient transaction-abort style conflicts must opt in via this helper
+// so the parity client retry loop can engage.
+func TestRetryableConflict_RetryableTrue(t *testing.T) {
+	err := common.RetryableConflict("transaction conflict — retry")
+	if err.Status != http.StatusConflict {
+		t.Errorf("status = %d, want 409", err.Status)
+	}
+	if !err.Retryable {
+		t.Error("RetryableConflict() must set retryable=true")
+	}
+	if err.Code != common.ErrCodeConflict {
+		t.Errorf("code = %q, want %q", err.Code, common.ErrCodeConflict)
+	}
+}
+
+// TestWriteError_PermanentConflict_NoRetryableProperty verifies the wire
+// shape the parity client sees: when retryable=false the response body
+// must NOT advertise properties.retryable=true. Without that, the
+// client would amplify load 5x on every business-logic 409.
+func TestWriteError_PermanentConflict_NoRetryableProperty(t *testing.T) {
+	common.SetErrorResponseMode("sanitized")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/test", nil)
+
+	common.WriteError(w, r, common.Conflict("model already locked"))
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409", w.Code)
+	}
+	var pd map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&pd); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	props, _ := pd["properties"].(map[string]any)
+	if props == nil {
+		t.Fatal("expected properties map in problem detail")
+	}
+	if v, ok := props["retryable"]; ok {
+		t.Errorf("permanent conflict must omit properties.retryable, got %v", v)
+	}
+}
+
+// TestWriteError_RetryableConflict_AdvertisesRetryable verifies the
+// retry-eligible path still advertises properties.retryable=true so the
+// parity client can engage its backoff loop.
+func TestWriteError_RetryableConflict_AdvertisesRetryable(t *testing.T) {
+	common.SetErrorResponseMode("sanitized")
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/test", nil)
+
+	common.WriteError(w, r, common.RetryableConflict("transaction conflict — retry"))
+
+	var pd map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&pd); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	props, _ := pd["properties"].(map[string]any)
+	if props == nil {
+		t.Fatal("expected properties map in problem detail")
+	}
+	got, ok := props["retryable"].(bool)
+	if !ok || !got {
+		t.Errorf("retryable conflict must advertise properties.retryable=true, got %v", props["retryable"])
+	}
+}

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -226,7 +226,7 @@ func (h *Handler) CreateEntity(ctx context.Context, input CreateEntityInput) (*E
 	// Commit transaction.
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.Conflict("transaction conflict — retry")
+			return nil, common.RetryableConflict("transaction conflict — retry")
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}
@@ -487,7 +487,7 @@ func (h *Handler) DeleteEntity(ctx context.Context, entityID string) (*deleteEnt
 	// Commit transaction.
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.Conflict("transaction conflict — retry")
+			return nil, common.RetryableConflict("transaction conflict — retry")
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}
@@ -607,7 +607,7 @@ func (h *Handler) DeleteAllEntities(ctx context.Context, entityName string, mode
 	// Commit transaction.
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.Conflict("transaction conflict — retry")
+			return nil, common.RetryableConflict("transaction conflict — retry")
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}
@@ -787,7 +787,7 @@ func (h *Handler) CreateEntityCollection(ctx context.Context, items []Collection
 	// Commit transaction.
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.Conflict("transaction conflict — retry")
+			return nil, common.RetryableConflict("transaction conflict — retry")
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}
@@ -927,7 +927,7 @@ func (h *Handler) UpdateEntity(ctx context.Context, input UpdateEntityInput) (*E
 	// Commit transaction.
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.Conflict("transaction conflict — retry")
+			return nil, common.RetryableConflict("transaction conflict — retry")
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}
@@ -1065,7 +1065,7 @@ func (h *Handler) UpdateEntityCollection(ctx context.Context, items []UpdateColl
 
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.Conflict("transaction conflict — retry")
+			return nil, common.RetryableConflict("transaction conflict — retry")
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}


### PR DESCRIPTION
Closes #126.

## What

`common.Conflict()` baked `Retryable=true` into every 409. The parity
HTTP client (`e2e/parity/client/http.go isRetryableConflict`) reads
that flag and retries up to 5 times. Permanent business-logic conflicts
(model already locked, If-Match ETag mismatch, "cannot delete: N
entities exist") will never succeed without a state change, so calling
them retryable causes 5x request amplification on every permanent 409.

This PR:

- `Conflict()` now returns `Retryable=false`. This is the right default
  for the bulk of current callers in `internal/domain/model/service.go`
  ("already locked", "not locked", entities-exist preventing unlock/
  delete) and the If-Match path in `internal/domain/entity/service.go`
  (line 911), all of which are permanent without external state change.
- New `RetryableConflict()` constructor for transient conflicts
  (SERIALIZABLE 40001/40P01 transaction aborts, optimistic-lock
  failures triggered by concurrent writers).
- Six TX-commit conflict spots in `internal/domain/entity/service.go`
  (lines 229, 490, 610, 790, 930, 1068) switched to
  `RetryableConflict`.
- `Internal()`'s `spi.ErrConflict` auto-routing also switched to
  `RetryableConflict` — same Retryable=true semantics as before, just
  via the new explicit name.

## Caller audit

| File | Caller | Before | After | Reason |
|---|---|---|---|---|
| entity/service.go:229 | TX commit aborted | retryable | retryable (RetryableConflict) | 40001/40P01 — succeeds on retry |
| entity/service.go:490 | TX commit aborted | retryable | retryable (RetryableConflict) | same |
| entity/service.go:610 | TX commit aborted | retryable | retryable (RetryableConflict) | same |
| entity/service.go:790 | TX commit aborted | retryable | retryable (RetryableConflict) | same |
| entity/service.go:911 | If-Match ETag mismatch | retryable | **non-retryable** (Conflict) | client must re-read first; same If-Match always fails |
| entity/service.go:930 | TX commit aborted | retryable | retryable (RetryableConflict) | 40001/40P01 |
| entity/service.go:1068 | TX commit aborted | retryable | retryable (RetryableConflict) | 40001/40P01 |
| model/service.go:115 | model already registered | retryable | **non-retryable** (Conflict) | permanent — needs delete |
| model/service.go:221 | model already locked | retryable | **non-retryable** (Conflict) | permanent — needs unlock |
| model/service.go:263 | model is not locked | retryable | **non-retryable** (Conflict) | permanent — needs lock |
| model/service.go:276 | cannot unlock: N entities exist | retryable | **non-retryable** (Conflict) | permanent — needs entity delete |
| model/service.go:320 | cannot delete: N entities exist | retryable | **non-retryable** (Conflict) | permanent — needs entity delete |
| Internal() route | spi.ErrConflict | retryable | retryable (RetryableConflict) | unchanged behavior |

## Tests

- `TestConflict_NotRetryableByDefault` — pins `Retryable=false` default.
- `TestRetryableConflict_RetryableTrue` — pins the new constructor's
  `Retryable=true` contract.
- `TestWriteError_PermanentConflict_NoRetryableProperty` — verifies the
  RFC 9457 problem detail body the client sees: permanent 409s OMIT
  `properties.retryable`.
- `TestWriteError_RetryableConflict_AdvertisesRetryable` — verifies
  retry-eligible 409s still advertise `properties.retryable=true`.
- Existing `TestInternal_AutoRoutesErrConflict` still passes — the
  TX-commit auto-route still surfaces retryable=true as before.

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test -race -count=1 ./internal/common/... ./internal/domain/...` ✅
  (all 11 internal/domain packages green under -race)
- E2E (`internal/e2e/`) requires Docker; not run locally — CI will
  exercise it.