### PR TITLE
fix(entity): propagate pointInTime in GetEntityChangesMetadata (#152)

### DIFF
--- a/e2e/externalapi/dictionary-mapping.md
+++ b/e2e/externalapi/dictionary-mapping.md
@@ -110,7 +110,7 @@ Status vocabulary:
 | pit/01-get-single-entity-at-point-in-time | new:RunExternalAPI_07_01_GetEntityAtPointInTime | tranche 2 — three timestamps, three states |
 | pit/02-get-single-entity-by-transaction-id | new:RunExternalAPI_07_02_GetEntityByTransactionID (skipped) | tranche 2 — t.Skip pending parity-client surface addition (no transactionId-scoped GET helper today). Same gap as 12/05. |
 | pit/03-entity-change-history-full | new:RunExternalAPI_07_03_ChangeHistoryFull | tranche 2 — note: cyoda-go uses `"CREATED"` / `"UPDATED"` enum values where the YAML spec uses `"CREATE"` / `"UPDATE"`. `different_naming_same_level`. Test asserts on cyoda-go's emission. |
-| pit/04-entity-change-history-point-in-time | new:RunExternalAPI_07_04_ChangeHistoryAtPointInTime (skipped) | tranche 2 — t.Skip pending parity-client surface addition (no pointInTime-scoped change history helper today) |
+| pit/04-entity-change-history-point-in-time | new:RunExternalAPI_07_04_ChangeHistoryAtPointInTime | tranche 2 — `equiv_or_better`. Surfaced and fixed cyoda-go bug #152: `GetEntityChangesMetadata` handler was silently dropping the `pointInTime` query param. Service-level filter now truncates the history to entries with `timeOfChange <= pointInTime`. Parity-client `GetEntityChangesAt` helper added alongside the fix. |
 | pit/05-change-history-non-existent-entity | new:RunExternalAPI_07_05_ChangeHistoryNonExistent | tranche 2 — string-based 404 detection (stopgap until GetEntityChangesRaw, added in Phase 5 of tranche 2, is wired in). NB: also surfaced and fixed a real parity bug in postgres plugin's `GetVersionHistory` (was returning empty slice instead of `spi.ErrNotFound` for unknown entities). |
 
 ---

--- a/e2e/externalapi/driver/driver.go
+++ b/e2e/externalapi/driver/driver.go
@@ -255,6 +255,13 @@ func (d *Driver) GetEntityChanges(id uuid.UUID) ([]parityclient.EntityChangeMeta
 	return d.client.GetEntityChanges(d.t, id)
 }
 
+// GetEntityChangesAt issues GET /api/entity/{entityId}/changes?pointInTime=<ISO8601>.
+// Returns the change history truncated to entries at or before the supplied
+// timestamp. YAML action: get_entity_changes (with pointInTime).
+func (d *Driver) GetEntityChangesAt(id uuid.UUID, pointInTime time.Time) ([]parityclient.EntityChangeMeta, error) {
+	return d.client.GetEntityChangesAt(d.t, id, pointInTime)
+}
+
 // --- Edge-message helpers ---
 
 // CreateMessage issues POST /api/message/new/{subject} with a JSON

--- a/e2e/externalapi/driver/vocabulary_test.go
+++ b/e2e/externalapi/driver/vocabulary_test.go
@@ -287,6 +287,32 @@ func TestDriver_GetEntityChanges_GET(t *testing.T) {
 	}
 }
 
