### PR TITLE
fix(search): explicit pageNumber cap and bits.Mul64 offset overflow (#68 item 10)

### DIFF
--- a/internal/domain/entity/handler.go
+++ b/internal/domain/entity/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cyoda-platform/cyoda-go/internal/common"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/importer"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/pagination"
 	wfengine "github.com/cyoda-platform/cyoda-go/internal/domain/workflow"
 )
 
@@ -436,6 +437,17 @@ func (h *Handler) GetAllEntities(w http.ResponseWriter, r *http.Request, entityN
 	}
 	if params.PageNumber != nil {
 		pageNumber = *params.PageNumber
+	}
+
+	// Reject negative / over-cap / overflow-prone values BEFORE the
+	// storage lookup. Without this guard, an attacker-supplied
+	// pageNumber=MaxInt32 panics in ListEntities (slice bounds out of
+	// range) and surfaces as 500 — see PR #149 follow-up. ValidateOffset
+	// returns *common.AppError as error; classifyError routes it to the
+	// 400 BAD_REQUEST response.
+	if err := pagination.ValidateOffset(int64(pageNumber), int64(pageSize)); err != nil {
+		common.WriteError(w, r, classifyError(err))
+		return
 	}
 
 	envelopes, err := h.ListEntities(r.Context(), entityName, fmt.Sprintf("%d", modelVersion), PaginationParams{

--- a/internal/domain/entity/handler_pagination_test.go
+++ b/internal/domain/entity/handler_pagination_test.go
@@ -1,0 +1,64 @@
+package entity_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// Regression tests for PR #149 follow-up: GET /entity/{name}/{version} must
+// reject out-of-bound pagination parameters with the same caps as the
+// search endpoints. Validation must happen BEFORE the storage lookup —
+// asserted by passing an unknown entity name (would otherwise be a 404)
+// alongside oversized params and confirming the response is a 400 with a
+// pagination message rather than a not-found.
+
+// TestGetAllEntities_PageSizeExceedsCap_RejectedBeforeStorage — pageSize
+// above MaxPageSize must surface 400 even when the entity model is
+// unknown.
+func TestGetAllEntities_PageSizeExceedsCap_RejectedBeforeStorage(t *testing.T) {
+	srv := newTestServer(t)
+	resp := doGetAllEntitiesRaw(t, srv.URL, "UnknownModel", 1, "pageSize=100000&pageNumber=0")
+	defer resp.Body.Close()
+	body := string(readBody(t, resp))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("pageSize=100000 → got %d, want 400; body: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(strings.ToLower(body), "pagesize") {
+		t.Errorf("expected pageSize error in body, got: %s", body)
+	}
+}
+
+// TestGetAllEntities_PageNumberExceedsCap_RejectedBeforeStorage — even
+// though int32×int32 cannot overflow Go's int64-promoted product on
+// supported platforms, an absurd pageNumber that would let an attacker
+// blow past realistic snapshots must be capped consistently with the
+// async-search path.
+func TestGetAllEntities_PageNumberExceedsCap_RejectedBeforeStorage(t *testing.T) {
+	srv := newTestServer(t)
+	// MaxPageNumber = MaxInt32 / MaxPageSize = 2147483647 / 10000 = 214748;
+	// pageNumber=2147483647 is well above it.
+	resp := doGetAllEntitiesRaw(t, srv.URL, "UnknownModel", 1, "pageSize=10&pageNumber=2147483647")
+	defer resp.Body.Close()
+	body := string(readBody(t, resp))
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("pageNumber=MaxInt32 → got %d, want 400; body: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(strings.ToLower(body), "pagenumber") {
+		t.Errorf("expected pageNumber error in body, got: %s", body)
+	}
+}
+
+// doGetAllEntitiesRaw lets a test pass the query string verbatim so it
+// can supply oversized values that would not round-trip through the
+// integer-typed helper.
+func doGetAllEntitiesRaw(t *testing.T, base, entityName string, version int, query string) *http.Response {
+	t.Helper()
+	url := fmt.Sprintf("%s/entity/%s/%d?%s", base, entityName, version, query)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("get all entities request failed: %v", err)
+	}
+	return resp
+}

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -18,6 +18,7 @@ import (
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/importer"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/pagination"
 	wfengine "github.com/cyoda-platform/cyoda-go/internal/domain/workflow"
 )
 
@@ -622,7 +623,16 @@ func (h *Handler) DeleteAllEntities(ctx context.Context, entityName string, mode
 }
 
 // ListEntities retrieves all entities for a model with pagination.
-func (h *Handler) ListEntities(ctx context.Context, entityName string, modelVersion string, pagination PaginationParams) ([]EntityEnvelope, error) {
+func (h *Handler) ListEntities(ctx context.Context, entityName string, modelVersion string, page PaginationParams) ([]EntityEnvelope, error) {
+	// Defense-in-depth: HTTP and gRPC handlers SHOULD validate before
+	// reaching the service, but enforce the same caps here so the
+	// `start := int(PageNumber * PageSize)` multiplication below cannot
+	// be reached with attacker-supplied values that overflow on 32-bit
+	// platforms or yield negative slice indices.
+	if appErr := pagination.ValidateOffset(int64(page.PageNumber), int64(page.PageSize)); appErr != nil {
+		return nil, appErr
+	}
+
 	entityStore, err := h.factory.EntityStore(ctx)
 	if err != nil {
 		return nil, common.Internal("failed to access entity store", err)
@@ -643,20 +653,21 @@ func (h *Handler) ListEntities(ctx context.Context, entityName string, modelVers
 		return entities[i].Meta.ID < entities[j].Meta.ID
 	})
 
-	// Apply pagination
-	start := int(pagination.PageNumber * pagination.PageSize)
+	// Apply pagination — caps above guarantee start/end are non-negative
+	// and within int range.
+	start := int(page.PageNumber) * int(page.PageSize)
 	if start > len(entities) {
 		start = len(entities)
 	}
-	end := start + int(pagination.PageSize)
+	end := start + int(page.PageSize)
 	if end > len(entities) {
 		end = len(entities)
 	}
-	page := entities[start:end]
+	pageSlice := entities[start:end]
 
 	// Build envelopes without modelKey in meta
-	result := make([]EntityEnvelope, 0, len(page))
-	for _, ent := range page {
+	result := make([]EntityEnvelope, 0, len(pageSlice))
+	for _, ent := range pageSlice {
 		var data any
 		if err := decodeJSONPreservingNumbers(ent.Data, &data); err != nil {
 			return nil, common.Internal("failed to parse entity data", err)

--- a/internal/domain/pagination/pagination.go
+++ b/internal/domain/pagination/pagination.go
@@ -1,0 +1,65 @@
+// Package pagination centralizes shared validation rules for paginated
+// HTTP / gRPC endpoints. The bounds and overflow checks below were
+// originally inlined in internal/domain/search/handler.go (issues #98 and
+// #68 item 10); they are extracted here so every entry point that
+// computes `offset = pageNumber * pageSize` enforces the same caps and
+// catches the same int64 overflow before reaching storage.
+package pagination
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+	"net/http"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+)
+
+const (
+	// MaxPageSize caps sync and async pagination limits. Attacker-supplied
+	// values above this would let a single request pull an unreasonable
+	// volume of data (issue #98).
+	MaxPageSize = 10000
+	// MaxPageNumber caps pageNumber. Even when the offset multiplication
+	// fits in int64, an absurd pageNumber by itself is a sign of misuse:
+	// with the maximum allowed pageSize (10000), a result set that fills
+	// MaxInt32 pages would contain ~2.1e13 entities — orders of magnitude
+	// beyond any realistic snapshot. Capping pageNumber independently
+	// catches this earlier than the overflow guard alone (issue #68 item
+	// 10).
+	MaxPageNumber = math.MaxInt32 / MaxPageSize
+)
+
+// ValidateOffset rejects pagination parameters that are negative, exceed
+// the per-request caps, or whose product overflows int64. Inputs are int64
+// because the offending entry points come from int32 (HTTP/OpenAPI) or
+// untyped JSON-int (gRPC); widening to int64 lets callers pass the raw
+// value without first narrowing it and losing the overflow information.
+//
+// Returns a 400 *common.AppError on violation, nil otherwise.
+func ValidateOffset(pageNumber, pageSize int64) error {
+	if pageNumber < 0 {
+		return common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "invalid pageNumber")
+	}
+	if pageSize < 0 {
+		return common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "invalid pageSize")
+	}
+	if pageSize > MaxPageSize {
+		return common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest,
+			fmt.Sprintf("pageSize exceeds maximum %d", MaxPageSize))
+	}
+	if pageNumber > MaxPageNumber {
+		return common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest,
+			fmt.Sprintf("pageNumber exceeds maximum %d", MaxPageNumber))
+	}
+	// Defense-in-depth: even with both caps enforced, prove the offset
+	// fits in int64 before any caller multiplies. bits.Mul64 is the
+	// platform-independent way to detect overflow: hi != 0 means the
+	// product does not fit in uint64; lo > MaxInt64 means it fits in
+	// uint64 but overflows int64.
+	hi, lo := bits.Mul64(uint64(pageNumber), uint64(pageSize))
+	if hi != 0 || lo > math.MaxInt64 {
+		return common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "pageNumber*pageSize overflows int64")
+	}
+	return nil
+}

