### PR TITLE
fix(workflow): return 404 MODEL_NOT_FOUND on import for unknown model (#131)

### DIFF
--- a/e2e/externalapi/dictionary-mapping.md
+++ b/e2e/externalapi/dictionary-mapping.md
@@ -182,7 +182,7 @@ The `parity.BackendFixture` exposes a compute-tenant matched to the running `cmd
 | neg/07-condition-delete-at-pit-too-many-matches | gap_on_our_side (#124) | tranche 2 — t.Skip pending #124. Whole delete-by-condition surface is a v0.7.0 server-side gap (handler ignores condition body and pointInTime). |
 | neg/08-update-with-unknown-transition | new:RunExternalAPI_12_08_UpdateUnknownTransition | tranche 2 — `equiv_or_better` after wiring `TRANSITION_NOT_FOUND` into the engine-failure code path (review C1 fix). cyoda-go emits `TRANSITION_NOT_FOUND` @400 — matches dictionary's `(IllegalTransition\|TransitionNotFound)` semantically. |
 | neg/09-get-model-after-delete | new:RunExternalAPI_12_09_GetModelAfterDelete | tranche 2 — `different_naming_same_level`: cyoda-go has no per-model GET endpoint; test verifies via `ListModels` and confirms absence. Semantically equivalent to per-model 404; reconcile in tranche-5 cloud smoke if cyoda-go ever adds a per-model GET. |
-| neg/10-import-workflow-on-unknown-model | gap_on_our_side (#131) | tranche 2 negative path classified `worse`: cyoda-go returns HTTP 200 `{"success":true}` instead of 404 for workflow imports on non-existent models. Real bug — dictionary requires HTTP 404 with `(ModelNotFound\|EntityModelNotFound)`. Test body in place; flipping `t.Skip` is the close-the-issue checklist item. |
+| neg/10-import-workflow-on-unknown-model | new:RunExternalAPI_12_10_ImportWorkflowOnUnknownModel | tranche 2 negative path; resolved by #131. cyoda-go now returns HTTP 404 with `MODEL_NOT_FOUND` for workflow imports on non-existent models, matching dictionary's `(ModelNotFound\|EntityModelNotFound)` regex. `equiv_or_better`. |
 
 ---
 

--- a/e2e/parity/externalapi/negative_validation.go
+++ b/e2e/parity/externalapi/negative_validation.go
@@ -208,18 +208,16 @@ func RunExternalAPI_12_09_GetModelAfterDelete(t *testing.T, fixture parity.Backe
 
 // RunExternalAPI_12_10_ImportWorkflowOnUnknownModel — dictionary 12/neg/10.
 // Dictionary expects HTTP 404 + (ModelNotFound|EntityModelNotFound).
-// worse: cyoda-go returns HTTP 200 {"success":true} for workflow import on an
-// unregistered model. Tracked by #131.
+// equiv_or_better: cyoda-go now returns HTTP 404 + MODEL_NOT_FOUND for workflow
+// import on an unregistered model (resolved by #131).
 func RunExternalAPI_12_10_ImportWorkflowOnUnknownModel(t *testing.T, fixture parity.BackendFixture) {
 	t.Helper()
-	t.Skip("pending #131 — cyoda-go returns HTTP 200 {success:true} for workflow import on unknown model; dictionary requires HTTP 404 (ModelNotFound/EntityModelNotFound). Discover-and-compare worse case.")
 	d := driver.NewInProcess(t, fixture)
 	body := `{"workflows":[{"version":"1.0","name":"w","initialState":"s","states":{"s":{"transitions":[]}}}]}`
 	status, respBody, err := d.ImportWorkflowRaw("unknownModel", 1, body)
 	if err != nil {
 		t.Fatalf("ImportWorkflowRaw: %v", err)
 	}
-	// Tighten to MODEL_NOT_FOUND once #131 lands.
 	errorcontract.Match(t, status, respBody, errorcontract.ExpectedError{
 		HTTPStatus: http.StatusNotFound,
 		ErrorCode:  "MODEL_NOT_FOUND",

--- a/internal/domain/workflow/handler.go
+++ b/internal/domain/workflow/handler.go
@@ -59,6 +59,29 @@ func (h *Handler) ImportEntityModelWorkflow(w http.ResponseWriter, r *http.Reque
 		ModelVersion: fmt.Sprintf("%d", modelVersion),
 	}
 
+	// Verify the target model exists before applying the workflow. Without this
+	// guard, importing a workflow on a non-existent model silently succeeded
+	// (issue #131); cyoda-cloud parity requires HTTP 404 + MODEL_NOT_FOUND.
+	modelStore, err := h.factory.ModelStore(r.Context())
+	if err != nil {
+		common.WriteError(w, r, common.Internal("failed to get model store", err))
+		return
+	}
+	if _, err := modelStore.Get(r.Context(), ref); err != nil {
+		if errors.Is(err, spi.ErrNotFound) {
+			appErr := common.Operational(http.StatusNotFound, common.ErrCodeModelNotFound,
+				fmt.Sprintf("cannot find model entityName=%s, version=%d", entityName, modelVersion))
+			appErr.Props = map[string]any{
+				"entityName":    entityName,
+				"entityVersion": modelVersion,
+			}
+			common.WriteError(w, r, appErr)
+			return
+		}
+		common.WriteError(w, r, common.Internal("failed to load model", err))
+		return
+	}
+
 	wfStore, err := h.factory.WorkflowStore(r.Context())
 	if err != nil {
 		common.WriteError(w, r, common.Internal("failed to get workflow store", err))

--- a/internal/domain/workflow/handler_test.go
+++ b/internal/domain/workflow/handler_test.go
@@ -12,6 +12,7 @@ import (
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/app"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/common/commontest"
 )
 
 // newTestServer creates an App with default config and returns an httptest.Server.
@@ -447,6 +448,36 @@ func TestImportFullWorkflow(t *testing.T) {
 			t.Errorf("%s: expected 0 transitions, got %d", state, len(s.Transitions))
 		}
 	}
+}
+
+// TestImport_UnknownModel_Returns404 covers issue #131: importing a workflow
+// targeting a model that does not exist must return HTTP 404 with the
+// MODEL_NOT_FOUND error code, rather than the legacy 200 {"success":true}.
+func TestImport_UnknownModel_Returns404(t *testing.T) {
+	srv := newTestServer(t)
+	// NOTE: deliberately do NOT call importModel — the model "Ghost" does not exist.
+
+	body := `{
+		"importMode": "MERGE",
+		"workflows": [
+			{
+				"version": "1.0",
+				"name": "ghost-flow",
+				"initialState": "S1",
+				"active": true,
+				"states": {"S1": {"transitions": []}}
+			}
+		]
+	}`
+
+	resp := doWorkflowImport(t, srv.URL, "Ghost", 1, body)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 404 for workflow import on unknown model, got %d: %s", resp.StatusCode, b)
+	}
+	commontest.ExpectErrorCode(t, resp, common.ErrCodeModelNotFound)
 }
 
 func TestImportDefaultMode(t *testing.T) {

--- a/internal/domain/workflow/scenarios_test.go
+++ b/internal/domain/workflow/scenarios_test.go
@@ -503,6 +503,19 @@ func TestScenarioStaticLoopDetectionViaImport(t *testing.T) {
 
 	ctx := ctxWithTenant(testTenant)
 
+	// Register the target model so the import handler reaches static
+	// validation (since #131, the handler returns 404 if the model is missing).
+	mstore, err := factory.ModelStore(ctx)
+	if err != nil {
+		t.Fatalf("ModelStore: %v", err)
+	}
+	if err := mstore.Save(ctx, &spi.ModelDescriptor{
+		Ref:   spi.ModelRef{EntityName: "looptest", ModelVersion: "1"},
+		State: spi.ModelLocked,
+	}); err != nil {
+		t.Fatalf("ModelStore.Save: %v", err)
+	}
+
 	// Prepare the HTTP request with a looping workflow.
 	body := `{
 		"importMode": "REPLACE",

--- a/internal/e2e/workflow_test.go
+++ b/internal/e2e/workflow_test.go
@@ -169,6 +169,37 @@ func TestWorkflow_OverwriteWorkflow(t *testing.T) {
 	}
 }
 
+// TestWorkflow_ImportUnknownModel verifies that importing a workflow targeting
+// a model that does not exist returns 404 MODEL_NOT_FOUND. This covers issue
+// #131: previously the import silently succeeded with 200 {"success":true};
+// cyoda-cloud parity requires HTTP 404 + MODEL_NOT_FOUND. See the workflow
+// handler unit test TestImport_UnknownModel_Returns404 for the canonical
+// assertion.
+func TestWorkflow_ImportUnknownModel(t *testing.T) {
+	const entityName = "e2e-ghost-model"
+	const modelVersion = 1
+
+	// Deliberately do NOT import the model — it must not exist.
+	status, body := importWorkflowE2E(t, entityName, modelVersion, workflowV1)
+	if status != http.StatusNotFound {
+		t.Fatalf("workflow import on unknown model: expected 404, got %d: %s", status, body)
+	}
+
+	// Parse RFC 9457 problem-detail body and assert the error code is in the detail.
+	var problem map[string]any
+	if err := json.Unmarshal([]byte(body), &problem); err != nil {
+		t.Fatalf("workflow import 404: failed to parse problem-detail JSON: %v\nbody: %s", err, body)
+	}
+	detail, _ := problem["detail"].(string)
+	if detail == "" {
+		t.Fatal("workflow import 404: expected non-empty detail in response body")
+	}
+	const wantCode = "MODEL_NOT_FOUND"
+	if !strings.Contains(detail, wantCode) {
+		t.Errorf("workflow import 404: expected error code %s in detail, got: %s", wantCode, detail)
+	}
+}
+
 // TestWorkflow_ExportEmpty verifies that exporting a workflow for a model
 // that has no imported workflows returns 404 WORKFLOW_NOT_FOUND. A properly
 // structured GET on a non-existent resource should return NOT FOUND, not


### PR DESCRIPTION
## Summary
- Workflow import now resolves the `ModelStore` and validates the target model exists before applying the import. On `spi.ErrNotFound` the handler emits `common.Operational(404, MODEL_NOT_FOUND, ...)` with structured Props (`entityName`, `entityVersion`), matching cyoda-cloud's `(ModelNotFound|EntityModelNotFound)` dictionary expectation.
- Existing `TestScenarioStaticLoopDetectionViaImport` updated to seed a `ModelDescriptor` so it still reaches static loop validation under the new precondition.
- Parity scenario `RunExternalAPI_12_10_ImportWorkflowOnUnknownModel` unblocked (t.Skip removed); `e2e/externalapi/dictionary-mapping.md` flipped from `gap_on_our_side (#131)` to `equiv_or_better`.

## Test plan
- [x] `go test ./internal/domain/workflow/... -v` — green incl. new `TestImport_UnknownModel_Returns404`
- [x] `go test ./e2e/parity/memory/ -run "TestParity/.*ExternalAPI_12_10" -v` — green
- [x] `go vet ./...` clean
- [x] `go test -short ./...` — full root module green
- [x] `go test -race -count=1 ./...` — full root module green under race detector

Closes #131