### PR TITLE
fix(search): negative cache for unknown field-path validation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -302,7 +302,14 @@ func New(cfg Config) *App {
 			"error", err.Error())
 		os.Exit(1)
 	}
-	a.searchService = search.NewSearchService(a.storeFactory, common.NewDefaultUUIDGenerator(), searchStore)
+	// Negative cache for pre-execution field-path validation. Shares
+	// the model.invalidate gossip topic with the descriptor cache so a
+	// single schema-change event drops both layers in lock step. The
+	// cache is bounded; otter's S3-FIFO eviction handles overflow.
+	pathValidationCache := search.NewPathValidationCache(cacheBroadcaster)
+	a.searchService = search.
+		NewSearchService(a.storeFactory, common.NewDefaultUUIDGenerator(), searchStore).
+		WithPathValidationCache(pathValidationCache)
 
 	// Search snapshot TTL reaper (uses stopSearchReaper for graceful shutdown)
 	a.stopSearchReaper = make(chan struct{})

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/memberlist v0.5.4
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/joho/godotenv v1.5.1
+	github.com/maypok86/otter/v2 v2.3.0
 	github.com/muesli/termenv v0.16.0
 	github.com/oapi-codegen/runtime v1.3.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/mattn/go-runewidth v0.0.17/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/maypok86/otter/v2 v2.3.0 h1:8H8AVVFUSzJwIegKwv1uF5aGitTY+AIrtktg7OcLs8w=
+github.com/maypok86/otter/v2 v2.3.0/go.mod h1:XgIdlpmL6jYz882/CAx1E4C1ukfgDKSaw4mWq59+7l8=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
 github.com/mdelapenya/tlscert v0.2.0/go.mod h1:O4njj3ELLnJjGdkN7M/vIVCpZ+Cf0L6muqOG4tLSl8o=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=