--- a/internal/domain/pagination/pagination_test.go
+++ b/internal/domain/pagination/pagination_test.go
@@ -1,0 +1,113 @@
+package pagination_test
+
+import (
+	"errors"
+	"math"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/pagination"
+)
+
+// TestValidateOffset_Normal — normal values pass.
+func TestValidateOffset_Normal(t *testing.T) {
+	if err := pagination.ValidateOffset(0, 20); err != nil {
+		t.Fatalf("0,20 → unexpected err: %v", err)
+	}
+	if err := pagination.ValidateOffset(10, 100); err != nil {
+		t.Fatalf("10,100 → unexpected err: %v", err)
+	}
+	if err := pagination.ValidateOffset(0, 0); err != nil {
+		t.Fatalf("0,0 → unexpected err: %v", err)
+	}
+}
+
+// TestValidateOffset_Negative — negative values are rejected with 400.
+func TestValidateOffset_Negative(t *testing.T) {
+	cases := []struct {
+		name string
+		pn   int64
+		ps   int64
+	}{
+		{"negative pageNumber", -1, 20},
+		{"negative pageSize", 0, -1},
+		{"both negative", -1, -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := pagination.ValidateOffset(tc.pn, tc.ps)
+			assertBadRequest(t, err)
+		})
+	}
+}
+
+// TestValidateOffset_PageSizeExceedsCap — pageSize above MaxPageSize → 400.
+func TestValidateOffset_PageSizeExceedsCap(t *testing.T) {
+	err := pagination.ValidateOffset(0, pagination.MaxPageSize+1)
+	assertBadRequest(t, err)
+	if !strings.Contains(strings.ToLower(err.Error()), "pagesize") {
+		t.Errorf("expected message to mention pageSize, got: %s", err.Error())
+	}
+}
+
+// TestValidateOffset_PageSizeAtCap — pageSize exactly at the cap is allowed.
+func TestValidateOffset_PageSizeAtCap(t *testing.T) {
+	if err := pagination.ValidateOffset(0, pagination.MaxPageSize); err != nil {
+		t.Fatalf("pageSize=cap → unexpected err: %v", err)
+	}
+}
+
+// TestValidateOffset_PageNumberJustUnderCap — pageNumber just under MaxPageNumber passes.
+func TestValidateOffset_PageNumberJustUnderCap(t *testing.T) {
+	if err := pagination.ValidateOffset(pagination.MaxPageNumber-1, pagination.MaxPageSize); err != nil {
+		t.Fatalf("pageNumber=cap-1 → unexpected err: %v", err)
+	}
+}
+
+// TestValidateOffset_PageNumberAtCap — pageNumber exactly at MaxPageNumber passes.
+func TestValidateOffset_PageNumberAtCap(t *testing.T) {
+	if err := pagination.ValidateOffset(pagination.MaxPageNumber, pagination.MaxPageSize); err != nil {
+		t.Fatalf("pageNumber=cap → unexpected err: %v", err)
+	}
+}
+
+// TestValidateOffset_PageNumberJustOverCap — pageNumber > MaxPageNumber → 400.
+func TestValidateOffset_PageNumberJustOverCap(t *testing.T) {
+	err := pagination.ValidateOffset(pagination.MaxPageNumber+1, 1)
+	assertBadRequest(t, err)
+	if !strings.Contains(strings.ToLower(err.Error()), "pagenumber") {
+		t.Errorf("expected message to mention pageNumber, got: %s", err.Error())
+	}
+}
+
+// TestValidateOffset_OverflowMaxInt64 — pageNumber*pageSize overflows int64 → 400.
+func TestValidateOffset_OverflowMaxInt64(t *testing.T) {
+	// MaxInt64 with any pageSize > 1 would overflow, but pageNumber alone
+	// already trips the cap — choose a value that bypasses the cap by
+	// disabling/raising it would be unsafe. Here we just make sure the
+	// guard is reached when the cap is somehow not engaged: feed
+	// MaxInt64 and pageSize 1000.
+	err := pagination.ValidateOffset(math.MaxInt64, 1000)
+	assertBadRequest(t, err)
+}
+
+// assertBadRequest fails the test if err is not a 400 AppError with
+// ErrCodeBadRequest.
+func assertBadRequest(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var appErr *common.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *common.AppError, got %T: %v", err, err)
+	}
+	if appErr.Status != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", appErr.Status)
+	}
+	if appErr.Code != common.ErrCodeBadRequest {
+		t.Errorf("code: got %q, want %q", appErr.Code, common.ErrCodeBadRequest)
+	}
+}

