### PR TITLE
fix(security): cap validator recursion depth (H4)

### DIFF
--- a/internal/domain/model/schema/validate.go
+++ b/internal/domain/model/schema/validate.go
@@ -6,6 +6,13 @@ import (
 	"math/big"
 )
 
+// MaxValidationDepth caps recursion in Validate to defend against stack
+// exhaustion from deeply nested user-supplied documents. At roughly 8 bytes
+// per nesting level a 10MB body could otherwise encode hundreds of thousands
+// of levels and crash the goroutine. 256 is well above any realistic JSON
+// nesting and well below the stack-blow threshold.
+const MaxValidationDepth = 256
+
 // ErrorKind classifies a ValidationError so handlers can branch on
 // specific failure modes without matching error message text.
 type ErrorKind int
@@ -54,15 +61,22 @@ func HasUnknownSchemaElement(errs []ValidationError) bool {
 // Validate checks whether data conforms to the given model schema.
 // It returns a slice of validation errors; an empty slice means the data is valid.
 func Validate(model *ModelNode, data any) []ValidationError {
-	return validateNode(model, data, "")
+	return validateNode(model, data, "", 0)
 }
 
-func validateNode(model *ModelNode, data any, path string) []ValidationError {
+func validateNode(model *ModelNode, data any, path string, depth int) []ValidationError {
+	if depth >= MaxValidationDepth {
+		return []ValidationError{{
+			Path:    path,
+			Message: fmt.Sprintf("validation depth exceeded (max %d)", MaxValidationDepth),
+			Kind:    ErrKindGeneric,
+		}}
+	}
 	switch model.Kind() {
 	case KindObject:
-		return validateObject(model, data, path)
+		return validateObject(model, data, path, depth)
 	case KindArray:
-		return validateArray(model, data, path)
+		return validateArray(model, data, path, depth)
 	case KindLeaf:
 		return validateLeaf(model, data, path)
 	default:
@@ -70,7 +84,7 @@ func validateNode(model *ModelNode, data any, path string) []ValidationError {
 	}
 }
 
-func validateObject(model *ModelNode, data any, path string) []ValidationError {
+func validateObject(model *ModelNode, data any, path string, depth int) []ValidationError {
 	// Polymorphic guard: when the node's TypeSet contains more than one type
 	// (i.e. the schema was built from merging structurally-different elements),
 	// accept data whose Go/JSON shape matches any participating type rather than
@@ -92,7 +106,7 @@ func validateObject(model *ModelNode, data any, path string) []ValidationError {
 			// Missing fields are accepted — model describes known structure, not required fields.
 			continue
 		}
-		errs = append(errs, validateNode(childModel, val, childPath)...)
+		errs = append(errs, validateNode(childModel, val, childPath, depth+1)...)
 	}
 	// Extra fields in data that are not in the model are rejected.
 	for name := range obj {
@@ -107,7 +121,7 @@ func validateObject(model *ModelNode, data any, path string) []ValidationError {
 	return errs
 }
 
-func validateArray(model *ModelNode, data any, path string) []ValidationError {
+func validateArray(model *ModelNode, data any, path string, depth int) []ValidationError {
 	// Polymorphic guard: identical rationale as validateObject.
 	if validatePolymorphicFallback(model, data) {
 		return nil
@@ -125,7 +139,7 @@ func validateArray(model *ModelNode, data any, path string) []ValidationError {
 	var errs []ValidationError
 	for i, item := range arr {
 		elemPath := fmt.Sprintf("%s[%d]", path, i)
-		errs = append(errs, validateNode(elem, item, elemPath)...)
+		errs = append(errs, validateNode(elem, item, elemPath, depth+1)...)
 	}
 	return errs
 }

--- a/internal/domain/model/schema/validate_depth_test.go
+++ b/internal/domain/model/schema/validate_depth_test.go
@@ -1,0 +1,82 @@
+package schema_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+)
+
+// buildNestedModel constructs an object model schema nested `depth` levels
+// deep along the field name "a". Each level is an object containing a single
+// child "a" whose type matches the next level.
+func buildNestedModel(depth int) *schema.ModelNode {
+	if depth <= 0 {
+		return schema.NewLeafNode(schema.String)
+	}
+	node := schema.NewObjectNode()
+	node.SetChild("a", buildNestedModel(depth-1))
+	return node
+}
+
+// buildNestedData constructs a `{"a": {"a": ...}}` document nested `depth`
+// levels deep, terminated with a string leaf.
+func buildNestedData(depth int) any {
+	if depth <= 0 {
+		return "leaf"
+	}
+	return map[string]any{"a": buildNestedData(depth - 1)}
+}
+
+// TestValidateRejectsExcessivelyDeepDocument confirms that the validator
+// terminates with a depth-exceeded error rather than recursing without bound
+// when the data document nests deeper than schema.MaxValidationDepth. This is
+// the H4 stack-exhaustion fix: at ~8 bytes/level a 10MB body could encode
+// hundreds of thousands of levels and blow the goroutine stack. The depth
+// guard caps recursion well below the stack-blow threshold.
+func TestValidateRejectsExcessivelyDeepDocument(t *testing.T) {
+	const tooDeep = 1000
+	if tooDeep <= schema.MaxValidationDepth {
+		t.Fatalf("test invariant: tooDeep (%d) must exceed MaxValidationDepth (%d)", tooDeep, schema.MaxValidationDepth)
+	}
+
+	// Model only needs to be deep enough for validation to descend into the
+	// document — the data drives the recursion, not the schema. Using a
+	// matching-depth model exercises the same code path the schema validator
+	// uses for entity create.
+	model := buildNestedModel(tooDeep)
+	data := buildNestedData(tooDeep)
+
+	// Must not panic; a stack-overflow surfaces as a goroutine crash, not a
+	// panic recoverable here, so the test relying on a clean error return is
+	// itself the regression guard.
+	errs := schema.Validate(model, data)
+	if len(errs) == 0 {
+		t.Fatalf("expected validation error for excessively deep document, got none")
+	}
+
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "validation depth exceeded") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected at least one error mentioning 'validation depth exceeded', got: %v", errs)
+	}
+}
+
+// TestValidateAcceptsDocumentAtDepthBoundary confirms a document nested
+// exactly to MaxValidationDepth-1 (the deepest legal level) still validates.
+// This guards against an off-by-one tightening of the cap.
+func TestValidateAcceptsDocumentAtDepthBoundary(t *testing.T) {
+	depth := schema.MaxValidationDepth - 1
+	model := buildNestedModel(depth)
+	data := buildNestedData(depth)
+
+	errs := schema.Validate(model, data)
+	if len(errs) != 0 {
+		t.Errorf("expected document at depth %d (= MaxValidationDepth-1) to validate cleanly, got: %v", depth, errs)
+	}
+}

--- a/internal/domain/search/condition_depth_test.go
+++ b/internal/domain/search/condition_depth_test.go
@@ -1,0 +1,99 @@
+package search
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+)
+
+// buildNestedGroupCondition constructs a chain of GroupConditions each
+// containing one child, terminated by a SimpleCondition. The total nesting
+// depth is `depth` (0 = bare SimpleCondition).
+func buildNestedGroupCondition(depth int) predicate.Condition {
+	var cur predicate.Condition = &predicate.SimpleCondition{
+		JsonPath:     "$.x",
+		OperatorType: "EQUALS",
+		Value:        "v",
+	}
+	for i := 0; i < depth; i++ {
+		cur = &predicate.GroupCondition{
+			Operator:   "AND",
+			Conditions: []predicate.Condition{cur},
+		}
+	}
+	return cur
+}
+
+// TestValidateCondition_RejectsExcessivelyDeepGroup confirms the operator
+// validator (operators.go) terminates with a depth-exceeded error rather
+// than recursing without bound when the predicate tree nests deeper than
+// MaxConditionDepth. Programmatic call sites (workflow engine criteria,
+// internal constructions) bypass the parser's depth cap, so the walker
+// itself must guard.
+func TestValidateCondition_RejectsExcessivelyDeepGroup(t *testing.T) {
+	const tooDeep = 1000
+	if tooDeep <= MaxConditionDepth {
+		t.Fatalf("test invariant: tooDeep (%d) must exceed MaxConditionDepth (%d)", tooDeep, MaxConditionDepth)
+	}
+
+	cond := buildNestedGroupCondition(tooDeep)
+
+	err := ValidateCondition(cond)
+	if err == nil {
+		t.Fatalf("expected depth-exceeded error for %d-level group, got nil", tooDeep)
+	}
+	if !strings.Contains(err.Error(), "condition depth exceeded") {
+		t.Errorf("expected error mentioning 'condition depth exceeded', got: %v", err)
+	}
+}
+
+// TestValidateCondition_AcceptsBoundary confirms a predicate at exactly
+// MaxConditionDepth-1 (the deepest legal nesting) still validates.
+func TestValidateCondition_AcceptsBoundary(t *testing.T) {
+	cond := buildNestedGroupCondition(MaxConditionDepth - 1)
+	if err := ValidateCondition(cond); err != nil {
+		t.Errorf("expected predicate at depth %d (= MaxConditionDepth-1) to validate cleanly, got: %v", MaxConditionDepth-1, err)
+	}
+}
+
+// TestValidateConditionValueTypes_RejectsExcessivelyDeepGroup confirms the
+// type-checking walker (condition_type_validate.go) also caps recursion.
+// Same defense-in-depth rationale: callers other than the HTTP parser may
+// supply arbitrarily-nested predicates.
+func TestValidateConditionValueTypes_RejectsExcessivelyDeepGroup(t *testing.T) {
+	const tooDeep = 1000
+	if tooDeep <= MaxConditionDepth {
+		t.Fatalf("test invariant: tooDeep (%d) must exceed MaxConditionDepth (%d)", tooDeep, MaxConditionDepth)
+	}
+
+	model := schema.NewObjectNode()
+	model.SetChild("x", schema.NewLeafNode(schema.String))
+	cond := buildNestedGroupCondition(tooDeep)
+
+	err := ValidateConditionValueTypes(model, cond)
+	if err == nil {
+		t.Fatalf("expected depth-exceeded error for %d-level group, got nil", tooDeep)
+	}
+	if !strings.Contains(err.Error(), "condition depth exceeded") {
+		t.Errorf("expected error mentioning 'condition depth exceeded', got: %v", err)
+	}
+	// The depth-exceeded error must not impersonate a type mismatch — that
+	// would route through the wrong error code in the handler.
+	if errors.Is(err, errConditionTypeMismatch) {
+		t.Errorf("depth-exceeded error must not satisfy errConditionTypeMismatch sentinel: %v", err)
+	}
+}
+
+// TestValidateConditionValueTypes_AcceptsBoundary confirms a predicate at
+// exactly MaxConditionDepth-1 still type-checks cleanly.
+func TestValidateConditionValueTypes_AcceptsBoundary(t *testing.T) {
+	model := schema.NewObjectNode()
+	model.SetChild("x", schema.NewLeafNode(schema.String))
+	cond := buildNestedGroupCondition(MaxConditionDepth - 1)
+	if err := ValidateConditionValueTypes(model, cond); err != nil {
+		t.Errorf("expected predicate at depth %d (= MaxConditionDepth-1) to validate cleanly, got: %v", MaxConditionDepth-1, err)
+	}
+}

--- a/internal/domain/search/condition_type_validate.go
+++ b/internal/domain/search/condition_type_validate.go
@@ -34,19 +34,22 @@ func ValidateConditionValueTypes(model *schema.ModelNode, cond predicate.Conditi
 		return nil
 	}
 	fm := model.FieldsMap()
-	return walkConditionTypes(fm, cond)
+	return walkConditionTypes(fm, cond, 0)
 }
 
-func walkConditionTypes(fm map[string]schema.FieldDescriptor, cond predicate.Condition) error {
+func walkConditionTypes(fm map[string]schema.FieldDescriptor, cond predicate.Condition, depth int) error {
 	if cond == nil {
 		return nil
+	}
+	if depth >= MaxConditionDepth {
+		return fmt.Errorf("condition depth exceeded (max %d)", MaxConditionDepth)
 	}
 	switch c := cond.(type) {
 	case *predicate.SimpleCondition:
 		return validateSimpleConditionType(fm, c)
 	case *predicate.GroupCondition:
 		for _, child := range c.Conditions {
-			if err := walkConditionTypes(fm, child); err != nil {
+			if err := walkConditionTypes(fm, child, depth+1); err != nil {
 				return err
 			}
 		}

--- a/internal/domain/search/operators.go
+++ b/internal/domain/search/operators.go
@@ -8,6 +8,16 @@ import (
 	"github.com/cyoda-platform/cyoda-go-spi/predicate"
 )
 
+// MaxConditionDepth caps recursion in the condition validators
+// (ValidateCondition, ValidateConditionValueTypes) to defend against stack
+// exhaustion from deeply nested predicate trees. The HTTP parser
+// (predicate.ParseCondition) already caps incoming requests at a smaller
+// depth, but in-process callers (workflow engine criteria, programmatic
+// constructions) bypass that cap and can otherwise pass an arbitrarily
+// nested tree directly to the walkers. 256 is well above any realistic
+// query nesting and well below the goroutine stack-blow threshold.
+const MaxConditionDepth = 256
+
 // canonicalOperators is the single source of truth for the valid
 // `operatorType` values accepted by Simple / Lifecycle / Array conditions.
 // The list is mirrored in cmd/cyoda/help/content/search.md and in the
@@ -53,8 +63,15 @@ var canonicalOperators = map[string]struct{}{
 // identifying any unknown operator. The returned error text lists the
 // canonical set so callers can self-correct.
 func ValidateCondition(cond predicate.Condition) error {
+	return validateConditionAtDepth(cond, 0)
+}
+
+func validateConditionAtDepth(cond predicate.Condition, depth int) error {
 	if cond == nil {
 		return nil
+	}
+	if depth >= MaxConditionDepth {
+		return fmt.Errorf("condition depth exceeded (max %d)", MaxConditionDepth)
 	}
 	switch c := cond.(type) {
 	case *predicate.SimpleCondition:
@@ -68,7 +85,7 @@ func ValidateCondition(cond predicate.Condition) error {
 		return nil
 	case *predicate.GroupCondition:
 		for _, child := range c.Conditions {
-			if err := ValidateCondition(child); err != nil {
+			if err := validateConditionAtDepth(child, depth+1); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary
- Schema validator (`internal/domain/model/schema/validate.go`) and condition validators (`internal/domain/search/operators.go`, `condition_type_validate.go`) recursed without depth guards. A 10MB JSON body at ~8 bytes per nesting level can encode hundreds of thousands of levels, exhausting the goroutine stack and crashing the process. Authenticated client could trigger via entity create or search.
- Add `schema.MaxValidationDepth = 256` and `search.MaxConditionDepth = 256` (well above realistic JSON nesting, well below the stack-blow threshold). Thread a depth counter through each recursive walker; on overflow, return a typed error that flows through the existing 4xx classification.
- Schema validator: depth-exceeded error becomes a `ValidationError` mapped to `VALIDATION_FAILED` 400 via the existing classification path.
- Condition validators: depth-exceeded error returns `BAD_REQUEST` 400 (operator path) or short-circuits before the type-check sentinel (verified by test); the HTTP parser already caps at depth 50, so this is defense-in-depth for in-process callers (workflow engine criteria, programmatic constructions).

Closes the H4 finding from the v0.6.3 security audit. Umbrella issue: #68.

## Test plan
- [x] `internal/domain/model/schema/validate_depth_test.go` — RED then GREEN. Asserts a 1000-level-deep document terminates with a `validation depth exceeded` error and does not panic; asserts a document at exactly `MaxValidationDepth - 1` still validates cleanly.
- [x] `internal/domain/search/condition_depth_test.go` — RED then GREEN. Same shape for both `ValidateCondition` and `ValidateConditionValueTypes`. Includes a guard that the depth error must not satisfy the `errConditionTypeMismatch` sentinel.
- [x] `go test -short ./...` clean across the root module.
- [x] `go vet ./...` clean.
- [x] `go test -race -short ./internal/domain/model/schema/... ./internal/domain/search/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)