### PR TITLE
fix(memory): hold tx.OpMu.RLock around tx-state mutations in Save and CompareAndSave

### DIFF
--- a/plugins/memory/concurrency_cas_test.go
+++ b/plugins/memory/concurrency_cas_test.go
@@ -1,0 +1,192 @@
+package memory_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/memory"
+)
+
+// TestCompareAndSave_TxBufferWriteVsCommit_NoRace exercises the locking
+// discipline that CompareAndSave's tx-path must follow: an in-flight tx
+// mutation must hold tx.OpMu.RLock so it is serialised against Commit /
+// Rollback (which take tx.OpMu.Lock).
+//
+// The contract on TransactionState (see txmanager.Join godoc) is that callers
+// must coordinate concurrent writes within a single tx themselves; the race
+// the plugin must defend against is plugin-side tx access vs Commit/Rollback.
+// Without tx.OpMu.RLock acquisition in CompareAndSave:
+//
+//   - The writer's read of tx.RolledBack races with Rollback's write to
+//     tx.RolledBack. Rollback takes tx.OpMu.Lock specifically so in-flight
+//     ops can finish first; honoring that contract requires the op to take
+//     tx.OpMu.RLock.
+//   - The writer's writes to tx.Buffer / tx.WriteSet race with Commit's
+//     reads of those maps under tx.OpMu.Lock.
+//
+// The race detector flags either pattern; the fixed path passes clean.
+//
+// This test is most useful with -race.
+func TestCompareAndSave_TxBufferWriteVsCommit_NoRace(t *testing.T) {
+	// Iterate to give the scheduler many chances to interleave the writer's
+	// buffer write with the committer's flush.
+	const iterations = 50
+
+	for iter := 0; iter < iterations; iter++ {
+		func() {
+			factory := memory.NewStoreFactory()
+			defer factory.Close()
+			uuids := newTestUUIDGenerator()
+			txMgr := factory.NewTransactionManager(uuids)
+
+			ctx := ctxWithTenant("tenant-A")
+			store, err := factory.EntityStore(ctx)
+			if err != nil {
+				t.Fatalf("EntityStore failed: %v", err)
+			}
+			modelRef := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+			// Pre-seed an entity with a known TransactionID so the
+			// CompareAndSave call has a committed predecessor to match
+			// against.
+			seed := &spi.Entity{
+				Meta: spi.EntityMeta{
+					ID:            "e-cas",
+					TenantID:      "tenant-A",
+					ModelRef:      modelRef,
+					State:         "NEW",
+					TransactionID: "tx-seed",
+				},
+				Data: []byte(`{"v":0}`),
+			}
+			if _, err := store.Save(ctx, seed); err != nil {
+				t.Fatalf("seed Save failed: %v", err)
+			}
+
+			txID, txCtx, err := txMgr.Begin(ctx)
+			if err != nil {
+				t.Fatalf("Begin failed: %v", err)
+			}
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+
+			// Single writer goroutine driving CompareAndSave.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				e := &spi.Entity{
+					Meta: spi.EntityMeta{
+						ID:            "e-cas",
+						TenantID:      "tenant-A",
+						ModelRef:      modelRef,
+						State:         "NEW",
+						TransactionID: "tx-new",
+					},
+					Data: []byte(fmt.Sprintf(`{"iter":%d}`, iter)),
+				}
+				_, cerr := store.CompareAndSave(txCtx, e, "tx-seed")
+				if cerr == nil || errors.Is(cerr, spi.ErrConflict) {
+					return
+				}
+				msg := cerr.Error()
+				if strings.Contains(msg, "rolled back") ||
+					strings.Contains(msg, "already completed") ||
+					strings.Contains(msg, "not found") {
+					return
+				}
+				t.Errorf("CompareAndSave failed: %v", cerr)
+			}()
+
+			// Rollback goroutine fires Rollback concurrently with the
+			// writer's buffer mutation. Rollback writes tx.RolledBack
+			// under tx.OpMu.Lock; CompareAndSave reads tx.RolledBack and
+			// must take tx.OpMu.RLock to read it without a race.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				_ = txMgr.Rollback(ctx, txID)
+			}()
+
+			close(start)
+			wg.Wait()
+		}()
+	}
+}
+
+// TestSave_TxBufferWriteVsRollback_NoRace mirrors the CompareAndSave race
+// test against Save(). The memory-plugin Save() tx-path also reads
+// tx.RolledBack and writes tx.Buffer / tx.WriteSet, and must take
+// tx.OpMu.RLock for the same reason CompareAndSave does. Resolving the
+// CompareAndSave bug exposed that Save had the identical defect (per Gate 6
+// in CLAUDE.md, "resolve, don't defer").
+func TestSave_TxBufferWriteVsRollback_NoRace(t *testing.T) {
+	const iterations = 50
+
+	for iter := 0; iter < iterations; iter++ {
+		func() {
+			factory := memory.NewStoreFactory()
+			defer factory.Close()
+			uuids := newTestUUIDGenerator()
+			txMgr := factory.NewTransactionManager(uuids)
+
+			ctx := ctxWithTenant("tenant-A")
+			store, err := factory.EntityStore(ctx)
+			if err != nil {
+				t.Fatalf("EntityStore failed: %v", err)
+			}
+			modelRef := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+			txID, txCtx, err := txMgr.Begin(ctx)
+			if err != nil {
+				t.Fatalf("Begin failed: %v", err)
+			}
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				e := &spi.Entity{
+					Meta: spi.EntityMeta{
+						ID:            "e-save",
+						TenantID:      "tenant-A",
+						ModelRef:      modelRef,
+						State:         "NEW",
+						TransactionID: "tx-new",
+					},
+					Data: []byte(fmt.Sprintf(`{"iter":%d}`, iter)),
+				}
+				_, serr := store.Save(txCtx, e)
+				if serr == nil {
+					return
+				}
+				msg := serr.Error()
+				if strings.Contains(msg, "rolled back") ||
+					strings.Contains(msg, "already completed") ||
+					strings.Contains(msg, "not found") {
+					return
+				}
+				t.Errorf("Save failed: %v", serr)
+			}()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				_ = txMgr.Rollback(ctx, txID)
+			}()
+
+			close(start)
+			wg.Wait()
+		}()
+	}
+}