--- a/internal/domain/search/handler.go
+++ b/internal/domain/search/handler.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
-	"math/bits"
 	"net/http"
 	"strconv"
 	"time"
@@ -20,22 +18,11 @@ import (
 	genapi "github.com/cyoda-platform/cyoda-go/api"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/pagination"
 )
 
 const (
 	maxSearchBodySize = 10 * 1024 * 1024 // 10 MiB
-	// maxPageSize caps sync and async pagination limits. Attacker-supplied
-	// values above this would let a single request pull an unreasonable
-	// volume of data (issue #98).
-	maxPageSize = 10000
-	// maxPageNumber caps the async pageNumber. Even when the offset
-	// multiplication fits in int64, an absurd pageNumber by itself is a
-	// sign of misuse: with the maximum allowed pageSize (10000), a result
-	// set that fills MaxInt32 pages would contain ~2.1e13 entities — orders
-	// of magnitude beyond any realistic snapshot. Capping pageNumber
-	// independently catches this earlier than the overflow guard alone
-	// (issue #68 item 10).
-	maxPageNumber = math.MaxInt32 / maxPageSize
 )
 
 // jobLookupError maps a service-level error to a handler response. Job-not-
@@ -149,8 +136,8 @@ func (h *Handler) SearchEntities(w http.ResponseWriter, r *http.Request, entityN
 		// Reject (don't silently clamp): the async path does the same.
 		// Silent clamping would hide misuse from clients and mask bugs
 		// where a caller assumed a larger window than the server allows.
-		if lim > maxPageSize {
-			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, fmt.Sprintf("limit exceeds maximum %d", maxPageSize)))
+		if lim > pagination.MaxPageSize {
+			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, fmt.Sprintf("limit exceeds maximum %d", pagination.MaxPageSize)))
 			return
 		}
 		opts.Limit = lim
