### PR TITLE
fix(auth): uniform 401 message + structured reason log (#68 item 12)

### DIFF
--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"log/slog"
 	"net/http"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
@@ -9,20 +8,21 @@ import (
 	"github.com/cyoda-platform/cyoda-go/internal/contract"
 )
 
+// Auth wraps the next handler in an authentication step. The
+// authService.Authenticate implementation is responsible for emitting the
+// per-failure structured slog.Warn record (with reason slug and operator
+// context) — see internal/auth/delegating.go. The middleware therefore does
+// not log here: a duplicate WARN per failed request would violate the
+// "one event = one log line" rule in .claude/rules/logging.md.
+//
+// On any auth failure the response is the uniform RFC 9457 problem-detail
+// body with HTTP 401 and code UNAUTHORIZED, carrying no enumeration signal
+// (issues #100, #68 item 12).
 func Auth(authService contract.AuthenticationService) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			uc, err := authService.Authenticate(r.Context(), r)
 			if err != nil {
-				// Log the specific failure reason for operators; the
-				// client body stays generic so distinct failure modes
-				// cannot be distinguished via the response (issue #100).
-				slog.Warn("HTTP auth failed",
-					"pkg", "api/middleware",
-					"method", r.Method,
-					"path", r.URL.Path,
-					"reason", err.Error(),
-				)
 				common.WriteError(w, r, common.Operational(http.StatusUnauthorized, common.ErrCodeUnauthorized, "authentication failed"))
 				return
 			}

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -27,16 +26,20 @@ func (s *stubAuthService) Authenticate(_ context.Context, _ *http.Request) (*spi
 	return nil, s.err
 }
 
-// TestAuthMiddleware_ResponseBodyIsGenericForEveryFailureMode is the
-// regression test for issue #100. Clients must not be able to distinguish
-// between distinct auth failure modes via the HTTP response body — all
-// failures yield the same generic "authentication failed" text.
+// TestAuthMiddleware_ResponseBodyIsGenericForEveryFailureMode pins issues
+// #100 / #68 item 12: regardless of which Authenticate failure mode the
+// upstream auth service signalled, the HTTP response body must be the same
+// generic "authentication failed" RFC 9457 problem-detail. No per-branch
+// detail may leak into the body — that's the user-enumeration risk.
 func TestAuthMiddleware_ResponseBodyIsGenericForEveryFailureMode(t *testing.T) {
+	// The DelegatingAuthenticator now returns the bare sentinel for every
+	// failure mode; that is the only error shape the middleware ever sees in
+	// production. We still assert that even an exotic error wrapping the
+	// sentinel produces the generic body — defence in depth against future
+	// implementations of contract.AuthenticationService.
 	cases := []error{
-		fmt.Errorf("%w: missing Authorization header", auth.ErrAuthenticationFailed),
-		fmt.Errorf("%w: invalid Authorization header: expected Bearer scheme", auth.ErrAuthenticationFailed),
-		fmt.Errorf("%w: empty bearer token", auth.ErrAuthenticationFailed),
-		fmt.Errorf("%w: token validation failed: signature verification failed", auth.ErrAuthenticationFailed),
+		auth.ErrAuthenticationFailed,
+		errors.New("some-future-implementation-leak: token=abc.def.ghi"),
 	}
 
 	for _, authErr := range cases {
@@ -58,27 +61,29 @@ func TestAuthMiddleware_ResponseBodyIsGenericForEveryFailureMode(t *testing.T) {
 			if !strings.Contains(body, "authentication failed") {
 				t.Errorf("body = %q; expected generic \"authentication failed\"", body)
 			}
-			// The specific reason (per branch) must NOT appear in the body —
-			// that's the enumeration risk the fix closes.
-			specific := strings.TrimPrefix(authErr.Error(), "authentication failed: ")
-			if specific != "" && strings.Contains(body, specific) {
-				t.Errorf("response body leaked reason %q: %q", specific, body)
+			// Body must never carry the auth implementation's raw error
+			// string — that would re-open the enumeration channel.
+			if authErr != auth.ErrAuthenticationFailed {
+				if strings.Contains(body, "some-future-implementation-leak") || strings.Contains(body, "abc.def.ghi") {
+					t.Errorf("response body leaked auth-impl detail: %q", body)
+				}
 			}
 		})
 	}
 }
 
-// TestAuthMiddleware_LogsSpecificFailureReason pins that the HTTP auth
-// middleware emits an operator-visible log with the specific failure reason,
-// so collapsing client-facing messages does not also collapse observability.
-func TestAuthMiddleware_LogsSpecificFailureReason(t *testing.T) {
+// TestAuthMiddleware_DoesNotDuplicateAuthLayerLog pins the
+// "one event = one log line" rule for auth failures. The auth-layer
+// implementation (DelegatingAuthenticator) is the source of truth for the
+// per-failure structured WARN record; the middleware must not emit a
+// duplicate WARN keyed on the now-uniform err.Error() string.
+func TestAuthMiddleware_DoesNotDuplicateAuthLayerLog(t *testing.T) {
 	var logBuf bytes.Buffer
 	prev := slog.Default()
 	t.Cleanup(func() { slog.SetDefault(prev) })
 	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 
-	authErr := fmt.Errorf("%w: missing Authorization header", auth.ErrAuthenticationFailed)
-	mw := middleware.Auth(&stubAuthService{err: authErr})
+	mw := middleware.Auth(&stubAuthService{err: auth.ErrAuthenticationFailed})
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 
 	rec := httptest.NewRecorder()
@@ -86,10 +91,7 @@ func TestAuthMiddleware_LogsSpecificFailureReason(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 
 	logs := logBuf.String()
-	if !strings.Contains(logs, "missing Authorization header") {
-		t.Errorf("expected log to include specific reason \"missing Authorization header\"; got: %s", logs)
-	}
-	if !errors.Is(authErr, auth.ErrAuthenticationFailed) {
-		t.Fatalf("test-fixture assertion: authErr must wrap ErrAuthenticationFailed")
+	if strings.Contains(logs, "HTTP auth failed") {
+		t.Errorf("middleware emitted a duplicate auth-failure log; the auth layer is the single source of truth: %s", logs)
 	}
 }

--- a/internal/auth/delegating.go
+++ b/internal/auth/delegating.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
-	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -11,11 +11,25 @@ import (
 )
 
 // ErrAuthenticationFailed is the generic client-facing auth failure sentinel.
-// All Authenticate branches wrap this via `%w` so callers can detect auth
-// failure with errors.Is and so that err.Error() always begins with the same
-// string — preventing enumeration-style probing that could otherwise tell
-// "no token sent" apart from "token is wrong" (issue #100).
+// Every Authenticate failure path returns this sentinel verbatim — without
+// any per-branch suffix — so that err.Error() is always the exact same string
+// "authentication failed" and a probing client cannot distinguish "no token
+// sent" from "token is wrong" via the response body (issues #100, #68 item 12).
+//
+// The specific failure mode is logged server-side via a single slog.Warn
+// record carrying a structured `reason` field (see Authenticate). This keeps
+// operator observability intact without leaking enumeration signal to
+// callers.
 var ErrAuthenticationFailed = errors.New("authentication failed")
+
+// Reason slugs used for the structured `reason` field of the per-failure
+// slog.Warn record. Stable values — operators key alerts on these.
+const (
+	authReasonMissingHeader = "missing-header"
+	authReasonInvalidFormat = "invalid-format"
+	authReasonEmptyBearer   = "empty-bearer"
+	authReasonTokenInvalid  = "token-invalid"
+)
 
 // DelegatingAuthenticator implements contract.AuthenticationService by delegating
 // token validation to a JWKSValidator.
@@ -29,25 +43,54 @@ func NewDelegatingAuthenticator(validator *JWKSValidator) *DelegatingAuthenticat
 }
 
 // Authenticate extracts a Bearer token from the Authorization header and validates it.
+//
+// On any failure path it returns the generic ErrAuthenticationFailed sentinel
+// (no wrapped detail) so the caller-visible error string carries no
+// enumeration signal, and emits a single slog.Warn record with a structured
+// `reason` field plus operator-relevant context (remote address, request
+// method/path). No token material or other PII is logged.
 func (a *DelegatingAuthenticator) Authenticate(_ context.Context, r *http.Request) (*spi.UserContext, error) {
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
-		return nil, fmt.Errorf("%w: missing Authorization header", ErrAuthenticationFailed)
+		logAuthFailure(r, authReasonMissingHeader, nil)
+		return nil, ErrAuthenticationFailed
 	}
 
 	if !strings.HasPrefix(authHeader, "Bearer ") {
-		return nil, fmt.Errorf("%w: invalid Authorization header: expected Bearer scheme", ErrAuthenticationFailed)
+		logAuthFailure(r, authReasonInvalidFormat, nil)
+		return nil, ErrAuthenticationFailed
 	}
 
 	token := strings.TrimPrefix(authHeader, "Bearer ")
 	if token == "" {
-		return nil, fmt.Errorf("%w: empty bearer token", ErrAuthenticationFailed)
+		logAuthFailure(r, authReasonEmptyBearer, nil)
+		return nil, ErrAuthenticationFailed
 	}
 
 	uc, err := a.validator.Validate(token)
 	if err != nil {
-		return nil, fmt.Errorf("%w: token validation failed: %w", ErrAuthenticationFailed, err)
+		logAuthFailure(r, authReasonTokenInvalid, err)
+		return nil, ErrAuthenticationFailed
 	}
 
 	return uc, nil
+}
+
+// logAuthFailure emits exactly one structured slog.Warn record describing the
+// authentication failure. The detail err (if any) is the validator's
+// description of *why* the token failed — this never contains the raw token
+// (validator errors only reference kid/issuer/aud/algorithm); see
+// internal/auth/validator.go and EnsureAlgRS256.
+func logAuthFailure(r *http.Request, reason string, detail error) {
+	attrs := []any{
+		"pkg", "auth",
+		"reason", reason,
+		"remote_addr", r.RemoteAddr,
+		"method", r.Method,
+		"path", r.URL.Path,
+	}
+	if detail != nil {
+		attrs = append(attrs, "detail", detail.Error())
+	}
+	slog.Warn("authentication failed", attrs...)
 }

--- a/internal/auth/delegating_enumeration_test.go
+++ b/internal/auth/delegating_enumeration_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,47 +12,46 @@ import (
 )
 
 // TestDelegatingAuthenticator_ErrorsAreWrappedAsAuthFailed is the regression
-// test for issue #100. All four Authenticate failure branches must wrap a
-// single sentinel `ErrAuthenticationFailed` so that:
-//   - err.Error() always starts with the generic string "authentication failed"
-//     (so if a caller ever surfaces err.Error() to the client, it can't be used
-//     to distinguish "no token sent" from "token is wrong")
-//   - errors.Is(err, auth.ErrAuthenticationFailed) returns true for every branch
-//     so callers can detect auth failure generically
+// test for issues #100 and #68 item 12. All four Authenticate failure
+// branches must:
+//   - return the unwrapped sentinel `ErrAuthenticationFailed` so that
+//     err.Error() is exactly "authentication failed" — no per-branch suffix
+//     leaks to a probing client and lets them distinguish "no token sent"
+//     from "token is wrong" (user-enumeration mitigation).
+//   - errors.Is(err, auth.ErrAuthenticationFailed) returns true for every
+//     branch so callers can detect auth failure generically.
+//
+// The specific failure reason is now carried by the structured slog.Warn
+// record emitted from Authenticate (see TestDelegatingAuthenticator_LogsStructuredReason).
 func TestDelegatingAuthenticator_ErrorsAreWrappedAsAuthFailed(t *testing.T) {
 	validator := auth.NewJWKSValidator("http://localhost:0/jwks", "cyoda", 5*time.Minute)
 	authn := auth.NewDelegatingAuthenticator(validator)
 
 	cases := []struct {
-		name         string
-		setHeader    func(r *http.Request)
-		reasonSubstr string
+		name      string
+		setHeader func(r *http.Request)
 	}{
 		{
-			name:         "missing Authorization header",
-			setHeader:    func(r *http.Request) {},
-			reasonSubstr: "missing Authorization header",
+			name:      "missing Authorization header",
+			setHeader: func(r *http.Request) {},
 		},
 		{
 			name: "non-Bearer scheme",
 			setHeader: func(r *http.Request) {
 				r.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
 			},
-			reasonSubstr: "Bearer",
 		},
 		{
 			name: "empty bearer token",
 			setHeader: func(r *http.Request) {
 				r.Header.Set("Authorization", "Bearer ")
 			},
-			reasonSubstr: "empty",
 		},
 		{
 			name: "invalid token value",
 			setHeader: func(r *http.Request) {
 				r.Header.Set("Authorization", "Bearer not.a.real.token")
 			},
-			reasonSubstr: "token validation failed",
 		},
 	}
 
@@ -69,13 +67,8 @@ func TestDelegatingAuthenticator_ErrorsAreWrappedAsAuthFailed(t *testing.T) {
 			if !errors.Is(err, auth.ErrAuthenticationFailed) {
 				t.Errorf("errors.Is(err, ErrAuthenticationFailed) = false; err = %v", err)
 			}
-			if !strings.HasPrefix(err.Error(), "authentication failed") {
-				t.Errorf("err.Error() = %q; must start with \"authentication failed\" so it is safe to surface", err.Error())
-			}
-			// The specific reason must remain in the chain (for logging),
-			// it just must not be the PREFIX.
-			if !strings.Contains(err.Error(), tc.reasonSubstr) {
-				t.Errorf("err.Error() = %q; expected to contain reason %q for operator logs", err.Error(), tc.reasonSubstr)
+			if err.Error() != "authentication failed" {
+				t.Errorf("err.Error() = %q; want exactly \"authentication failed\" so the message is safe to surface and carries no enumeration signal", err.Error())
 			}
 		})
 	}

--- a/internal/auth/delegating_test.go
+++ b/internal/auth/delegating_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -185,8 +186,13 @@ func TestDelegatingAuthenticator_NoToken(t *testing.T) {
 		t.Fatal("expected error for missing Authorization header")
 	}
 
-	if !strings.Contains(err.Error(), "missing Authorization header") {
+	// Per #68 item 12 the caller-facing message is uniform; the specific
+	// reason ("missing-header") goes to the server log only.
+	if err.Error() != "authentication failed" {
 		t.Errorf("unexpected error message: %s", err.Error())
+	}
+	if !errors.Is(err, ErrAuthenticationFailed) {
+		t.Errorf("errors.Is(err, ErrAuthenticationFailed) = false; err = %v", err)
 	}
 }
 
@@ -220,8 +226,12 @@ func TestDelegatingAuthenticator_InvalidToken(t *testing.T) {
 		t.Fatal("expected error for invalid token")
 	}
 
-	if !strings.Contains(err.Error(), "token validation failed") {
+	// Per #68 item 12 the caller-facing message is uniform.
+	if err.Error() != "authentication failed" {
 		t.Errorf("unexpected error message: %s", err.Error())
+	}
+	if !errors.Is(err, ErrAuthenticationFailed) {
+		t.Errorf("errors.Is(err, ErrAuthenticationFailed) = false; err = %v", err)
 	}
 }
 
@@ -237,7 +247,11 @@ func TestDelegatingAuthenticator_NonBearerScheme(t *testing.T) {
 		t.Fatal("expected error for non-Bearer scheme")
 	}
 
-	if !strings.Contains(err.Error(), "expected Bearer scheme") {
+	// Per #68 item 12 the caller-facing message is uniform.
+	if err.Error() != "authentication failed" {
 		t.Errorf("unexpected error message: %s", err.Error())
+	}
+	if !errors.Is(err, ErrAuthenticationFailed) {
+		t.Errorf("errors.Is(err, ErrAuthenticationFailed) = false; err = %v", err)
 	}
 }

--- a/internal/auth/delegating_uniform_message_test.go
+++ b/internal/auth/delegating_uniform_message_test.go
@@ -1,0 +1,172 @@
+package auth_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/internal/auth"
+)
+
+// TestDelegatingAuthenticator_UniformClientMessage pins the user-enumeration
+// mitigation for issue #68 item 12: every Authenticate failure must return
+// an error whose Error() is exactly the generic string "authentication failed",
+// with no per-branch suffix that would let a probing client distinguish the
+// failure mode (e.g. "missing header" vs "token invalid").
+//
+// The middleware translates this error into the response body verbatim, so
+// pinning err.Error() at this layer pins the client-visible string.
+func TestDelegatingAuthenticator_UniformClientMessage(t *testing.T) {
+	validator := auth.NewJWKSValidator("http://localhost:0/jwks", "cyoda", 5*time.Minute)
+	authn := auth.NewDelegatingAuthenticator(validator)
+
+	cases := []struct {
+		name      string
+		setHeader func(r *http.Request)
+	}{
+		{
+			name:      "missing-header",
+			setHeader: func(r *http.Request) {},
+		},
+		{
+			name: "invalid-format",
+			setHeader: func(r *http.Request) {
+				r.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+			},
+		},
+		{
+			name: "empty-bearer",
+			setHeader: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer ")
+			},
+		},
+		{
+			name: "token-invalid",
+			setHeader: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer not.a.real.token")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			tc.setHeader(req)
+
+			_, err := authn.Authenticate(context.Background(), req)
+			if err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+			if !errors.Is(err, auth.ErrAuthenticationFailed) {
+				t.Errorf("errors.Is(err, ErrAuthenticationFailed) = false; err = %v", err)
+			}
+			if err.Error() != "authentication failed" {
+				t.Errorf("err.Error() = %q; want exactly \"authentication failed\" (no per-branch suffix that could enable user enumeration)", err.Error())
+			}
+		})
+	}
+}
+
+// TestDelegatingAuthenticator_LogsStructuredReason pins the operator-side
+// observability mirror to TestDelegatingAuthenticator_UniformClientMessage:
+// even though the client-facing error string is uniform, server-side each
+// failure must emit exactly one slog.Warn record with a structured `reason`
+// field carrying the specific failure mode slug.
+func TestDelegatingAuthenticator_LogsStructuredReason(t *testing.T) {
+	validator := auth.NewJWKSValidator("http://localhost:0/jwks", "cyoda", 5*time.Minute)
+	authn := auth.NewDelegatingAuthenticator(validator)
+
+	cases := []struct {
+		name       string
+		setHeader  func(r *http.Request)
+		wantReason string
+	}{
+		{
+			name:       "missing-header",
+			setHeader:  func(r *http.Request) {},
+			wantReason: "missing-header",
+		},
+		{
+			name: "invalid-format",
+			setHeader: func(r *http.Request) {
+				r.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+			},
+			wantReason: "invalid-format",
+		},
+		{
+			name: "empty-bearer",
+			setHeader: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer ")
+			},
+			wantReason: "empty-bearer",
+		},
+		{
+			name: "token-invalid",
+			setHeader: func(r *http.Request) {
+				r.Header.Set("Authorization", "Bearer not.a.real.token")
+			},
+			wantReason: "token-invalid",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			prev := slog.Default()
+			t.Cleanup(func() { slog.SetDefault(prev) })
+			slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			req.RemoteAddr = "192.0.2.7:54321"
+			tc.setHeader(req)
+
+			_, err := authn.Authenticate(context.Background(), req)
+			if err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+
+			// Parse exactly the warn-level lines emitted by Authenticate.
+			lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+			var records []map[string]any
+			for _, ln := range lines {
+				if ln == "" {
+					continue
+				}
+				var rec map[string]any
+				if err := json.Unmarshal([]byte(ln), &rec); err != nil {
+					t.Fatalf("unparseable log line %q: %v", ln, err)
+				}
+				if lvl, _ := rec["level"].(string); lvl == "WARN" {
+					records = append(records, rec)
+				}
+			}
+			if len(records) != 1 {
+				t.Fatalf("expected exactly 1 WARN log record, got %d; buf=%s", len(records), buf.String())
+			}
+			rec := records[0]
+			if got, _ := rec["reason"].(string); got != tc.wantReason {
+				t.Errorf("reason = %q, want %q", got, tc.wantReason)
+			}
+			// remote_addr context is required for operator triage.
+			if got, _ := rec["remote_addr"].(string); got != "192.0.2.7:54321" {
+				t.Errorf("remote_addr = %q, want %q", got, "192.0.2.7:54321")
+			}
+			// pkg label per logging.md.
+			if got, _ := rec["pkg"].(string); got != "auth" {
+				t.Errorf("pkg = %q, want \"auth\"", got)
+			}
+			// No PII / token material may appear in the log message or fields.
+			full := buf.String()
+			if strings.Contains(full, "not.a.real.token") {
+				t.Errorf("log leaked raw token: %s", full)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Collapse the four `DelegatingAuthenticator` failure paths (missing header / invalid format / empty bearer / token invalid) to return the bare `ErrAuthenticationFailed` sentinel so `err.Error()` is exactly `"authentication failed"`. No per-branch suffix leaks to a probing client (user-enumeration mitigation, #68 item 12).
- Emit one structured `slog.Warn` record per failure inside `Authenticate`, carrying `reason` ∈ {`missing-header`, `invalid-format`, `empty-bearer`, `token-invalid`}, plus `remote_addr`, `method`, `path`, and (where the validator surfaced one) a non-PII `detail` field. No token material is logged.
- Drop the now-redundant HTTP-middleware `slog.Warn`; the auth layer is the single source of truth per the "one event = one log line" rule in `.claude/rules/logging.md`. The HTTP response body remains the uniform RFC 9457 problem-detail `"authentication failed"`.

## Tests

- `internal/auth/delegating_uniform_message_test.go` (new):
  - Pins `err.Error() == "authentication failed"` for every branch.
  - Pins one WARN record per failure with the structured `reason` slug and `remote_addr` context.
- `internal/auth/delegating_enumeration_test.go` (rewritten): asserts the new uniform shape (`err.Error()` equality, `errors.Is(err, ErrAuthenticationFailed)`).
- `internal/api/middleware/auth_test.go` (rewritten): pins that middleware does not duplicate the auth-layer log.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test -short ./...` — green across root module
- [x] `go test ./internal/e2e/...` — green (29s, full HTTP stack)
- [x] `go test -race -count=1 ./internal/auth/... ./internal/api/middleware/... ./internal/grpc/...` — race-clean

Contributes to #68 (item 12). Do NOT auto-close #68.