### PR TITLE
feat(search): wire pre-execution field-path validation with bounded refresh (#77)

### DIFF
--- a/cmd/cyoda/help/content/errors.md
+++ b/cmd/cyoda/help/content/errors.md
@@ -71,6 +71,7 @@ The `retryable` property is present and `true` only when the operation is safe t
 - `errors.HELP_TOPIC_NOT_FOUND` — `404` — not retryable — help topic path does not resolve to any topic in the tree
 - `errors.IDEMPOTENCY_CONFLICT` — `409` — not retryable — request with the same idempotency key was received but payload differs from the original
 - `errors.INVALID_CHANGE_LEVEL` — `400` — not retryable — `POST /model/{name}/{version}/changeLevel/{changeLevel}` supplied a value that is not one of `ARRAY_LENGTH`, `ARRAY_ELEMENTS`, `TYPE`, `STRUCTURAL`
+- `errors.INVALID_FIELD_PATH` — `400` — not retryable — search condition references one or more JSONPath field paths absent from the target model's locked schema; bounded refresh did not surface the path
 - `errors.MODEL_ALREADY_LOCKED` — `409` — not retryable — admin operation requires `UNLOCKED` state but the model is `LOCKED` (relock attempt or re-import on a locked model)
 - `errors.MODEL_ALREADY_UNLOCKED` — `409` — not retryable — admin operation requires `LOCKED` state but the model is `UNLOCKED` (unlock-of-already-unlocked-model)
 - `errors.MODEL_HAS_ENTITIES` — `409` — not retryable — unlock or delete blocked because at least one entity of the model exists

--- a/cmd/cyoda/help/content/errors/CONDITION_TYPE_MISMATCH.md
+++ b/cmd/cyoda/help/content/errors/CONDITION_TYPE_MISMATCH.md
@@ -22,7 +22,7 @@ HTTP: `400` `Bad Request`. Retryable: `no`.
 
 Each field in a locked model has an inferred DataType (e.g. INTEGER, DOUBLE, BOOLEAN). When a search condition references a numeric or boolean field, the condition's value must be type-compatible with that field. For example, submitting a string value `"abc"` against a DOUBLE field is rejected.
 
-String fields are not strictly enforced — any comparison value (numeric or string) is accepted to support lexicographic and coerced comparisons. Conditions that reference unknown field paths (not present in the model schema) are also accepted without type checking.
+String fields are not strictly enforced — any comparison value (numeric or string) is accepted to support lexicographic and coerced comparisons. Conditions that reference field paths not present in the model schema are rejected by a separate pre-execution validation pass with `BAD_REQUEST` (see issue #77); the type-checker itself has no opinion on unknown paths.
 
 IS_NULL and NOT_NULL operators bypass type checking entirely. Null values are compatible with any field type.
 

--- a/cmd/cyoda/help/content/errors/CONDITION_TYPE_MISMATCH.md
+++ b/cmd/cyoda/help/content/errors/CONDITION_TYPE_MISMATCH.md
@@ -5,6 +5,7 @@ stability: stable
 see_also:
   - errors
   - errors.BAD_REQUEST
+  - errors.INVALID_FIELD_PATH
   - errors.VALIDATION_FAILED
 ---
 
@@ -22,7 +23,7 @@ HTTP: `400` `Bad Request`. Retryable: `no`.
 
 Each field in a locked model has an inferred DataType (e.g. INTEGER, DOUBLE, BOOLEAN). When a search condition references a numeric or boolean field, the condition's value must be type-compatible with that field. For example, submitting a string value `"abc"` against a DOUBLE field is rejected.
 
-String fields are not strictly enforced — any comparison value (numeric or string) is accepted to support lexicographic and coerced comparisons. Conditions that reference field paths not present in the model schema are rejected by a separate pre-execution validation pass with `BAD_REQUEST` (see issue #77); the type-checker itself has no opinion on unknown paths.
+String fields are not strictly enforced — any comparison value (numeric or string) is accepted to support lexicographic and coerced comparisons. Conditions that reference field paths not present in the model schema are rejected by a separate pre-execution validation pass with `INVALID_FIELD_PATH` (see issue #77); the type-checker itself has no opinion on unknown paths.
 
 IS_NULL and NOT_NULL operators bypass type checking entirely. Null values are compatible with any field type.
 
@@ -32,4 +33,5 @@ Correct the condition value so that its type matches the target field's declared
 
 - errors
 - errors.BAD_REQUEST
+- errors.INVALID_FIELD_PATH
 - errors.VALIDATION_FAILED

--- a/cmd/cyoda/help/content/errors/INVALID_FIELD_PATH.md
+++ b/cmd/cyoda/help/content/errors/INVALID_FIELD_PATH.md
@@ -1,0 +1,43 @@
+---
+topic: errors.INVALID_FIELD_PATH
+title: "INVALID_FIELD_PATH — search condition references unknown field path"
+stability: stable
+see_also:
+  - errors
+  - errors.BAD_REQUEST
+  - errors.CONDITION_TYPE_MISMATCH
+  - search
+---
+
+# errors.INVALID_FIELD_PATH
+
+## NAME
+
+INVALID_FIELD_PATH — a search condition references one or more JSONPath field paths that are absent from the target model's locked schema.
+
+## SYNOPSIS
+
+HTTP: `400` `Bad Request`. Retryable: `no` (unless the model schema is then extended via re-import; the request is then valid against the new locked schema).
+
+## DESCRIPTION
+
+Before executing a search, the server validates that every data-field path referenced by the condition (e.g. `$.price`, `$.profile.email`) resolves against the target model's locked schema. Lifecycle paths (`state`, `previousTransition`, etc.) and meta paths (`$._meta.*`) bypass this check.
+
+If any referenced path is unknown, the server performs at most one bounded `RefreshAndGet` against the model store to recover from a stale cached schema (issue #77). If the path is still unknown after the refresh, the request is rejected with HTTP 400 and `errorCode: "INVALID_FIELD_PATH"`. The response detail names every offending path so clients can correct the request without round-tripping to the support team.
+
+Programmatic clients should branch on `errorCode == "INVALID_FIELD_PATH"` (not on HTTP 400) to distinguish unknown-field-path errors from other 400s such as `BAD_REQUEST` (malformed JSON) or `CONDITION_TYPE_MISMATCH` (incompatible value type).
+
+Common causes:
+
+- The condition references a field that has not been declared in the model schema.
+- The model has been re-imported with a different shape and the client's condition uses an old field name.
+- The path is misspelled (e.g. `$.Name` vs `$.name`).
+
+To resolve: verify the field path against the model's schema (`GET /api/model/.../export`), or extend the model schema and re-lock it before retrying.
+
+## SEE ALSO
+
+- errors
+- errors.BAD_REQUEST
+- errors.CONDITION_TYPE_MISMATCH
+- search

--- a/cmd/cyoda/help/content/search.md
+++ b/cmd/cyoda/help/content/search.md
@@ -10,6 +10,8 @@ see_also:
   - errors.SEARCH_JOB_ALREADY_TERMINAL
   - errors.SEARCH_RESULT_LIMIT
   - errors.SEARCH_SHARD_TIMEOUT
+  - errors.INVALID_FIELD_PATH
+  - errors.CONDITION_TYPE_MISMATCH
   - openapi
 ---
 
@@ -304,6 +306,8 @@ Synchronous search does not paginate; use the `limit` parameter (max 10000) to b
 - `errors.SEARCH_JOB_ALREADY_TERMINAL` — `400` — cancel attempted on a job that is already `SUCCESSFUL`, `FAILED`, or `CANCELLED`; error code in response is `BAD_REQUEST`
 - `errors.SEARCH_RESULT_LIMIT` — result set exceeds configured limit
 - `errors.SEARCH_SHARD_TIMEOUT` — per-shard search timeout exceeded (relevant for distributed backends)
+- `errors.INVALID_FIELD_PATH` — `400` — condition references one or more JSONPath field paths absent from the model's locked schema; the response detail names each offending path
+- `errors.CONDITION_TYPE_MISMATCH` — `400` — condition value type is incompatible with the target field's locked DataType
 - `errors.BAD_REQUEST` — `400` — malformed condition JSON, invalid limit/pageSize/pageNumber, result retrieval on non-SUCCESSFUL job, unknown async job ID in result retrieval
 
 ## EXAMPLES

--- a/internal/common/error_codes.go
+++ b/internal/common/error_codes.go
@@ -16,6 +16,7 @@ const (
 	ErrCodeEpochMismatch        = "EPOCH_MISMATCH"
 	ErrCodeBadRequest           = "BAD_REQUEST"
 	ErrCodeInvalidChangeLevel   = "INVALID_CHANGE_LEVEL"
+	ErrCodeInvalidFieldPath     = "INVALID_FIELD_PATH"
 	ErrCodePolymorphicSlot      = "POLYMORPHIC_SLOT"
 	ErrCodeUnauthorized         = "UNAUTHORIZED"
 	ErrCodeForbidden            = "FORBIDDEN"

--- a/internal/domain/search/handler.go
+++ b/internal/domain/search/handler.go
@@ -150,6 +150,14 @@ func (h *Handler) SearchEntities(w http.ResponseWriter, r *http.Request, entityN
 
 	results, err := h.searchSvc.Search(r.Context(), modelRef, cond, opts)
 	if err != nil {
+		// Pre-execution validation (issue #77) returns a classified
+		// *common.AppError directly; forward it so the 4xx surfaces
+		// instead of being shrouded as a 5xx ticket.
+		var appErr *common.AppError
+		if errors.As(err, &appErr) {
+			common.WriteError(w, r, appErr)
+			return
+		}
 		common.WriteError(w, r, common.Internal("search failed", err))
 		return
 	}
@@ -208,6 +216,14 @@ func (h *Handler) SubmitAsyncSearchJob(w http.ResponseWriter, r *http.Request, e
 
 	jobID, err := h.searchSvc.SubmitAsync(r.Context(), modelRef, cond, opts)
 	if err != nil {
+		// Pre-execution validation (issue #77) returns a classified
+		// *common.AppError directly; forward it so the 4xx surfaces
+		// instead of being shrouded as a 5xx ticket.
+		var appErr *common.AppError
+		if errors.As(err, &appErr) {
+			common.WriteError(w, r, appErr)
+			return
+		}
 		common.WriteError(w, r, common.Internal("failed to submit async search", err))
 		return
 	}

--- a/internal/domain/search/handler_condition_type_test.go
+++ b/internal/domain/search/handler_condition_type_test.go
@@ -152,10 +152,12 @@ func TestSearch_ConditionType_IntegerFieldWithStringValue_Rejects(t *testing.T) 
 
 // TestSearch_ConditionType_UnknownField_Rejected verifies that a search
 // condition referencing a field absent from the model schema is
-// rejected with HTTP 400 once pre-execution path validation is in
-// effect (issue #77). Type-checking still has no opinion on unknown
-// paths, so the rejection comes from the field-path validator and the
-// response body explicitly names the offending path.
+// rejected with HTTP 400 and errorCode INVALID_FIELD_PATH once
+// pre-execution path validation is in effect (issue #77). Type-checking
+// still has no opinion on unknown paths, so the rejection comes from the
+// field-path validator and the response body explicitly names the
+// offending path so clients can correct their request without a
+// support round-trip.
 func TestSearch_ConditionType_UnknownField_Rejected(t *testing.T) {
 	srv := newTestServer(t)
 	importAndLockModel(t, srv.URL, "simpleModel", 1, `{"name": "Alice"}`)
@@ -172,6 +174,18 @@ func TestSearch_ConditionType_UnknownField_Rejected(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "$.unknown") {
 		t.Errorf("expected response body to name the unknown path; got: %s", body)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		t.Fatalf("parse response body: %v; raw: %s", err, body)
+	}
+	props, _ := obj["properties"].(map[string]any)
+	if props == nil {
+		t.Fatalf("expected properties in error response; body: %s", body)
+	}
+	errorCode, _ := props["errorCode"].(string)
+	if errorCode != "INVALID_FIELD_PATH" {
+		t.Errorf("errorCode = %q, want INVALID_FIELD_PATH; body: %s", errorCode, body)
 	}
 }
 

--- a/internal/domain/search/handler_condition_type_test.go
+++ b/internal/domain/search/handler_condition_type_test.go
@@ -150,14 +150,16 @@ func TestSearch_ConditionType_IntegerFieldWithStringValue_Rejects(t *testing.T) 
 	}
 }
 
-// TestSearch_ConditionType_UnknownField_Accepted verifies that a search
-// condition referencing an unknown field path is not rejected by the
-// type-checking pass (unknown paths have no type constraint).
-func TestSearch_ConditionType_UnknownField_Accepted(t *testing.T) {
+// TestSearch_ConditionType_UnknownField_Rejected verifies that a search
+// condition referencing a field absent from the model schema is
+// rejected with HTTP 400 once pre-execution path validation is in
+// effect (issue #77). Type-checking still has no opinion on unknown
+// paths, so the rejection comes from the field-path validator and the
+// response body explicitly names the offending path.
+func TestSearch_ConditionType_UnknownField_Rejected(t *testing.T) {
 	srv := newTestServer(t)
 	importAndLockModel(t, srv.URL, "simpleModel", 1, `{"name": "Alice"}`)
 
-	// Unknown field "$.unknown" — no type constraint, should not reject.
 	const condition = `{
 		"type":"simple","jsonPath":"$.unknown","operatorType":"EQUALS","value":"whatever"
 	}`
@@ -165,8 +167,11 @@ func TestSearch_ConditionType_UnknownField_Accepted(t *testing.T) {
 	defer resp.Body.Close()
 	body := readBody(t, resp)
 
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("unknown field path: expected 200, got %d; body: %s", resp.StatusCode, body)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unknown field path: expected 400, got %d; body: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "$.unknown") {
+		t.Errorf("expected response body to name the unknown path; got: %s", body)
 	}
 }
 

--- a/internal/domain/search/path_validate.go
+++ b/internal/domain/search/path_validate.go
@@ -1,0 +1,174 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+)
+
+// extractFieldPaths walks a predicate.Condition tree and collects every
+// JSONPath expression that names a data field. Lifecycle, function and
+// nil sub-conditions are skipped — they do not address user-defined
+// schema paths.
+//
+// Returned paths are normalised so they line up with the FieldsMap keys
+// produced by *schema.ModelNode.FieldsMap (paths begin with "$." and use
+// "[*]" to mark array-wildcard hops). Unrecognised path syntax is
+// dropped — pre-execution validation is best-effort and the matcher
+// will still fail the request downstream if the path is genuinely
+// inaccessible.
+//
+// Duplicate paths are folded out so callers can rely on the slice as a
+// set without further work.
+func extractFieldPaths(cond predicate.Condition) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	walkConditionPaths(cond, seen, &out)
+	return out
+}
+
+func walkConditionPaths(cond predicate.Condition, seen map[string]struct{}, out *[]string) {
+	switch c := cond.(type) {
+	case nil:
+		return
+	case *predicate.SimpleCondition:
+		addPath(c.JsonPath, seen, out)
+	case *predicate.ArrayCondition:
+		addPath(c.JsonPath, seen, out)
+	case *predicate.GroupCondition:
+		for _, child := range c.Conditions {
+			walkConditionPaths(child, seen, out)
+		}
+	case *predicate.LifecycleCondition, *predicate.FunctionCondition:
+		// Lifecycle conditions match metadata fields; function conditions
+		// are evaluated dynamically. Neither participates in schema-path
+		// validation.
+		return
+	}
+}
+
+func addPath(raw string, seen map[string]struct{}, out *[]string) {
+	p := normalisePath(raw)
+	if p == "" {
+		return
+	}
+	if _, ok := seen[p]; ok {
+		return
+	}
+	seen[p] = struct{}{}
+	*out = append(*out, p)
+}
+
+// normalisePath rewrites a user-supplied JSONPath into the canonical
+// form used as a key by schema.ModelNode.FieldsMap. The canonical form
+// always starts with "$." and represents array hops as "[*]". Inputs
+// that already lead with "$." pass through untouched. Inputs that omit
+// the dollar prefix get one prepended. Empty paths return "" so the
+// caller can drop them.
+func normalisePath(raw string) string {
+	p := strings.TrimSpace(raw)
+	if p == "" {
+		return ""
+	}
+	switch {
+	case strings.HasPrefix(p, "$."):
+		return p
+	case strings.HasPrefix(p, "$"):
+		return p
+	default:
+		return "$." + p
+	}
+}
+
+// findUnknownPaths returns the subset of paths absent from the supplied
+// FieldsMap. Paths whose direct key is missing are also probed with a
+// trailing "[*]" segment stripped, so a condition naming an array field
+// (e.g. "$.tags[*]") still matches a leaf descriptor recorded as
+// "$.tags[*]" — both representations are accepted to stay compatible
+// with the matcher's input shapes.
+func findUnknownPaths(paths []string, fields map[string]schema.FieldDescriptor) []string {
+	var unknown []string
+	for _, p := range paths {
+		if isPathKnown(p, fields) {
+			continue
+		}
+		unknown = append(unknown, p)
+	}
+	return unknown
+}
+
+// isPathKnown reports whether p (or a prefix of p that itself addresses
+// a structural field) appears in fields. Wildcard suffixes are tolerated
+// so "$.tags[*]" matches a leaf described as "$.tags[*]" exactly, and
+// nested wildcards such as "$.tags[*].name" also resolve.
+func isPathKnown(p string, fields map[string]schema.FieldDescriptor) bool {
+	if _, ok := fields[p]; ok {
+		return true
+	}
+	// Prefix-match: a condition path may address an interior object that
+	// itself is not a leaf in FieldsMap (which only records leaves). We
+	// accept it when at least one recorded leaf descends from the same
+	// prefix — evidence that the structural field exists in the schema.
+	prefix := p + "."
+	for known := range fields {
+		if strings.HasPrefix(known, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// loadFieldsMap fetches and parses the cached schema for ref, returning
+// the path → FieldDescriptor view used by pre-execution validation.
+//
+// Returns (nil, nil) when the model has not been registered (the memory
+// plugin admits entity writes without a prior model, so search must
+// preserve that behaviour). Other errors propagate so the caller can
+// log and skip validation rather than mistakenly reject the search.
+func loadFieldsMap(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) (map[string]schema.FieldDescriptor, error) {
+	desc, err := store.Get(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return fieldsFromDescriptor(desc)
+}
+
+// refreshFieldsMap forces a cache refresh via RefreshAndGet (when the
+// store implements it) and returns the refreshed FieldsMap. Returns
+// (nil, false, nil) when the store has no refresh capability — callers
+// should treat that as "no further authority to consult".
+func refreshFieldsMap(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) (map[string]schema.FieldDescriptor, bool, error) {
+	refresher, ok := store.(interface {
+		RefreshAndGet(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error)
+	})
+	if !ok {
+		return nil, false, nil
+	}
+	desc, err := refresher.RefreshAndGet(ctx, ref)
+	if err != nil {
+		return nil, true, err
+	}
+	fm, err := fieldsFromDescriptor(desc)
+	if err != nil {
+		return nil, true, err
+	}
+	return fm, true, nil
+}
+
+// fieldsFromDescriptor unmarshals desc.Schema and returns its FieldsMap.
+// A nil descriptor is treated as "no model registered" and yields a nil
+// map without error.
+func fieldsFromDescriptor(desc *spi.ModelDescriptor) (map[string]schema.FieldDescriptor, error) {
+	if desc == nil {
+		return nil, nil
+	}
+	node, err := schema.Unmarshal(desc.Schema)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal model schema: %w", err)
+	}
+	return node.FieldsMap(), nil
+}

--- a/internal/domain/search/path_validate_test.go
+++ b/internal/domain/search/path_validate_test.go
@@ -1,0 +1,198 @@
+package search_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
+	"github.com/cyoda-platform/cyoda-go/plugins/memory"
+)
+
+// refreshingModelStore is a ModelStore fake used to drive the search
+// service's pre-execution path-validation logic. Get returns the head
+// of getQueue; RefreshAndGet returns the head of refreshQueue. Both
+// counters are observable so tests can assert refresh behaviour.
+type refreshingModelStore struct {
+	mu           sync.Mutex
+	getQueue     []*spi.ModelDescriptor
+	refreshQueue []*spi.ModelDescriptor
+	getCount     int
+	refreshCount int
+}
+
+func (s *refreshingModelStore) Get(_ context.Context, _ spi.ModelRef) (*spi.ModelDescriptor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getCount++
+	if len(s.getQueue) == 0 {
+		// Drain to last refresh result so post-validation lookups still resolve.
+		if len(s.refreshQueue) > 0 {
+			return s.refreshQueue[0], nil
+		}
+		return nil, nil
+	}
+	d := s.getQueue[0]
+	s.getQueue = s.getQueue[1:]
+	return d, nil
+}
+
+func (s *refreshingModelStore) RefreshAndGet(_ context.Context, _ spi.ModelRef) (*spi.ModelDescriptor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.refreshCount++
+	if len(s.refreshQueue) == 0 {
+		return nil, nil
+	}
+	d := s.refreshQueue[0]
+	s.refreshQueue = s.refreshQueue[1:]
+	return d, nil
+}
+
+func (s *refreshingModelStore) Save(context.Context, *spi.ModelDescriptor) error     { return nil }
+func (s *refreshingModelStore) GetAll(context.Context) ([]spi.ModelRef, error)       { return nil, nil }
+func (s *refreshingModelStore) Delete(context.Context, spi.ModelRef) error           { return nil }
+func (s *refreshingModelStore) Lock(context.Context, spi.ModelRef) error             { return nil }
+func (s *refreshingModelStore) Unlock(context.Context, spi.ModelRef) error           { return nil }
+func (s *refreshingModelStore) IsLocked(context.Context, spi.ModelRef) (bool, error) { return true, nil }
+func (s *refreshingModelStore) SetChangeLevel(context.Context, spi.ModelRef, spi.ChangeLevel) error {
+	return nil
+}
+func (s *refreshingModelStore) ExtendSchema(context.Context, spi.ModelRef, spi.SchemaDelta) error {
+	return nil
+}
+
+var _ spi.ModelStore = (*refreshingModelStore)(nil)
+
+func (s *refreshingModelStore) RefreshCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.refreshCount
+}
+
+// modelStoreFactory wraps an inner StoreFactory and returns a fixed
+// ModelStore (the refreshingModelStore under test). EntityStore and other
+// methods delegate to the inner factory so fallback search still works.
+type modelStoreFactory struct {
+	spi.StoreFactory
+	modelStore spi.ModelStore
+}
+
+func (f *modelStoreFactory) ModelStore(_ context.Context) (spi.ModelStore, error) {
+	return f.modelStore, nil
+}
+
+// buildSearchDescriptor constructs a LOCKED descriptor whose schema declares
+// the given top-level string fields. Mirrors the helper in
+// internal/domain/entity/handler_validate_refresh_test.go.
+func buildSearchDescriptor(t *testing.T, ref spi.ModelRef, fields ...string) *spi.ModelDescriptor {
+	t.Helper()
+	node := schema.NewObjectNode()
+	for _, f := range fields {
+		node.SetChild(f, schema.NewLeafNode(schema.String))
+	}
+	raw, err := schema.Marshal(node)
+	if err != nil {
+		t.Fatalf("schema.Marshal: %v", err)
+	}
+	return &spi.ModelDescriptor{
+		Ref:    ref,
+		State:  spi.ModelLocked,
+		Schema: raw,
+	}
+}
+
+// TestSearch_StaleSchema_RefreshesOnceAndSucceeds verifies that a search
+// referencing a field absent from the cached schema but present in the
+// authoritative (post-RefreshAndGet) schema triggers exactly one refresh
+// and then succeeds. This is the issue-#77 contract.
+func TestSearch_StaleSchema_RefreshesOnceAndSucceeds(t *testing.T) {
+	base := memory.NewStoreFactory()
+	defer base.Close()
+
+	ctx := tenantCtx("tenant-1")
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+
+	// Save a single entity carrying field "z". The fallback search will
+	// match it once validation accepts the path.
+	saveEntity(t, ctx, base, ref, "e1", []byte(`{"z":"hello"}`))
+
+	stale := buildSearchDescriptor(t, ref, "a")
+	fresh := buildSearchDescriptor(t, ref, "a", "z")
+	ms := &refreshingModelStore{
+		getQueue:     []*spi.ModelDescriptor{stale},
+		refreshQueue: []*spi.ModelDescriptor{fresh},
+	}
+	factory := &modelStoreFactory{StoreFactory: base, modelStore: ms}
+
+	uuids := common.NewTestUUIDGenerator()
+	searchStore, _ := base.AsyncSearchStore(context.Background())
+	svc := search.NewSearchService(factory, uuids, searchStore)
+
+	cond := &predicate.SimpleCondition{
+		JsonPath:     "$.z",
+		OperatorType: "EQUALS",
+		Value:        "hello",
+	}
+
+	results, err := svc.Search(ctx, ref, cond, search.SearchOptions{})
+	if err != nil {
+		t.Fatalf("expected search to succeed after one refresh, got error: %v", err)
+	}
+	if len(results) != 1 || results[0].Meta.ID != "e1" {
+		t.Fatalf("expected 1 result (e1), got %d results", len(results))
+	}
+	if got := ms.RefreshCount(); got != 1 {
+		t.Errorf("expected exactly 1 RefreshAndGet call, got %d", got)
+	}
+}
+
+// TestSearch_TrulyMissingPath_FourxxAfterOneRefresh verifies that when the
+// referenced field is absent from BOTH the cached and the authoritative
+// schemas, Search rejects the request with a 4xx and triggers refresh at
+// most once (no unbounded refresh loop).
+func TestSearch_TrulyMissingPath_FourxxAfterOneRefresh(t *testing.T) {
+	base := memory.NewStoreFactory()
+	defer base.Close()
+
+	ctx := tenantCtx("tenant-1")
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+
+	stale := buildSearchDescriptor(t, ref, "a")
+	stillStale := buildSearchDescriptor(t, ref, "a")
+	ms := &refreshingModelStore{
+		getQueue:     []*spi.ModelDescriptor{stale},
+		refreshQueue: []*spi.ModelDescriptor{stillStale},
+	}
+	factory := &modelStoreFactory{StoreFactory: base, modelStore: ms}
+
+	uuids := common.NewTestUUIDGenerator()
+	searchStore, _ := base.AsyncSearchStore(context.Background())
+	svc := search.NewSearchService(factory, uuids, searchStore)
+
+	cond := &predicate.SimpleCondition{
+		JsonPath:     "$.z",
+		OperatorType: "EQUALS",
+		Value:        "hello",
+	}
+
+	_, err := svc.Search(ctx, ref, cond, search.SearchOptions{})
+	if err == nil {
+		t.Fatalf("expected validation error for truly-missing path, got nil")
+	}
+	var appErr *common.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *common.AppError, got %T: %v", err, err)
+	}
+	if appErr.Status < 400 || appErr.Status >= 500 {
+		t.Errorf("expected 4xx status, got %d", appErr.Status)
+	}
+	if got := ms.RefreshCount(); got != 1 {
+		t.Errorf("expected exactly 1 RefreshAndGet call (bounded), got %d", got)
+	}
+}

--- a/internal/domain/search/path_validate_test.go
+++ b/internal/domain/search/path_validate_test.go
@@ -192,6 +192,9 @@ func TestSearch_TrulyMissingPath_FourxxAfterOneRefresh(t *testing.T) {
 	if appErr.Status < 400 || appErr.Status >= 500 {
 		t.Errorf("expected 4xx status, got %d", appErr.Status)
 	}
+	if appErr.Code != common.ErrCodeInvalidFieldPath {
+		t.Errorf("expected errorCode %q, got %q", common.ErrCodeInvalidFieldPath, appErr.Code)
+	}
 	if got := ms.RefreshCount(); got != 1 {
 		t.Errorf("expected exactly 1 RefreshAndGet call (bounded), got %d", got)
 	}

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -521,7 +521,7 @@ func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi
 func invalidPathError(paths []string) error {
 	return common.Operational(
 		http.StatusBadRequest,
-		common.ErrCodeBadRequest,
+		common.ErrCodeInvalidFieldPath,
 		fmt.Sprintf("condition references unknown field path(s): %s", strings.Join(paths, ", ")),
 	)
 }

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -6,11 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
 	"github.com/cyoda-platform/cyoda-go/internal/match"
 
 	"github.com/cyoda-platform/cyoda-go-spi/predicate"
@@ -77,14 +80,20 @@ func NewSearchService(factory spi.StoreFactory, uuids spi.UUIDGenerator, searchS
 // transaction, Search delegates to the plugin for SQL predicate pushdown.
 // Otherwise it falls back to GetAll + in-memory filtering.
 //
-// TODO(model-schema-extensions-F3): when field-path validation against the
-// model schema is added here (pre-execution, rejecting unknown paths early),
-// wrap it via entity.Handler.ValidateWithRefresh so a stale cached schema
-// triggers one bounded RefreshAndGet before the rejection surfaces. Today
-// the service has no such pre-execution validation step; unknown paths are
-// caught downstream by match.Evaluate / plugin Searcher. Integration point
-// belongs here when the validation hook is introduced.
+// Pre-execution path validation: every condition path is checked against
+// the cached model schema's FieldsMap. When a path is unknown, the
+// schema cache is refreshed exactly once via RefreshAndGet (mirroring
+// entity.Handler.ValidateWithRefresh's bounded-retry contract) so a
+// search referencing a peer's freshly-extended path succeeds after one
+// authoritative read. Truly-unknown paths surface as 4xx BAD_REQUEST.
+// Models that have never been registered are admitted unchanged —
+// pre-execution validation is best-effort and only applies once the
+// model exists. See issue #77.
 func (s *SearchService) Search(ctx context.Context, modelRef spi.ModelRef, cond predicate.Condition, opts SearchOptions) ([]*spi.Entity, error) {
+	if vErr := s.validateConditionPaths(ctx, modelRef, cond); vErr != nil {
+		return nil, vErr
+	}
+
 	store, err := s.factory.EntityStore(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get entity store: %w", err)
@@ -153,10 +162,19 @@ func (s *SearchService) Search(ctx context.Context, modelRef spi.ModelRef, cond 
 }
 
 // SubmitAsync starts an asynchronous search job and returns the job ID.
+//
+// Pre-execution path validation runs synchronously before the job is
+// recorded (issue #77) — a request that names paths the model does not
+// know about returns a 4xx without ever creating a job, sparing the
+// client a round-trip through the polling endpoint.
 func (s *SearchService) SubmitAsync(ctx context.Context, modelRef spi.ModelRef, cond predicate.Condition, opts SearchOptions) (string, error) {
 	uc := spi.GetUserContext(ctx)
 	if uc == nil {
 		return "", fmt.Errorf("no user context — cannot determine tenant")
+	}
+
+	if vErr := s.validateConditionPaths(ctx, modelRef, cond); vErr != nil {
+		return "", vErr
 	}
 
 	if opts.PointInTime == nil {
@@ -404,4 +422,106 @@ func (s *SearchService) GetAsyncSearchResults(ctx context.Context, snapshotID st
 func (s *SearchService) CancelAsyncSearch(ctx context.Context, snapshotID string) error {
 	_, err := s.CancelAsync(ctx, snapshotID)
 	return err
+}
+
+// validateConditionPaths runs the pre-execution field-path validation
+// step for Search. The cached schema is consulted first; if any path
+// referenced by the condition is absent, exactly one RefreshAndGet is
+// issued (when the store implements it) and the recheck decides the
+// outcome. This mirrors the semantics of
+// entity.Handler.ValidateWithRefresh — a stale-schema search referencing
+// a peer's freshly-extended path succeeds after one bounded refresh,
+// and a truly-unknown path surfaces as 4xx without a refresh loop.
+//
+// Returns nil when validation passes, when no data-field paths are
+// addressed (lifecycle-only conditions), or when the model has not been
+// registered (the memory plugin admits entity writes without a prior
+// model, and search must preserve that behaviour). Validator failures
+// surface as a 4xx common.AppError with the missing paths listed.
+func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi.ModelRef, cond predicate.Condition) error {
+	paths := extractFieldPaths(cond)
+	if len(paths) == 0 {
+		return nil
+	}
+
+	modelStore, err := s.factory.ModelStore(ctx)
+	if err != nil {
+		// A factory that cannot produce a ModelStore cannot validate;
+		// log and proceed so the search itself can still surface a
+		// useful error from the matcher.
+		slog.Debug("model store unavailable; skipping pre-execution path validation",
+			"pkg", "search", "error", err)
+		return nil
+	}
+
+	fields, err := loadFieldsMap(ctx, modelStore, modelRef)
+	if err != nil {
+		if errors.Is(err, spi.ErrNotFound) {
+			// Unregistered model — nothing to validate against.
+			return nil
+		}
+		// Decoding-the-schema failures are upstream: log and continue so
+		// search can still proceed via the matcher's own error path.
+		slog.Debug("failed to load schema for pre-execution validation",
+			"pkg", "search",
+			"entityName", modelRef.EntityName,
+			"modelVersion", modelRef.ModelVersion,
+			"error", err)
+		return nil
+	}
+	if fields == nil {
+		// Descriptor returned nil (no schema bound) — treat as
+		// unregistered and admit the search.
+		return nil
+	}
+
+	missing := findUnknownPaths(paths, fields)
+	if len(missing) == 0 {
+		return nil
+	}
+
+	// Some paths are unknown to the cached schema. Refresh exactly once
+	// before declaring the request invalid — the bound is required by
+	// issue #77 to avoid amplifying a misconfigured client into a
+	// refresh storm.
+	freshFields, refreshed, refreshErr := refreshFieldsMap(ctx, modelStore, modelRef)
+	if !refreshed {
+		// Store has no cache layer — the cached miss is authoritative.
+		return invalidPathError(missing)
+	}
+	if refreshErr != nil {
+		if errors.Is(refreshErr, spi.ErrNotFound) {
+			// Model was deleted between Get and RefreshAndGet — fall
+			// back to the cached fields outcome (paths are unknown
+			// because there is no model).
+			return invalidPathError(missing)
+		}
+		slog.Debug("schema refresh failed during pre-execution validation",
+			"pkg", "search",
+			"entityName", modelRef.EntityName,
+			"modelVersion", modelRef.ModelVersion,
+			"error", refreshErr)
+		return invalidPathError(missing)
+	}
+	if freshFields == nil {
+		return invalidPathError(missing)
+	}
+
+	stillMissing := findUnknownPaths(missing, freshFields)
+	if len(stillMissing) == 0 {
+		return nil
+	}
+	return invalidPathError(stillMissing)
+}
+
+// invalidPathError builds the 4xx response surfaced when one or more
+// condition paths cannot be resolved against the (refreshed) model
+// schema. The message lists each offending path so clients can correct
+// their request without round-tripping to the support team.
+func invalidPathError(paths []string) error {
+	return common.Operational(
+		http.StatusBadRequest,
+		common.ErrCodeBadRequest,
+		fmt.Sprintf("condition references unknown field path(s): %s", strings.Join(paths, ", ")),
+	)
 }

--- a/internal/e2e/search_test.go
+++ b/internal/e2e/search_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common/commontest"
 )
 
 // --- Search helpers ---
@@ -110,4 +112,60 @@ func TestSearch_ORGroup(t *testing.T) {
 		}
 		t.Errorf("expected 2 results (Alice + Bob), got %d: %v", len(results), strings.Join(names, ", "))
 	}
+}
+
+// TestSearch_UnknownFieldPath_Returns400_InvalidFieldPath verifies the
+// pre-execution field-path validator surfaces a dedicated INVALID_FIELD_PATH
+// errorCode (not the generic BAD_REQUEST) when a search condition references
+// a JSONPath that is absent from the model's locked schema. Programmatic
+// clients branch on this code to distinguish unknown-field errors from
+// other 400s (malformed JSON, type mismatch). See PR #162 / issue #77.
+func TestSearch_UnknownFieldPath_Returns400_InvalidFieldPath(t *testing.T) {
+	const model = "e2e-search-invalid-field-path"
+	setupSearchModel(t, model)
+
+	// Seed at least one entity so the model schema is populated with the
+	// known fields (name, amount, status). The seeded entity is irrelevant
+	// to the assertion — the validator runs before any matching.
+	createEntityE2E(t, model, 1, `{"name":"Alice","amount":100,"status":"active"}`)
+
+	// Reference an unknown JSONPath. The validator must reject before
+	// touching the storage layer.
+	const badCondition = `{"type":"simple","jsonPath":"$.unknownField","operatorType":"EQUALS","value":"whatever"}`
+	path := fmt.Sprintf("/api/search/direct/%s/1", model)
+	resp := doAuth(t, http.MethodPost, path, badCondition)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		body := readBody(t, resp)
+		t.Fatalf("expected 400, got %d; body: %s", resp.StatusCode, body)
+	}
+	commontest.ExpectErrorCode(t, resp, "INVALID_FIELD_PATH")
+
+	// Body must name the offending path so clients can correct without
+	// a support round-trip.
+	body := readBody(t, resp)
+	if !strings.Contains(body, "$.unknownField") {
+		t.Errorf("expected response detail to name the unknown path; body: %s", body)
+	}
+}
+
+// TestSearch_AsyncSubmit_UnknownFieldPath_Returns400_InvalidFieldPath
+// verifies the async submission path applies the same field-path
+// validator and surfaces the same dedicated INVALID_FIELD_PATH code.
+func TestSearch_AsyncSubmit_UnknownFieldPath_Returns400_InvalidFieldPath(t *testing.T) {
+	const model = "e2e-search-invalid-field-path-async"
+	setupSearchModel(t, model)
+	createEntityE2E(t, model, 1, `{"name":"Bob","amount":42,"status":"active"}`)
+
+	const badCondition = `{"type":"simple","jsonPath":"$.absentField","operatorType":"EQUALS","value":"x"}`
+	path := fmt.Sprintf("/api/search/async/%s/1", model)
+	resp := doAuth(t, http.MethodPost, path, badCondition)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		body := readBody(t, resp)
+		t.Fatalf("expected 400, got %d; body: %s", resp.StatusCode, body)
+	}
+	commontest.ExpectErrorCode(t, resp, "INVALID_FIELD_PATH")
 }


### PR DESCRIPTION
## Summary
- Field-path validation now runs before every `Search` and `SubmitAsync` call. Unknown paths trigger exactly one `RefreshAndGet`; if the path is still absent after the refresh, the request is rejected with HTTP 400 naming the offending path (no unbounded refresh loop, no 5xx leak).
- The lookup uses `*schema.ModelNode.FieldsMap` directly rather than synthesising a touch document for `entity.Handler.ValidateWithRefresh` — a placeholder value would be rejected by typed-leaf validation before the path-existence question could be asked. The bounded-refresh contract is preserved (cached hit → one refresh → recheck → fail).
- Search and submit handlers now forward classified `*common.AppError` instances untouched instead of masking them as 5xx ticket-correlated server errors.

## Behaviour change
Searches whose conditions reference field paths absent from the model schema previously returned `200` with empty results. They now return `400 BAD_REQUEST` with a domain message such as `condition references unknown field path(s): $.unknown`. The `CONDITION_TYPE_MISMATCH` help topic and the matching handler test are updated to document the new contract. Models that have never been registered (memory plugin admits entity writes without a prior model) are still admitted unchanged — pre-execution validation is best-effort and only applies once a model exists.

## Test plan
- [x] `go test ./internal/domain/search/... -v` — all green, including the two new TDD tests `TestSearch_StaleSchema_RefreshesOnceAndSucceeds` and `TestSearch_TrulyMissingPath_FourxxAfterOneRefresh`.
- [x] `go test -short ./...` — all green.
- [x] `make test-short-all` — all plugin submodules green.
- [x] `go vet ./...` — clean.
- [x] `go test -race -count=1 ./internal/domain/search/... ./internal/domain/entity/... ./internal/grpc/... ./e2e/parity/memory/... ./e2e/parity/sqlite/...` — clean (one transient `e2e/parity/postgres` flake on the first full root-module run that disappeared on rerun; no `DATA RACE` reported).

Closes #77.