@@ -254,52 +241,42 @@ func (h *Handler) GetAsyncSearchResults(w http.ResponseWriter, r *http.Request, 
 	pageSize := 1000 // default
 	if params.PageSize != nil {
 		ps, err := strconv.Atoi(*params.PageSize)
-		if err != nil || ps < 0 {
+		if err != nil {
 			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "invalid pageSize"))
 			return
 		}
-		// Match the sync path's ceiling (handler.go sync branch): a
-		// pageSize above the cap would let attackers pull much more data
-		// per request than the endpoint is designed for (issue #98).
-		if ps > maxPageSize {
-			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, fmt.Sprintf("pageSize exceeds maximum %d", maxPageSize)))
-			return
-		}
-		opts.Limit = ps
 		pageSize = ps
 	}
 
 	pageNumber := 0
 	if params.PageNumber != nil {
 		pn, err := strconv.Atoi(*params.PageNumber)
-		if err != nil || pn < 0 {
+		if err != nil {
 			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "invalid pageNumber"))
 			return
 		}
-		// Explicit upper cap on pageNumber, defense-in-depth alongside the
-		// offset-overflow check below. Catches absurd values that would
-		// otherwise pass overflow validation when paired with a small
-		// pageSize (issue #68 item 10).
-		if pn > maxPageNumber {
-			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, fmt.Sprintf("pageNumber exceeds maximum %d", maxPageNumber)))
-			return
-		}
 		pageNumber = pn