--- a/internal/domain/search/path_validation_cache.go
+++ b/internal/domain/search/path_validation_cache.go
@@ -1,0 +1,191 @@
+package search
+
+import (
+	"sync"
+
+	"github.com/maypok86/otter/v2"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/cluster/modelcache"
+)
+
+// pathValidationCacheTopic is the gossip topic the path-validation
+// negative cache subscribes to. It is the same topic used by the
+// model-descriptor cache (internal/cluster/modelcache) so a single
+// schema-change event drops both the descriptor and the negative
+// path entries derived from it.
+const pathValidationCacheTopic = "model.invalidate"
+
+// pathValidationCacheCapacity bounds the negative cache size. Otter's
+// S3-FIFO eviction handles overflow automatically — this bound is the
+// memory ceiling, not a TTL: a hot unknown path stays cached as long as
+// it keeps being queried (or until an invalidation event fires for its
+// model).
+const pathValidationCacheCapacity = 10000
+
+// pathCacheKey identifies a single (tenant, modelRef, fieldPath) tuple
+// in the negative cache. Otter requires comparable keys; the struct is
+// comparable by value so it works directly without a hash function.
+type pathCacheKey struct {
+	tenant       string
+	entityName   string
+	modelVersion string
+	fieldPath    string
+}
+
+// modelRefKey is the (tenant, modelRef) generation-bucket key. A single
+// schema-change event for one model bumps its generation, which causes
+// every cached path under that model to be treated as stale on the next
+// lookup. Otter's S3-FIFO eviction reaps the stale entries naturally.
+type modelRefKey struct {
+	tenant       string
+	entityName   string
+	modelVersion string
+}
+
+// PathValidationCache is a loading-cache-style negative cache for the
+// search-service's pre-execution field-path validation. It records
+// "this path was confirmed absent from this (tenant, modelRef)'s
+// schema FieldsMap as of generation N". A serial flood of validation
+// requests for the same unknown path collapses into a single inner-
+// store Get + RefreshAndGet pair instead of one pair per request.
+//
+// Invalidation is event-driven: the cache subscribes to the cluster
+// broadcaster's "model.invalidate" topic. When an event arrives for
+// (tenant, modelRef), the generation for that bucket is bumped so
+// subsequent lookups treat any prior negative entry as stale. This
+// preserves the issue #77 contract — a peer extending the schema
+// must not be hidden behind a stale negative entry.
+//
+// The cache is bounded (10000 entries by default); otter's S3-FIFO
+// policy evicts cold entries automatically, so unbounded memory growth
+// is impossible even under adversarial traffic.
+//
+// The zero value is not safe — use NewPathValidationCache.
+type PathValidationCache struct {
+	cache *otter.Cache[pathCacheKey, uint64]
+
+	mu          sync.RWMutex
+	generations map[modelRefKey]uint64
+}
+
+// NewPathValidationCache constructs a PathValidationCache. broadcaster
+// may be nil for single-node deployments; when non-nil the cache
+// subscribes to the cluster invalidation topic and drops affected
+// entries on every received event.
+func NewPathValidationCache(broadcaster spi.ClusterBroadcaster) *PathValidationCache {
+	c := otter.Must(&otter.Options[pathCacheKey, uint64]{
+		MaximumSize: pathValidationCacheCapacity,
+	})
+	pvc := &PathValidationCache{
+		cache:       c,
+		generations: make(map[modelRefKey]uint64),
+	}
+	if broadcaster != nil {
+		broadcaster.Subscribe(pathValidationCacheTopic, pvc.handleInvalidation)
+	}
+	return pvc
+}
+
+// IsAbsent reports whether the (tenant, ref, path) tuple has a current
+// negative-cache entry — i.e. the path was previously confirmed absent
+// from the model's FieldsMap and no schema-change event has fired for
+// that model since. A cached entry whose generation is below the
+// current bucket generation is treated as a miss (and will be reaped
+// by S3-FIFO eviction in time).
+func (c *PathValidationCache) IsAbsent(tenant string, ref spi.ModelRef, path string) bool {
+	if c == nil {
+		return false
+	}
+	key := pathCacheKey{
+		tenant:       tenant,
+		entityName:   ref.EntityName,
+		modelVersion: ref.ModelVersion,
+		fieldPath:    path,
+	}
+	cached, ok := c.cache.GetIfPresent(key)
+	if !ok {
+		return false
+	}
+	current := c.currentGeneration(modelRefKey{
+		tenant:       tenant,
+		entityName:   ref.EntityName,
+		modelVersion: ref.ModelVersion,
+	})
+	return cached == current
+}
+
+// MarkAbsent records the (tenant, ref, path) tuple as confirmed absent
+// at the current generation. Subsequent IsAbsent calls return true
+// until the next invalidation event for that (tenant, ref).
+func (c *PathValidationCache) MarkAbsent(tenant string, ref spi.ModelRef, path string) {
+	if c == nil {
+		return
+	}
+	gen := c.currentGeneration(modelRefKey{
+		tenant:       tenant,
+		entityName:   ref.EntityName,
+		modelVersion: ref.ModelVersion,
+	})
+	c.cache.Set(pathCacheKey{
+		tenant:       tenant,
+		entityName:   ref.EntityName,
+		modelVersion: ref.ModelVersion,
+		fieldPath:    path,
+	}, gen)
+}
+
+// MarkPresent removes any negative cache entry for the (tenant, ref,
+// path) tuple. Defensive: callers invoke this when a path has been
+// confirmed present in the schema, ensuring a follow-up rename or
+// schema fix is reflected immediately rather than waiting for an
+// invalidation event.
+func (c *PathValidationCache) MarkPresent(tenant string, ref spi.ModelRef, path string) {
+	if c == nil {
+		return
+	}
+	c.cache.Invalidate(pathCacheKey{
+		tenant:       tenant,
+		entityName:   ref.EntityName,
+		modelVersion: ref.ModelVersion,
+		fieldPath:    path,
+	})
+}
+
+// InvalidateRef bumps the generation for (tenant, ref) so every
+// previously-cached negative entry under that model is treated as
+// stale. The entries themselves are not eagerly removed; otter's S3-
+// FIFO eviction handles cold reaping as new traffic arrives. This
+// design avoids holding a per-bucket index of paths solely for the
+// invalidation path, at the cost of a small amount of dead-but-stale
+// space in the cache between events.
+func (c *PathValidationCache) InvalidateRef(tenant string, ref spi.ModelRef) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.generations[modelRefKey{
+		tenant:       tenant,
+		entityName:   ref.EntityName,
+		modelVersion: ref.ModelVersion,
+	}]++
+}
+
+func (c *PathValidationCache) currentGeneration(k modelRefKey) uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.generations[k]
+}
+
+// handleInvalidation is the gossip-topic subscriber. Decoded payloads
+// reuse the modelcache encoding so the descriptor cache and the
+// negative cache react to the same schema-change broadcasts in lock
+// step.
+func (c *PathValidationCache) handleInvalidation(payload []byte) {
+	tenant, ref, ok := modelcache.DecodeInvalidation(payload)
+	if !ok {
+		return
+	}
+	c.InvalidateRef(tenant, ref)
+}

