### PR TITLE
chore(auth): drop unused parseRSAPublicKeyFromPEM helper

### DIFF
--- a/internal/auth/trusted.go
+++ b/internal/auth/trusted.go
@@ -2,9 +2,7 @@ package auth
 
 import (
 	"crypto/rsa"
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -244,23 +242,6 @@ func extractKeyID(path, prefix string) string {
 		return ""
 	}
 	return kid
-}
-
-// parseRSAPublicKeyFromPEM parses a PEM-encoded RSA public key.
-func parseRSAPublicKeyFromPEM(pemData []byte) (*rsa.PublicKey, error) {
-	block, _ := pem.Decode(pemData)
-	if block == nil {
-		return nil, fmt.Errorf("no PEM block found")
-	}
-	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse public key: %w", err)
-	}
-	rsaPub, ok := pub.(*rsa.PublicKey)
-	if !ok {
-		return nil, fmt.Errorf("not an RSA public key")
-	}
-	return rsaPub, nil
 }
 
 // parseRSAPublicKeyFromJWK parses an RSA public key from a JWK JSON object.


### PR DESCRIPTION
## Summary

Misc hygiene sweep for release/v0.6.3. The original sweep brief covered three findings; only one turned out to apply to this branch.

- Remove `parseRSAPublicKeyFromPEM` in `internal/auth/trusted.go` and its now-orphaned `crypto/x509` / `encoding/pem` imports. The function had no callers in production or tests — `TrustedKey` ingestion goes through `parseRSAPublicKeyFromJWK` exclusively. Confirmed via repo-wide grep before deletion.

## Findings dropped from this PR

Per Gate 6 ("don't fabricate fixes for issues that aren't there"), two of the three sweep items do not apply to release/v0.6.3 as it stands:

- **Log-injection echo in path validator.** The brief referenced `internal/domain/search/path_validate.go` with an `invalidPathError` and a `"condition references unknown field path(s): %s"` message. No such file or symbol exists on this branch — `internal/domain/search/condition_type_validate.go` documents that unknown field paths are intentionally accepted (no rejection, no error message echo). The brief also referenced `INVALID_CHANGE_LEVEL` props in `internal/domain/model/service.go`; the `SetChangeLevel` path delegates to `spi.ValidateChangeLevel` (external module), and the in-repo handler does not assemble a props payload echoing the supplied value.
- **Hard-exit signal log in `cmd/cyoda/main.go`.** The current `main.go` has a single graceful-shutdown handler (`sig := <-sigCh`) and no second-signal / hard-exit code path, no `hardExitCh` channel, and no `main_hard_exit_test.go`. Nothing to enrich.

If those concerns are still in scope, they need to be paired with the PR that introduces the corresponding code — happy to revisit then.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short ./...` green (root module)
- [ ] CI verifies plugin submodules and full (non-short) suite