-		if pageSize <= 0 {
-			pageSize = 1000
-		}
-		// Guard against int64 overflow when computing offset = pn*pageSize
-		// with attacker-supplied values (issue #98, #68 item 10). Use
-		// bits.Mul64 for an explicit, platform-independent overflow check:
-		// hi != 0 means the product does not fit in uint64 (and therefore
-		// cannot fit in int64 either). lo > MaxInt64 means the product
-		// fits in uint64 but overflows int64.
-		hi, lo := bits.Mul64(uint64(pn), uint64(pageSize))
-		if hi != 0 || lo > math.MaxInt64 {
-			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "pageNumber*pageSize overflows int64"))
-			return
-		}
-		opts.Offset = int(lo)
+	}
+
+	// Cap + overflow check via the shared helper (issue #98, #68 item
+	// 10): rejects negative values, pageSize > MaxPageSize, pageNumber >
+	// MaxPageNumber, and any pageNumber*pageSize that overflows int64.
+	// Apply the cap to the *effective* pageSize (with the 1000 default
+	// substituted for non-positive values) so the bound matches what is
+	// actually used downstream.
+	effectivePageSize := pageSize
+	if effectivePageSize <= 0 {
+		effectivePageSize = 1000
+	}
+	if vErr := pagination.ValidateOffset(int64(pageNumber), int64(effectivePageSize)); vErr != nil {
+		common.WriteError(w, r, vErr.(*common.AppError))
+		return
+	}
+	if params.PageSize != nil {
+		opts.Limit = pageSize
+	}
+	if params.PageNumber != nil {
+		opts.Offset = pageNumber * effectivePageSize
 	}
 
 	page, err := h.searchSvc.GetAsyncResults(r.Context(), jobId.String(), opts)

--- a/internal/domain/search/handler.go
+++ b/internal/domain/search/handler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"math/bits"
 	"net/http"
 	"strconv"
 	"time"
@@ -27,6 +28,14 @@ const (
 	// values above this would let a single request pull an unreasonable
 	// volume of data (issue #98).
 	maxPageSize = 10000
+	// maxPageNumber caps the async pageNumber. Even when the offset
+	// multiplication fits in int64, an absurd pageNumber by itself is a
+	// sign of misuse: with the maximum allowed pageSize (10000), a result
+	// set that fills MaxInt32 pages would contain ~2.1e13 entities — orders
+	// of magnitude beyond any realistic snapshot. Capping pageNumber
+	// independently catches this earlier than the overflow guard alone
+	// (issue #68 item 10).
+	maxPageNumber = math.MaxInt32 / maxPageSize
 )
 
 // jobLookupError maps a service-level error to a handler response. Job-not-
@@ -267,18 +276,30 @@ func (h *Handler) GetAsyncSearchResults(w http.ResponseWriter, r *http.Request, 
 			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "invalid pageNumber"))
 			return
 		}
+		// Explicit upper cap on pageNumber, defense-in-depth alongside the
+		// offset-overflow check below. Catches absurd values that would
+		// otherwise pass overflow validation when paired with a small
+		// pageSize (issue #68 item 10).
+		if pn > maxPageNumber {
+			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, fmt.Sprintf("pageNumber exceeds maximum %d", maxPageNumber)))
+			return
+		}
 		pageNumber = pn
 		if pageSize <= 0 {
 			pageSize = 1000
 		}
