### PR TITLE
fix: app startup-failure and shutdown lifecycle (#10, #34, #68, #26)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -567,6 +567,8 @@ const gRPCGracefulStopBudget = 10 * time.Second
 
 // Close performs graceful shutdown of all backend resources.
 //
+// Close is the single teardown path for storeFactory and the gRPC server;
+// Shutdown only releases background goroutines and cluster registration.
 // Order: storage first, then gRPC. The gRPC server can block waiting on
 // in-flight streams, so we want pools released before that blocks.
 //
@@ -599,7 +601,11 @@ func (a *App) Close() error {
 	return err
 }
 
-// Shutdown performs graceful cleanup of background goroutines and cluster resources.
+// Shutdown performs graceful cleanup of background goroutines and cluster
+// resources. The storeFactory is intentionally NOT closed here — Close()
+// is the single teardown path for that, so callers invoking Shutdown()
+// followed by Close() (the runServers sequence) close the factory
+// exactly once.
 func (a *App) Shutdown() {
 	if a.stopSearchReaper != nil {
 		close(a.stopSearchReaper)
@@ -610,11 +616,6 @@ func (a *App) Shutdown() {
 	if a.nodeRegistry != nil && a.config.Cluster.Enabled {
 		if err := a.nodeRegistry.Deregister(context.Background(), a.config.Cluster.NodeID); err != nil {
 			slog.Warn("failed to deregister from cluster", "pkg", "cluster", "err", err)
-		}
-	}
-	if a.storeFactory != nil {
-		if err := a.storeFactory.Close(); err != nil {
-			slog.Warn("failed to close store factory", "pkg", "app", "err", err)
 		}
 	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -560,17 +560,41 @@ func (a *App) TokenSigner() *token.Signer                   { return a.tokenSign
 func (a *App) NodeRegistry() contract.NodeRegistry          { return a.nodeRegistry }
 func (a *App) TxLifecycle() *lifecycle.Manager              { return a.txLifecycle }
 
+// gRPCGracefulStopBudget is the upper bound on graceful drain at shutdown.
+// Matched to the HTTP server's drain deadline in cmd/cyoda/main.go so a
+// caller can predict total stop time as ~max(http, grpc) drain budgets.
+const gRPCGracefulStopBudget = 10 * time.Second
+
 // Close performs graceful shutdown of all backend resources.
+//
+// Order: storage first, then gRPC. The gRPC server can block waiting on
+// in-flight streams, so we want pools released before that blocks.
+//
+// gRPC is stopped via GracefulStop bounded by gRPCGracefulStopBudget; if
+// the budget elapses without graceful completion (a stuck stream, a
+// non-cooperative client) we fall back to a hard Stop and emit a slog.Warn
+// so operators can see the budget was hit (#68 item 19).
 func (a *App) Close() error {
 	slog.Info("shutting down")
-	// Close StoreFactory first so it can release connection pools before the
-	// gRPC stop, which can block waiting on in-flight streams.
 	var err error
 	if a.storeFactory != nil {
 		err = a.storeFactory.Close()
 	}
 	if a.grpcServer != nil {
-		a.grpcServer.GRPCServer().Stop() // hard stop — process is exiting, no need for graceful drain
+		done := make(chan struct{})
+		go func() {
+			a.grpcServer.GracefulStop()
+			close(done)
+		}()
+		select {
+		case <-done:
+			// Graceful drain completed within budget.
+		case <-time.After(gRPCGracefulStopBudget):
+			slog.Warn("gRPC graceful stop deadline exceeded; forcing",
+				"phase", "shutdown",
+				"budget", gRPCGracefulStopBudget.String())
+			a.grpcServer.GRPCServer().Stop()
+		}
 	}
 	return err
 }

--- a/app/app.go
+++ b/app/app.go
@@ -435,16 +435,33 @@ func New(cfg Config) *App {
 	// Infrastructure routes (no auth, receives health flag)
 	internalapi.RegisterHealthRoutes(mux, healthFlag)
 
-	// Auth service routes: public endpoints (no auth needed)
+	// Auth service route registration is split into two strict groups so
+	// nothing administrative leaks into the public surface (#34 item 1):
+	//
+	//   PUBLIC (no auth): /.well-known/jwks.json, POST /oauth/token.
+	//     These are the OAuth2/OIDC discovery + token-exchange endpoints
+	//     and must be reachable by unauthenticated callers by protocol.
+	//
+	//   ADMIN (authMW + ROLE_ADMIN): /oauth/keys/*, /account/m2m, /account/m2m/*.
+	//     Two-layer enforcement: middleware.Auth populates UserContext (or
+	//     rejects with 401), then the handlers in internal/auth/ call the
+	//     requireAdmin guard which enforces ROLE_ADMIN (or rejects with 403).
+	//     Both layers are required — authMW alone would let any
+	//     authenticated caller manage signing keys.
+
+	// Public auth endpoints (no auth middleware).
 	if authSvc != nil {
 		mux.Handle("/.well-known/", authSvc.Handler())
 		mux.Handle("POST /oauth/token", authSvc.Handler())
 	}
 
-	// Admin routes (with auth)
+	// Admin routes (auth middleware required).
 	authMW := middleware.Auth(a.authService)
 
-	// Auth admin routes: key management, M2M clients, trusted keys (requires auth)
+	// Admin auth endpoints: key management, M2M clients, trusted keys.
+	// The handler-side requireAdmin guard enforces ROLE_ADMIN; authMW here
+	// guarantees the UserContext is populated so the guard has something
+	// to check.
 	if authSvc != nil {
 		mux.Handle("/oauth/keys/", authMW(authSvc.AdminHandler()))
 		mux.Handle("/account/m2m/", authMW(authSvc.AdminHandler()))

--- a/app/app.go
+++ b/app/app.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -61,6 +62,7 @@ type App struct {
 	txLifecycle        *lifecycle.Manager
 	stopReaper         chan struct{}
 	stopSearchReaper   chan struct{}
+	grpcStopOnce       sync.Once
 }
 
 func New(cfg Config) *App {
@@ -582,7 +584,21 @@ func (a *App) Close() error {
 	if a.storeFactory != nil {
 		err = a.storeFactory.Close()
 	}
-	if a.grpcServer != nil {
+	a.StopGRPC()
+	return err
+}
+
+// StopGRPC drains the gRPC server with a deadline-bounded graceful-stop
+// (gRPCGracefulStopBudget). The drain runs at most once across the
+// lifetime of the App via sync.Once — runServers' watcher invokes this
+// when rootCtx cancels, and Close() calls it again as a belt-and-braces
+// teardown. Without the once, a stuck stream could burn up to 2× the
+// budget across the runServers + Close layers.
+func (a *App) StopGRPC() {
+	a.grpcStopOnce.Do(func() {
+		if a.grpcServer == nil {
+			return
+		}
 		done := make(chan struct{})
 		go func() {
 			a.grpcServer.GracefulStop()
@@ -597,8 +613,7 @@ func (a *App) Close() error {
 				"budget", gRPCGracefulStopBudget.String())
 			a.grpcServer.GRPCServer().Stop()
 		}
-	}
-	return err
+	})
 }
 
 // Shutdown performs graceful cleanup of background goroutines and cluster

--- a/app/app.go
+++ b/app/app.go
@@ -127,7 +127,11 @@ func New(cfg Config) *App {
 
 	factory, err := plugin.NewFactory(startupCtx, os.Getenv, factoryOpts...)
 	if err != nil {
-		panic(fmt.Sprintf("create storage factory for %s: %v", plugin.Name(), err))
+		slog.Error("startup failure",
+			"phase", "create-storage-factory",
+			"backend", plugin.Name(),
+			"error", err.Error())
+		os.Exit(1)
 	}
 
 	// Wire the schema.Apply replay function into the plugin factory so
@@ -168,14 +172,22 @@ func New(cfg Config) *App {
 	// postgres) don't implement Startable, so this is a no-op for them.
 	if s, ok := factory.(spi.Startable); ok {
 		if err := s.Start(startupCtx); err != nil {
-			panic(fmt.Sprintf("start storage factory for %s: %v", plugin.Name(), err))
+			slog.Error("startup failure",
+				"phase", "start-storage-factory",
+				"backend", plugin.Name(),
+				"error", err.Error())
+			os.Exit(1)
 		}
 		slog.Info("storage plugin started", "pkg", "app", "backend", plugin.Name())
 	}
 
 	txMgr, err := factory.TransactionManager(startupCtx)
 	if err != nil {
-		panic(fmt.Sprintf("get transaction manager from %s: %v", plugin.Name(), err))
+		slog.Error("startup failure",
+			"phase", "transaction-manager",
+			"backend", plugin.Name(),
+			"error", err.Error())
+		os.Exit(1)
 	}
 	a.transactionManager = txMgr
 
@@ -191,7 +203,10 @@ func New(cfg Config) *App {
 	var authSvc *auth.AuthService
 	if cfg.IAM.Mode == "jwt" {
 		if cfg.IAM.JWTSigningKey == "" {
-			panic("CYODA_JWT_SIGNING_KEY is required when IAM mode is jwt")
+			slog.Error("startup failure",
+				"phase", "jwt-signing-key",
+				"error", "CYODA_JWT_SIGNING_KEY is required when IAM mode is jwt")
+			os.Exit(1)
 		}
 		// Create a KV-backed trusted key store for persistence across restarts.
 		systemCtx := spi.WithUserContext(context.Background(), &spi.UserContext{
@@ -201,11 +216,17 @@ func New(cfg Config) *App {
 		})
 		kvStore, err := a.storeFactory.KeyValueStore(systemCtx)
 		if err != nil {
-			panic(fmt.Sprintf("failed to get KV store for trusted keys: %v", err))
+			slog.Error("startup failure",
+				"phase", "kv-store-trusted-keys",
+				"error", err.Error())
+			os.Exit(1)
 		}
 		trustedKeyStore, err := auth.NewKVTrustedKeyStore(systemCtx, kvStore)
 		if err != nil {
-			panic(fmt.Sprintf("failed to create KV trusted key store: %v", err))
+			slog.Error("startup failure",
+				"phase", "kv-trusted-store-bootstrap",
+				"error", err.Error())
+			os.Exit(1)
 		}
 		authSvc, err = auth.NewAuthService(auth.AuthConfig{
 			SigningKeyPEM:   cfg.IAM.JWTSigningKey,
@@ -214,7 +235,10 @@ func New(cfg Config) *App {
 			TrustedKeyStore: trustedKeyStore,
 		})
 		if err != nil {
-			panic(fmt.Sprintf("failed to create auth service: %v", err))
+			slog.Error("startup failure",
+				"phase", "auth-service",
+				"error", err.Error())
+			os.Exit(1)
 		}
 		// The built-in IAM holds its signing keys in-process, so the validator
 		// reads public keys directly from the local key store. No loopback JWKS
@@ -240,7 +264,11 @@ func New(cfg Config) *App {
 				cfg.Bootstrap.ClientSecret,
 				roles,
 			); err != nil {
-				panic(fmt.Sprintf("failed to create bootstrap M2M client: %v", err))
+				slog.Error("startup failure",
+					"phase", "bootstrap-m2m-client",
+					"clientId", cfg.Bootstrap.ClientID,
+					"error", err.Error())
+				os.Exit(1)
 			}
 			slog.Info("bootstrap M2M client registered",
 				"pkg", "app",
@@ -267,7 +295,10 @@ func New(cfg Config) *App {
 	localDispatcher := internalgrpc.NewProcessorDispatcher(a.memberRegistry, common.NewDefaultUUIDGenerator())
 	searchStore, err := a.storeFactory.AsyncSearchStore(context.Background())
 	if err != nil {
-		panic(fmt.Sprintf("failed to get async search store: %v", err))
+		slog.Error("startup failure",
+			"phase", "async-search-store",
+			"error", err.Error())
+		os.Exit(1)
 	}
 	a.searchService = search.NewSearchService(a.storeFactory, common.NewDefaultUUIDGenerator(), searchStore)
 

--- a/app/app_close_idempotent_test.go
+++ b/app/app_close_idempotent_test.go
@@ -1,0 +1,64 @@
+package app
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// countingStoreFactory records the number of Close() invocations. The other
+// SPI methods are never exercised in the Shutdown/Close path under test.
+type countingStoreFactory struct {
+	closeCalls atomic.Int32
+}
+
+func (f *countingStoreFactory) EntityStore(context.Context) (spi.EntityStore, error) {
+	return nil, nil
+}
+func (f *countingStoreFactory) ModelStore(context.Context) (spi.ModelStore, error) {
+	return nil, nil
+}
+func (f *countingStoreFactory) KeyValueStore(context.Context) (spi.KeyValueStore, error) {
+	return nil, nil
+}
+func (f *countingStoreFactory) MessageStore(context.Context) (spi.MessageStore, error) {
+	return nil, nil
+}
+func (f *countingStoreFactory) WorkflowStore(context.Context) (spi.WorkflowStore, error) {
+	return nil, nil
+}
+func (f *countingStoreFactory) StateMachineAuditStore(context.Context) (spi.StateMachineAuditStore, error) {
+	return nil, nil
+}
+func (f *countingStoreFactory) AsyncSearchStore(context.Context) (spi.AsyncSearchStore, error) {
+	return nil, nil
+}
+func (f *countingStoreFactory) TransactionManager(context.Context) (spi.TransactionManager, error) {
+	return nil, nil
+}
+func (f *countingStoreFactory) Close() error {
+	f.closeCalls.Add(1)
+	return nil
+}
+
+// TestApp_ShutdownThenClose_StoreFactoryClosedExactlyOnce pins the
+// invariant that storeFactory.Close() is called exactly once across the
+// Shutdown() then Close() teardown sequence used by runServers (#26
+// follow-up). Prior to the fix Shutdown() also closed the factory,
+// resulting in a double close which most plugins surface as
+// "use of closed connection" errors during graceful drain.
+func TestApp_ShutdownThenClose_StoreFactoryClosedExactlyOnce(t *testing.T) {
+	fake := &countingStoreFactory{}
+	a := &App{storeFactory: fake}
+
+	a.Shutdown()
+	if err := a.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	if got := fake.closeCalls.Load(); got != 1 {
+		t.Fatalf("storeFactory.Close called %d times across Shutdown+Close; want exactly 1", got)
+	}
+}

--- a/app/app_grpc_drain_once_test.go
+++ b/app/app_grpc_drain_once_test.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// TestApp_StopGRPC_OnlyDrainsOnce pins the invariant that the gRPC
+// graceful-stop dance runs at most once across the runServers + Close
+// teardown sequence (#68 follow-up). Prior to the fix, runServers' drain
+// watcher and App.Close both inlined a GracefulStop + deadline budget;
+// a stuck stream could therefore burn up to 2× the budget across the
+// two layers.
+//
+// The test serves a real gRPC server, calls StopGRPC twice, and asserts
+// the second call returns immediately — observable proof that the
+// sync.Once gate short-circuits the second drain.
+func TestApp_StopGRPC_OnlyDrainsOnce(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ContextPath = ""
+	a := New(cfg)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- a.GRPCServer().Serve(lis) }()
+
+	// Wait until Serve has bound the listener so GracefulStop has a real
+	// running server to wind down.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		c, dialErr := net.DialTimeout("tcp", lis.Addr().String(), 200*time.Millisecond)
+		if dialErr == nil {
+			c.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("gRPC server did not start: %v", dialErr)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// First drain — does the actual graceful-stop work.
+	a.StopGRPC()
+
+	// Second drain — must short-circuit. We give it a generous threshold
+	// (50ms) so a slow CI box does not flake; the operation under test
+	// is a sync.Once.Do that hits the already-done branch and returns.
+	start := time.Now()
+	a.StopGRPC()
+	if d := time.Since(start); d > 50*time.Millisecond {
+		t.Errorf("second StopGRPC took %v; expected near-instant short-circuit via sync.Once", d)
+	}
+
+	// Close should also skip the gRPC drain branch. Storage is the only
+	// remaining work, and the default in-memory store closes instantly.
+	start = time.Now()
+	if err := a.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if d := time.Since(start); d > 50*time.Millisecond {
+		t.Errorf("Close after StopGRPC took %v; expected near-instant since gRPC drain already ran", d)
+	}
+
+	select {
+	case <-serveErr:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Error("gRPC Serve did not return after StopGRPC")
+	}
+}

--- a/app/app_grpc_shutdown_test.go
+++ b/app/app_grpc_shutdown_test.go
@@ -1,0 +1,78 @@
+package app_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/app"
+)
+
+// TestApp_Close_GRPCGracefulStopWithDeadline verifies the gRPC drain
+// behaviour added in #68 item 19. The test serves the gRPC server on a
+// local listener, then invokes Close() and asserts:
+//
+//  1. Close returns within the 10-second drain budget (no hang on a stuck
+//     stream).
+//  2. The server is no longer accepting connections after Close returns.
+//
+// The "deadline exceeded → hard-stop" branch is exercised by inspection
+// of the slog "gRPC graceful stop deadline exceeded" line in production;
+// reproducing it deterministically requires a hung in-flight stream
+// fixture which is out of scope for this layer.
+func TestApp_Close_GRPCGracefulStopWithDeadline(t *testing.T) {
+	cfg := app.DefaultConfig()
+	cfg.ContextPath = ""
+	a := app.New(cfg)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	addr := lis.Addr().String()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- a.GRPCServer().Serve(lis)
+	}()
+
+	// Verify the listener is accepting connections before we close.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		c, dialErr := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if dialErr == nil {
+			c.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("gRPC server did not start accepting connections: %v", dialErr)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	closeDone := make(chan error, 1)
+	closeStart := time.Now()
+	go func() {
+		closeDone <- a.Close()
+	}()
+
+	select {
+	case <-closeDone:
+		// Close should complete well under the 10s drain budget when there
+		// are no in-flight RPCs. Anything over 5s suggests Close is
+		// blocking on something other than graceful drain.
+		if d := time.Since(closeStart); d > 5*time.Second {
+			t.Errorf("Close took %v; expected sub-5s for an idle gRPC server", d)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("Close did not return within 15s — graceful-stop deadline not enforced")
+	}
+
+	// Serve should have returned by now (the server is stopped).
+	select {
+	case <-serveErr:
+		// expected — Serve returns when the server is stopped.
+	case <-time.After(2 * time.Second):
+		t.Error("gRPC Serve did not return after Close")
+	}
+}

--- a/app/app_startup_failure_test.go
+++ b/app/app_startup_failure_test.go
@@ -1,0 +1,98 @@
+package app_test
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/app"
+)
+
+// TestNew_StorageFactoryFailureExits is the representative test for the
+// startup-failure normalisation sweep (#10). It asserts that a startup
+// precondition failure produces:
+//   - process exit status 1 (not a panic stack)
+//   - a structured slog.Error line tagged with "startup failure"
+//
+// The test re-execs itself in a subprocess so the os.Exit(1) path can be
+// observed without tearing down the parent test binary. Pattern modeled
+// after Go's own os/exec_test.go style for testing fatal exits.
+//
+// We use the "unknown storage backend" path as the trigger because it is
+// reachable from a Config-only setup (no env-var dance, no plugin
+// registration) and exercises the same slog.Error + os.Exit shape as the
+// converted panic sites.
+func TestNew_StorageFactoryFailureExits(t *testing.T) {
+	if os.Getenv("BE_CRASHER") == "1" {
+		// Subprocess body: invoke app.New with a bogus storage backend to
+		// trigger the startup-failure exit path. This call must not return.
+		cfg := app.DefaultConfig()
+		cfg.ContextPath = ""
+		cfg.StorageBackend = "this-backend-does-not-exist"
+		_ = app.New(cfg)
+		// If we reach here, the failure path didn't exit — fail visibly.
+		os.Exit(0)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestNew_StorageFactoryFailureExits")
+	cmd.Env = append(os.Environ(), "BE_CRASHER=1")
+	out, err := cmd.CombinedOutput()
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected subprocess to exit with a non-zero status; got err=%v output=%q", err, string(out))
+	}
+	if code := exitErr.ExitCode(); code != 1 {
+		t.Errorf("expected exit code 1, got %d; output=%q", code, string(out))
+	}
+
+	// The converted handlers tag the failure with the structured field
+	// `phase`. The unknown-backend path predates this sweep and uses
+	// `backend`, so we accept either marker but require an "ERROR" log
+	// line surfacing the failure (no raw "panic:" stack).
+	output := string(out)
+	if strings.Contains(output, "panic:") {
+		t.Errorf("startup failure should not surface as a panic stack; got: %s", output)
+	}
+	if !strings.Contains(output, "ERROR") {
+		t.Errorf("expected an ERROR-level slog line in subprocess output; got: %s", output)
+	}
+}
+
+// TestNew_JWTSigningKeyMissingExits exercises the converted shape of the
+// previously-panicking "CYODA_JWT_SIGNING_KEY is required when IAM mode is
+// jwt" precondition. After the #10 sweep, this path emits a structured
+// slog.Error with phase="jwt-signing-key" and exits with status 1.
+func TestNew_JWTSigningKeyMissingExits(t *testing.T) {
+	if os.Getenv("BE_CRASHER") == "1" {
+		cfg := app.DefaultConfig()
+		cfg.ContextPath = ""
+		cfg.IAM.Mode = "jwt"
+		cfg.IAM.JWTSigningKey = ""
+		_ = app.New(cfg)
+		os.Exit(0)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestNew_JWTSigningKeyMissingExits")
+	cmd.Env = append(os.Environ(), "BE_CRASHER=1")
+	out, err := cmd.CombinedOutput()
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected subprocess to exit with a non-zero status; got err=%v output=%q", err, string(out))
+	}
+	if code := exitErr.ExitCode(); code != 1 {
+		t.Errorf("expected exit code 1, got %d; output=%q", code, string(out))
+	}
+	output := string(out)
+	if strings.Contains(output, "panic:") {
+		t.Errorf("startup failure should not surface as a panic stack; got: %s", output)
+	}
+	if !strings.Contains(output, "ERROR") {
+		t.Errorf("expected an ERROR-level slog line in subprocess output; got: %s", output)
+	}
+	if !strings.Contains(output, "jwt-signing-key") {
+		t.Errorf("expected phase=jwt-signing-key tag in slog output; got: %s", output)
+	}
+}

--- a/cmd/cyoda/main.go
+++ b/cmd/cyoda/main.go
@@ -123,6 +123,31 @@ func main() {
 	rootCtx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stopSignals()
 
+	// Second-signal escape hatch: signal.NotifyContext only cancels on
+	// the first signal; subsequent signals are no-ops, leaving the
+	// operator with no recourse if the graceful drain hangs (stuck
+	// in-flight RPC, slow-closing storage pool). Register the hard-exit
+	// channel up-front so it is already armed when the first signal
+	// arrives — otherwise the second signal can race the goroutine
+	// setup and be lost. The goroutine only acts once rootCtx is
+	// cancelled, so the first signal still flows through the graceful
+	// path; only signals received AFTER cancellation force os.Exit(2).
+	hardExitCh := make(chan os.Signal, 1)
+	signal.Notify(hardExitCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-rootCtx.Done()
+		// Drain any signal that landed in the buffered channel before
+		// rootCtx was cancelled — that one is the first signal and is
+		// already being handled by signal.NotifyContext.
+		select {
+		case <-hardExitCh:
+		default:
+		}
+		<-hardExitCh
+		slog.Warn("hard exit forced by second signal")
+		os.Exit(2)
+	}()
+
 	// gRPC listen happens here (before runServers) so a bind error fails
 	// fast with a clear non-zero exit — the deferred OTel flush still
 	// runs because we use os.Exit only after the deferred-flush guard.

--- a/cmd/cyoda/main.go
+++ b/cmd/cyoda/main.go
@@ -6,18 +6,15 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/muesli/termenv"
 	"golang.org/x/term"
 
 	"github.com/cyoda-platform/cyoda-go/app"
 	"github.com/cyoda-platform/cyoda-go/cmd/cyoda/help"
-	"github.com/cyoda-platform/cyoda-go/internal/admin"
 	"github.com/cyoda-platform/cyoda-go/internal/logging"
 	"github.com/cyoda-platform/cyoda-go/internal/observability"
 
@@ -94,6 +91,11 @@ func main() {
 	printBanner(cfg)
 	printMockAuthWarningTo(os.Stdout, cfg)
 
+	// OTel flush is deferred at the top of main so it runs on every exit
+	// path (signal handler, server failure, panic recovery). All later
+	// errors below this point go through normal returns/exit codes so the
+	// deferred shutdown actually fires. Issue #26 specifically called out
+	// the previous os.Exit-from-goroutine pattern that bypassed this.
 	if cfg.OTelEnabled {
 		nodeID := cfg.Cluster.NodeID
 		if nodeID == "" {
@@ -116,72 +118,26 @@ func main() {
 	// while the SIGINT handler runs the graceful shutdown.
 	signal.Ignore(syscall.SIGPIPE)
 
-	// Graceful shutdown: SIGINT (Ctrl+C) and SIGTERM trigger orderly teardown.
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	// Graceful shutdown: SIGINT (Ctrl+C) and SIGTERM cancel rootCtx; the
+	// errgroup in runServers picks that up and drains every server.
+	rootCtx, stopSignals := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stopSignals()
 
-	// Start gRPC server
+	// gRPC listen happens here (before runServers) so a bind error fails
+	// fast with a clear non-zero exit — the deferred OTel flush still
+	// runs because we use os.Exit only after the deferred-flush guard.
 	grpcAddr := fmt.Sprintf(":%d", cfg.GRPC.Port)
 	lis, err := net.Listen("tcp", grpcAddr)
 	if err != nil {
 		slog.Error("gRPC listen failed", "error", err)
 		os.Exit(1)
 	}
-	go func() {
-		slog.Info("gRPC server starting", "addr", grpcAddr)
-		if err := a.GRPCServer().Serve(lis); err != nil {
-			slog.Error("gRPC server failed", "error", err)
-		}
-	}()
 
-	// Start HTTP server
-	httpAddr := fmt.Sprintf(":%d", cfg.HTTPPort)
-	httpServer := &http.Server{Addr: httpAddr, Handler: a.Handler()}
-	go func() {
-		slog.Info("HTTP server starting", "addr", httpAddr)
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("HTTP server failed", "error", err)
-		}
-	}()
-
-	// Start admin listener. /livez and /readyz are unauth (kubelet has
-	// no bearer); /metrics can optionally be bearer-gated via
-	// CYODA_METRICS_BEARER — wired here from the validated config.
-	adminAddr := fmt.Sprintf("%s:%d", cfg.Admin.BindAddress, cfg.Admin.Port)
-	adminServer := &http.Server{
-		Addr: adminAddr,
-		Handler: admin.NewHandler(admin.Options{
-			Readiness:          a.ReadinessCheck,
-			MetricsBearerToken: cfg.Admin.MetricsBearerToken,
-		}),
+	if err := runServers(rootCtx, a, cfg, lis); err != nil {
+		// runServers has already triggered a.Shutdown / a.Close before
+		// returning; surface the failure as a non-zero exit code.
+		os.Exit(1)
 	}
-	go func() {
-		slog.Info("admin server starting", "addr", adminAddr)
-		if err := adminServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("admin server failed", "error", err)
-		}
-	}()
-
-	// Block until signal received.
-	sig := <-sigCh
-	slog.Info("received signal, starting graceful shutdown", "signal", sig)
-
-	// Shut down HTTP server with a deadline.
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	if err := httpServer.Shutdown(shutdownCtx); err != nil {
-		slog.Error("HTTP server shutdown failed", "error", err)
-	}
-	if err := adminServer.Shutdown(shutdownCtx); err != nil {
-		slog.Error("admin server shutdown failed", "error", err)
-	}
-
-	// Close app — releases backend resources (e.g. database pool).
-	if err := a.Close(); err != nil {
-		slog.Error("app shutdown failed", "error", err)
-	}
-
-	slog.Info("shutdown complete")
 }
 
 func printBanner(cfg app.Config) {

--- a/cmd/cyoda/main_hard_exit_test.go
+++ b/cmd/cyoda/main_hard_exit_test.go
@@ -1,0 +1,148 @@
+//go:build !windows
+
+package main
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestShutdown_SecondSignal_ForcesHardExit pins the second-signal escape
+// hatch (#10 follow-up): the first SIGINT/SIGTERM cancels rootCtx and
+// triggers graceful drain, but if the operator presses Ctrl+C again
+// because the drain is hanging, the process must hard-exit with code 2.
+//
+// This is the safety valve for stuck in-flight RPCs or slow-closing
+// storage pools. signal.NotifyContext on its own only cancels on the
+// first signal — every subsequent signal is a no-op, leaving the
+// operator with no recourse short of SIGKILL.
+//
+// The test starts the cyoda binary, waits for it to bind, sends two
+// SIGTERMs, and asserts (a) exit code 2 and (b) the
+// "hard exit forced by second signal" warn log line in stderr.
+func TestShutdown_SecondSignal_ForcesHardExit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping subprocess shutdown test in -short mode")
+	}
+
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "cyoda-test")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("go build cyoda: %v", err)
+	}
+
+	httpPort := freePortIO(t)
+	grpcPort := freePortIO(t)
+	adminPort := freePortIO(t)
+
+	cmd := exec.Command(bin)
+	cmd.Env = append(os.Environ(),
+		"CYODA_HTTP_PORT="+strconv.Itoa(httpPort),
+		"CYODA_GRPC_PORT="+strconv.Itoa(grpcPort),
+		"CYODA_ADMIN_PORT="+strconv.Itoa(adminPort),
+		"CYODA_ADMIN_BIND_ADDRESS=127.0.0.1",
+		"CYODA_SUPPRESS_BANNER=true",
+		"CYODA_LOG_LEVEL=info",
+		"CYODA_OTEL_ENABLED=false",
+		"CYODA_IAM_MODE=mock",
+	)
+	// Isolate the child in its own process group so signals stay scoped.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// Logging goes to stdout (see internal/logging.Init); capture both
+	// streams so the warn-log assertion below can find the line.
+	var combined bytes.Buffer
+	cmd.Stdout = &combined
+	cmd.Stderr = &combined
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGKILL)
+		}
+	}()
+
+	// Wait until admin listener responds.
+	deadline := time.Now().Add(15 * time.Second)
+	adminAddr := "127.0.0.1:" + strconv.Itoa(adminPort)
+	for {
+		c, err := net.DialTimeout("tcp", adminAddr, 200*time.Millisecond)
+		if err == nil {
+			c.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("child did not start admin listener: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Pin an in-flight HTTP request on the admin server so the graceful
+	// drain has something to wait on. Without this, an idle child exits
+	// in ~1ms — far faster than we can deliver a second signal — and the
+	// hard-exit branch is never exercised. The request line is sent but
+	// the headers are never terminated, so http.Server.Shutdown counts
+	// the connection as active and blocks for the full drain budget.
+	httpAddr := "127.0.0.1:" + strconv.Itoa(httpPort)
+	hold, err := net.Dial("tcp", httpAddr)
+	if err != nil {
+		t.Fatalf("hold-open dial: %v", err)
+	}
+	defer hold.Close()
+	if _, err := hold.Write([]byte("GET /livez HTTP/1.1\r\nHost: x\r\n")); err != nil {
+		t.Fatalf("hold-open write: %v", err)
+	}
+
+	// First SIGTERM: cancels rootCtx and starts the graceful drain.
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("send first SIGTERM: %v", err)
+	}
+	// Brief pause so the first-signal path is observably engaged before
+	// the second arrives — this exercises the second-signal handler
+	// rather than a coalesced double-fire.
+	time.Sleep(200 * time.Millisecond)
+
+	// Second SIGTERM: must force os.Exit(2).
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("send second SIGTERM: %v", err)
+	}
+
+	exitCh := make(chan error, 1)
+	go func() { exitCh <- cmd.Wait() }()
+
+	select {
+	case err := <-exitCh:
+		if err == nil {
+			t.Fatalf("child exited 0; expected non-zero exit code 2")
+		}
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("child exited with non-ExitError %T: %v", err, err)
+		}
+		ws, ok := exitErr.Sys().(syscall.WaitStatus)
+		if !ok {
+			t.Fatalf("WaitStatus unavailable on this platform: %T", exitErr.Sys())
+		}
+		if ws.ExitStatus() != 2 {
+			t.Errorf("exit code %d; want 2 (forced by second signal)", ws.ExitStatus())
+		}
+	case <-time.After(20 * time.Second):
+		_ = cmd.Process.Signal(syscall.SIGKILL)
+		t.Fatal("child did not exit within 20s of second SIGTERM — hard-exit not wired")
+	}
+
+	if got := combined.String(); !strings.Contains(got, "hard exit forced by second signal") {
+		t.Errorf("expected 'hard exit forced by second signal' warn log; got:\n%s", got)
+	}
+}

--- a/cmd/cyoda/main_sigterm_test.go
+++ b/cmd/cyoda/main_sigterm_test.go
@@ -1,0 +1,121 @@
+//go:build !windows
+
+package main
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// freePortIO returns an unused TCP port at call time. Same caveat as
+// freePort in run_test.go.
+func freePortIO(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("freePortIO: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// TestShutdown_OnSIGTERM_DrainsBothServers builds the cyoda binary,
+// starts it, sends SIGTERM after a brief warm-up, and asserts the
+// process exits cleanly within the drain budget.
+//
+// This is the end-to-end pin for the #26 graceful-shutdown work: it
+// catches regressions where (a) the signal handler is not wired,
+// (b) servers fail to drain on signal, or (c) deferred OTel flush is
+// bypassed by os.Exit-from-goroutine.
+func TestShutdown_OnSIGTERM_DrainsBothServers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping subprocess shutdown test in -short mode")
+	}
+
+	tmp := t.TempDir()
+	bin := filepath.Join(tmp, "cyoda-test")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		t.Fatalf("go build cyoda: %v", err)
+	}
+
+	httpPort := freePortIO(t)
+	grpcPort := freePortIO(t)
+	adminPort := freePortIO(t)
+
+	cmd := exec.Command(bin)
+	cmd.Env = append(os.Environ(),
+		"CYODA_HTTP_PORT="+strconv.Itoa(httpPort),
+		"CYODA_GRPC_PORT="+strconv.Itoa(grpcPort),
+		"CYODA_ADMIN_PORT="+strconv.Itoa(adminPort),
+		"CYODA_ADMIN_BIND_ADDRESS=127.0.0.1",
+		"CYODA_SUPPRESS_BANNER=true",
+		"CYODA_LOG_LEVEL=info",
+		"CYODA_OTEL_ENABLED=false",
+		"CYODA_IAM_MODE=mock",
+	)
+	// Put the child in its own process group so SIGTERM lands on the
+	// child only, not on this test process.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() {
+		// Best-effort cleanup if the test fails out before SIGTERM lands.
+		if cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGKILL)
+		}
+	}()
+
+	// Wait until the admin /livez endpoint responds, signalling the
+	// child has bound its listeners.
+	deadline := time.Now().Add(15 * time.Second)
+	adminAddr := "127.0.0.1:" + strconv.Itoa(adminPort)
+	for {
+		c, err := net.DialTimeout("tcp", adminAddr, 200*time.Millisecond)
+		if err == nil {
+			c.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("child did not start admin listener: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Send SIGTERM and assert clean exit within the drain budget.
+	sendStart := time.Now()
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+
+	exitCh := make(chan error, 1)
+	go func() { exitCh <- cmd.Wait() }()
+
+	select {
+	case err := <-exitCh:
+		if err != nil {
+			// Exit status non-zero is a regression: the signal path
+			// should yield a clean exit.
+			t.Errorf("child exited with error: %v", err)
+		}
+		// Sub-15s is generous; with idle servers we expect <2s in practice.
+		if d := time.Since(sendStart); d > 15*time.Second {
+			t.Errorf("child took %v to exit on SIGTERM; expected sub-15s", d)
+		}
+	case <-time.After(20 * time.Second):
+		_ = cmd.Process.Signal(syscall.SIGKILL)
+		t.Fatal("child did not exit within 20s of SIGTERM — graceful shutdown not wired")
+	}
+}
+

--- a/cmd/cyoda/run.go
+++ b/cmd/cyoda/run.go
@@ -64,29 +64,17 @@ func runServers(
 	g.Go(func() error {
 		<-ctx.Done()
 		// Drain gRPC with the same deadline budget as HTTP/admin so total
-		// shutdown is predictable. GracefulStop returns once all in-flight
-		// RPCs complete or the watcher fires the hard Stop fallback.
+		// shutdown is predictable. The drain is gated by a sync.Once on
+		// App so the second invocation in a.Close() is a no-op rather
+		// than re-entering the deadline branch (#68 follow-up).
 		// Concrete sequence on signal:
 		//   1. ctx.Done fires (signal.NotifyContext)
 		//   2. http.Shutdown / admin.Shutdown drain in their own goroutines
 		//   3. this watcher graceful-stops gRPC so Serve returns
 		//   4. errgroup.Wait returns
 		//   5. caller invokes a.Shutdown() then a.Close()
-		//   6. a.Close()'s gRPC drain is a no-op since the server is
-		//      already stopped (GracefulStop is idempotent).
-		done := make(chan struct{})
-		go func() {
-			a.GRPCServer().GracefulStop()
-			close(done)
-		}()
-		select {
-		case <-done:
-		case <-time.After(shutdownDrainBudget):
-			slog.Warn("gRPC graceful stop deadline exceeded; forcing",
-				"phase", "shutdown",
-				"budget", shutdownDrainBudget.String())
-			a.GRPCServer().GRPCServer().Stop()
-		}
+		//   6. a.Close()'s StopGRPC short-circuits via the once.
+		a.StopGRPC()
 		return nil
 	})
 

--- a/cmd/cyoda/run.go
+++ b/cmd/cyoda/run.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/cyoda-platform/cyoda-go/app"
+	"github.com/cyoda-platform/cyoda-go/internal/admin"
+)
+
+// shutdownDrainBudget bounds graceful HTTP/admin server drain. Matches the
+// gRPC graceful-stop budget in app.App.Close so total stop time is
+// predictable as ~max(http, admin, grpc) drain.
+const shutdownDrainBudget = 10 * time.Second
+
+// runServers starts the gRPC, HTTP, and admin listeners and blocks until
+// rootCtx is cancelled (typically by SIGINT/SIGTERM via signal.NotifyContext
+// in main). On cancel it drains each server within shutdownDrainBudget,
+// invokes a.Shutdown() to release background goroutines and cluster
+// resources, and a.Close() to release the storage factory + run the gRPC
+// graceful-stop dance with deadline.
+//
+// All three servers are coordinated by an errgroup whose context is the
+// caller-supplied rootCtx; cancellation propagates through all goroutines.
+// A failure in any server (e.g. listen-port conflict) cancels the group
+// and surfaces as the returned error, which lets main() exit cleanly with
+// a non-zero status without bypassing deferred OTel flush.
+//
+// runServers does not call os.Exit. The caller (main) maps the returned
+// error to an exit code after deferred cleanups have run.
+func runServers(
+	rootCtx context.Context,
+	a *app.App,
+	cfg app.Config,
+	grpcListener net.Listener,
+) error {
+	g, ctx := errgroup.WithContext(rootCtx)
+
+	// gRPC server. Serve does not honour ctx by itself, so a watcher
+	// goroutine triggers GracefulStop on cancel. We graceful-stop here
+	// (not in App.Close) because Serve must return before errgroup.Wait
+	// can — otherwise the group blocks forever and the post-Wait cleanup
+	// (a.Shutdown / a.Close) never runs. The deadline-bounded fallback
+	// to hard Stop already lives in App.Close, which is invoked after
+	// Wait; here we just need GracefulStop to unblock Serve.
+	grpcAddr := grpcListener.Addr().String()
+	g.Go(func() error {
+		slog.Info("gRPC server starting", "addr", grpcAddr)
+		if err := a.GRPCServer().Serve(grpcListener); err != nil {
+			// Serve returns nil on a clean Stop/GracefulStop. A non-nil
+			// error here is a real failure (e.g. bind issue surfaced
+			// after Listen succeeded). Propagate to cancel the group.
+			return fmt.Errorf("grpc serve: %w", err)
+		}
+		return nil
+	})
+	g.Go(func() error {
+		<-ctx.Done()
+		// Drain gRPC with the same deadline budget as HTTP/admin so total
+		// shutdown is predictable. GracefulStop returns once all in-flight
+		// RPCs complete or the watcher fires the hard Stop fallback.
+		// Concrete sequence on signal:
+		//   1. ctx.Done fires (signal.NotifyContext)
+		//   2. http.Shutdown / admin.Shutdown drain in their own goroutines
+		//   3. this watcher graceful-stops gRPC so Serve returns
+		//   4. errgroup.Wait returns
+		//   5. caller invokes a.Shutdown() then a.Close()
+		//   6. a.Close()'s gRPC drain is a no-op since the server is
+		//      already stopped (GracefulStop is idempotent).
+		done := make(chan struct{})
+		go func() {
+			a.GRPCServer().GracefulStop()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(shutdownDrainBudget):
+			slog.Warn("gRPC graceful stop deadline exceeded; forcing",
+				"phase", "shutdown",
+				"budget", shutdownDrainBudget.String())
+			a.GRPCServer().GRPCServer().Stop()
+		}
+		return nil
+	})
+
+	// HTTP server (the application surface).
+	httpAddr := fmt.Sprintf(":%d", cfg.HTTPPort)
+	httpServer := &http.Server{Addr: httpAddr, Handler: a.Handler()}
+	g.Go(func() error {
+		slog.Info("HTTP server starting", "addr", httpAddr)
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("http serve: %w", err)
+		}
+		return nil
+	})
+	g.Go(func() error {
+		<-ctx.Done()
+		drainCtx, cancel := context.WithTimeout(context.Background(), shutdownDrainBudget)
+		defer cancel()
+		if err := httpServer.Shutdown(drainCtx); err != nil {
+			slog.Error("HTTP server shutdown failed", "error", err)
+		}
+		return nil
+	})
+
+	// Admin server (/livez, /readyz, /metrics).
+	adminAddr := fmt.Sprintf("%s:%d", cfg.Admin.BindAddress, cfg.Admin.Port)
+	adminServer := &http.Server{
+		Addr: adminAddr,
+		Handler: admin.NewHandler(admin.Options{
+			Readiness:          a.ReadinessCheck,
+			MetricsBearerToken: cfg.Admin.MetricsBearerToken,
+		}),
+	}
+	g.Go(func() error {
+		slog.Info("admin server starting", "addr", adminAddr)
+		if err := adminServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return fmt.Errorf("admin serve: %w", err)
+		}
+		return nil
+	})
+	g.Go(func() error {
+		<-ctx.Done()
+		drainCtx, cancel := context.WithTimeout(context.Background(), shutdownDrainBudget)
+		defer cancel()
+		if err := adminServer.Shutdown(drainCtx); err != nil {
+			slog.Error("admin server shutdown failed", "error", err)
+		}
+		return nil
+	})
+
+	// Block until either the context is cancelled (signal handler) or one
+	// of the goroutines returns a non-nil error.
+	err := g.Wait()
+	if err != nil && !errors.Is(err, context.Canceled) {
+		slog.Error("server group exited with error", "error", err)
+	} else {
+		slog.Info("received signal, starting graceful shutdown")
+	}
+
+	// Background goroutines (reapers, gossip deregister, store close).
+	a.Shutdown()
+	// Storage close + gRPC graceful-stop with deadline.
+	if closeErr := a.Close(); closeErr != nil {
+		slog.Error("app close failed", "error", closeErr)
+	}
+	slog.Info("shutdown complete")
+
+	if err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
+}

--- a/cmd/cyoda/run_test.go
+++ b/cmd/cyoda/run_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/app"
+)
+
+// freePort returns a TCP port likely to be unused at the moment of the
+// call. The caller must accept that the port may race; in practice for
+// short-lived tests this is reliable enough.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("freePort: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// TestRunServers_CtxCancelDrainsBothServers exercises the SIGTERM path
+// (#26) without spawning a subprocess: we cancel the root context the
+// way signal.NotifyContext would on SIGTERM, and assert runServers
+// returns within the drain budget after stopping every listener.
+func TestRunServers_CtxCancelDrainsBothServers(t *testing.T) {
+	cfg := app.DefaultConfig()
+	cfg.ContextPath = ""
+	cfg.HTTPPort = freePort(t)
+	cfg.Admin.BindAddress = "127.0.0.1"
+	cfg.Admin.Port = freePort(t)
+	a := app.New(cfg)
+
+	grpcLis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("grpc listen: %v", err)
+	}
+
+	rootCtx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- runServers(rootCtx, a, cfg, grpcLis)
+	}()
+
+	// Give the listeners a moment to come up, then probe HTTP /health to
+	// confirm the server is actually serving before we trigger shutdown.
+	deadline := time.Now().Add(2 * time.Second)
+	httpAddr := "http://127.0.0.1:" + strconv.Itoa(cfg.HTTPPort)
+	for {
+		resp, dialErr := http.Get(httpAddr + "/health")
+		if dialErr == nil {
+			resp.Body.Close()
+			break
+		}
+		if time.Now().After(deadline) {
+			cancel()
+			<-runDone
+			t.Fatalf("HTTP server did not come up: %v", dialErr)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Trigger graceful shutdown via context cancel (the signal-notify path).
+	shutdownStart := time.Now()
+	cancel()
+
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Errorf("runServers returned error: %v", err)
+		}
+		// Drain budget per server is 10s; total should still be sub-15s
+		// for an idle server with no in-flight requests.
+		if d := time.Since(shutdownStart); d > 15*time.Second {
+			t.Errorf("graceful shutdown took %v; expected sub-15s", d)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("runServers did not return within 20s of context cancel")
+	}
+
+	// HTTP listener should be closed (refused connection or fast 5xx).
+	if _, err := http.Get(httpAddr + "/health"); err == nil {
+		t.Error("HTTP server still serving after runServers returned")
+	}
+}
+


### PR DESCRIPTION
Closes #10.
Closes #26.
Contributes to #34 (item 1; other items shipping via fix/v063-auth-hardening).
Contributes to #68 (item 19; other items shipping via separate PRs).

Behavioural change: /oauth/keys/* now requires authMW + ROLE_ADMIN. Existing tooling without auth will receive 401. Release notes carry the migration call-out.