+func TestDriver_GetEntityChangesAt_GET_PointInTimeQuery(t *testing.T) {
+	cap := &capturedReq{}
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.method = r.Method
+		cap.path = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+	d := driver.NewRemote(t, srv.URL, "tok")
+	pit := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	id := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	if _, err := d.GetEntityChangesAt(id, pit); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if cap.method != http.MethodGet || !strings.HasSuffix(cap.path, "/changes") {
+		t.Errorf("got %s %s", cap.method, cap.path)
+	}
+	if !strings.Contains(gotQuery, "pointInTime=") {
+		t.Errorf("query missing pointInTime: %q", gotQuery)
+	}
+}
+
 func TestDriver_SetChangeLevelRaw(t *testing.T) {
 	cap := &capturedReq{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/e2e/parity/client/http.go
+++ b/e2e/parity/client/http.go
@@ -373,6 +373,20 @@ func (c *Client) GetEntityChanges(t *testing.T, entityID uuid.UUID) ([]EntityCha
 	return changes, nil
 }
 
+// GetEntityChangesAt issues GET /api/entity/{entityId}/changes?pointInTime=<t>.
+// Returns the change history truncated to entries at or before the supplied
+// timestamp.
+// Canonical: docs/cyoda/openapi.yml (getEntityChangesMetadata with pointInTime query param).
+func (c *Client) GetEntityChangesAt(t *testing.T, entityID uuid.UUID, pointInTime time.Time) ([]EntityChangeMeta, error) {
+	t.Helper()
+	path := fmt.Sprintf("/api/entity/%s/changes?pointInTime=%s", entityID.String(), pointInTime.Format(time.RFC3339Nano))
+	var changes []EntityChangeMeta
+	if _, err := c.doJSON(t, http.MethodGet, path, nil, &changes); err != nil {
+		return nil, err
+	}
+	return changes, nil
+}
+
 // ListEntitiesByModel issues GET /api/entity/{name}/{version}.
 // Returns the entity list (each as EntityResult without modelKey per A2).
 // Canonical: docs/cyoda/openapi.yml:1326 (getAllEntities).

--- a/e2e/parity/externalapi/point_in_time.go
+++ b/e2e/parity/externalapi/point_in_time.go
@@ -117,10 +117,56 @@ func RunExternalAPI_07_03_ChangeHistoryFull(t *testing.T, fixture parity.Backend
 }
 
 // RunExternalAPI_07_04_ChangeHistoryAtPointInTime — dictionary 07/04.
-// Skipped: parity client's GetEntityChanges has no pointInTime variant.
+// Asserts that GET /entity/{id}/changes?pointInTime=<t> truncates the
+// returned change history to entries at or before the supplied timestamp.
+//
+// Sequence: CREATE @ k=1 → UPDATE @ k=2 → cutoff → UPDATE @ k=3.
+// Full history is 3 entries; truncated history is 2 (CREATE + first UPDATE).
 func RunExternalAPI_07_04_ChangeHistoryAtPointInTime(t *testing.T, fixture parity.BackendFixture) {
 	t.Helper()
-	t.Skip("pending #132: parity client does not yet expose pointInTime-scoped change history")
+	d := driver.NewInProcess(t, fixture)
+	if err := d.CreateModelFromSample("pit4", 1, `{"k":1}`); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := d.LockModel("pit4", 1); err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+	id, err := d.CreateEntity("pit4", 1, `{"k":1}`)
+	if err != nil {
+		t.Fatalf("create entity: %v", err)
+	}
+	if err := d.UpdateEntityData(id, `{"k":2}`); err != nil {
+		t.Fatalf("update@k=2: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	cutoff := time.Now().UTC()
+	time.Sleep(50 * time.Millisecond)
+	if err := d.UpdateEntityData(id, `{"k":3}`); err != nil {
+		t.Fatalf("update@k=3: %v", err)
+	}
+
+	// Full history — 3 entries.
+	full, err := d.GetEntityChanges(id)
+	if err != nil {
+		t.Fatalf("GetEntityChanges (full): %v", err)
+	}
+	if len(full) != 3 {
+		t.Errorf("full history: got %d entries, want 3", len(full))
+	}
+
+	// Truncated history at cutoff — 2 entries (CREATE + first UPDATE).
+	truncated, err := d.GetEntityChangesAt(id, cutoff)
+	if err != nil {
+		t.Fatalf("GetEntityChangesAt: %v", err)
+	}
+	if len(truncated) != 2 {
+		t.Fatalf("truncated history at cutoff: got %d entries, want 2", len(truncated))
+	}
+	for i, entry := range truncated {
+		if entry.TimeOfChange.After(cutoff) {
+			t.Errorf("entry %d: timeOfChange %s is after cutoff %s", i, entry.TimeOfChange, cutoff)
+		}
+	}
 }
 
 // RunExternalAPI_07_05_ChangeHistoryNonExistent — dictionary 07/05 (NEGATIVE).

--- a/internal/domain/entity/handler.go
+++ b/internal/domain/entity/handler.go
@@ -385,7 +385,7 @@ func (h *Handler) DeleteSingleEntity(w http.ResponseWriter, r *http.Request, ent
 }
 
 func (h *Handler) GetEntityChangesMetadata(w http.ResponseWriter, r *http.Request, entityId openapi_types.UUID, params genapi.GetEntityChangesMetadataParams) {
-	entries, err := h.GetChangesMetadata(r.Context(), entityId.String())
+	entries, err := h.GetChangesMetadata(r.Context(), entityId.String(), params.PointInTime)
 	if err != nil {
 		common.WriteError(w, r, classifyError(err))
 		return

--- a/internal/domain/entity/handler_test.go
+++ b/internal/domain/entity/handler_test.go
@@ -1391,6 +1391,85 @@ func TestGetEntityChangesMetadata(t *testing.T) {
 	resp.Body.Close()
 }
 
+// TestGetEntityChangesMetadata_PointInTime asserts that the pointInTime
+// query parameter constrains the returned change history to entries whose
+// timeOfChange is at or before the supplied timestamp. Regression test
+// for issue #152: handler previously dropped the parameter silently.
+func TestGetEntityChangesMetadata_PointInTime(t *testing.T) {
+	srv := newTestServer(t)
+	importAndLockModel(t, srv.URL, "ChangesMetaPIT", 1, `{"k":1}`)
+
+	// Create entity (k=1).
+	entityID := createEntityAndGetID(t, srv.URL, "ChangesMetaPIT", 1, `{"k":1}`)
+
+	// Update (k=2).
+	resp := doUpdateEntity(t, srv.URL, "JSON", entityID, "UPDATE", `{"k":2}`)
+	expectStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	// Capture cutoff between updates.
+	time.Sleep(50 * time.Millisecond)
+	cutoff := time.Now().UTC()
+	time.Sleep(50 * time.Millisecond)
+
+	// Update (k=3) — after cutoff.
+	resp = doUpdateEntity(t, srv.URL, "JSON", entityID, "UPDATE", `{"k":3}`)
+	expectStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	// Without pointInTime — full history (3 entries).
+	url := fmt.Sprintf("%s/entity/%s/changes", srv.URL, entityID)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("get changes (full): %v", err)
+	}
+	expectStatus(t, resp, http.StatusOK)
+	body := readBody(t, resp)
+	var full []map[string]any
+	if err := json.Unmarshal(body, &full); err != nil {
+		t.Fatalf("parse full: %v", err)
+	}
+	if len(full) != 3 {
+		t.Fatalf("full history: expected 3 entries, got %d", len(full))
+	}
+
+	// With pointInTime=cutoff — truncated history (2 entries: CREATED + first UPDATED).
+	pitURL := fmt.Sprintf("%s/entity/%s/changes?pointInTime=%s",
+		srv.URL, entityID, cutoff.Format(time.RFC3339Nano))
+	resp, err = http.Get(pitURL)
+	if err != nil {
+		t.Fatalf("get changes (pit): %v", err)
+	}
+	expectStatus(t, resp, http.StatusOK)
+	body = readBody(t, resp)
+	var truncated []map[string]any
+	if err := json.Unmarshal(body, &truncated); err != nil {
+		t.Fatalf("parse truncated: %v", err)
+	}
+	if len(truncated) != 2 {
+		t.Fatalf("truncated history: expected 2 entries (CREATED + UPDATED), got %d: %v", len(truncated), truncated)
+	}
+	// Newest-first order: [UPDATED, CREATED].
+	if ct, _ := truncated[0]["changeType"].(string); ct != "UPDATED" {
+		t.Errorf("truncated[0].changeType: got %v, want UPDATED", truncated[0]["changeType"])
+	}
+	if ct, _ := truncated[1]["changeType"].(string); ct != "CREATED" {
+		t.Errorf("truncated[1].changeType: got %v, want CREATED", truncated[1]["changeType"])
+	}
+
+	// All returned entries must have timeOfChange <= cutoff.
+	for i, entry := range truncated {
+		ts, _ := entry["timeOfChange"].(string)
+		got, err := time.Parse(time.RFC3339Nano, ts)
+		if err != nil {
+			t.Fatalf("entry %d: bad timeOfChange %q: %v", i, ts, err)
+		}
+		if got.After(cutoff) {
+			t.Errorf("entry %d: timeOfChange %s is after cutoff %s", i, got, cutoff)
+		}
+	}
+}
+
 // --- Workflow integration tests ---
 
 // importWorkflow posts a workflow definition for the given model.

--- a/internal/domain/entity/handler_test.go
+++ b/internal/domain/entity/handler_test.go
@@ -1470,6 +1470,139 @@ func TestGetEntityChangesMetadata_PointInTime(t *testing.T) {
 	}
 }
 
+// TestGetEntityChangesMetadata_PointInTimeFuture asserts that a pointInTime
+// strictly after the latest change returns the full history — equivalent to
+// omitting the parameter. Boundary case for issue #152.
+func TestGetEntityChangesMetadata_PointInTimeFuture(t *testing.T) {
+	srv := newTestServer(t)
+	importAndLockModel(t, srv.URL, "ChangesMetaPITFuture", 1, `{"k":1}`)
+
+	entityID := createEntityAndGetID(t, srv.URL, "ChangesMetaPITFuture", 1, `{"k":1}`)
+	resp := doUpdateEntity(t, srv.URL, "JSON", entityID, "UPDATE", `{"k":2}`)
+	expectStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	resp = doUpdateEntity(t, srv.URL, "JSON", entityID, "UPDATE", `{"k":3}`)
+	expectStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	// pointInTime strictly after the latest change.
+	future := time.Now().UTC().Add(1 * time.Hour)
+	pitURL := fmt.Sprintf("%s/entity/%s/changes?pointInTime=%s",
+		srv.URL, entityID, future.Format(time.RFC3339Nano))
+	resp, err := http.Get(pitURL)
+	if err != nil {
+		t.Fatalf("get changes (future pit): %v", err)
+	}
+	expectStatus(t, resp, http.StatusOK)
+	body := readBody(t, resp)
+	var futureResult []map[string]any
+	if err := json.Unmarshal(body, &futureResult); err != nil {
+		t.Fatalf("parse future result: %v", err)
+	}
+	if len(futureResult) != 3 {
+		t.Fatalf("future pointInTime: expected full history (3 entries), got %d", len(futureResult))
+	}
+
+	// Cross-check: omitting the parameter yields the same result set.
+	url := fmt.Sprintf("%s/entity/%s/changes", srv.URL, entityID)
+	resp, err = http.Get(url)
+	if err != nil {
+		t.Fatalf("get changes (no pit): %v", err)
+	}
+	expectStatus(t, resp, http.StatusOK)
+	body = readBody(t, resp)
+	var fullResult []map[string]any
+	if err := json.Unmarshal(body, &fullResult); err != nil {
+		t.Fatalf("parse full result: %v", err)
+	}
+	if len(fullResult) != len(futureResult) {
+		t.Fatalf("future pointInTime length %d != full history length %d", len(futureResult), len(fullResult))
+	}
+	for i := range fullResult {
+		if fullResult[i]["timeOfChange"] != futureResult[i]["timeOfChange"] {
+			t.Errorf("entry %d: full timeOfChange=%v, future timeOfChange=%v",
+				i, fullResult[i]["timeOfChange"], futureResult[i]["timeOfChange"])
+		}
+		if fullResult[i]["changeType"] != futureResult[i]["changeType"] {
+			t.Errorf("entry %d: full changeType=%v, future changeType=%v",
+				i, fullResult[i]["changeType"], futureResult[i]["changeType"])
+		}
+	}
+}
+
+// TestGetEntityChangesMetadata_PointInTimeExactBoundary asserts that a
+// pointInTime exactly equal to a change's timestamp INCLUDES that change —
+// the filter is at-or-before (<=), not strictly-before. Boundary case for
+// issue #152.
+func TestGetEntityChangesMetadata_PointInTimeExactBoundary(t *testing.T) {
+	srv := newTestServer(t)
+	importAndLockModel(t, srv.URL, "ChangesMetaPITExact", 1, `{"k":1}`)
+
+	entityID := createEntityAndGetID(t, srv.URL, "ChangesMetaPITExact", 1, `{"k":1}`)
+	resp := doUpdateEntity(t, srv.URL, "JSON", entityID, "UPDATE", `{"k":2}`)
+	expectStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+	resp = doUpdateEntity(t, srv.URL, "JSON", entityID, "UPDATE", `{"k":3}`)
+	expectStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	// Read the full history to discover an actual change timestamp.
+	url := fmt.Sprintf("%s/entity/%s/changes", srv.URL, entityID)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("get changes (full): %v", err)
+	}
+	expectStatus(t, resp, http.StatusOK)
+	body := readBody(t, resp)
+	var full []map[string]any
+	if err := json.Unmarshal(body, &full); err != nil {
+		t.Fatalf("parse full: %v", err)
+	}
+	if len(full) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(full))
+	}
+
+	// History is newest-first: pick the middle change (first UPDATED).
+	// Using its exact timestamp as pointInTime must include that change
+	// (the boundary is inclusive) and exclude the later one.
+	boundaryStr, _ := full[1]["timeOfChange"].(string)
+	boundary, err := time.Parse(time.RFC3339Nano, boundaryStr)
+	if err != nil {
+		t.Fatalf("parse boundary timestamp %q: %v", boundaryStr, err)
+	}
+
+	pitURL := fmt.Sprintf("%s/entity/%s/changes?pointInTime=%s",
+		srv.URL, entityID, boundary.Format(time.RFC3339Nano))
+	resp, err = http.Get(pitURL)
+	if err != nil {
+		t.Fatalf("get changes (exact pit): %v", err)
+	}
+	expectStatus(t, resp, http.StatusOK)
+	body = readBody(t, resp)
+	var atBoundary []map[string]any
+	if err := json.Unmarshal(body, &atBoundary); err != nil {
+		t.Fatalf("parse boundary result: %v", err)
+	}
+
+	// Inclusive semantics: the boundary entry (full[1]) AND the older
+	// CREATED entry (full[2]) must be present; the newer entry (full[0])
+	// must be absent.
+	if len(atBoundary) != 2 {
+		t.Fatalf("exact-boundary pointInTime: expected 2 entries (boundary + older), got %d: %v",
+			len(atBoundary), atBoundary)
+	}
+	// Newest-first: [boundary UPDATED, CREATED].
+	if got := atBoundary[0]["timeOfChange"]; got != boundaryStr {
+		t.Errorf("atBoundary[0].timeOfChange: got %v, want %s (boundary entry must be included)", got, boundaryStr)
+	}
+	if ct, _ := atBoundary[0]["changeType"].(string); ct != "UPDATED" {
+		t.Errorf("atBoundary[0].changeType: got %v, want UPDATED", atBoundary[0]["changeType"])
+	}
+	if ct, _ := atBoundary[1]["changeType"].(string); ct != "CREATED" {
+		t.Errorf("atBoundary[1].changeType: got %v, want CREATED", atBoundary[1]["changeType"])
+	}
+}
+
 // --- Workflow integration tests ---
 
 // importWorkflow posts a workflow definition for the given model.

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -510,7 +510,12 @@ type deleteEntityResult struct {
 }
 
 // GetChangesMetadata retrieves version history metadata for an entity.
-func (h *Handler) GetChangesMetadata(ctx context.Context, entityID string) ([]EntityChangeEntry, error) {
+//
+// If pointInTime is non-nil, the result is truncated to versions whose
+// Timestamp is at or before pointInTime — the caller sees the change
+// history exactly as it would have appeared at that moment. A nil
+// pointInTime returns the full history.
+func (h *Handler) GetChangesMetadata(ctx context.Context, entityID string, pointInTime *time.Time) ([]EntityChangeEntry, error) {
 	entityStore, err := h.factory.EntityStore(ctx)
 	if err != nil {
 		return nil, common.Internal("failed to access entity store", err)
@@ -526,6 +531,18 @@ func (h *Handler) GetChangesMetadata(ctx context.Context, entityID string) ([]En
 			return nil, appErr
 		}
 		return nil, common.Internal("failed to get version history", err)
+	}
+
+	// Truncate to versions at-or-before pointInTime when set.
+	if pointInTime != nil && !pointInTime.IsZero() {
+		cutoff := *pointInTime
+		filtered := versions[:0]
+		for _, v := range versions {
+			if !v.Timestamp.After(cutoff) {
+				filtered = append(filtered, v)
+			}
+		}
+		versions = filtered
 	}
 
 	// Sort newest first (descending by timestamp)

--- a/internal/grpc/search.go
+++ b/internal/grpc/search.go
@@ -495,7 +495,7 @@ func (s *CloudEventsServiceImpl) handleEntityChangesMetadataGetRequest(ctx conte
 		return status.Errorf(codes.InvalidArgument, "invalid payload: %v", err)
 	}
 
-	entries, err := s.entityHandler.GetChangesMetadata(ctx, req.EntityID)
+	entries, err := s.entityHandler.GetChangesMetadata(ctx, req.EntityID, req.PointInTime)
 	if err != nil {
 		slog.Error("operation failed", "pkg", "grpc", "rpc", "entitySearchCollection", "type", EntityChangesMetadataGetRequest, "ceId", ce.Id, "error", err.Error())
 		errCE, ceErr := entityChangesMetadataError(ctx, ce.Id, err)


### PR DESCRIPTION
## Summary

- Service `GetChangesMetadata` now takes an optional `*time.Time` and truncates the change-history slice to versions with `Timestamp <= pointInTime`. Same bug fixed in the gRPC `EntityChangesMetadataGetRequest` handler — the field was on the payload but never read.
- HTTP handler `GetEntityChangesMetadata` forwards `params.PointInTime` to the service. Previously parsed and silently dropped, so `GET /api/entity/{id}/changes?pointInTime=<t>` returned the full history.
- Parity client/driver gain `GetEntityChangesAt(id, t)`. Parity scenario `ExternalAPI_07_04_ChangeHistoryAtPointInTime` is now implemented (was `t.Skip` referencing #132/#152). Dictionary-mapping row flipped to `equiv_or_better`.

No SPI extension was needed — `EntityVersion.Timestamp` already carries the validity time and the truncation is a pure post-fetch filter at the service layer. All three storage plugins (memory, sqlite, postgres) pass the new parity scenario unchanged.

Closes #152. Unblocks parity scenario 07/04 (PR #161).

## Test plan

- [x] New unit test `TestGetEntityChangesMetadata_PointInTime` (RED → GREEN): asserts truncation at cutoff and full history when absent.
- [x] Existing `TestGetEntityChangesMetadata` regression — full-history path unchanged.
- [x] New driver vocab test `TestDriver_GetEntityChangesAt_GET_PointInTimeQuery` — wire-format check on the query param.
- [x] Parity scenario `TestParity/ExternalAPI_07_04_ChangeHistoryAtPointInTime` — passes on memory, sqlite, postgres backends.
- [x] `go test -short ./...` and `make test-short-all` — all green.
- [x] `go test ./internal/e2e/...` — all green.
- [x] `go test -race -count=1 ./...` — clean.
- [x] `go vet ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)