-		// Guard against int overflow when computing offset = pn*pageSize
-		// with attacker-supplied values (issue #98). Reject anything whose
-		// product would wrap int.
-		if pn > 0 && pageSize > 0 && pn > math.MaxInt/pageSize {
-			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "pageNumber*pageSize overflows int"))
+		// Guard against int64 overflow when computing offset = pn*pageSize
+		// with attacker-supplied values (issue #98, #68 item 10). Use
+		// bits.Mul64 for an explicit, platform-independent overflow check:
+		// hi != 0 means the product does not fit in uint64 (and therefore
+		// cannot fit in int64 either). lo > MaxInt64 means the product
+		// fits in uint64 but overflows int64.
+		hi, lo := bits.Mul64(uint64(pn), uint64(pageSize))
+		if hi != 0 || lo > math.MaxInt64 {
+			common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "pageNumber*pageSize overflows int64"))
 			return
 		}
-		opts.Offset = pn * pageSize
+		opts.Offset = int(lo)
 	}
 
 	page, err := h.searchSvc.GetAsyncResults(r.Context(), jobId.String(), opts)

--- a/internal/domain/search/handler_pagination_test.go
+++ b/internal/domain/search/handler_pagination_test.go
@@ -64,6 +64,33 @@ func TestGetAsyncResults_PageNumberTimesPageSizeOverflow_RejectedBeforeJobLookup
 	}
 }
 
