### PR TITLE
chore(ci): security hardening for v0.6.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,79 @@
+version: 2
+updates:
+  # Root Go module
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Plugin submodules each have their own go.mod and are independently
+  # consumable, so each must be tracked separately.
+  - package-ecosystem: gomod
+    directory: "/plugins/memory"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: gomod
+    directory: "/plugins/sqlite"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: gomod
+    directory: "/plugins/postgres"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # Container base image. Tracks the digest pin in deploy/docker/Dockerfile
+  # so distroless/static base updates surface as PRs.
+  - package-ecosystem: docker
+    directory: "/deploy/docker"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions used by workflows in .github/workflows.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/bump-chart-appversion.yml
+++ b/.github/workflows/bump-chart-appversion.yml
@@ -27,7 +27,7 @@ jobs:
           fi
 
       - name: Install yq
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@751d8ad57b84f1794661bc70c0afb92a22ad7b3c # v4.53.2
 
       - name: Update Chart.yaml appVersion
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
     branches: [develop, main]
   workflow_dispatch:
 
+# Default to read-only token for all jobs. Individual jobs may opt-in to
+# additional scopes if they need them; none currently do.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -13,6 +13,11 @@ on:
       - '.github/workflows/helm-chart-ci.yml'
       - '.github/ct.yaml'
 
+# Default to read-only token for all jobs. Individual jobs may opt-in to
+# additional scopes if they need them; none currently do.
+permissions:
+  contents: read
+
 jobs:
   helm-lint-and-validate:
     name: Lint, template, kubeconform


### PR DESCRIPTION
## Summary

CI security hardening targeting `release/v0.6.3`. Three findings, one commit each.

- **HIGH** — Add `.github/dependabot.yml` covering `gomod` (root + every plugin submodule), `docker` (deploy/docker base image, picks up the digest pin from #147), and `github-actions`. Weekly Monday cadence; minor+patch updates grouped per ecosystem; `open-pull-requests-limit: 10`.
- **MED** — Add top-level `permissions: { contents: read }` to `ci.yml` and `helm-chart-ci.yml`. Other workflows (`release.yml`, `release-chart.yml`, `codeql.yml`, `release-smoke.yml`, `bump-chart-appversion.yml`) already declare permissions and are unchanged.
- **LOW** — Replace floating `mikefarah/yq@master` in `bump-chart-appversion.yml` with a commit SHA pin (`751d8ad5...` annotated as `v4.53.2`). Future pin upgrades will surface via the Dependabot `github-actions` ecosystem added in this PR.

## Test plan

- [ ] Confirm `ci.yml` and `helm-chart-ci.yml` jobs run green on this PR (the new `permissions:` block does not break any job that currently relies on the default token scope).
- [ ] Confirm Dependabot picks up the new config (alerts/PRs appear within ~24h).
- [ ] On next release tag, confirm `bump-chart-appversion.yml` still runs against the SHA-pinned `mikefarah/yq` action.