--- a/plugins/memory/entity_store.go
+++ b/plugins/memory/entity_store.go
@@ -96,6 +96,12 @@ func (s *EntityStore) SaveAll(ctx context.Context, entities iter.Seq[*spi.Entity
 func (s *EntityStore) Save(ctx context.Context, entity *spi.Entity) (int64, error) {
 	tx := spi.GetTransaction(ctx)
 	if tx != nil {
+		// Hold tx.OpMu.RLock for the duration of the buffer mutation so
+		// that Commit/Rollback (which take tx.OpMu.Lock) cannot race with
+		// writes to tx.Buffer / tx.WriteSet. Lock order matches
+		// txmanager.Commit: tx.OpMu before factory.entityMu.
+		tx.OpMu.RLock()
+		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
 			return 0, fmt.Errorf("transaction has been rolled back")
 		}
@@ -115,29 +121,43 @@ func (s *EntityStore) Save(ctx context.Context, entity *spi.Entity) (int64, erro
 func (s *EntityStore) CompareAndSave(ctx context.Context, entity *spi.Entity, expectedTxID string) (int64, error) {
 	tx := spi.GetTransaction(ctx)
 	if tx != nil {
+		// Hold tx.OpMu.RLock for the duration of the CAS+buffer mutation
+		// so that Commit/Rollback (which take tx.OpMu.Lock) cannot race
+		// with writes to tx.Buffer / tx.WriteSet. Lock order matches
+		// txmanager.Commit: tx.OpMu before factory.entityMu.
+		tx.OpMu.RLock()
+		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
 			return 0, fmt.Errorf("transaction has been rolled back")
 		}
 		// Check CAS against main store (committed data), not buffer.
-		// Hold RLock through both version check AND buffer write to prevent TOCTOU.
-		s.factory.entityMu.RLock()
-		versions := s.factory.entityData[s.tenant][entity.Meta.ID]
-		if len(versions) > 0 {
-			for i := len(versions) - 1; i >= 0; i-- {
-				if !versions[i].deleted && versions[i].entity != nil {
-					if versions[i].entity.Meta.TransactionID != expectedTxID {
-						s.factory.entityMu.RUnlock()
-						return 0, spi.ErrConflict
+		// Hold entityMu.RLock through both version check AND buffer write
+		// to prevent TOCTOU. Wrap in an IIFE so the unlock runs via defer
+		// (per .claude/rules/go-mutex-discipline.md).
+		var conflict bool
+		func() {
+			s.factory.entityMu.RLock()
+			defer s.factory.entityMu.RUnlock()
+			versions := s.factory.entityData[s.tenant][entity.Meta.ID]
+			if len(versions) > 0 {
+				for i := len(versions) - 1; i >= 0; i-- {
+					if !versions[i].deleted && versions[i].entity != nil {
+						if versions[i].entity.Meta.TransactionID != expectedTxID {
+							conflict = true
+							return
+						}
+						break
 					}
-					break
 				}
 			}
+			// Write to buffer under the same lock hold.
+			cp := copyEntity(entity)
+			tx.Buffer[entity.Meta.ID] = cp
+			tx.WriteSet[entity.Meta.ID] = true
+		}()
+		if conflict {
+			return 0, spi.ErrConflict
 		}
-		// Write to buffer under the same lock hold.
-		cp := copyEntity(entity)
-		tx.Buffer[entity.Meta.ID] = cp
-		tx.WriteSet[entity.Meta.ID] = true
-		s.factory.entityMu.RUnlock()
 		return 0, nil
 	}
 


### PR DESCRIPTION
## Summary

Fixes the data race in the memory plugin's transaction-aware `Save()` and `CompareAndSave()` paths.

`TransactionManager.Commit` and `TransactionManager.Rollback` take `tx.OpMu.Lock` so in-flight operations can finish first. The memory plugin's `Save()` and `CompareAndSave()` tx-paths previously read `tx.RolledBack` and wrote `tx.Buffer` / `tx.WriteSet` without taking the corresponding `tx.OpMu.RLock`, so:

- `Rollback`'s write to `tx.RolledBack` raced with `Save`/`CompareAndSave`'s read of the same flag, and
- `Commit`'s reads of `tx.Buffer` / `tx.WriteSet` (under `tx.OpMu.Lock`) raced with the writers' map mutations.

`go test -race` flags both patterns on the pre-fix code; both pass cleanly after.

Issue #68 item 17 named `CompareAndSave` only and stated `Save()` already held `tx.OpMu.RLock`. The audit was incorrect — `Save()` had the same defect — so per Gate 6 in `CLAUDE.md` ("resolve, don't defer") both are fixed in this PR. The `CompareAndSave` path's `entityMu.RLock` is also wrapped in an IIFE so the unlock runs via `defer`, per `.claude/rules/go-mutex-discipline.md`.

## Test plan

- [x] `cd plugins/memory && go test -race ./...` — green (was racing pre-fix)
- [x] `cd plugins/memory && go vet ./... && go test -short ./...` — green
- [x] `make test-short-all` from repo root — green

Two new race-conditional tests in `plugins/memory/concurrency_cas_test.go`:

- `TestCompareAndSave_TxBufferWriteVsCommit_NoRace`
- `TestSave_TxBufferWriteVsRollback_NoRace`

Both confirmed to flag the data race under `-race` against the pre-fix code, and to pass cleanly after.

## Out of scope

A similar audit of the other tx-aware operations (`Get`, `GetAll`, `Delete`, `DeleteAll`, `Exists`, `Count`) suggests they have the same missing-`tx.OpMu.RLock` defect — they read `tx.RolledBack` and mutate `tx.Buffer` / `tx.Deletes` / `tx.ReadSet` without the lock. Resolving them in this PR would balloon the change beyond the bucket scope; surfacing here so a follow-up bucket can pick them up.

Contributes to #68 (item 17). Do NOT auto-close #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)