--- a/internal/domain/search/path_validation_cache_test.go
+++ b/internal/domain/search/path_validation_cache_test.go
@@ -1,0 +1,246 @@
+package search_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
+	"github.com/cyoda-platform/cyoda-go/internal/cluster/modelcache"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
+	"github.com/cyoda-platform/cyoda-go/plugins/memory"
+)
+
+// countingModelStore extends refreshingModelStore semantics but tracks
+// concurrent counters for both Get and RefreshAndGet so the negative-
+// cache test can assert the inner-store call shape under serial and
+// concurrent flooding.
+type countingModelStore struct {
+	mu           sync.Mutex
+	descriptor   *spi.ModelDescriptor
+	getCount     atomic.Int64
+	refreshCount atomic.Int64
+}
+
+func (s *countingModelStore) Get(_ context.Context, _ spi.ModelRef) (*spi.ModelDescriptor, error) {
+	s.getCount.Add(1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.descriptor, nil
+}
+
+func (s *countingModelStore) RefreshAndGet(_ context.Context, _ spi.ModelRef) (*spi.ModelDescriptor, error) {
+	s.refreshCount.Add(1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.descriptor, nil
+}
+
+func (s *countingModelStore) Save(context.Context, *spi.ModelDescriptor) error     { return nil }
+func (s *countingModelStore) GetAll(context.Context) ([]spi.ModelRef, error)       { return nil, nil }
+func (s *countingModelStore) Delete(context.Context, spi.ModelRef) error           { return nil }
+func (s *countingModelStore) Lock(context.Context, spi.ModelRef) error             { return nil }
+func (s *countingModelStore) Unlock(context.Context, spi.ModelRef) error           { return nil }
+func (s *countingModelStore) IsLocked(context.Context, spi.ModelRef) (bool, error) { return true, nil }
+func (s *countingModelStore) SetChangeLevel(context.Context, spi.ModelRef, spi.ChangeLevel) error {
+	return nil
+}
+func (s *countingModelStore) ExtendSchema(context.Context, spi.ModelRef, spi.SchemaDelta) error {
+	return nil
+}
+
+var _ spi.ModelStore = (*countingModelStore)(nil)
+
+// TestSearch_NegativeCache_CollapsesSerialFloodForUnknownPath asserts that
+// a serial flood of validation requests for the same unknown field path
+// hits the inner ModelStore at most once for the initial Get and once for
+// the bounded RefreshAndGet. Without the negative cache every request
+// would fire its own Get + RefreshAndGet pair, amplifying client error
+// into a denial-of-service vector against the schema cache.
+func TestSearch_NegativeCache_CollapsesSerialFloodForUnknownPath(t *testing.T) {
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+	desc := buildSearchDescriptor(t, ref, "a")
+	ms := &countingModelStore{descriptor: desc}
+
+	base := memory.NewStoreFactory()
+	defer base.Close()
+	factory := &modelStoreFactory{StoreFactory: base, modelStore: ms}
+
+	uuids := common.NewTestUUIDGenerator()
+	searchStore, _ := base.AsyncSearchStore(context.Background())
+
+	cache := search.NewPathValidationCache(nil)
+	svc := search.NewSearchService(factory, uuids, searchStore).
+		WithPathValidationCache(cache)
+
+	ctx := tenantCtx("tenant-1")
+	cond := &predicate.SimpleCondition{
+		JsonPath:     "$.unknown",
+		OperatorType: "EQUALS",
+		Value:        "x",
+	}
+
+	const reqCount = 100
+	for i := 0; i < reqCount; i++ {
+		_, err := svc.Search(ctx, ref, cond, search.SearchOptions{})
+		if err == nil {
+			t.Fatalf("iter %d: expected error for unknown path, got nil", i)
+		}
+	}
+
+	if got := ms.getCount.Load(); got > 2 {
+		t.Errorf("inner Get count: want <=2 (cached negative), got %d", got)
+	}
+	if got := ms.refreshCount.Load(); got > 1 {
+		t.Errorf("inner RefreshAndGet count: want <=1 (bounded), got %d", got)
+	}
+}
+
+// TestSearch_NegativeCache_InvalidatedOnSchemaChangeBroadcast asserts that
+// after a schema-change invalidation event for the (tenant, ref) is
+// broadcast, the previously-cached negative entry is dropped: the next
+// validation re-consults the inner store. Required to preserve the issue
+// #77 "fresh-after-extend" contract — a peer extending the model must not
+// be hidden behind a stale negative cache.
+func TestSearch_NegativeCache_InvalidatedOnSchemaChangeBroadcast(t *testing.T) {
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+	desc := buildSearchDescriptor(t, ref, "a")
+	ms := &countingModelStore{descriptor: desc}
+
+	base := memory.NewStoreFactory()
+	defer base.Close()
+	factory := &modelStoreFactory{StoreFactory: base, modelStore: ms}
+
+	uuids := common.NewTestUUIDGenerator()
+	searchStore, _ := base.AsyncSearchStore(context.Background())
+
+	bc := newFakePathBroadcaster()
+	cache := search.NewPathValidationCache(bc)
+	svc := search.NewSearchService(factory, uuids, searchStore).
+		WithPathValidationCache(cache)
+
+	ctx := tenantCtx("tenant-1")
+	cond := &predicate.SimpleCondition{
+		JsonPath:     "$.unknown",
+		OperatorType: "EQUALS",
+		Value:        "x",
+	}
+
+	// First request: warms the negative cache.
+	if _, err := svc.Search(ctx, ref, cond, search.SearchOptions{}); err == nil {
+		t.Fatalf("expected error on first call")
+	}
+	getsBefore := ms.getCount.Load()
+	refreshesBefore := ms.refreshCount.Load()
+
+	// Second request hits the negative cache (no inner store calls).
+	if _, err := svc.Search(ctx, ref, cond, search.SearchOptions{}); err == nil {
+		t.Fatalf("expected error on second call")
+	}
+	if ms.getCount.Load() != getsBefore || ms.refreshCount.Load() != refreshesBefore {
+		t.Fatalf("expected no inner store calls between warmup and invalidation, got Δgets=%d Δrefreshes=%d",
+			ms.getCount.Load()-getsBefore, ms.refreshCount.Load()-refreshesBefore)
+	}
+
+	// Broadcast schema-change invalidation — peer's ExtendSchema would
+	// look like this from this node's view. The negative cache must
+	// drop the entry so the next request goes back to the inner store.
+	payload, err := modelcache.EncodeInvalidation("tenant-1", ref)
+	if err != nil {
+		t.Fatalf("EncodeInvalidation: %v", err)
+	}
+	bc.Broadcast("model.invalidate", payload)
+
+	// Third request: cache invalidated, inner Get must fire again.
+	if _, err := svc.Search(ctx, ref, cond, search.SearchOptions{}); err == nil {
+		t.Fatalf("expected error on third call")
+	}
+	if ms.getCount.Load() <= getsBefore {
+		t.Errorf("expected inner Get to be re-issued after invalidation; getCount stayed at %d", ms.getCount.Load())
+	}
+}
+
+// TestSearch_NegativeCache_ConcurrentMissAndInvalidation drives 100
+// concurrent validation requests interleaved with a single broadcast
+// invalidation. The contract: no panics, no races, all requests return
+// the expected 4xx error. Run with -race once before PR.
+func TestSearch_NegativeCache_ConcurrentMissAndInvalidation(t *testing.T) {
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+	desc := buildSearchDescriptor(t, ref, "a")
+	ms := &countingModelStore{descriptor: desc}
+
+	base := memory.NewStoreFactory()
+	defer base.Close()
+	factory := &modelStoreFactory{StoreFactory: base, modelStore: ms}
+
+	uuids := common.NewTestUUIDGenerator()
+	searchStore, _ := base.AsyncSearchStore(context.Background())
+
+	bc := newFakePathBroadcaster()
+	cache := search.NewPathValidationCache(bc)
+	svc := search.NewSearchService(factory, uuids, searchStore).
+		WithPathValidationCache(cache)
+
+	ctx := tenantCtx("tenant-1")
+	cond := &predicate.SimpleCondition{
+		JsonPath:     "$.unknown",
+		OperatorType: "EQUALS",
+		Value:        "x",
+	}
+
+	var wg sync.WaitGroup
+	const concurrency = 100
+	wg.Add(concurrency)
+	errs := make(chan error, concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func(i int) {
+			defer wg.Done()
+			if i == concurrency/2 {
+				payload, _ := modelcache.EncodeInvalidation("tenant-1", ref)
+				bc.Broadcast("model.invalidate", payload)
+			}
+			_, err := svc.Search(ctx, ref, cond, search.SearchOptions{})
+			errs <- err
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err == nil {
+			t.Errorf("expected error for unknown path, got nil")
+		}
+	}
+}
+
+// fakePathBroadcaster mirrors fakeBroadcaster but lives in the search
+// package's test scope. Synchronous delivery to every subscriber so
+// invalidation events take effect before the next request.
+type fakePathBroadcaster struct {
+	mu       sync.Mutex
+	handlers map[string][]func([]byte)
+}
+
+func newFakePathBroadcaster() *fakePathBroadcaster {
+	return &fakePathBroadcaster{handlers: make(map[string][]func([]byte))}
+}
+
+func (b *fakePathBroadcaster) Broadcast(topic string, payload []byte) {
+	b.mu.Lock()
+	hs := append([]func([]byte){}, b.handlers[topic]...)
+	b.mu.Unlock()
+	for _, h := range hs {
+		h(payload)
+	}
+}
+
+func (b *fakePathBroadcaster) Subscribe(topic string, h func([]byte)) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.handlers[topic] = append(b.handlers[topic], h)
+}
+
+var _ spi.ClusterBroadcaster = (*fakePathBroadcaster)(nil)

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -63,6 +63,11 @@ type SearchService struct {
 	factory     spi.StoreFactory
 	uuids       spi.UUIDGenerator
 	searchStore spi.AsyncSearchStore
+
+	// pathCache is an optional negative cache for unknown field-path
+	// validation. nil-safe: when unset, validation falls back to the
+	// inner-store Get + bounded RefreshAndGet pair on every request.
+	pathCache *PathValidationCache
 }
 
 // NewSearchService creates a SearchService backed by the given store factory.
@@ -72,6 +77,17 @@ func NewSearchService(factory spi.StoreFactory, uuids spi.UUIDGenerator, searchS
 		uuids:       uuids,
 		searchStore: searchStore,
 	}
+}
+
+// WithPathValidationCache wires a negative cache for field-path
+// validation. Returns the receiver so the call can chain after
+// NewSearchService. The cache is optional; without it every
+// validation attempt routes through the inner ModelStore. With it,
+// confirmed-absent paths short-circuit until a schema-change event
+// invalidates the (tenant, modelRef) bucket.
+func (s *SearchService) WithPathValidationCache(c *PathValidationCache) *SearchService {
+	s.pathCache = c
+	return s
 }
 
 // Search performs a synchronous entity search, returning matching entities.
@@ -444,6 +460,16 @@ func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi
 		return nil
 	}
 
