### PR TITLE
fix(sqlite): derive CountByState IN-clause cap from SQLITE_MAX_VARIABLE_NUMBER (#68 item 11)

### DIFF
--- a/plugins/sqlite/count_by_state_cap_test.go
+++ b/plugins/sqlite/count_by_state_cap_test.go
@@ -9,14 +9,15 @@ import (
 	"github.com/cyoda-platform/cyoda-go/plugins/sqlite"
 )
 
-// Regression test for issue #99.
+// Regression tests for issues #99 and #68 (item 11).
 //
-// CountByState's IN-clause is built by string concatenation of `?`
-// placeholder markers (values themselves are bound — no injection risk
-// today). To keep it that way and to prevent attackers from ever pushing
-// past SQLite's bound-variable limit (SQLITE_MAX_VARIABLE_NUMBER, default
-// 999 on some builds), the plugin caps the list length and rejects
-// anything larger via ErrStateFilterTooLarge.
+// CountByState's IN-clause is built from `?` placeholder markers only;
+// state values are bound as SQL parameters (no interpolation). To stay
+// safely under SQLite's bound-variable limit (SQLITE_MAX_VARIABLE_NUMBER,
+// default 999 on builds that haven't been recompiled), the plugin caps
+// the list length at sqliteMaxVariableNumber − countByStateBaseParams
+// and rejects oversized lists via ErrStateFilterTooLarge — see the
+// derivation tests in count_by_state_in_clause_test.go.
 
 // TestCountByState_RejectsTooManyStates asserts the plugin rejects state
 // lists above the cap with ErrStateFilterTooLarge. Without the cap, the

--- a/plugins/sqlite/count_by_state_in_clause_test.go
+++ b/plugins/sqlite/count_by_state_in_clause_test.go
@@ -1,0 +1,127 @@
+package sqlite_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/sqlite"
+)
+
+// Tests for issue #68 item 11 — SQLite IN-clause parameterization.
+//
+// The state-filter IN-clause is composed entirely of `?` markers; state
+// values are bound as SQL parameters. To stay safely under SQLite's
+// SQLITE_MAX_VARIABLE_NUMBER (default 999), the cap on the state list is
+// derived from the SQLite limit minus the count of other parameters bound
+// in the same query (tenant_id, model_name, model_version → 3). Oversized
+// lists are rejected at the helper boundary with a wrapped sentinel error,
+// not a SQL driver-error leak.
+
+// TestCountByState_CapDerivedFromSQLiteVariableLimit asserts the cap is
+// expressed as the SQLite default minus the number of other parameters
+// bound in the CountByState query, rather than an unrelated arbitrary
+// constant. This pins the documented derivation as part of the contract.
+func TestCountByState_CapDerivedFromSQLiteVariableLimit(t *testing.T) {
+	const sqliteDefaultMaxVars = 999
+	const baseParams = 3 // tenant_id, model_name, model_version
+	want := sqliteDefaultMaxVars - baseParams
+	if got := sqlite.MaxStateFilterSize; got != want {
+		t.Fatalf("MaxStateFilterSize = %d; want %d (SQLITE_MAX_VARIABLE_NUMBER %d - %d base params)",
+			got, want, sqliteDefaultMaxVars, baseParams)
+	}
+}
+
+// TestCountByState_ManyStateFilter_ReturnsCorrectCounts pins the
+// many-state-filter execution path: with a state list near the cap, the
+// query must execute without error AND return correct counts for the
+// states actually present in the data set. This guards against any future
+// refactor of the placeholder-list construction silently breaking the
+// IN-clause semantics (e.g. wrong number of `?` markers, wrong arg
+// ordering, off-by-one in the cap).
+func TestCountByState_ManyStateFilter_ReturnsCorrectCounts(t *testing.T) {
+	factory, ctx := setupSearcherTest(t)
+	store, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore: %v", err)
+	}
+
+	// The setup helper saves 5 entities all in state "NEW". We construct
+	// a state list at the cap and place "NEW" at a non-trivial position
+	// to catch any off-by-one in the placeholder/argument ordering.
+	states := make([]string, sqlite.MaxStateFilterSize)
+	for i := range states {
+		states[i] = fmt.Sprintf("STATE_%d", i)
+	}
+	// Replace the middle slot with the state our fixtures actually use.
+	states[len(states)/2] = "NEW"
+
+	got, err := store.CountByState(ctx, spi.ModelRef{EntityName: "person", ModelVersion: "1"}, states)
+	if err != nil {
+		t.Fatalf("CountByState with %d states: %v", len(states), err)
+	}
+
+	if got["NEW"] != 5 {
+		t.Fatalf("CountByState[NEW] = %d; want 5 (got full map: %#v)", got["NEW"], got)
+	}
+	// No other configured state matches any fixture entity.
+	for st, n := range got {
+		if st != "NEW" && n != 0 {
+			t.Errorf("unexpected non-zero count for state %q: %d", st, n)
+		}
+	}
+}
+
+// TestCountByState_SmallStateFilter_ReturnsCorrectCounts is the canonical
+// small-N case: with a 10-element filter, counts for each requested state
+// must be returned correctly. Matched-state buckets get the correct count;
+// non-matched states are simply absent from the result map.
+func TestCountByState_SmallStateFilter_ReturnsCorrectCounts(t *testing.T) {
+	factory, ctx := setupSearcherTest(t)
+	store, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore: %v", err)
+	}
+
+	states := []string{"S0", "S1", "S2", "S3", "S4", "NEW", "S6", "S7", "S8", "S9"}
+
+	got, err := store.CountByState(ctx, spi.ModelRef{EntityName: "person", ModelVersion: "1"}, states)
+	if err != nil {
+		t.Fatalf("CountByState: %v", err)
+	}
+	if got["NEW"] != 5 {
+		t.Fatalf("CountByState[NEW] = %d; want 5", got["NEW"])
+	}
+}
+
+// TestCountByState_OversizedRejection_WrapsSentinelError pins that
+// oversized state lists yield a wrapped sentinel error usable with
+// errors.Is — i.e. NOT a raw SQL driver "too many SQL variables" error
+// leaked through the helper boundary.
+func TestCountByState_OversizedRejection_WrapsSentinelError(t *testing.T) {
+	factory, ctx := setupSearcherTest(t)
+	store, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore: %v", err)
+	}
+
+	// One past the cap.
+	states := make([]string, sqlite.MaxStateFilterSize+1)
+	for i := range states {
+		states[i] = fmt.Sprintf("STATE_%d", i)
+	}
+
+	_, err = store.CountByState(ctx, spi.ModelRef{EntityName: "person", ModelVersion: "1"}, states)
+	if err == nil {
+		t.Fatalf("CountByState: expected error for %d states, got nil", len(states))
+	}
+	if !errors.Is(err, sqlite.ErrStateFilterTooLarge) {
+		t.Fatalf("CountByState err = %v; want errors.Is(err, ErrStateFilterTooLarge)", err)
+	}
+	// The error message should be informative without leaking SQL internals.
+	msg := err.Error()
+	if msg == "" {
+		t.Fatalf("err.Error() returned empty string")
+	}
+}

