### PR TITLE
fix(test): make TestShutdown_SecondSignal_ForcesHardExit deterministic on slow CI

### DIFF
--- a/cmd/cyoda/main_hard_exit_test.go
+++ b/cmd/cyoda/main_hard_exit_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"net"
 	"os"
 	"os/exec"
@@ -88,30 +89,84 @@ func TestShutdown_SecondSignal_ForcesHardExit(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	// Pin an in-flight HTTP request on the admin server so the graceful
-	// drain has something to wait on. Without this, an idle child exits
-	// in ~1ms — far faster than we can deliver a second signal — and the
-	// hard-exit branch is never exercised. The request line is sent but
-	// the headers are never terminated, so http.Server.Shutdown counts
-	// the connection as active and blocks for the full drain budget.
+	// Pin an in-flight HTTP request on the application server so the
+	// graceful drain has something to wait on. Without this, an idle
+	// child exits in ~1ms — far faster than we can deliver a second
+	// signal — and the hard-exit branch is never exercised.
+	//
+	// Earlier revisions sent only "GET /livez HTTP/1.1\r\nHost: x\r\n"
+	// (one trailing CRLF, headers never terminated) and relied on the
+	// server having parsed those bytes before SIGTERM arrived. On slow
+	// CI workers the bytes were still in the kernel's TCP buffer when
+	// the first signal fired, so http.Server.Shutdown saw the
+	// connection as idle, closed it immediately, completed graceful
+	// drain in ~ms, and the child exited 0 before the second signal
+	// could land. The fix below removes that timing dependency.
+	//
+	// We send a complete chunked POST: a valid request line, terminated
+	// headers (\r\n\r\n), one chunk-size announcement (256 bytes), and
+	// only a few bytes of the announced chunk body. The server parses
+	// the request, dispatches to its handler, writes a response (we
+	// read at least one byte back as the synchronisation gate), and
+	// then — crucially — stays blocked draining the unfinished request
+	// body before it can transition the connection to keep-alive idle.
+	// While that drain blocks, http.Server.Shutdown classifies the
+	// connection as StateActive and waits for the full drain budget,
+	// keeping the graceful-shutdown path open long enough for the
+	// second SIGTERM to exercise the hard-exit branch.
 	httpAddr := "127.0.0.1:" + strconv.Itoa(httpPort)
 	hold, err := net.Dial("tcp", httpAddr)
 	if err != nil {
 		t.Fatalf("hold-open dial: %v", err)
 	}
 	defer hold.Close()
-	if _, err := hold.Write([]byte("GET /livez HTTP/1.1\r\nHost: x\r\n")); err != nil {
+	// 256-byte chunk announced (0x100), only 5 bytes of body sent — no
+	// chunk terminator, no zero chunk, no trailing CRLF. The server's
+	// body discard after the handler returns will block reading the
+	// missing bytes, which is what makes the connection stay active
+	// during Shutdown.
+	const inflightReq = "POST /livez HTTP/1.1\r\n" +
+		"Host: x\r\n" +
+		"Transfer-Encoding: chunked\r\n" +
+		"Content-Type: application/octet-stream\r\n" +
+		"\r\n" +
+		"100\r\n" +
+		"hello"
+	if _, err := hold.Write([]byte(inflightReq)); err != nil {
 		t.Fatalf("hold-open write: %v", err)
 	}
+
+	// Synchronisation gate: read at least one response byte from the
+	// hold-open connection. Once we see bytes, the server has fully
+	// parsed the request and dispatched the handler, so the connection
+	// is unambiguously past the kernel's TCP buffer and has reached
+	// StateActive. This eliminates the "bytes still in flight when
+	// SIGTERM arrives" race that produced the original CI flake.
+	hold.SetReadDeadline(time.Now().Add(1 * time.Second))
+	probe := make([]byte, 1)
+	if _, err := hold.Read(probe); err != nil {
+		// A net.OpError with a timeout is acceptable — the server is
+		// blocked reading our partial chunk before sending the
+		// response, which still counts as StateActive. We only fail
+		// on hard errors like ECONNRESET that mean the conn was
+		// dropped.
+		var ne net.Error
+		if !errors.As(err, &ne) || !ne.Timeout() {
+			t.Fatalf("hold-open response read: %v", err)
+		}
+	}
+	hold.SetReadDeadline(time.Time{})
 
 	// First SIGTERM: cancels rootCtx and starts the graceful drain.
 	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 		t.Fatalf("send first SIGTERM: %v", err)
 	}
-	// Brief pause so the first-signal path is observably engaged before
-	// the second arrives — this exercises the second-signal handler
-	// rather than a coalesced double-fire.
-	time.Sleep(200 * time.Millisecond)
+	// Pause so the first-signal path is observably engaged before the
+	// second arrives — this exercises the second-signal handler rather
+	// than a coalesced double-fire. 500ms gives the goroutine that
+	// arms the hard-exit channel time to register reliably across all
+	// schedulers, including slow CI workers.
+	time.Sleep(500 * time.Millisecond)
 
 	// Second SIGTERM: must force os.Exit(2).
 	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {


### PR DESCRIPTION
## Summary

Fixes the intermittent CI flake in `TestShutdown_SecondSignal_ForcesHardExit` (cmd/cyoda/main_hard_exit_test.go) that surfaced as `child exited 0; expected non-zero exit code 2` on slow CI workers. Production code unchanged — only the test setup was non-deterministic.

- The test pinned an "active" HTTP connection by writing partial headers (`GET /livez HTTP/1.1\r\nHost: x\r\n` — single CRLF) and immediately signalling. On slow workers those bytes were still in the kernel TCP buffer when SIGTERM fired, so `http.Server.Shutdown` saw an idle connection, drained instantly, and the child exited 0 before the second signal could land.
- Replaced with a complete chunked POST whose body is truncated mid-chunk, plus a deterministic read-back gate that confirms the server has engaged with the connection before the first signal. Both branches of the gate (response byte received, or read deadline expires while server is blocked draining body) leave the connection in `StateActive`, so `Shutdown` blocks for the full drain budget — the window in which the second signal exercises the hard-exit branch.
- Bumped inter-signal sleep from 200ms to 500ms for goroutine-registration headroom on slow schedulers.

## Test plan

- [x] `go test ./cmd/cyoda/... -run TestShutdown_SecondSignal -v -count=10` — 10/10 pass locally
- [x] `go test -race ./cmd/cyoda/... -run TestShutdown_SecondSignal -count=1` — pass
- [x] `go test -short ./...` — green
- [x] `go vet ./...` — clean
- [ ] CI green on this branch (release/v0.6.3 base)