+	// Negative cache fast-path: if any path is recorded as confirmed
+	// absent for this (tenant, modelRef) at the current generation,
+	// short-circuit without touching the inner store. This collapses
+	// a serial flood of bad requests into one inner-store round-trip
+	// per (tenant, modelRef, path) tuple between schema events.
+	tenant := tenantFromContext(ctx)
+	if cachedMissing := s.cachedAbsentPaths(tenant, modelRef, paths); len(cachedMissing) > 0 {
+		return invalidPathError(cachedMissing)
+	}
+
 	modelStore, err := s.factory.ModelStore(ctx)
 	if err != nil {
 		// A factory that cannot produce a ModelStore cannot validate;
@@ -477,6 +503,7 @@ func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi
 
 	missing := findUnknownPaths(paths, fields)
 	if len(missing) == 0 {
+		s.markPathsPresent(tenant, modelRef, paths)
 		return nil
 	}
 
@@ -487,13 +514,15 @@ func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi
 	freshFields, refreshed, refreshErr := refreshFieldsMap(ctx, modelStore, modelRef)
 	if !refreshed {
 		// Store has no cache layer — the cached miss is authoritative.
+		s.markPathsAbsent(tenant, modelRef, missing)
 		return invalidPathError(missing)
 	}
 	if refreshErr != nil {
 		if errors.Is(refreshErr, spi.ErrNotFound) {
 			// Model was deleted between Get and RefreshAndGet — fall
 			// back to the cached fields outcome (paths are unknown
-			// because there is no model).
+			// because there is no model). Do NOT populate the negative
+			// cache: there is no schema authority to invalidate against.
 			return invalidPathError(missing)
 		}
 		slog.Debug("schema refresh failed during pre-execution validation",
@@ -509,9 +538,63 @@ func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi
 
 	stillMissing := findUnknownPaths(missing, freshFields)
 	if len(stillMissing) == 0 {
+		s.markPathsPresent(tenant, modelRef, paths)
 		return nil
 	}
+	s.markPathsAbsent(tenant, modelRef, stillMissing)
 	return invalidPathError(stillMissing)
+}
+
+// cachedAbsentPaths returns the subset of paths recorded as confirmed
+// absent in the negative cache for (tenant, modelRef) at the current
+// generation. Returns nil when the cache is unset or no path matches.
+func (s *SearchService) cachedAbsentPaths(tenant string, ref spi.ModelRef, paths []string) []string {
+	if s.pathCache == nil {
+		return nil
+	}
+	var out []string
+	for _, p := range paths {
+		if s.pathCache.IsAbsent(tenant, ref, p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// markPathsAbsent records each path as confirmed absent for (tenant,
+// modelRef). No-op when the cache is unset.
+func (s *SearchService) markPathsAbsent(tenant string, ref spi.ModelRef, paths []string) {
+	if s.pathCache == nil {
+		return
+	}
+	for _, p := range paths {
+		s.pathCache.MarkAbsent(tenant, ref, p)
+	}
+}
+
+// markPathsPresent removes each path from the negative cache for
+// (tenant, modelRef). Defensive: ensures a path that previously
+// resolved as absent and now resolves as present is reflected without
+// waiting for an invalidation event. No-op when the cache is unset.
+func (s *SearchService) markPathsPresent(tenant string, ref spi.ModelRef, paths []string) {
+	if s.pathCache == nil {
+		return
+	}
+	for _, p := range paths {
+		s.pathCache.MarkPresent(tenant, ref, p)
+	}
+}
+
+// tenantFromContext mirrors the modelcache cache's tenant extractor.
+// Empty string when no UserContext is bound — that bucket is shared
+// among unauthenticated requests, which is acceptable for negative
+// caching: invalidation events name the tenant explicitly.
+func tenantFromContext(ctx context.Context) string {
+	uc := spi.GetUserContext(ctx)
+	if uc == nil {
+		return ""
+	}
+	return string(uc.Tenant.ID)
 }
 
 // invalidPathError builds the 4xx response surfaced when one or more


### PR DESCRIPTION
## Motivation

PR #162 adds pre-execution field-path validation for search conditions: every request whose condition references a field absent from the cached model schema triggers one inner `ModelStore.Get` plus a bounded `RefreshAndGet`. The bounded refresh prevents an unbounded loop, but it does **not** prevent a serial flood of bad requests from re-paying the same round-trip on every request.

A misconfigured client (or hostile client) sending unknown-path searches at e.g. 100 RPS amplifies into 100 inner `Get` calls and 100 `RefreshAndGet` calls per second, hammering the schema-cache layer and any backing store behind it. This is a denial-of-service amplification vector against the model subsystem.

## Solution

Add a loading-cache-style **negative cache** for `(tenantID, modelRef, fieldPath)` tuples. A cache hit means "this path was confirmed absent from this model's `FieldsMap` as of generation N". Subsequent serial floods short-circuit at the cache layer without touching the model store.

### Why a loading cache and not TTL

TTL trades staleness for amplification: a 60-second TTL still amplifies the first 60 seconds of a flood. Worse, TTL adds a staleness window that conflicts with PR #162's "fresh-after-extend" contract — a peer extending the schema must be visible immediately, not after TTL expiry.

This cache is **event-driven**: it subscribes to the same `model.invalidate` gossip topic the descriptor cache uses (`internal/cluster/modelcache`). When a peer extends, locks, unlocks, or deletes a model, the negative cache bumps the (tenant, modelRef) generation and any prior cached entry for that bucket is treated as stale on the next lookup. No TTL, no staleness window, no extra schema-version coordination.

### Why otter v2

[otter v2](https://github.com/maypok86/otter) provides:
- **Bounded memory**: `MaximumSize=10000` ceiling enforced by **S3-FIFO** eviction (modern, hit-rate-competitive with W-TinyLFU; outperforms LRU under scan-heavy workloads typical of misbehaving clients).
- **Generic, comparable keys**: our `(tenant, entityName, modelVersion, fieldPath)` struct works directly without a hash function.
- **Built-in singleflight semantics**: not used here (modelcache already collapses concurrent inner Gets), but available if we want to extend later.

S3-FIFO handles the TTL-via-LRU role naturally: cold negative entries are reaped automatically; hot ones stay cached.

## Design notes

- **Cache key**: comparable struct `{tenant, entityName, modelVersion, fieldPath}`.
- **Cache value**: `uint64` generation observed at insert. A separate `map[modelRefKey]uint64` (RWMutex-guarded) tracks current generation. On lookup, a value < current generation is a stale hit — treated as a miss; S3-FIFO eviction reaps it in time.
- **Invalidation**: gossip subscription on `model.invalidate` reuses `modelcache.DecodeInvalidation` so descriptor cache and negative cache react to identical broadcasts in lock step.
- **Defensive eviction**: when `validateConditionPaths` resolves a path as **present**, the cache invalidates that path's entry — covers the rare race where a path's schema state flips faster than gossip propagates.
- **Single-node**: when no broadcaster is wired, the cache operates as a pure local bounded LRU. The bump-on-event invalidation path is no-op; S3-FIFO eviction still bounds memory.

## Test results

```
=== RUN   TestSearch_NegativeCache_CollapsesSerialFloodForUnknownPath
--- PASS: TestSearch_NegativeCache_CollapsesSerialFloodForUnknownPath (0.00s)
=== RUN   TestSearch_NegativeCache_InvalidatedOnSchemaChangeBroadcast
--- PASS: TestSearch_NegativeCache_InvalidatedOnSchemaChangeBroadcast (0.00s)
=== RUN   TestSearch_NegativeCache_ConcurrentMissAndInvalidation
--- PASS: TestSearch_NegativeCache_ConcurrentMissAndInvalidation (0.00s)
PASS
ok  	github.com/cyoda-platform/cyoda-go/internal/domain/search	0.429s
```

The serial-flood test fires 100 sequential validation requests for the same unknown path and asserts:
- inner `Get` count ≤ 2 (one for first miss, plus the bounded refresh)
- inner `RefreshAndGet` count ≤ 1

Pre-fix the counts would be 100 each.

Full short suite, race-detector run, and `go vet ./...` all clean.

## Stacked on #162

This PR depends on PR #162 (`fix/v063-search-validate-refresh`) which introduces `validateConditionPaths` and the `INVALID_FIELD_PATH` error code. The PR is stacked: GitHub will rebase the base to `release/v0.6.3` automatically once #162 merges. The 3 commits unique to this PR are:

- `chore(deps): add github.com/maypok86/otter/v2 for path-validation cache`
- `feat(search): add negative cache for unknown field-path validation`
- `feat(search): wire negative-cache invalidation to model-change broadcast`

## Test plan

- [x] Unit tests in `internal/domain/search/path_validation_cache_test.go`
- [x] `go test -short ./...` clean
- [x] `go test -race ./internal/domain/search/...` clean
- [x] `go test -race -short ./...` clean
- [x] `go vet ./...` clean

Closes the negative-cache item from the v0.6.3 outstanding fixes plan.