--- a/plugins/sqlite/entity_store.go
+++ b/plugins/sqlite/entity_store.go
@@ -798,17 +798,34 @@ func (s *entityStore) Count(ctx context.Context, modelRef spi.ModelRef) (int64, 
 	return count, nil
 }
 
+// sqliteMaxVariableNumber matches the conservative default for
+// SQLITE_MAX_VARIABLE_NUMBER. SQLite ≥3.32 raised the compiled-in default
+// to 32766, but builds that haven't been recompiled (and embedded
+// distributions older callers may load) still use 999. We pick the lower
+// bound so the cap holds across all reachable SQLite builds without
+// requiring runtime PRAGMA inspection.
+const sqliteMaxVariableNumber = 999
+
+// countByStateBaseParams is the number of bound parameters in the
+// CountByState query that are NOT state values: tenant_id, model_name,
+// model_version. Each consumed slot reduces what's left for the IN list.
+const countByStateBaseParams = 3
+
 // MaxStateFilterSize caps the number of state names accepted in a
-// CountByState filter. SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999
-// on some builds (32766 on others); the cap below sits well under the
-// conservative limit with room for the three other bound parameters
-// (tenant_id, model_name, model_version). Issue #99 added the cap — state
-// values are already bound as parameters, but a bounded-input contract
-// closes the door on a future caller accidentally passing a huge list.
-const MaxStateFilterSize = 500
+// CountByState filter. The cap is derived from SQLite's bound-variable
+// limit minus the count of other parameters bound in the same query, so
+// the IN-clause `?`-list combined with the base params can never exceed
+// SQLITE_MAX_VARIABLE_NUMBER. State values are already bound as
+// parameters (no interpolation), but the bounded-input contract closes
+// the door on a caller accidentally passing a huge list and triggering a
+// driver-level "too many SQL variables" error rather than a clean
+// helper-boundary rejection. See issue #68 (item 11) and #99.
+const MaxStateFilterSize = sqliteMaxVariableNumber - countByStateBaseParams
 
 // ErrStateFilterTooLarge is returned by CountByState when the caller