+// TestGetAsyncResults_PageNumberExceedsCap_RejectedBeforeJobLookup — even
+// when the multiplication pageNumber × pageSize fits in int64, an absurd
+// pageNumber by itself is a sign of misuse (e.g. attacker probing). The
+// async path should enforce an explicit pageNumber upper cap consistent
+// with the sync path's pageSize cap. With pageSize=10000 (the cap) and
+// pageNumber=MaxInt32 the product is ~2.1e13 which fits in int64, so the
+// overflow check alone would NOT reject — only an explicit pageNumber cap
+// catches this (issue #68 item 10).
+func TestGetAsyncResults_PageNumberExceedsCap_RejectedBeforeJobLookup(t *testing.T) {
+	srv := newTestServer(t)
+	jobID := uuid.New().String()
+
+	resp := doGetAsyncResults(t, srv.URL, jobID, "pageNumber=2147483647", "pageSize=10000")
+	defer resp.Body.Close()
+
+	body := readBodyStr(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("pageNumber=MaxInt32, pageSize=10000 → got %d, want 400; body: %s", resp.StatusCode, body)
+	}
+	if strings.Contains(body, "job "+jobID+" not found") || strings.Contains(body, "job not found") {
+		t.Errorf("validation should reject before job lookup, but got job-not-found response: %s", body)
+	}
+	if !strings.Contains(strings.ToLower(body), "pagenumber") {
+		t.Errorf("expected pageNumber error in body, got: %s", body)
+	}
+}
+
 func readBodyStr(t *testing.T, resp *http.Response) string {
 	t.Helper()
 	return string(readBody(t, resp))

--- a/internal/grpc/search.go
+++ b/internal/grpc/search.go
@@ -19,6 +19,7 @@ import (
 	events "github.com/cyoda-platform/cyoda-go/api/grpc/events"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/entity"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/pagination"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
 	"github.com/cyoda-platform/cyoda-go/internal/logging"
 )
@@ -245,14 +246,28 @@ func (s *CloudEventsServiceImpl) handleEntityGetAllRequest(ctx context.Context, 
 		return status.Errorf(codes.InvalidArgument, "invalid payload: %v", err)
 	}
 
-	pageSize := int32(req.PageSize)
+	pageSize := req.PageSize
 	if pageSize <= 0 {
 		pageSize = 20
 	}
+	pageNumber := req.PageNumber
+
+	// Reject negative / over-cap / overflow-prone values BEFORE the
+	// storage lookup (PR #149 follow-up). Without this guard, an
+	// attacker-supplied PageNumber up to MaxInt would propagate to the
+	// service layer and panic with a slice-bounds error.
+	if vErr := pagination.ValidateOffset(int64(pageNumber), int64(pageSize)); vErr != nil {
+		slog.Error("operation failed", "pkg", "grpc", "rpc", "entitySearchCollection", "type", EntityGetAllRequest, "ceId", ce.Id, "error", vErr.Error())
+		errCE, ceErr := entityResponseError(ctx, ce.Id, vErr)
+		if ceErr != nil {
+			return status.Errorf(codes.Internal, "failed to build error response: %v", ceErr)
+		}
+		return stream.Send(errCE)
+	}
 
 	envelopes, err := s.entityHandler.ListEntities(ctx, req.Model.Name, fmt.Sprintf("%d", req.Model.Version), entity.PaginationParams{
-		PageSize:   pageSize,
-		PageNumber: int32(req.PageNumber),
+		PageSize:   int32(pageSize),
+		PageNumber: int32(pageNumber),
 	})
 	if err != nil {
 		slog.Error("operation failed", "pkg", "grpc", "rpc", "entitySearchCollection", "type", EntityGetAllRequest, "ceId", ce.Id, "error", err.Error())
@@ -585,6 +600,19 @@ func (s *CloudEventsServiceImpl) handleSnapshotGetRequestStreaming(
 	var req events.SnapshotGetRequestJson
 	if err := json.Unmarshal(payload, &req); err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid payload: %v", err)
+	}
+
+	// Reject negative / over-cap / overflow-prone values BEFORE the
+	// snapshot lookup (PR #149 follow-up). The HTTP async-results path
+	// already validates here; the gRPC entry point did not, leaving the
+	// same offset = pageNumber*pageSize multiplication exposed.
+	if vErr := pagination.ValidateOffset(int64(req.PageNumber), int64(req.PageSize)); vErr != nil {
+		slog.Error("operation failed", "pkg", "grpc", "rpc", "entitySearchCollection", "type", SnapshotGetRequest, "ceId", ce.Id, "error", vErr.Error())
+		errCE, ceErr := entityResponseError(ctx, ce.Id, vErr)
+		if ceErr != nil {
+			return status.Errorf(codes.Internal, "failed to build error response: %v", ceErr)
+		}
+		return stream.Send(errCE)
 	}
 
 	results, err := s.searchService.GetAsyncSearchResults(ctx, req.SnapshotID, req.PageNumber, req.PageSize)

--- a/internal/grpc/search_pagination_test.go
+++ b/internal/grpc/search_pagination_test.go
@@ -1,0 +1,106 @@
+package grpc
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	cepb "github.com/cyoda-platform/cyoda-go/api/grpc/cloudevents"
+	events "github.com/cyoda-platform/cyoda-go/api/grpc/events"
+)
+
+// Regression tests for PR #149 follow-up: gRPC search/getAll handlers
+// must apply the same pagination caps and overflow guard as the HTTP
+// search handler. Validation must happen BEFORE the storage / job
+// lookup — asserted by passing an unknown model or unknown snapshot ID
+// alongside oversized params and confirming the response surfaces a
+// CLIENT_ERROR with a pagination message rather than an internal /
+// not-found.
+
+// TestRPC_EntityGetAll_PageNumberExceedsCap_RejectedBeforeStorage —
+// handleEntityGetAllRequest forwards req.PageNumber/PageSize to
+// ListEntities, where `start := PageNumber * PageSize` panics with a
+// slice-bounds error for attacker-supplied MaxInt32. The handler must
+// reject the request first.
+func TestRPC_EntityGetAll_PageNumberExceedsCap_RejectedBeforeStorage(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+
+	ce := makeCE(EntityGetAllRequest, map[string]any{
+		"id":         "test",
+		"model":      map[string]any{"name": "person", "version": 1},
+		"pageSize":   10,
+		"pageNumber": math.MaxInt32, // far above MaxPageNumber=214748
+	})
+
+	stream := &mockEntityStream{ctx: ctx}
+	if err := svc.EntitySearchCollection(ce, stream); err != nil {
+		t.Fatalf("unexpected stream error (validation should produce a CloudEvent error response, not a stream error): %v", err)
+	}
+	requireClientError(t, stream.sent, "pagenumber")
+}
+
+// TestRPC_EntityGetAll_PageSizeExceedsCap_RejectedBeforeStorage —
+// pageSize above MaxPageSize must surface as a CLIENT_ERROR.
+func TestRPC_EntityGetAll_PageSizeExceedsCap_RejectedBeforeStorage(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+
+	ce := makeCE(EntityGetAllRequest, map[string]any{
+		"id":       "test",
+		"model":    map[string]any{"name": "person", "version": 1},
+		"pageSize": 100000, // above MaxPageSize=10000
+	})
+
+	stream := &mockEntityStream{ctx: ctx}
+	if err := svc.EntitySearchCollection(ce, stream); err != nil {
+		t.Fatalf("unexpected stream error: %v", err)
+	}
+	requireClientError(t, stream.sent, "pagesize")
+}
+
+// TestRPC_SnapshotGetResults_PageNumberOverflow_RejectedBeforeJobLookup —
+// handleSnapshotGetRequestStreaming previously passed PageNumber/PageSize
+// straight through to GetAsyncSearchResults with no cap. An attacker
+// supplying MaxInt64 caused the same overflow class as PR #149 fixed in
+// HTTP. The handler must validate before the snapshot lookup, surfacing a
+// CLIENT_ERROR rather than an internal/not-found.
+func TestRPC_SnapshotGetResults_PageNumberOverflow_RejectedBeforeJobLookup(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+
+	ce := makeCE(SnapshotGetRequest, map[string]any{
+		"id":         "test",
+		"snapshotId": "00000000-0000-0000-0000-000000000000",
+		"pageNumber": math.MaxInt32,
+		"pageSize":   10,
+	})
+
+	stream := &mockEntityStream{ctx: ctx}
+	if err := svc.EntitySearchCollection(ce, stream); err != nil {
+		t.Fatalf("unexpected stream error: %v", err)
+	}
+	requireClientError(t, stream.sent, "pagenumber")
+}
+
+// requireClientError asserts the streamed response is a single
+// EntityResponse with success=false and a CLIENT_ERROR error code whose
+// message contains the expected substring (lowercase compare).
+func requireClientError(t *testing.T, sent []*cepb.CloudEvent, msgFragment string) {
+	t.Helper()
+	if len(sent) == 0 {
+		t.Fatalf("expected an error response on the stream, got 0 events")
+	}
+	var typed events.EntityResponseJson
+	validateResponse(t, sent[0], &typed)
+	if typed.Success {
+		t.Fatalf("expected success=false, got success=true")
+	}
+	if typed.Error == nil {
+		t.Fatalf("expected error block, got nil")
+	}
+	if typed.Error.Code != "CLIENT_ERROR" {
+		t.Errorf("expected code=CLIENT_ERROR, got %q", typed.Error.Code)
+	}
+	if !strings.Contains(strings.ToLower(typed.Error.Message), msgFragment) {
+		t.Errorf("expected error message to contain %q, got %q", msgFragment, typed.Error.Message)
+	}
+}
+


### PR DESCRIPTION
## Summary

- Add explicit `maxPageNumber = math.MaxInt32 / maxPageSize` upper cap on the async results path. Catches absurd pageNumber values that would otherwise pass the multiplication-overflow guard when paired with a small pageSize.
- Switch the `offset = pageNumber * pageSize` overflow check from the division-based `pn > math.MaxInt/pageSize` to `math/bits.Mul64`, giving an explicit, platform-independent int64 overflow detection (`hi != 0 || lo > math.MaxInt64`).
- New regression test: `TestGetAsyncResults_PageNumberExceedsCap_RejectedBeforeJobLookup` covers the pageNumber=MaxInt32, pageSize=10000 case where the product (~2.1e13) fits in int64 but is still absurd.

The pre-existing `pageSize` upper cap and the `PageSizeExceedsCap_RejectedBeforeJobLookup` / `PageNumberTimesPageSizeOverflow_RejectedBeforeJobLookup` regression tests (PR #105) are preserved.

Contributes to #68 (item 10). Do NOT auto-close #68 — other items in flight in separate buckets.

## Test plan

- [x] `go test ./internal/domain/search/... -run "TestGetAsyncResults_Page" -v` — three pagination tests green
- [x] `go test -short ./...` — full suite green
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test -race -count=1 -short ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)