-// supplies more state names than MaxStateFilterSize allows.
+// supplies more state names than MaxStateFilterSize allows. Callers can
+// detect it via errors.Is — wrapped with the actual and max sizes to aid
+// diagnostics without leaking SQL driver internals.
 var ErrStateFilterTooLarge = errors.New("state filter exceeds maximum size")
 
 // inPlaceholders returns `?,?,?,...` with n markers. n must be > 0 —
@@ -871,7 +888,18 @@ func (s *entityStore) CountByState(ctx context.Context, modelRef spi.ModelRef, s
 	}
 
 	// Non-transaction: aggregate at the database.
-	args := []any{string(s.tenantID), modelRef.EntityName, modelRef.ModelVersion}
+	// The base parameters bound here MUST match countByStateBaseParams —
+	// MaxStateFilterSize is derived as sqliteMaxVariableNumber minus that
+	// constant, so any drift here would silently let the IN-list-plus-base
+	// total exceed the SQLite variable limit.
+	args := make([]any, 0, countByStateBaseParams+len(states))
+	args = append(args, string(s.tenantID), modelRef.EntityName, modelRef.ModelVersion)
+	if len(args) != countByStateBaseParams {
+		// Defensive: if a future edit adds/removes a base bind, this trips
+		// before the query reaches the driver.
+		return nil, fmt.Errorf("count by state: base param count drift (got %d, want %d)",
+			len(args), countByStateBaseParams)
+	}
 	// Entities with no $._meta.state are bucketed under "" rather than dropped,
 	// preserving them for diagnostic visibility. This matches the in-tx Go path
 	// which reads e.Meta.State (also "" if unset).
@@ -883,7 +911,8 @@ func (s *entityStore) CountByState(ctx context.Context, modelRef spi.ModelRef, s
 		// Build IN (?, ?, ...) placeholder list. The string is built from
 		// `?` markers only — no state value ever enters the query text.
 		// State values are bound as SQL parameters below. Size is bounded
-		// by MaxStateFilterSize above.
+		// by MaxStateFilterSize above (derived from sqliteMaxVariableNumber
+		// minus countByStateBaseParams).
 		q += ` AND json_extract(json(meta), '$.state') IN (` + inPlaceholders(len(states)) + `)`
 		for _, st := range states {
 			args = append(args, st)


### PR DESCRIPTION
## Summary

- Refactors the SQLite `CountByState` state-filter cap from a hard-coded `500` to an explicit derivation: `MaxStateFilterSize = sqliteMaxVariableNumber − countByStateBaseParams = 999 − 3 = 996`. The IN-clause itself was already parameterised (`?`-only string from `inPlaceholders`), so this is a contract-hygiene change rather than an injection fix — the derivation now ties the cap to its underlying constraint.
- Adds a defensive runtime check inside `CountByState` so any future drift in the count of base parameters trips before the query reaches the SQLite driver.
- Continues to wrap `ErrStateFilterTooLarge` on oversized lists so callers can detect the boundary via `errors.Is`, with no SQL driver-error leak.

## Tests

New file `plugins/sqlite/count_by_state_in_clause_test.go`:

- `TestCountByState_CapDerivedFromSQLiteVariableLimit` — pins the formula.
- `TestCountByState_ManyStateFilter_ReturnsCorrectCounts` — cap-sized state list with the matching state placed mid-list; verifies counts are correct.
- `TestCountByState_SmallStateFilter_ReturnsCorrectCounts` — canonical small-N (10) case.
- `TestCountByState_OversizedRejection_WrapsSentinelError` — `errors.Is` path for the boundary rejection.

The pre-existing `count_by_state_cap_test.go` regression suite (issue #99) continues to pass; comment header updated to cross-reference the new file.

## Test plan

- [x] `cd plugins/sqlite && go test ./...` — green.
- [x] `cd plugins/sqlite && go vet ./...` — green.
- [x] `cd plugins/sqlite && go test -race ./...` — green.
- [x] `make test-short-all` from repo root — green (root + memory + sqlite + postgres plugin submodules).

## Issue references

Contributes to #68 (item 11). Do NOT auto-close #68 — other items in flight in separate buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)