### PR TITLE
fix(api): API-wide CORS support (#196)

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ The `./scripts/dev/run-local.sh` script is a convenience wrapper that sets `CYOD
 | `CYODA_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 | `CYODA_SUPPRESS_BANNER` | `false` | Set to `true` to silence the startup banner and any mock-auth warnings. Intended for CI/test harnesses; never set in production so operators see security-relevant warnings. |
 | `CYODA_ERROR_RESPONSE_MODE` | `sanitized` | Error detail: `sanitized` (production) or `verbose` (development) |
+| `CYODA_CORS_ENABLED` | `true` | Master switch for CORS. Set to `false` to disable and handle CORS at an ingress/proxy. |
+| `CYODA_CORS_ALLOWED_ORIGINS` | *(unset)* | Comma-separated allowlist or `*` for wildcard. Unset = loopback mode (only `localhost`/`127.0.0.1`/`[::1]` permitted). See `cyoda help config cors`. |
 
 ### Authentication
 

--- a/app/app.go
+++ b/app/app.go
@@ -530,6 +530,14 @@ func New(cfg Config) *App {
 		a.handler = proxy.HTTPRouting(a.tokenSigner, a.nodeRegistry, cfg.Cluster.NodeID, cfg.Cluster.ProxyTimeout)(a.handler)
 	}
 
+	// CORS middleware — outermost wrapper. Sits outside cluster-routing
+	// so preflights short-circuit at the receiving node and never get
+	// proxied. Sits outside outerMux so /help, discovery, and the API
+	// surface are all covered by a single CORS policy. See spec
+	// docs/superpowers/specs/2026-05-01-issue-196-cors-design.md.
+	corsPolicy := middleware.NewCORSPolicy(cfg.CORS.Enabled, cfg.CORS.Wildcard, cfg.CORS.AllowedOrigins)
+	a.handler = middleware.CORS(corsPolicy)(a.handler)
+
 	// gRPC server — uses inner handler (without context path prefix)
 	a.grpcServer = internalgrpc.NewServer(a.authService, a.memberRegistry, a.transactionManager, entityHandler, modelHandler, a.searchService, cfg.OTelEnabled)
 

--- a/app/app_cors_wired_test.go
+++ b/app/app_cors_wired_test.go
@@ -1,0 +1,75 @@
+package app_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/app"
+)
+
+// TestApp_CORSWiredUp_Preflight verifies that a fully-constructed
+// app.Handler() actually has the CORS middleware installed in the
+// chain. A future refactor that drops the install site would fail
+// this test loud (it would 405 instead of 204).
+func TestApp_CORSWiredUp_Preflight(t *testing.T) {
+	cfg := app.DefaultConfig()
+	cfg.CORS.Enabled = true
+	cfg.CORS.Wildcard = true
+	cfg.CORS.AllowedOrigins = nil
+	// Force an in-memory store so the test does not require Postgres.
+	cfg.StorageBackend = "memory"
+	cfg.Cluster.Enabled = false
+
+	a := app.New(cfg)
+	defer a.Close()
+
+	// Synthetic preflight against an arbitrary path. CORS middleware
+	// short-circuits before any router can 404/405 — so we should see
+	// 204 with the preflight headers regardless of whether the path
+	// is registered.
+	req := httptest.NewRequest(http.MethodOptions, "/api/entity/00000000-0000-0000-0000-000000000000", nil)
+	req.Header.Set("Origin", "https://x.example")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	rec := httptest.NewRecorder()
+	a.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204 (CORS middleware not installed?)", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got == "" {
+		t.Error("Access-Control-Allow-Methods missing — CORS middleware not installed?")
+	}
+}
+
+// TestApp_CORSWiredUp_DisabledNoHeaders verifies that with
+// CYODA_CORS_ENABLED=false the chain emits no CORS headers — the
+// identity-wrapper path. A regression here would silently re-enable
+// CORS in production deployments that opted out.
+func TestApp_CORSWiredUp_DisabledNoHeaders(t *testing.T) {
+	cfg := app.DefaultConfig()
+	cfg.CORS.Enabled = false
+	cfg.StorageBackend = "memory"
+	cfg.Cluster.Enabled = false
+
+	a := app.New(cfg)
+	defer a.Close()
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/entity/00000000-0000-0000-0000-000000000000", nil)
+	req.Header.Set("Origin", "https://x.example")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	rec := httptest.NewRecorder()
+	a.Handler().ServeHTTP(rec, req)
+
+	// With CORS disabled, the chi router is reached and 405s the OPTIONS
+	// (no preflight handling, no preflight short-circuit).
+	if rec.Code == http.StatusNoContent {
+		t.Errorf("status = %d (204) — CORS middleware should NOT be installed when disabled", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty when disabled", got)
+	}
+	if got := rec.Header().Get("Vary"); got == "Origin" {
+		t.Errorf("Vary: Origin emitted while CORS is disabled")
+	}
+}

--- a/app/app_cors_wired_test.go
+++ b/app/app_cors_wired_test.go
@@ -3,6 +3,7 @@ package app_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/cyoda-platform/cyoda-go/app"
@@ -22,7 +23,10 @@ func TestApp_CORSWiredUp_Preflight(t *testing.T) {
 	cfg.Cluster.Enabled = false
 
 	a := app.New(cfg)
-	defer a.Close()
+	t.Cleanup(func() {
+		a.Shutdown()
+		_ = a.Close()
+	})
 
 	// Synthetic preflight against an arbitrary path. CORS middleware
 	// short-circuits before any router can 404/405 — so we should see
@@ -40,6 +44,9 @@ func TestApp_CORSWiredUp_Preflight(t *testing.T) {
 	if got := rec.Header().Get("Access-Control-Allow-Methods"); got == "" {
 		t.Error("Access-Control-Allow-Methods missing — CORS middleware not installed?")
 	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got == "" {
+		t.Error("Access-Control-Allow-Origin missing on preflight (CORS middleware not installed?)")
+	}
 }
 
 // TestApp_CORSWiredUp_DisabledNoHeaders verifies that with
@@ -53,7 +60,10 @@ func TestApp_CORSWiredUp_DisabledNoHeaders(t *testing.T) {
 	cfg.Cluster.Enabled = false
 
 	a := app.New(cfg)
-	defer a.Close()
+	t.Cleanup(func() {
+		a.Shutdown()
+		_ = a.Close()
+	})
 
 	req := httptest.NewRequest(http.MethodOptions, "/api/entity/00000000-0000-0000-0000-000000000000", nil)
 	req.Header.Set("Origin", "https://x.example")
@@ -69,7 +79,7 @@ func TestApp_CORSWiredUp_DisabledNoHeaders(t *testing.T) {
 	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
 		t.Errorf("Access-Control-Allow-Origin = %q, want empty when disabled", got)
 	}
-	if got := rec.Header().Get("Vary"); got == "Origin" {
-		t.Errorf("Vary: Origin emitted while CORS is disabled")
+	if got := rec.Header().Get("Vary"); strings.Contains(got, "Origin") {
+		t.Errorf("Vary: Origin appears in disabled mode (Vary=%q)", got)
 	}
 }

--- a/app/config.go
+++ b/app/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	GRPC               GRPCConfig
 	Admin              AdminConfig
 	Bootstrap          BootstrapConfig
+	CORS               CORSConfig
 	StorageBackend     string
 	StartupTimeout     time.Duration
 	Cluster            cluster.Config
@@ -76,6 +77,25 @@ type IAMConfig struct {
 	RequireJWT     bool   // CYODA_REQUIRE_JWT — when true, refuses to start unless mode=jwt and signing key set
 }
 
+// CORSConfig controls cross-origin resource sharing for the public HTTP
+// surface. See cmd/cyoda/help/content/config/cors.md for full operator-facing
+// documentation.
+//
+// Modes (mutually exclusive):
+//   - Disabled: Enabled=false. Middleware is not installed; deployers
+//     handle CORS at an upstream ingress. OPTIONS returns chi default 405.
+//   - Wildcard: Wildcard=true (CYODA_CORS_ALLOWED_ORIGINS=*). The literal
+//     "*" is emitted in Access-Control-Allow-Origin.
+//   - Allowlist: AllowedOrigins is non-empty. Exact-match only.
+//   - Loopback: Enabled=true and AllowedOrigins is empty and Wildcard is
+//     false. Default mode. Allows http(s)://localhost, 127.0.0.1, [::1] on
+//     any port.
+type CORSConfig struct {
+	Enabled        bool     // CYODA_CORS_ENABLED, default true
+	Wildcard       bool     // derived: true iff CYODA_CORS_ALLOWED_ORIGINS=="*"
+	AllowedOrigins []string // populated only in allowlist mode (Wildcard==false, len > 0)
+}
+
 type BootstrapConfig struct {
 	ClientID     string // CYODA_BOOTSTRAP_CLIENT_ID
 	ClientSecret string // CYODA_BOOTSTRAP_CLIENT_SECRET (optional, generated if empty)
@@ -112,6 +132,14 @@ func DefaultConfig() Config {
 			UserID:       envString("CYODA_BOOTSTRAP_USER_ID", "admin"),
 			Roles:        envString("CYODA_BOOTSTRAP_ROLES", "ROLE_ADMIN,ROLE_M2M"),
 		},
+		CORS: func() CORSConfig {
+			wildcard, origins := parseCORSAllowedOrigins(envString("CYODA_CORS_ALLOWED_ORIGINS", ""))
+			return CORSConfig{
+				Enabled:        envBool("CYODA_CORS_ENABLED", true),
+				Wildcard:       wildcard,
+				AllowedOrigins: origins,
+			}
+		}(),
 		SearchSnapshotTTL:  envDuration("CYODA_SEARCH_SNAPSHOT_TTL", 1*time.Hour),
 		SearchReapInterval: envDuration("CYODA_SEARCH_REAP_INTERVAL", 5*time.Minute),
 		ModelCacheLease:    envDuration("CYODA_MODEL_CACHE_LEASE", 5*time.Minute),
@@ -258,6 +286,29 @@ func splitCSV(s string) []string {
 		}
 	}
 	return result
+}
+
+// parseCORSAllowedOrigins parses the CYODA_CORS_ALLOWED_ORIGINS env var.
+// Returns wildcard=true iff the value is exactly "*". Otherwise returns the
+// comma-separated list with whitespace trimmed; semantic validation is in
+// ValidateCORS. An empty raw value yields wildcard=false, origins=nil
+// (loopback mode).
+func parseCORSAllowedOrigins(raw string) (wildcard bool, origins []string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false, nil
+	}
+	if raw == "*" {
+		return true, nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return false, out
 }
 
 // ValidateIAM enforces the CYODA_REQUIRE_JWT contract: when set, the binary

--- a/app/config.go
+++ b/app/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -358,13 +359,73 @@ func ValidateCORS(c CORSConfig) error {
 }
 
 // validateCORSOrigin returns nil iff o is a well-formed origin acceptable
-// in the allowlist. See ValidateCORS godoc for the rule set. Stub for
-// now — Task 3 fills in the real rules.
+// in the allowlist. Rejection rules per spec §"Allowlist normalization
+// and validation". Run once at startup, never on the hot path.
 func validateCORSOrigin(o string) error {
-	if o == "" {
+	if strings.TrimSpace(o) == "" {
 		return fmt.Errorf("origin %q: empty entry not allowed", o)
 	}
+	if o == "null" {
+		return fmt.Errorf("origin %q: literal \"null\" is not a valid allowlist entry", o)
+	}
+	if o == "*" || strings.Contains(o, "*") {
+		return fmt.Errorf("origin %q: wildcard/glob is not supported; use CYODA_CORS_ALLOWED_ORIGINS=* for unrestricted mode", o)
+	}
+	// url.Parse normalises the scheme to lowercase, so we must check the
+	// raw string before parsing to catch uppercase schemes.
+	if idx := strings.Index(o, "://"); idx > 0 {
+		rawScheme := o[:idx]
+		if rawScheme != strings.ToLower(rawScheme) {
+			return fmt.Errorf("origin %q: scheme must be lowercase", o)
+		}
+	}
+	u, err := url.Parse(o)
+	if err != nil {
+		return fmt.Errorf("origin %q: failed to parse: %w", o, err)
+	}
+	if u.Scheme == "" {
+		return fmt.Errorf("origin %q: missing scheme (must be http or https)", o)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("origin %q: invalid scheme %q (must be http or https)", o, u.Scheme)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("origin %q: missing host", o)
+	}
+	if host != strings.ToLower(host) {
+		return fmt.Errorf("origin %q: host must be lowercase", o)
+	}
+	if !isASCII(host) {
+		return fmt.Errorf("origin %q: has non-ASCII host; convert to punycode (e.g. xn--…) before configuring", o)
+	}
+	if u.User != nil {
+		return fmt.Errorf("origin %q: userinfo is not allowed", o)
+	}
+	if u.Path != "" {
+		return fmt.Errorf("origin %q: path component (including trailing slash) is not allowed", o)
+	}
+	if u.RawQuery != "" {
+		return fmt.Errorf("origin %q: query component is not allowed", o)
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("origin %q: fragment is not allowed", o)
+	}
+	if port := u.Port(); port != "" {
+		if (u.Scheme == "https" && port == "443") || (u.Scheme == "http" && port == "80") {
+			return fmt.Errorf("origin %q: default port (:%s) must be omitted", o, port)
+		}
+	}
 	return nil
+}
+
+func isASCII(s string) bool {
+	for _, r := range s {
+		if r > 0x7F {
+			return false
+		}
+	}
+	return true
 }
 
 // ValidateIAM enforces the CYODA_REQUIRE_JWT contract: when set, the binary

--- a/app/config.go
+++ b/app/config.go
@@ -341,8 +341,6 @@ func (c CORSConfig) Mode() string {
 //     query, fragment, or trailing slash; lowercase scheme and host;
 //     no non-ASCII characters in host (use punycode); not the literal
 //     string "null"; not the literal "*" (use Wildcard mode).
-//
-// Task 3 covers the rejection rules; Task 2 only the happy paths.
 func ValidateCORS(c CORSConfig) error {
 	if !c.Enabled {
 		return nil
@@ -414,6 +412,10 @@ func validateCORSOrigin(o string) error {
 	if port := u.Port(); port != "" {
 		if (u.Scheme == "https" && port == "443") || (u.Scheme == "http" && port == "80") {
 			return fmt.Errorf("origin %q: default port (:%s) must be omitted", o, port)
+		}
+		n, err := strconv.Atoi(port)
+		if err != nil || n < 1 || n > 65535 {
+			return fmt.Errorf("origin %q: port %q is not a valid TCP port (1-65535)", o, port)
 		}
 	}
 	return nil

--- a/app/config.go
+++ b/app/config.go
@@ -311,6 +311,61 @@ func parseCORSAllowedOrigins(raw string) (wildcard bool, origins []string) {
 	return false, out
 }
 
+// Mode returns a human-readable label describing the CORS mode this config
+// resolves to. Values: "disabled", "loopback", "wildcard", "allowlist".
+func (c CORSConfig) Mode() string {
+	switch {
+	case !c.Enabled:
+		return "disabled"
+	case c.Wildcard:
+		return "wildcard"
+	case len(c.AllowedOrigins) == 0:
+		return "loopback"
+	default:
+		return "allowlist"
+	}
+}
+
+// ValidateCORS verifies the CORS configuration. It is called once at startup
+// (from cmd/cyoda/main.go after slog initialisation) and returns an error
+// for any invalid origin or mode combination. A non-nil return causes the
+// binary to slog the error and os.Exit(1).
+//
+// Validation rules (full set):
+//   - Wildcard==true and AllowedOrigins non-empty is a programming error
+//     (parser rejects this earlier; defensive check here).
+//   - Each origin in AllowedOrigins must be a valid RFC 6454 origin:
+//     scheme + host + optional non-default port; no userinfo, path,
+//     query, fragment, or trailing slash; lowercase scheme and host;
+//     no non-ASCII characters in host (use punycode); not the literal
+//     string "null"; not the literal "*" (use Wildcard mode).
+//
+// Task 3 covers the rejection rules; Task 2 only the happy paths.
+func ValidateCORS(c CORSConfig) error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.Wildcard && len(c.AllowedOrigins) > 0 {
+		return fmt.Errorf("CYODA_CORS_ALLOWED_ORIGINS: wildcard \"*\" cannot be combined with explicit origins")
+	}
+	for _, o := range c.AllowedOrigins {
+		if err := validateCORSOrigin(o); err != nil {
+			return fmt.Errorf("CYODA_CORS_ALLOWED_ORIGINS: %w", err)
+		}
+	}
+	return nil
+}
+
+// validateCORSOrigin returns nil iff o is a well-formed origin acceptable
+// in the allowlist. See ValidateCORS godoc for the rule set. Stub for
+// now — Task 3 fills in the real rules.
+func validateCORSOrigin(o string) error {
+	if o == "" {
+		return fmt.Errorf("origin %q: empty entry not allowed", o)
+	}
+	return nil
+}
+
 // ValidateIAM enforces the CYODA_REQUIRE_JWT contract: when set, the binary
 // refuses to run with mock auth or a missing signing key. Intended for
 // production provisioning (Helm) where silent mock-auth fallback would be

--- a/app/config.go
+++ b/app/config.go
@@ -291,8 +291,11 @@ func splitCSV(s string) []string {
 // parseCORSAllowedOrigins parses the CYODA_CORS_ALLOWED_ORIGINS env var.
 // Returns wildcard=true iff the value is exactly "*". Otherwise returns the
 // comma-separated list with whitespace trimmed; semantic validation is in
-// ValidateCORS. An empty raw value yields wildcard=false, origins=nil
-// (loopback mode).
+// ValidateCORS — empty-after-trim entries are deliberately preserved so
+// that ValidateCORS can reject them with a clear error per the spec
+// ("Reject empty entries — leading/trailing commas, double commas,
+// whitespace-only entries error out").
+// An empty raw value yields wildcard=false, origins=nil (loopback mode).
 func parseCORSAllowedOrigins(raw string) (wildcard bool, origins []string) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -304,9 +307,7 @@ func parseCORSAllowedOrigins(raw string) (wildcard bool, origins []string) {
 	parts := strings.Split(raw, ",")
 	out := make([]string, 0, len(parts))
 	for _, p := range parts {
-		if trimmed := strings.TrimSpace(p); trimmed != "" {
-			out = append(out, trimmed)
-		}
+		out = append(out, strings.TrimSpace(p))
 	}
 	return false, out
 }

--- a/app/config.go
+++ b/app/config.go
@@ -394,6 +394,9 @@ func validateCORSOrigin(o string) error {
 	if host != strings.ToLower(host) {
 		return fmt.Errorf("origin %q: host must be lowercase", o)
 	}
+	if strings.HasPrefix(host, "0x") || strings.HasPrefix(host, "0X") {
+		return fmt.Errorf("origin %q: hex-encoded IPv4 host (%q) is not a canonical origin form", o, host)
+	}
 	if !isASCII(host) {
 		return fmt.Errorf("origin %q: has non-ASCII host; convert to punycode (e.g. xn--…) before configuring", o)
 	}

--- a/app/config_cors_test.go
+++ b/app/config_cors_test.go
@@ -81,3 +81,50 @@ func TestValidateCORS_RejectsWildcardMixedWithExplicit(t *testing.T) {
 		t.Errorf("error message should mention wildcard: %v", err)
 	}
 }
+
+func TestParseCORSAllowedOrigins_PreservesEmptyEntries(t *testing.T) {
+	// Spec requires empty-after-trim entries to reach ValidateCORS so it
+	// can reject them with a clear startup error. The parser must not
+	// silently filter them out.
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{"double comma", "https://a.com,,https://b.com", []string{"https://a.com", "", "https://b.com"}},
+		{"trailing comma", "https://a.com,", []string{"https://a.com", ""}},
+		{"leading comma", ",https://a.com", []string{"", "https://a.com"}},
+		{"whitespace-only entry", "https://a.com,   ,https://b.com", []string{"https://a.com", "", "https://b.com"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wildcard, got := parseCORSAllowedOrigins(tt.raw)
+			if wildcard {
+				t.Fatal("wildcard should be false")
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d entries (%v), want %d (%v)", len(got), got, len(tt.want), tt.want)
+			}
+			for i, g := range got {
+				if g != tt.want[i] {
+					t.Errorf("entry[%d] = %q, want %q", i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestParseCORSAllowedOrigins_ThenValidateCORS_RejectsEmptyEntries(t *testing.T) {
+	// End-to-end env-path: the parser preserves empties, the validator
+	// rejects them. This catches the regression where a deployer typos
+	// "https://a.com,,https://b.com" and silently gets a 2-element
+	// allowlist.
+	wildcard, origins := parseCORSAllowedOrigins("https://a.com,,https://b.com")
+	if wildcard {
+		t.Fatal("wildcard should be false")
+	}
+	cfg := CORSConfig{Enabled: true, AllowedOrigins: origins}
+	if err := ValidateCORS(cfg); err == nil {
+		t.Error("expected ValidateCORS to reject empty entry, got nil")
+	}
+}

--- a/app/config_cors_test.go
+++ b/app/config_cors_test.go
@@ -157,6 +157,7 @@ func TestValidateCORS_RejectionRules(t *testing.T) {
 		{"port too large", "https://x.com:65536", "1-65535"},
 		{"port way too large", "https://x.com:99999", "1-65535"},
 		{"uppercase non-http scheme", "FTP://x.com", "lowercase"},
+		{"hex-encoded IPv4 host", "http://0x7f000001", "hex"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/app/config_cors_test.go
+++ b/app/config_cors_test.go
@@ -153,6 +153,10 @@ func TestValidateCORS_RejectionRules(t *testing.T) {
 		{"glob pattern", "https://*.x.com", "wildcard"},
 		{"unparseable", "://garbage", "parse"},
 		{"whitespace only after trim", "   ", "empty"},
+		{"port zero", "https://x.com:0", "1-65535"},
+		{"port too large", "https://x.com:65536", "1-65535"},
+		{"port way too large", "https://x.com:99999", "1-65535"},
+		{"uppercase non-http scheme", "FTP://x.com", "lowercase"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/app/config_cors_test.go
+++ b/app/config_cors_test.go
@@ -1,0 +1,83 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateCORS_HappyPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  CORSConfig
+	}{
+		{
+			name: "disabled",
+			cfg:  CORSConfig{Enabled: false},
+		},
+		{
+			name: "loopback (default)",
+			cfg:  CORSConfig{Enabled: true},
+		},
+		{
+			name: "wildcard",
+			cfg:  CORSConfig{Enabled: true, Wildcard: true},
+		},
+		{
+			name: "allowlist single",
+			cfg:  CORSConfig{Enabled: true, AllowedOrigins: []string{"https://admin.example.com"}},
+		},
+		{
+			name: "allowlist multiple",
+			cfg: CORSConfig{Enabled: true, AllowedOrigins: []string{
+				"https://admin.example.com",
+				"http://localhost:3000",
+				"https://[::1]:8443",
+				"https://xn--e1afmkfd.example",
+			}},
+		},
+		{
+			name: "allowlist with non-default port",
+			cfg:  CORSConfig{Enabled: true, AllowedOrigins: []string{"http://x.com:8080"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateCORS(tt.cfg); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateCORS_Mode(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  CORSConfig
+		want string
+	}{
+		{"disabled", CORSConfig{Enabled: false}, "disabled"},
+		{"loopback", CORSConfig{Enabled: true}, "loopback"},
+		{"wildcard", CORSConfig{Enabled: true, Wildcard: true}, "wildcard"},
+		{"allowlist", CORSConfig{Enabled: true, AllowedOrigins: []string{"https://x.com"}}, "allowlist"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.Mode(); got != tt.want {
+				t.Errorf("Mode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateCORS_RejectsWildcardMixedWithExplicit(t *testing.T) {
+	// CORSConfig itself shouldn't be reachable in this state via env parsing,
+	// but ValidateCORS must defend against it at the boundary.
+	cfg := CORSConfig{Enabled: true, Wildcard: true, AllowedOrigins: []string{"https://x.com"}}
+	err := ValidateCORS(cfg)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "wildcard") {
+		t.Errorf("error message should mention wildcard: %v", err)
+	}
+}

--- a/app/config_cors_test.go
+++ b/app/config_cors_test.go
@@ -128,3 +128,55 @@ func TestParseCORSAllowedOrigins_ThenValidateCORS_RejectsEmptyEntries(t *testing
 		t.Error("expected ValidateCORS to reject empty entry, got nil")
 	}
 }
+
+func TestValidateCORS_RejectionRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		origin    string
+		wantInErr string // substring expected in error message
+	}{
+		{"empty entry", "", "empty"},
+		{"uppercase scheme", "HTTPS://x.com", "lowercase"},
+		{"uppercase host", "https://X.com", "lowercase"},
+		{"non-https/http scheme", "ftp://x.com", "scheme"},
+		{"missing scheme", "//x.com", "scheme"},
+		{"default port https", "https://x.com:443", "default port"},
+		{"default port http", "http://x.com:80", "default port"},
+		{"trailing slash", "https://x.com/", "path"},
+		{"path component", "https://x.com/admin", "path"},
+		{"query component", "https://x.com?q=1", "query"},
+		{"fragment", "https://x.com#frag", "fragment"},
+		{"userinfo", "https://user@x.com", "userinfo"},
+		{"non-ascii host", "https://пример.example", "punycode"},
+		{"literal null", "null", "null"},
+		{"literal wildcard mixed", "*", "wildcard"},
+		{"glob pattern", "https://*.x.com", "wildcard"},
+		{"unparseable", "://garbage", "parse"},
+		{"whitespace only after trim", "   ", "empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := CORSConfig{Enabled: true, AllowedOrigins: []string{tt.origin}}
+			err := ValidateCORS(cfg)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", tt.origin)
+			}
+			if !strings.Contains(err.Error(), tt.wantInErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantInErr)
+			}
+		})
+	}
+}
+
+func TestValidateCORS_PunycodeMessage(t *testing.T) {
+	cfg := CORSConfig{Enabled: true, AllowedOrigins: []string{"https://пример.example"}}
+	err := ValidateCORS(cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// The spec binds this exact wording for discoverability.
+	want := "convert to punycode"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q must contain %q to be discoverable", err.Error(), want)
+	}
+}

--- a/cmd/cyoda/cors_log_test.go
+++ b/cmd/cyoda/cors_log_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/app"
+)
+
+// captureLog redirects slog default for the duration of fn and returns the
+// recorded JSON-line records.
+func captureLog(t *testing.T, level slog.Level, fn func()) []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: level})
+	slog.SetDefault(slog.New(h))
+	defer slog.SetDefault(prev)
+
+	fn()
+
+	var records []map[string]any
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("failed to parse log line %q: %v", line, err)
+		}
+		records = append(records, m)
+	}
+	return records
+}
+
+func TestLogCORSMode_Disabled(t *testing.T) {
+	cfg := app.CORSConfig{Enabled: false}
+	records := captureLog(t, slog.LevelDebug, func() { logCORSMode(cfg) })
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1: %v", len(records), records)
+	}
+	r := records[0]
+	if r["level"] != "INFO" {
+		t.Errorf("level = %v, want INFO", r["level"])
+	}
+	if !strings.Contains(r["msg"].(string), "cors: disabled") {
+		t.Errorf("msg = %q, want substring \"cors: disabled\"", r["msg"])
+	}
+	if r["pkg"] != "cors" {
+		t.Errorf("pkg = %v, want \"cors\"", r["pkg"])
+	}
+}
+
+func TestLogCORSMode_Wildcard(t *testing.T) {
+	cfg := app.CORSConfig{Enabled: true, Wildcard: true}
+	records := captureLog(t, slog.LevelDebug, func() { logCORSMode(cfg) })
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1: %v", len(records), records)
+	}
+	r := records[0]
+	if r["level"] != "WARN" {
+		t.Errorf("level = %v, want WARN", r["level"])
+	}
+	if !strings.Contains(r["msg"].(string), "wildcard mode active") {
+		t.Errorf("msg = %q, want \"wildcard mode active\" substring", r["msg"])
+	}
+}
+
+func TestLogCORSMode_Loopback(t *testing.T) {
+	cfg := app.CORSConfig{Enabled: true}
+	records := captureLog(t, slog.LevelDebug, func() { logCORSMode(cfg) })
+	if len(records) != 1 {
+		t.Fatalf("got %d records, want 1: %v", len(records), records)
+	}
+	r := records[0]
+	if r["level"] != "INFO" {
+		t.Errorf("level = %v, want INFO", r["level"])
+	}
+	if !strings.Contains(r["msg"].(string), "loopback mode active") {
+		t.Errorf("msg = %q, want \"loopback mode active\" substring", r["msg"])
+	}
+}
+
+func TestLogCORSMode_Allowlist_InfoOnly(t *testing.T) {
+	cfg := app.CORSConfig{Enabled: true, AllowedOrigins: []string{"https://a.com", "https://b.com"}}
+	records := captureLog(t, slog.LevelInfo, func() { logCORSMode(cfg) })
+	if len(records) != 1 {
+		t.Fatalf("at INFO level we should see exactly the count record, got %d records: %v", len(records), records)
+	}
+	r := records[0]
+	if r["level"] != "INFO" {
+		t.Errorf("level = %v, want INFO", r["level"])
+	}
+	if !strings.Contains(r["msg"].(string), "allowlist mode active") {
+		t.Errorf("msg = %q", r["msg"])
+	}
+	if cnt, ok := r["origin_count"].(float64); !ok || int(cnt) != 2 {
+		t.Errorf("origin_count = %v, want 2", r["origin_count"])
+	}
+	// Spec: contents must NOT appear at INFO. Verify no "origins" key.
+	if _, present := r["origins"]; present {
+		t.Errorf("origins key leaked into INFO record: %v", r)
+	}
+}
+
+func TestLogCORSMode_Allowlist_DebugIncludesOrigins(t *testing.T) {
+	cfg := app.CORSConfig{Enabled: true, AllowedOrigins: []string{"https://a.com", "https://b.com"}}
+	records := captureLog(t, slog.LevelDebug, func() { logCORSMode(cfg) })
+	if len(records) != 2 {
+		t.Fatalf("at DEBUG level we should see count + contents = 2 records, got %d: %v", len(records), records)
+	}
+	// First record: INFO with count.
+	if records[0]["level"] != "INFO" {
+		t.Errorf("first record level = %v, want INFO", records[0]["level"])
+	}
+	// Second record: DEBUG with origins slice.
+	if records[1]["level"] != "DEBUG" {
+		t.Errorf("second record level = %v, want DEBUG", records[1]["level"])
+	}
+	origins, ok := records[1]["origins"].([]any)
+	if !ok {
+		t.Fatalf("origins is not a slice: %v", records[1]["origins"])
+	}
+	if len(origins) != 2 {
+		t.Errorf("origins has %d entries, want 2", len(origins))
+	}
+}
+
+func TestLogCORSMode_UnknownMode(t *testing.T) {
+	// Construct a config that produces a Mode() Go currently doesn't know
+	// about. Easiest: simulate via a custom value — but Mode() is hard-coded
+	// to four cases, so we synthesize by calling logCORSMode through the
+	// default branch: this requires the default branch to exist. The test
+	// asserts that even an unrecognised mode produces a visible WARN, not
+	// silent omission.
+	//
+	// Since Mode() can't currently return anything else, we invoke
+	// logCORSMode with the default case via reflection of the underlying
+	// helper if exposed, or skip this test if the default branch is the
+	// only way to reach it. For now, assert the default branch fires by
+	// monkeying CORSConfig such that Mode() returns "" — Mode() returns
+	// "disabled" when Enabled=false, "wildcard" when Wildcard, "loopback"
+	// when no origins, "allowlist" otherwise. There is no input that
+	// produces an unknown mode through Mode(). We test the default case
+	// indirectly by checking that the logCORSMode source has a default
+	// branch — but that's a compile-time assertion. We'll use a workaround:
+	// the default branch is reached only if Mode() ever gains a new value;
+	// we can verify it exists by reading the source. Skip the runtime test.
+	t.Skip("Mode() currently can't produce an unknown value; default branch is defensive only")
+}

--- a/cmd/cyoda/help/content/cli/help.md
+++ b/cmd/cyoda/help/content/cli/help.md
@@ -44,14 +44,12 @@ The same topic tree is served over HTTP on the running server. No authentication
 
 - `GET {CYODA_CONTEXT_PATH}/help` — returns the full topic tree as a `HelpPayload` JSON document.
 - `GET {CYODA_CONTEXT_PATH}/help/{topic}` — returns a single `TopicDescriptor` JSON document for the addressed topic.
-- `OPTIONS {CYODA_CONTEXT_PATH}/help` — CORS preflight; returns `204 No Content`.
-- `OPTIONS {CYODA_CONTEXT_PATH}/help/{topic}` — CORS preflight; returns `204 No Content`.
 
 `CYODA_CONTEXT_PATH` defaults to `/api`. Both mount points are relative to the configured context path.
 
 ### Methods
 
-Only `GET` and `OPTIONS` are accepted. Any other method (`POST`, `PUT`, `DELETE`, `PATCH`) returns `405 Method Not Allowed` with header `Allow: GET, OPTIONS` and a `BAD_REQUEST` error body (`application/problem+json`).
+Only `GET` is accepted by the help handler. CORS preflights (`OPTIONS`) are handled by the unified middleware before reaching this handler. Any other method (`POST`, `PUT`, `DELETE`, `PATCH`) returns `405 Method Not Allowed` with header `Allow: GET` and a `BAD_REQUEST` error body (`application/problem+json`).
 
 ### Topic path syntax
 
@@ -137,22 +135,11 @@ Note: consecutive slashes (e.g. `cli//help`) are cleaned to a single slash by Go
 - `actions` (array of strings) — names of machine-readable actions the topic supports; empty array when none.
 - `children` (array of strings, omitted when empty) — dotted paths of direct child topics.
 
-### CORS
-
-All `GET` responses carry `Access-Control-Allow-Origin: *`.
-
-`OPTIONS` preflight responses carry:
-
-- `Access-Control-Allow-Origin: *`
-- `Access-Control-Allow-Methods: GET, OPTIONS`
-- `Access-Control-Allow-Headers: Content-Type, Authorization`
-- `Access-Control-Max-Age: 86400`
-
 ### Errors
 
 Errors use RFC 9457 Problem Details (`application/problem+json`). See `errors` topic for the full envelope shape.
 
-- `400 BAD_REQUEST` — the `{topic}` path segment contains disallowed characters (fails `^[A-Za-z0-9]([A-Za-z0-9._/-]*[A-Za-z0-9])?$`), or contains an empty segment (leading/trailing separator, double separator). Also returned for any method other than `GET` or `OPTIONS` (with `Allow: GET, OPTIONS` response header).
+- `400 BAD_REQUEST` — the `{topic}` path segment contains disallowed characters (fails `^[A-Za-z0-9]([A-Za-z0-9._/-]*[A-Za-z0-9])?$`), or contains an empty segment (leading/trailing separator, double separator). Also returned for any method other than `GET` (with `Allow: GET` response header).
 - `404 HELP_TOPIC_NOT_FOUND` — the `{topic}` is well-formed but does not resolve to any topic in the tree.
 
 ### Examples
@@ -178,10 +165,11 @@ curl -s -w "\nHTTP %{http_code}\n" http://localhost:8080/api/help/no.such.topic
 
 # Send a disallowed method and confirm 405 with Allow header
 curl -si -X POST http://localhost:8080/api/help | grep -E "^HTTP|^Allow:"
-
-# CORS preflight — confirm 204 and preflight headers
-curl -si -X OPTIONS http://localhost:8080/api/help | grep -E "^HTTP|^Access-Control"
 ```
+
+### CORS
+
+CORS is configured globally — see `config.cors` for the full env-var reference and deployment guidance.
 
 ## STABILITY
 

--- a/cmd/cyoda/help/content/config.md
+++ b/cmd/cyoda/help/content/config.md
@@ -6,6 +6,7 @@ see_also:
   - cli
   - run
   - config.auth
+  - config.cors
   - config.database
   - config.grpc
   - config.schema
@@ -21,8 +22,9 @@ config — environment-driven configuration for cyoda.
 
 All configuration is environment variables prefixed with `CYODA_`. Topics group related variables:
 
-- `config.database` — storage backend selection, per-backend connection settings
 - `config.auth` — IAM mode, JWT issuer, admin controls
+- `config.cors` — CORS middleware mode and allowed origins
+- `config.database` — storage backend selection, per-backend connection settings
 - `config.grpc` — gRPC listener and compute-node credentials
 - `config.schema` — schema-extension log tuning
 

--- a/cmd/cyoda/help/content/config/cors.md
+++ b/cmd/cyoda/help/content/config/cors.md
@@ -58,6 +58,110 @@ Only the origins listed in `CYODA_CORS_ALLOWED_ORIGINS` are permitted. Exact sch
 matching (no wildcards in individual entries). Origins must be absolute URIs with scheme and
 host; paths and query strings are not permitted.
 
+## BEHAVIOUR
+
+The following headers are emitted by the CORS middleware when it is installed
+(`CYODA_CORS_ENABLED=true`):
+
+**On every response (preflight and actual request):**
+
+- `Vary: Origin` — always appended (never overwrites an existing `Vary` value).
+  This instructs intermediate caches to key by `Origin` so that a mode change
+  does not cause a stale no-`Origin` response to be served to an `Origin`-bearing
+  request.
+
+**Access-Control-Allow-Origin:**
+
+- loopback mode: the matched origin is echoed literally; omitted if no match.
+- allowlist mode: the matched origin is echoed literally; omitted if no match.
+- wildcard mode: literal `*` for every request, never reflective of `Origin`.
+- disabled mode: not emitted.
+
+**On preflight responses only** (`OPTIONS` with `Origin` and
+`Access-Control-Request-Method`):
+
+- `Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS` (static)
+- `Access-Control-Allow-Headers: Authorization, Content-Type, traceparent, tracestate` (static)
+- `Access-Control-Max-Age: 86400` (static)
+
+**`Access-Control-Allow-Credentials` is NOT emitted in v1.** Authentication is
+bearer-in-`Authorization`; cookies and HTTP-auth are not used. Credentials mode
+adds attack surface without functional benefit for this auth model.
+
+## TENANT ISOLATION
+
+CORS is a browser-side defence against unauthorized cross-origin reads. It is
+**not** a tenant-isolation control. JWT claims and per-request authorization
+checks in the data path enforce tenant boundaries. An allowlisted SPA serving
+multiple tenants relies entirely on the auth layer, not CORS, to prevent
+cross-tenant access. No CORS rule substitutes for or displaces JWT-based authz.
+
+## DEPLOYMENT
+
+**Local dev / docker compose**
+
+No configuration needed. Loopback mode allows `http://localhost`, `http://127.0.0.1`,
+and `http://[::1]` on any port by default. Suitable for Vite/webpack dev servers
+and local docker-compose SPAs.
+
+**Behind an ingress that handles its own CORS**
+
+Set `CYODA_CORS_ENABLED=false` and configure CORS at the ingress (nginx, Envoy,
+cloud load balancer). Do not let both the ingress and cyoda-go emit
+`Access-Control-Allow-Origin`: a browser receiving two `Access-Control-Allow-Origin`
+values will reject the response.
+
+**Behind a reverse proxy with no CORS handling**
+
+Set `CYODA_CORS_ALLOWED_ORIGINS=https://your.spa.host`. The proxy forwards
+requests unchanged; cyoda-go's allowlist middleware emits the correct header
+for the matching origin.
+
+## PNA AND CSRF
+
+**Private Network Access (PNA):** cyoda-go does not handle
+`Access-Control-Request-Private-Network` / `Access-Control-Allow-Private-Network`.
+Deployers needing browsers on a public origin to reach cyoda-go on a private
+network should configure PNA at the ingress.
+
+**CSRF:** CSRF is not a threat for bearer-in-header authentication. The SPA
+explicitly attaches the bearer on each request rather than relying on ambient
+credentials. No anti-CSRF token is required or provided.
+
+## TOGGLING CORS_ENABLED
+
+Toggling `CYODA_CORS_ENABLED` between `true` and `false` requires a
+downstream-cache flush. Responses cached during the disabled period lack
+`Vary: Origin` and could be served to origins for which the post-toggle policy
+disagrees.
+
+## TROUBLESHOOTING
+
+- **Browser logs a CORS error but the service logs the request as `200`** —
+  the origin was rejected by the allowlist. The middleware omits
+  `Access-Control-Allow-Origin` and the browser blocks reading the body. Add
+  the origin to `CYODA_CORS_ALLOWED_ORIGINS` with exact scheme+host+port.
+
+- **Multi-valued `Access-Control-Allow-Origin`** — both the ingress and
+  cyoda-go are emitting the header. Set `CYODA_CORS_ENABLED=false` and handle
+  CORS entirely at the ingress.
+
+- **Startup failure: `cors: origin "..." has non-ASCII host; convert to punycode`**
+  — IDN host names must be supplied in punycode form (`xn--...`).
+
+- **Startup failure: default port rejected** — drop the port from the origin:
+  use `https://example.com`, not `https://example.com:443`; use `http://example.com`,
+  not `http://example.com:80`.
+
+- **Startup WARN about wildcard mode** — if wildcard is unintended, set a
+  specific allowlist with `CYODA_CORS_ALLOWED_ORIGINS=https://your.app.host`.
+
+- **Local SPA on `file://` cannot reach cyoda-go** — `file://` produces
+  `Origin: null`, which is not auto-allowed in any mode (in wildcard mode,
+  `null` receives `Access-Control-Allow-Origin: *`, which browsers honour for
+  non-credentialed requests). Serve the SPA via a local HTTP server (e.g.
+  `python3 -m http.server`) so a normal `http://localhost` origin is used instead.
+
 ## EXAMPLES
 
 **Loopback only (local dev, default):**

--- a/cmd/cyoda/help/content/config/cors.md
+++ b/cmd/cyoda/help/content/config/cors.md
@@ -1,0 +1,99 @@
+---
+topic: config.cors
+title: "CORS configuration"
+stability: stable
+see_also:
+  - config
+  - run
+---
+
+# config.cors
+
+## NAME
+
+config.cors — Cross-Origin Resource Sharing (CORS) controls for the public HTTP surface.
+
+## SYNOPSIS
+
+cyoda supports four CORS modes: `disabled`, `loopback` (default), `wildcard`, and `allowlist`.
+Configure the mode via `CYODA_CORS_ENABLED` and `CYODA_CORS_ALLOWED_ORIGINS`.
+
+## OPTIONS
+
+- `CYODA_CORS_ENABLED` — enable CORS middleware; set to `false` to disable and handle CORS at
+  an upstream ingress/proxy layer (default: `true`)
+- `CYODA_CORS_ALLOWED_ORIGINS` — comma-separated list of allowed origins, or `*` for wildcard
+  mode (default: empty — loopback mode)
+
+## MODES
+
+The effective mode is determined by the combination of the two env vars:
+
+- `CYODA_CORS_ENABLED=false` — **disabled** (regardless of `CYODA_CORS_ALLOWED_ORIGINS`)
+- `CYODA_CORS_ENABLED=true`, `CYODA_CORS_ALLOWED_ORIGINS` empty — **loopback** (default)
+- `CYODA_CORS_ENABLED=true`, `CYODA_CORS_ALLOWED_ORIGINS=*` — **wildcard**
+- `CYODA_CORS_ENABLED=true`, `CYODA_CORS_ALLOWED_ORIGINS=https://example.com,...` — **allowlist**
+
+### disabled
+
+CORS middleware is not installed. No `Access-Control-*` headers are emitted. OPTIONS requests
+return chi's default 405. Use this when CORS is handled at your ingress layer (nginx, Envoy,
+cloud load balancer).
+
+### loopback (default)
+
+Only loopback origins are permitted: `http(s)://localhost`, `http(s)://127.0.0.1`, and
+`http(s)://[::1]` on any port. Suitable for local development. Set
+`CYODA_CORS_ALLOWED_ORIGINS` to permit additional origins.
+
+### wildcard
+
+`Access-Control-Allow-Origin: *` is emitted for all cross-origin requests. Credentials
+(cookies, `Authorization` header) cannot be used with wildcard mode. Appropriate only for
+fully public, stateless read APIs.
+
+### allowlist
+
+Only the origins listed in `CYODA_CORS_ALLOWED_ORIGINS` are permitted. Exact scheme+host+port
+matching (no wildcards in individual entries). Origins must be absolute URIs with scheme and
+host; paths and query strings are not permitted.
+
+## EXAMPLES
+
+**Loopback only (local dev, default):**
+
+```
+# nothing to set — loopback is the default when CYODA_CORS_ENABLED=true
+```
+
+**Single production origin:**
+
+```
+CYODA_CORS_ENABLED=true
+CYODA_CORS_ALLOWED_ORIGINS=https://app.example.com
+```
+
+**Multiple origins:**
+
+```
+CYODA_CORS_ENABLED=true
+CYODA_CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+```
+
+**Wildcard (public read API):**
+
+```
+CYODA_CORS_ENABLED=true
+CYODA_CORS_ALLOWED_ORIGINS=*
+```
+
+**Disabled (CORS at ingress):**
+
+```
+CYODA_CORS_ENABLED=false
+```
+
+## SEE ALSO
+
+- config
+- run

--- a/cmd/cyoda/help/content/config/cors.md
+++ b/cmd/cyoda/help/content/config/cors.md
@@ -63,7 +63,7 @@ host; paths and query strings are not permitted.
 The following headers are emitted by the CORS middleware when it is installed
 (`CYODA_CORS_ENABLED=true`):
 
-**On every response (preflight and actual request):**
+**On every response from the installed middleware (preflight, CORS request, or no-`Origin` pass-through):**
 
 - `Vary: Origin` — always appended (never overwrites an existing `Vary` value).
   This instructs intermediate caches to key by `Origin` so that a mode change
@@ -83,6 +83,11 @@ The following headers are emitted by the CORS middleware when it is installed
 - `Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS` (static)
 - `Access-Control-Allow-Headers: Authorization, Content-Type, traceparent, tracestate` (static)
 - `Access-Control-Max-Age: 86400` (static)
+
+These three headers are emitted on every preflight regardless of whether
+the origin matched the policy. Only `Access-Control-Allow-Origin` is
+omitted when the origin is rejected — a deployer debugging an allowlist
+miss will see the static three present alongside the absent ACAO.
 
 **`Access-Control-Allow-Credentials` is NOT emitted in v1.** Authentication is
 bearer-in-`Authorization`; cookies and HTTP-auth are not used. Credentials mode

--- a/cmd/cyoda/main.go
+++ b/cmd/cyoda/main.go
@@ -87,6 +87,11 @@ func main() {
 		slog.Error("IAM validation failed", "error", err)
 		os.Exit(1)
 	}
+	if err := app.ValidateCORS(cfg.CORS); err != nil {
+		slog.Error("CORS validation failed", "error", err)
+		os.Exit(1)
+	}
+	logCORSMode(cfg.CORS)
 
 	printBanner(cfg)
 	printMockAuthWarningTo(os.Stdout, cfg)
@@ -162,6 +167,24 @@ func main() {
 		// runServers has already triggered a.Shutdown / a.Close before
 		// returning; surface the failure as a non-zero exit code.
 		os.Exit(1)
+	}
+}
+
+// logCORSMode emits a single startup line describing the resolved CORS
+// mode. The allowlist values themselves are logged only at DEBUG —
+// origins are operationally sensitive (internal hostnames, customer
+// subdomains in multi-tenant SaaS).
+func logCORSMode(c app.CORSConfig) {
+	switch c.Mode() {
+	case "disabled":
+		slog.Info("cors: disabled — no Access-Control-* headers will be emitted; configure CORS at your ingress/proxy layer", "pkg", "cors")
+	case "wildcard":
+		slog.Warn("cors: wildcard mode active (Access-Control-Allow-Origin: *)", "pkg", "cors")
+	case "loopback":
+		slog.Info("cors: loopback mode active — only http(s)://localhost, 127.0.0.1, [::1] are allowed; set CYODA_CORS_ALLOWED_ORIGINS to permit additional origins", "pkg", "cors")
+	case "allowlist":
+		slog.Info("cors: allowlist mode active", "pkg", "cors", "origin_count", len(c.AllowedOrigins))
+		slog.Debug("cors: allowlist contents", "pkg", "cors", "origins", c.AllowedOrigins)
 	}
 }
 

--- a/cmd/cyoda/main.go
+++ b/cmd/cyoda/main.go
@@ -183,8 +183,13 @@ func logCORSMode(c app.CORSConfig) {
 	case "loopback":
 		slog.Info("cors: loopback mode active — only http(s)://localhost, 127.0.0.1, [::1] are allowed; set CYODA_CORS_ALLOWED_ORIGINS to permit additional origins", "pkg", "cors")
 	case "allowlist":
+		// Two calls: count at INFO (always visible), contents at DEBUG (opt-in).
+		// Origins are operationally sensitive (internal hostnames, customer
+		// subdomains in multi-tenant SaaS) — never log them at INFO.
 		slog.Info("cors: allowlist mode active", "pkg", "cors", "origin_count", len(c.AllowedOrigins))
 		slog.Debug("cors: allowlist contents", "pkg", "cors", "origins", c.AllowedOrigins)
+	default:
+		slog.Warn("cors: unknown mode — this is a bug; please report", "pkg", "cors", "mode", c.Mode())
 	}
 }
 

--- a/docs/superpowers/plans/2026-05-02-issue-196-cors.md
+++ b/docs/superpowers/plans/2026-05-02-issue-196-cors.md
@@ -1,0 +1,2389 @@
+# Issue #196 — API-wide CORS support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-05-01-issue-196-cors-design.md` (v2.1).
+
+**Goal:** Add a single CORS middleware that covers every cyoda-go HTTP endpoint (entity, model, search, messaging, audit, account, admin, OAuth, discovery, health, help). Loopback origins (`http(s)://localhost`, `127.0.0.1`, `::1`) are allowed by default; deployers configure `CYODA_CORS_ALLOWED_ORIGINS` for non-loopback origins or `=*` for wildcard. Unify the existing `/help` inline CORS under the new middleware.
+
+**Architecture:** One middleware applied **outside** `outerMux` and outside the cluster-routing wrap in `app/app.go`. Pure `net/http` (no third-party CORS library). Validation in `app.ValidateCORS` produces a normalized config consumed by the middleware. Cluster proxy `Director` strips `Origin` and `Access-Control-Request-{Method,Headers}` on outbound peer-to-peer requests so peer B's middleware no-ops. The `/_internal/*` path-prefix is excluded from CORS at the middleware top.
+
+**Tech Stack:** Go 1.26+, `log/slog`, `net/http`, `net/url`, chi v5 (existing), no new dependencies.
+
+---
+
+## File Structure
+
+| Path | New / Modified | Responsibility |
+|---|---|---|
+| `internal/api/middleware/cors.go` | **New** | Middleware constructor and per-request CORS logic. ~90 LOC. |
+| `internal/api/middleware/cors_test.go` | **New** | Unit tests for the middleware (modes, headers, preflight, /_internal, Vary, no-Origin). |
+| `app/config.go` | Modified | Add `CORSConfig` struct, `DefaultConfig()` env reads, `ValidateCORS()` function. |
+| `app/config_cors_test.go` | **New** | Unit tests for `ValidateCORS()` (table-driven). |
+| `cmd/cyoda/main.go` | Modified | Call `ValidateCORS` after slog init; emit startup INFO/WARN per mode. |
+| `app/app.go` | Modified | Install CORS middleware as the outermost wrapper. |
+| `internal/cluster/proxy/http.go` | Modified | `Director` strips `Origin`, `Access-Control-Request-Method`, `Access-Control-Request-Headers`. |
+| `internal/cluster/proxy/http_test.go` | **New** (or extend if exists) | Unit test for `Director` header strip. |
+| `internal/api/help.go` | Modified | Remove `handleHelpPreflight` and inline `Access-Control-Allow-Origin` sets. Update `Allow` header on 405 from `GET, OPTIONS` to `GET`. |
+| `internal/api/help_test.go` | Modified | Delete `TestCORSHeadersPresent`, `TestCORSPreflight_204`. Update `TestNonGET_Returns405` to expect `Allow: GET`. |
+| `internal/e2e/cors_e2e_test.go` | **New** | E2E tests through full handler stack. |
+| `cmd/cyoda/help/content/config/cors.md` | **New** | Help topic for CORS configuration. |
+| `cmd/cyoda/help/content/cli/help.md` | Modified | Drop the help-only CORS bullet; link to `config/cors.md`. |
+| `README.md` | Modified | Add CORS row to the configuration table. |
+
+---
+
+## Pre-flight: Verify worktree baseline is green
+
+You should be on branch `issue-196-cors` in worktree `.worktrees/issue-196-cors`. Confirm with:
+
+```bash
+git -C /Users/paul/go-projects/cyoda-light/cyoda-go/.worktrees/issue-196-cors status
+git -C /Users/paul/go-projects/cyoda-light/cyoda-go/.worktrees/issue-196-cors branch --show-current
+```
+
+Expected: branch `issue-196-cors`, clean tree (or only untracked files unrelated to this work).
+
+Run baseline tests **once** before starting:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go/.worktrees/issue-196-cors
+go test -short ./...
+```
+
+Expected: all packages OK. If anything fails on baseline, stop and surface to the human — do not start implementation against a broken baseline.
+
+---
+
+## Task 1: Add `CORSConfig` struct and `DefaultConfig()` env reads
+
+**Files:**
+- Modify: `app/config.go` (add struct definition and field; wire env reads in `DefaultConfig`).
+
+This task is plumbing only — no behaviour, no tests yet (Task 2 covers validation tests). The struct holds `Enabled`, `Wildcard`, and `AllowedOrigins`. Parsing of `CYODA_CORS_ALLOWED_ORIGINS` happens here; semantic validation happens in Task 2's `ValidateCORS`.
+
+- [ ] **Step 1: Add `CORSConfig` struct definition next to the other config groups in `app/config.go`**
+
+After the `BootstrapConfig` struct definition, add:
+
+```go
+// CORSConfig controls cross-origin resource sharing for the public HTTP
+// surface. See cmd/cyoda/help/content/config/cors.md for full operator-facing
+// documentation.
+//
+// Modes (mutually exclusive):
+//   - Disabled: Enabled=false. Middleware is not installed; deployers
+//     handle CORS at an upstream ingress. OPTIONS returns chi default 405.
+//   - Wildcard: Wildcard=true (CYODA_CORS_ALLOWED_ORIGINS=*). The literal
+//     "*" is emitted in Access-Control-Allow-Origin.
+//   - Allowlist: AllowedOrigins is non-empty. Exact-match only.
+//   - Loopback: Enabled=true and AllowedOrigins is empty and Wildcard is
+//     false. Default mode. Allows http(s)://localhost, 127.0.0.1, [::1] on
+//     any port.
+type CORSConfig struct {
+	Enabled        bool     // CYODA_CORS_ENABLED, default true
+	Wildcard       bool     // derived: true iff CYODA_CORS_ALLOWED_ORIGINS=="*"
+	AllowedOrigins []string // populated only in allowlist mode (Wildcard==false, len > 0)
+}
+```
+
+- [ ] **Step 2: Add `CORS` field to the top-level `Config` struct**
+
+Find the existing `Config` struct (around `app/config.go:17`) and add the `CORS` field alongside the other group fields (e.g. after `Bootstrap`):
+
+```go
+type Config struct {
+	HTTPPort           int
+	ContextPath        string
+	ErrorResponseMode  string
+	MaxStateVisits     int
+	LogLevel           string
+	Version            string
+	IAM                IAMConfig
+	GRPC               GRPCConfig
+	Admin              AdminConfig
+	Bootstrap          BootstrapConfig
+	CORS               CORSConfig // ADD THIS LINE
+	StorageBackend     string
+	StartupTimeout     time.Duration
+	Cluster            cluster.Config
+	SearchSnapshotTTL  time.Duration
+	SearchReapInterval time.Duration
+	ModelCacheLease    time.Duration
+	OTelEnabled        bool
+	ExternalProcessing contract.ExternalProcessingService
+}
+```
+
+- [ ] **Step 3: Add a parser helper `parseCORSAllowedOrigins` near the bottom of `app/config.go`**
+
+Above the existing `ValidateIAM` function (around line 263):
+
+```go
+// parseCORSAllowedOrigins parses the CYODA_CORS_ALLOWED_ORIGINS env var.
+// Returns wildcard=true iff the value is exactly "*". Otherwise returns the
+// comma-separated list with whitespace trimmed; semantic validation is in
+// ValidateCORS. An empty raw value yields wildcard=false, origins=nil
+// (loopback mode).
+func parseCORSAllowedOrigins(raw string) (wildcard bool, origins []string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false, nil
+	}
+	if raw == "*" {
+		return true, nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, strings.TrimSpace(p))
+	}
+	return false, out
+}
+```
+
+- [ ] **Step 4: Wire env reads inside `DefaultConfig()`**
+
+Find `DefaultConfig()` (around `app/config.go:87`). After the `Bootstrap` block and before `SearchSnapshotTTL`, add:
+
+```go
+		CORS: func() CORSConfig {
+			wildcard, origins := parseCORSAllowedOrigins(envString("CYODA_CORS_ALLOWED_ORIGINS", ""))
+			return CORSConfig{
+				Enabled:        envBool("CYODA_CORS_ENABLED", true),
+				Wildcard:       wildcard,
+				AllowedOrigins: origins,
+			}
+		}(),
+```
+
+- [ ] **Step 5: Verify the package still compiles**
+
+```bash
+go build ./app/...
+```
+
+Expected: no output (success).
+
+- [ ] **Step 6: Verify existing tests still pass (no regression)**
+
+```bash
+go test -short ./app/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/config.go
+git commit -m "feat(config): add CORSConfig struct and env reads (#196)
+
+Plumbing only. Parses CYODA_CORS_ENABLED and CYODA_CORS_ALLOWED_ORIGINS
+into the new CORSConfig struct. Validation comes in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: TDD `ValidateCORS` — happy paths and mode detection
+
+**Files:**
+- Create: `app/config_cors_test.go`
+- Modify: `app/config.go` (add `ValidateCORS` function).
+
+This task covers the happy paths: disabled, loopback (no origins), wildcard, valid allowlist. Task 3 covers all rejection rules.
+
+- [ ] **Step 1: Write the failing test file `app/config_cors_test.go`**
+
+```go
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateCORS_HappyPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  CORSConfig
+	}{
+		{
+			name: "disabled",
+			cfg:  CORSConfig{Enabled: false},
+		},
+		{
+			name: "loopback (default)",
+			cfg:  CORSConfig{Enabled: true},
+		},
+		{
+			name: "wildcard",
+			cfg:  CORSConfig{Enabled: true, Wildcard: true},
+		},
+		{
+			name: "allowlist single",
+			cfg:  CORSConfig{Enabled: true, AllowedOrigins: []string{"https://admin.example.com"}},
+		},
+		{
+			name: "allowlist multiple",
+			cfg: CORSConfig{Enabled: true, AllowedOrigins: []string{
+				"https://admin.example.com",
+				"http://localhost:3000",
+				"https://[::1]:8443",
+				"https://xn--e1afmkfd.example",
+			}},
+		},
+		{
+			name: "allowlist with non-default port",
+			cfg:  CORSConfig{Enabled: true, AllowedOrigins: []string{"http://x.com:8080"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateCORS(tt.cfg); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateCORS_Mode(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  CORSConfig
+		want string
+	}{
+		{"disabled", CORSConfig{Enabled: false}, "disabled"},
+		{"loopback", CORSConfig{Enabled: true}, "loopback"},
+		{"wildcard", CORSConfig{Enabled: true, Wildcard: true}, "wildcard"},
+		{"allowlist", CORSConfig{Enabled: true, AllowedOrigins: []string{"https://x.com"}}, "allowlist"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.Mode(); got != tt.want {
+				t.Errorf("Mode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateCORS_RejectsWildcardMixedWithExplicit(t *testing.T) {
+	// CORSConfig itself shouldn't be reachable in this state via env parsing,
+	// but ValidateCORS must defend against it at the boundary.
+	cfg := CORSConfig{Enabled: true, Wildcard: true, AllowedOrigins: []string{"https://x.com"}}
+	err := ValidateCORS(cfg)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "wildcard") {
+		t.Errorf("error message should mention wildcard: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests — they should fail with "ValidateCORS undefined" or "Mode undefined"**
+
+```bash
+go test -short ./app/ -run TestValidateCORS -v
+```
+
+Expected: FAIL — `ValidateCORS undefined`, `Mode undefined`.
+
+- [ ] **Step 3: Implement `ValidateCORS` and `Mode` in `app/config.go`**
+
+After the existing `ValidateIAM` function (at the bottom of the file), add:
+
+```go
+// Mode returns a human-readable label describing the CORS mode this config
+// resolves to. Values: "disabled", "loopback", "wildcard", "allowlist".
+func (c CORSConfig) Mode() string {
+	switch {
+	case !c.Enabled:
+		return "disabled"
+	case c.Wildcard:
+		return "wildcard"
+	case len(c.AllowedOrigins) == 0:
+		return "loopback"
+	default:
+		return "allowlist"
+	}
+}
+
+// ValidateCORS verifies the CORS configuration. It is called once at startup
+// (from cmd/cyoda/main.go after slog initialisation) and returns an error
+// for any invalid origin or mode combination. A non-nil return causes the
+// binary to slog the error and os.Exit(1).
+//
+// Validation rules (full set):
+//   - Wildcard==true and AllowedOrigins non-empty is a programming error
+//     (parser rejects this earlier; defensive check here).
+//   - Each origin in AllowedOrigins must be a valid RFC 6454 origin:
+//     scheme + host + optional non-default port; no userinfo, path,
+//     query, fragment, or trailing slash; lowercase scheme and host;
+//     no non-ASCII characters in host (use punycode); not the literal
+//     string "null"; not the literal "*" (use Wildcard mode).
+//
+// Task 3 covers the rejection rules; Task 2 only the happy paths.
+func ValidateCORS(c CORSConfig) error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.Wildcard && len(c.AllowedOrigins) > 0 {
+		return fmt.Errorf("CYODA_CORS_ALLOWED_ORIGINS: wildcard \"*\" cannot be combined with explicit origins")
+	}
+	for _, o := range c.AllowedOrigins {
+		if err := validateCORSOrigin(o); err != nil {
+			return fmt.Errorf("CYODA_CORS_ALLOWED_ORIGINS: %w", err)
+		}
+	}
+	return nil
+}
+
+// validateCORSOrigin returns nil iff o is a well-formed origin acceptable
+// in the allowlist. See ValidateCORS godoc for the rule set. Stub for
+// now — Task 3 fills in the real rules.
+func validateCORSOrigin(o string) error {
+	if o == "" {
+		return fmt.Errorf("origin %q: empty entry not allowed", o)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run the tests — they should now pass**
+
+```bash
+go test -short ./app/ -run TestValidateCORS -v
+```
+
+Expected: PASS for all sub-tests including `TestValidateCORS_HappyPaths`, `TestValidateCORS_Mode`, `TestValidateCORS_RejectsWildcardMixedWithExplicit`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/config.go app/config_cors_test.go
+git commit -m "feat(config): add ValidateCORS happy-path validation and Mode (#196)
+
+Implements the wildcard-vs-explicit-mutex check and a stub origin
+validator. Full origin validation rules come in the next task.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: TDD `validateCORSOrigin` — full rejection rules
+
+**Files:**
+- Modify: `app/config_cors_test.go` (add table-driven rejection tests).
+- Modify: `app/config.go` (replace stub `validateCORSOrigin` with full implementation).
+
+- [ ] **Step 1: Append rejection tests to `app/config_cors_test.go`**
+
+```go
+func TestValidateCORS_RejectionRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		origin    string
+		wantInErr string // substring expected in error message
+	}{
+		{"empty entry", "", "empty"},
+		{"uppercase scheme", "HTTPS://x.com", "lowercase"},
+		{"uppercase host", "https://X.com", "lowercase"},
+		{"non-https/http scheme", "ftp://x.com", "scheme"},
+		{"missing scheme", "//x.com", "scheme"},
+		{"default port https", "https://x.com:443", "default port"},
+		{"default port http", "http://x.com:80", "default port"},
+		{"trailing slash", "https://x.com/", "path"},
+		{"path component", "https://x.com/admin", "path"},
+		{"query component", "https://x.com?q=1", "query"},
+		{"fragment", "https://x.com#frag", "fragment"},
+		{"userinfo", "https://user@x.com", "userinfo"},
+		{"non-ascii host", "https://пример.example", "punycode"},
+		{"literal null", "null", "null"},
+		{"literal wildcard mixed", "*", "wildcard"},
+		{"glob pattern", "https://*.x.com", "wildcard"},
+		{"unparseable", "://garbage", "parse"},
+		{"whitespace only after trim", "   ", "empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := CORSConfig{Enabled: true, AllowedOrigins: []string{tt.origin}}
+			err := ValidateCORS(cfg)
+			if err == nil {
+				t.Fatalf("expected error for %q, got nil", tt.origin)
+			}
+			if !strings.Contains(err.Error(), tt.wantInErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantInErr)
+			}
+		})
+	}
+}
+
+func TestValidateCORS_PunycodeMessage(t *testing.T) {
+	cfg := CORSConfig{Enabled: true, AllowedOrigins: []string{"https://пример.example"}}
+	err := ValidateCORS(cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// The spec binds this exact wording for discoverability.
+	want := "convert to punycode"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error %q must contain %q to be discoverable", err.Error(), want)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests — they should fail (stub validator accepts most inputs)**
+
+```bash
+go test -short ./app/ -run TestValidateCORS_RejectionRules -v
+go test -short ./app/ -run TestValidateCORS_PunycodeMessage -v
+```
+
+Expected: FAIL — many subtests failing because the stub only rejects empty strings.
+
+- [ ] **Step 3: Replace the stub `validateCORSOrigin` in `app/config.go` with the full implementation**
+
+Add `"net/url"` to the imports. Replace the stub `validateCORSOrigin` function with:
+
+```go
+// validateCORSOrigin returns nil iff o is a well-formed origin acceptable
+// in the allowlist. Rejection rules per spec §"Allowlist normalization
+// and validation". Run once at startup, never on the hot path.
+func validateCORSOrigin(o string) error {
+	if strings.TrimSpace(o) == "" {
+		return fmt.Errorf("origin %q: empty entry not allowed", o)
+	}
+	if o == "null" {
+		return fmt.Errorf("origin %q: literal \"null\" is not a valid allowlist entry", o)
+	}
+	if o == "*" || strings.Contains(o, "*") {
+		return fmt.Errorf("origin %q: wildcard/glob is not supported; use CYODA_CORS_ALLOWED_ORIGINS=* for unrestricted mode", o)
+	}
+	u, err := url.Parse(o)
+	if err != nil {
+		return fmt.Errorf("origin %q: failed to parse: %w", o, err)
+	}
+	if u.Scheme == "" {
+		return fmt.Errorf("origin %q: missing scheme (must be http or https)", o)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("origin %q: invalid scheme %q (must be http or https)", o, u.Scheme)
+	}
+	if u.Scheme != strings.ToLower(u.Scheme) {
+		return fmt.Errorf("origin %q: scheme must be lowercase", o)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return fmt.Errorf("origin %q: missing host", o)
+	}
+	if host != strings.ToLower(host) {
+		return fmt.Errorf("origin %q: host must be lowercase", o)
+	}
+	if !isASCII(host) {
+		return fmt.Errorf("origin %q: has non-ASCII host; convert to punycode (e.g. xn--…) before configuring", o)
+	}
+	if u.User != nil {
+		return fmt.Errorf("origin %q: userinfo is not allowed", o)
+	}
+	if u.Path != "" {
+		return fmt.Errorf("origin %q: path component (including trailing slash) is not allowed", o)
+	}
+	if u.RawQuery != "" {
+		return fmt.Errorf("origin %q: query component is not allowed", o)
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("origin %q: fragment is not allowed", o)
+	}
+	if port := u.Port(); port != "" {
+		if (u.Scheme == "https" && port == "443") || (u.Scheme == "http" && port == "80") {
+			return fmt.Errorf("origin %q: default port (:%s) must be omitted", o, port)
+		}
+	}
+	return nil
+}
+
+func isASCII(s string) bool {
+	for _, r := range s {
+		if r > 0x7F {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run the tests — they should now pass**
+
+```bash
+go test -short ./app/ -run TestValidateCORS -v
+```
+
+Expected: PASS for all subtests.
+
+- [ ] **Step 5: Run the broader app package tests to make sure nothing regressed**
+
+```bash
+go test -short ./app/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/config.go app/config_cors_test.go
+git commit -m "feat(config): full CORS allowlist origin validation rules (#196)
+
+Rejects: uppercase, non-http(s) schemes, default ports, path/query/
+fragment/trailing-slash, userinfo, non-ASCII hosts (with punycode hint),
+literal null, wildcard/glob mixed with explicit origins.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: TDD CORS middleware — core matching and preflight
+
+**Files:**
+- Create: `internal/api/middleware/cors.go`
+- Create: `internal/api/middleware/cors_test.go`
+
+This task covers wildcard, loopback, allowlist matching; preflight short-circuit; actual-request header attach; ENABLED=false identity wrapper. Task 5 adds `Vary: Origin` always-on, `/_internal/*` exclusion, and no-Origin handling.
+
+- [ ] **Step 1: Write the test file with table-driven cases**
+
+```go
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// dummyHandler returns 200 with body "ok" so we can confirm pass-through.
+var dummyHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+})
+
+func newCORSPolicy(t *testing.T, enabled, wildcard bool, allowed ...string) *CORSPolicy {
+	t.Helper()
+	return NewCORSPolicy(enabled, wildcard, allowed)
+}
+
+func TestCORS_DisabledIsIdentityWrapper(t *testing.T) {
+	p := newCORSPolicy(t, false, false)
+	h := CORS(p)(dummyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://anything.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty (disabled mode)", got)
+	}
+	if got := rec.Header().Get("Vary"); got != "" {
+		t.Errorf("Vary = %q, want empty (disabled mode)", got)
+	}
+}
+
+func TestCORS_WildcardActualRequest(t *testing.T) {
+	p := newCORSPolicy(t, true, true)
+	h := CORS(p)(dummyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want \"*\" (wildcard never reflects)", got)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestCORS_WildcardWithNullOrigin(t *testing.T) {
+	p := newCORSPolicy(t, true, true)
+	h := CORS(p)(dummyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "null")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	// Wildcard mode emits literal * for every origin including null.
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want \"*\" (null + wildcard)", got)
+	}
+}
+
+func TestCORS_LoopbackMatch(t *testing.T) {
+	cases := []string{
+		"http://localhost",
+		"http://localhost:3000",
+		"https://localhost:8443",
+		"http://127.0.0.1",
+		"http://127.0.0.1:5173",
+		"https://127.0.0.1:8080",
+		"http://[::1]",
+		"http://[::1]:8080",
+		"https://[::1]:8443",
+	}
+	p := newCORSPolicy(t, true, false) // loopback mode
+	h := CORS(p)(dummyHandler)
+	for _, origin := range cases {
+		t.Run(origin, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Origin", origin)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if got := rec.Header().Get("Access-Control-Allow-Origin"); got != origin {
+				t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, origin)
+			}
+		})
+	}
+}
+
+func TestCORS_LoopbackRejects(t *testing.T) {
+	cases := []string{
+		"https://evil.example",
+		"http://localhost.evil.example",       // suffix attack
+		"https://xn--lcalhost-ksb.example",    // IDN homograph
+		"http://localhost@evil.example",       // userinfo
+		"http://127.000.000.001:3000",         // non-canonical IPv4
+		"http://[0:0:0:0:0:0:0:1]",            // non-canonical IPv6
+		"null",                                // file://
+		"ftp://localhost",                     // wrong scheme
+		"http://localhost/admin",              // path component
+		"http://Localhost:3000",               // case (must be lowercase)
+	}
+	p := newCORSPolicy(t, true, false)
+	h := CORS(p)(dummyHandler)
+	for _, origin := range cases {
+		t.Run(origin, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Origin", origin)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+				t.Errorf("Access-Control-Allow-Origin = %q, want empty (rejected)", got)
+			}
+			// Underlying request must still succeed — only the header is omitted.
+			if rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200 (request still processed)", rec.Code)
+			}
+		})
+	}
+}
+
+func TestCORS_AllowlistMatch(t *testing.T) {
+	p := newCORSPolicy(t, true, false, "https://admin.example.com", "http://app.local:3000")
+	h := CORS(p)(dummyHandler)
+	t.Run("matched", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Origin", "https://admin.example.com")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://admin.example.com" {
+			t.Errorf("ACAO = %q, want match", got)
+		}
+	})
+	t.Run("unmatched", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Origin", "https://other.example.com")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("ACAO = %q, want empty (not in allowlist)", got)
+		}
+	})
+	t.Run("loopback not auto-allowed in allowlist mode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Origin", "http://localhost:3000") // not in the list
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("ACAO = %q, want empty (allowlist mode does not auto-allow loopback)", got)
+		}
+	})
+}
+
+func TestCORS_PreflightShortCircuit(t *testing.T) {
+	p := newCORSPolicy(t, true, false, "https://admin.example.com")
+	// downstream that would 200 if reached — preflight must NOT reach it
+	downstreamReached := false
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstreamReached = true
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CORS(p)(downstream)
+
+	req := httptest.NewRequest(http.MethodOptions, "/anything", nil)
+	req.Header.Set("Origin", "https://admin.example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if downstreamReached {
+		t.Error("downstream should not have been reached on preflight")
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://admin.example.com" {
+		t.Errorf("ACAO = %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got != "GET, POST, PUT, PATCH, DELETE, OPTIONS" {
+		t.Errorf("Allow-Methods = %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Headers"); got != "Authorization, Content-Type, traceparent, tracestate" {
+		t.Errorf("Allow-Headers = %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Max-Age"); got != "86400" {
+		t.Errorf("Max-Age = %q", got)
+	}
+}
+
+func TestCORS_PreflightWithoutACRMFallsThrough(t *testing.T) {
+	// OPTIONS with Origin but no Access-Control-Request-Method is NOT a preflight.
+	p := newCORSPolicy(t, true, true)
+	downstreamCode := http.StatusTeapot
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(downstreamCode)
+	})
+	h := CORS(p)(downstream)
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "https://x.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want %d (downstream); CORS must not short-circuit non-preflight OPTIONS", rec.Code, downstreamCode)
+	}
+}
+
+func TestCORS_PreflightWithoutOriginFallsThrough(t *testing.T) {
+	// OPTIONS with ACRM but no Origin: also not a preflight.
+	p := newCORSPolicy(t, true, true)
+	downstreamCode := http.StatusTeapot
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(downstreamCode)
+	})
+	h := CORS(p)(downstream)
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want %d", rec.Code, downstreamCode)
+	}
+}
+
+func TestCORS_PreflightUnmatchedOriginInAllowlist(t *testing.T) {
+	// Preflight is still 204, but Access-Control-Allow-Origin is omitted.
+	p := newCORSPolicy(t, true, false, "https://allowed.example.com")
+	h := CORS(p)(dummyHandler)
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "https://forbidden.example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("ACAO = %q, want empty (origin not allowed)", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests — they should fail with "package not declared" or undefined symbols**
+
+```bash
+go test -short ./internal/api/middleware/ -run TestCORS -v
+```
+
+Expected: FAIL — `CORSPolicy undefined`, `NewCORSPolicy undefined`, `CORS undefined`.
+
+- [ ] **Step 3: Create `internal/api/middleware/cors.go`**
+
+```go
+package middleware
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Static preflight-response values per spec.
+const (
+	corsAllowMethods = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+	corsAllowHeaders = "Authorization, Content-Type, traceparent, tracestate"
+	corsMaxAge       = "86400"
+	internalPrefix   = "/_internal/"
+)
+
+// loopbackHosts is the set of host strings (post-Hostname()-extraction,
+// post-lowercase) that the default loopback mode allows. String compare
+// only — no IP-equivalence, so non-canonical forms like 127.000.000.001
+// or 0:0:0:0:0:0:0:1 do NOT match.
+var loopbackHosts = map[string]struct{}{
+	"localhost": {},
+	"127.0.0.1": {},
+	"::1":       {},
+}
+
+// CORSPolicy holds the validated, resolved CORS state derived from
+// CYODA_CORS_ENABLED and CYODA_CORS_ALLOWED_ORIGINS. Build once at
+// startup via NewCORSPolicy. The middleware closure captures the policy
+// pointer; per-request work is allocation-free apart from header writes.
+type CORSPolicy struct {
+	enabled  bool
+	wildcard bool
+	// allowed is non-nil iff !wildcard && len(allowedOrigins) > 0
+	// (allowlist mode). Nil in loopback mode and disabled mode.
+	allowed map[string]struct{}
+}
+
+// NewCORSPolicy builds a CORSPolicy. Inputs must already have been
+// validated by app.ValidateCORS — this constructor performs no
+// validation and assumes the caller is the app startup path.
+func NewCORSPolicy(enabled, wildcard bool, allowedOrigins []string) *CORSPolicy {
+	p := &CORSPolicy{enabled: enabled, wildcard: wildcard}
+	if !wildcard && len(allowedOrigins) > 0 {
+		p.allowed = make(map[string]struct{}, len(allowedOrigins))
+		for _, o := range allowedOrigins {
+			p.allowed[o] = struct{}{}
+		}
+	}
+	return p
+}
+
+// CORS returns the CORS middleware constructor. When the policy is
+// disabled, returns an identity wrapper (no-op).
+func CORS(p *CORSPolicy) func(http.Handler) http.Handler {
+	if !p.enabled {
+		return func(next http.Handler) http.Handler { return next }
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			allowed := p.match(origin)
+
+			isPreflight := r.Method == http.MethodOptions &&
+				origin != "" &&
+				r.Header.Get("Access-Control-Request-Method") != ""
+
+			if isPreflight {
+				if allowed != "" {
+					w.Header().Set("Access-Control-Allow-Origin", allowed)
+				}
+				w.Header().Set("Access-Control-Allow-Methods", corsAllowMethods)
+				w.Header().Set("Access-Control-Allow-Headers", corsAllowHeaders)
+				w.Header().Set("Access-Control-Max-Age", corsMaxAge)
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			if origin != "" && allowed != "" {
+				w.Header().Set("Access-Control-Allow-Origin", allowed)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// match returns the value to emit in Access-Control-Allow-Origin, or
+// "" if the origin is not allowed.
+func (p *CORSPolicy) match(origin string) string {
+	if p.wildcard {
+		return "*"
+	}
+	if origin == "" {
+		return ""
+	}
+	if p.allowed != nil {
+		if _, ok := p.allowed[origin]; ok {
+			return origin
+		}
+		return ""
+	}
+	// Loopback mode.
+	if matchLoopback(origin) {
+		return origin
+	}
+	return ""
+}
+
+// matchLoopback implements the spec's "Loopback matching contract":
+// parse with net/url, exact (lowercase) host string-equal to one of
+// the three loopback names, scheme http or https, no userinfo/path/
+// query/fragment, any port permitted.
+func matchLoopback(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	scheme := u.Scheme
+	if scheme != strings.ToLower(scheme) {
+		return false
+	}
+	if scheme != "http" && scheme != "https" {
+		return false
+	}
+	host := u.Hostname()
+	if host != strings.ToLower(host) {
+		return false
+	}
+	if _, ok := loopbackHosts[host]; !ok {
+		return false
+	}
+	if u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run the tests — they should now pass**
+
+```bash
+go test -short ./internal/api/middleware/ -run TestCORS -v
+```
+
+Expected: PASS for all `TestCORS_*` subtests written so far.
+
+- [ ] **Step 5: Run the broader middleware package tests**
+
+```bash
+go test -short ./internal/api/middleware/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/middleware/cors.go internal/api/middleware/cors_test.go
+git commit -m "feat(middleware): CORS middleware with loopback/wildcard/allowlist (#196)
+
+Implements preflight short-circuit, exact-string allowlist matching,
+RFC-6454-aware loopback mode (localhost/127.0.0.1/::1, any port,
+no userinfo/path/query/fragment, exact lowercase host compare).
+
+Vary: Origin, /_internal/* exclusion, and no-Origin handling come
+in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: TDD CORS middleware — `Vary: Origin`, `/_internal/*` exclusion, no-Origin
+
+**Files:**
+- Modify: `internal/api/middleware/cors_test.go` (append tests).
+- Modify: `internal/api/middleware/cors.go` (add Vary always-on, /_internal short-circuit, no-Origin Vary).
+
+- [ ] **Step 1: Append the new tests to `internal/api/middleware/cors_test.go`**
+
+```go
+func TestCORS_VaryOriginAlwaysWhenEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		p    *CORSPolicy
+	}{
+		{"wildcard", NewCORSPolicy(true, true, nil)},
+		{"loopback (default)", NewCORSPolicy(true, false, nil)},
+		{"allowlist", NewCORSPolicy(true, false, []string{"https://x.example"})},
+	}
+	for _, c := range cases {
+		t.Run(c.name+"/with-origin", func(t *testing.T) {
+			h := CORS(c.p)(dummyHandler)
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Origin", "https://x.example")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if got := rec.Header().Get("Vary"); got != "Origin" {
+				t.Errorf("Vary = %q, want \"Origin\"", got)
+			}
+		})
+		t.Run(c.name+"/no-origin", func(t *testing.T) {
+			// Vary: Origin must be present even when Origin is absent
+			// (cache-poisoning protection on mode-flip).
+			h := CORS(c.p)(dummyHandler)
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if got := rec.Header().Get("Vary"); got != "Origin" {
+				t.Errorf("Vary = %q, want \"Origin\" even on no-Origin requests", got)
+			}
+			if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+				t.Errorf("ACAO = %q, want empty on no-Origin requests", got)
+			}
+		})
+	}
+}
+
+func TestCORS_VaryAppendedNotOverwritten(t *testing.T) {
+	// A downstream handler that also sets Vary: Accept must coexist with
+	// Vary: Origin — both values present, neither overwritten.
+	p := NewCORSPolicy(true, true, nil)
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Vary", "Accept")
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CORS(p)(downstream)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://x.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	vary := rec.Header().Values("Vary")
+	hasOrigin, hasAccept := false, false
+	for _, v := range vary {
+		if v == "Origin" {
+			hasOrigin = true
+		}
+		if v == "Accept" {
+			hasAccept = true
+		}
+	}
+	if !hasOrigin {
+		t.Errorf("Vary missing Origin: %v", vary)
+	}
+	if !hasAccept {
+		t.Errorf("Vary missing Accept: %v", vary)
+	}
+}
+
+func TestCORS_InternalPrefixSkipped(t *testing.T) {
+	p := NewCORSPolicy(true, true, nil) // wildcard — would otherwise emit *
+	h := CORS(p)(dummyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/_internal/dispatch", nil)
+	req.Header.Set("Origin", "https://anything.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("ACAO = %q, want empty on /_internal/", got)
+	}
+	if got := rec.Header().Get("Vary"); got != "" {
+		t.Errorf("Vary = %q, want empty on /_internal/", got)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("downstream not reached on /_internal/")
+	}
+}
+
+func TestCORS_InternalPrefixSkippedOnPreflight(t *testing.T) {
+	p := NewCORSPolicy(true, true, nil)
+	downstreamReached := false
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstreamReached = true
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+	h := CORS(p)(downstream)
+
+	// A preflight-shaped request to /_internal/ must NOT short-circuit;
+	// it must reach downstream so peer-side AEAD-auth can reject it.
+	req := httptest.NewRequest(http.MethodOptions, "/_internal/dispatch", nil)
+	req.Header.Set("Origin", "https://anything.example")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if !downstreamReached {
+		t.Error("downstream should have been reached for /_internal/ preflight")
+	}
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405 (downstream)", rec.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests — they should fail (Vary not yet emitted; /_internal not yet excluded)**
+
+```bash
+go test -short ./internal/api/middleware/ -run TestCORS -v
+```
+
+Expected: FAIL on `TestCORS_VaryOriginAlwaysWhenEnabled`, `TestCORS_VaryAppendedNotOverwritten`, `TestCORS_InternalPrefixSkipped`, `TestCORS_InternalPrefixSkippedOnPreflight`.
+
+- [ ] **Step 3: Update `internal/api/middleware/cors.go` — add the `/_internal/` short-circuit and Vary always-on**
+
+Replace the body of the `http.HandlerFunc` returned by `CORS(p)` with:
+
+```go
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// /_internal/* is excluded from CORS entirely — no headers, not
+			// even Vary: Origin. Defence-in-depth alongside the cluster
+			// proxy stripping Origin on outbound peer-to-peer requests.
+			if strings.HasPrefix(r.URL.Path, internalPrefix) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Vary: Origin always — even on no-Origin pass-through and
+			// even in wildcard mode. Closes the cache-poisoning vector
+			// where a CDN serves a no-Origin response (without Vary) to
+			// a later Origin-bearing request whose policy has changed.
+			w.Header().Add("Vary", "Origin")
+
+			origin := r.Header.Get("Origin")
+			allowed := p.match(origin)
+
+			isPreflight := r.Method == http.MethodOptions &&
+				origin != "" &&
+				r.Header.Get("Access-Control-Request-Method") != ""
+
+			if isPreflight {
+				if allowed != "" {
+					w.Header().Set("Access-Control-Allow-Origin", allowed)
+				}
+				w.Header().Set("Access-Control-Allow-Methods", corsAllowMethods)
+				w.Header().Set("Access-Control-Allow-Headers", corsAllowHeaders)
+				w.Header().Set("Access-Control-Max-Age", corsMaxAge)
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			if origin != "" && allowed != "" {
+				w.Header().Set("Access-Control-Allow-Origin", allowed)
+			}
+			next.ServeHTTP(w, r)
+		})
+```
+
+- [ ] **Step 4: Run the tests — they should now pass**
+
+```bash
+go test -short ./internal/api/middleware/ -run TestCORS -v
+```
+
+Expected: PASS for every `TestCORS_*` subtest.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/middleware/cors.go internal/api/middleware/cors_test.go
+git commit -m "feat(middleware): Vary: Origin always-on and /_internal/* exclusion (#196)
+
+Vary: Origin is appended (Header.Add, not Set) on every CORS response
+including no-Origin pass-throughs — closes the cache-poisoning vector
+where a CDN serves a no-Origin (no-Vary) response to a later
+Origin-bearing request whose policy has changed.
+
+/_internal/* is excluded entirely (no headers, not even Vary) so
+peer-to-peer dispatch traffic carries no CORS state.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: TDD cluster proxy header strip
+
+**Files:**
+- Modify: `internal/cluster/proxy/http.go` (extend `Director` to strip three headers).
+- Create or extend: `internal/cluster/proxy/http_test.go` (unit test on the strip).
+
+- [ ] **Step 1: Check whether `internal/cluster/proxy/http_test.go` exists**
+
+```bash
+ls /Users/paul/go-projects/cyoda-light/cyoda-go/.worktrees/issue-196-cors/internal/cluster/proxy/
+```
+
+- [ ] **Step 2: Write the failing test**
+
+The test exercises the `Director` directly. Because `Director` is currently a closure inside `proxyTo`, the cleanest way to test it is to extract it into a named helper. Write the test first against the helper we will create:
+
+If `http_test.go` already exists, append the test there. Otherwise create `internal/cluster/proxy/http_test.go`:
+
+```go
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestDirector_StripsCORSPreflightHeaders(t *testing.T) {
+	target, _ := url.Parse("http://peer-b:8080")
+	director := makeProxyDirector(target)
+
+	req, err := http.NewRequest(http.MethodPost, "http://peer-a/path", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Origin", "https://browser.example")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "Authorization")
+	req.Header.Set("Authorization", "Bearer xyz")
+
+	director(req)
+
+	for _, h := range []string{"Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"} {
+		if got := req.Header.Get(h); got != "" {
+			t.Errorf("%s should be stripped, got %q", h, got)
+		}
+	}
+	// Authorization (and other unrelated headers) must NOT be stripped.
+	if got := req.Header.Get("Authorization"); got != "Bearer xyz" {
+		t.Errorf("Authorization should be preserved, got %q", got)
+	}
+	// Director must rewrite scheme/host/Host onto the target.
+	if req.URL.Scheme != "http" || req.URL.Host != "peer-b:8080" {
+		t.Errorf("URL not rewritten: scheme=%q host=%q", req.URL.Scheme, req.URL.Host)
+	}
+	if req.Host != "peer-b:8080" {
+		t.Errorf("Host not rewritten: %q", req.Host)
+	}
+}
+
+func TestDirector_StripsAreIdempotent(t *testing.T) {
+	target, _ := url.Parse("http://peer-b:8080")
+	director := makeProxyDirector(target)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://peer-a/x", nil)
+	// No headers set. Strip should not panic and request should remain valid.
+	director(req)
+
+	if req.URL.Host != "peer-b:8080" {
+		t.Errorf("URL not rewritten: %q", req.URL.Host)
+	}
+}
+```
+
+- [ ] **Step 3: Run the test — it should fail (`makeProxyDirector` undefined)**
+
+```bash
+go test -short ./internal/cluster/proxy/ -run TestDirector -v
+```
+
+Expected: FAIL — `makeProxyDirector undefined`.
+
+- [ ] **Step 4: Refactor `internal/cluster/proxy/http.go` — extract the `Director` into a named helper and add the strip**
+
+Replace the inline `Director` field assignment in `proxyTo` (around line 122-127) with a call to the new helper. Add the helper function at the bottom of the file:
+
+```go
+// makeProxyDirector returns the Director that the per-request
+// httputil.ReverseProxy uses to rewrite an outbound peer-to-peer
+// request. It rewrites the URL onto the target node and strips any
+// CORS-related request headers — those are the responsibility of the
+// outermost CORS middleware on the receiving node, not the destination
+// peer. See spec §"Cluster proxy interaction".
+func makeProxyDirector(target *url.URL) func(*http.Request) {
+	return func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.Host = target.Host
+		// Strip CORS request headers — see spec §"Cluster proxy
+		// interaction". Owned by the outermost CORS middleware.
+		req.Header.Del("Origin")
+		req.Header.Del("Access-Control-Request-Method")
+		req.Header.Del("Access-Control-Request-Headers")
+	}
+}
+```
+
+In `proxyTo`, replace the `Director` literal:
+
+```go
+	rp := &httputil.ReverseProxy{
+		Director:  makeProxyDirector(target),
+		Transport: transport,
+		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
+			slog.Error("proxy request failed",
+				"pkg", "proxy",
+				"target", addr,
+				"error", err,
+			)
+			common.WriteError(rw, req, common.Operational(
+				http.StatusServiceUnavailable,
+				common.ErrCodeTransactionNodeUnavailable,
+				"transaction node is unreachable",
+			))
+		},
+	}
+```
+
+- [ ] **Step 5: Run the tests — they should now pass**
+
+```bash
+go test -short ./internal/cluster/proxy/ -run TestDirector -v
+```
+
+Expected: PASS for both `TestDirector_StripsCORSPreflightHeaders` and `TestDirector_StripsAreIdempotent`.
+
+- [ ] **Step 6: Run the broader proxy and cluster tests**
+
+```bash
+go test -short ./internal/cluster/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/cluster/proxy/http.go internal/cluster/proxy/http_test.go
+git commit -m "feat(cluster): proxy Director strips CORS request headers (#196)
+
+Origin, Access-Control-Request-Method, and Access-Control-Request-Headers
+are stripped on every outbound peer-to-peer request. This makes the peer
+node's CORS middleware a no-op on proxied requests and prevents
+multi-valued Access-Control-Allow-Origin headers from being merged
+into the response by the proxy.
+
+Defence-in-depth alongside the middleware's /_internal/* exclusion.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Wire `ValidateCORS` into `cmd/cyoda/main.go` with mode logging
+
+**Files:**
+- Modify: `cmd/cyoda/main.go`.
+
+- [ ] **Step 1: Insert the validation call and mode logging after slog init**
+
+In `cmd/cyoda/main.go`, find the existing `ValidateIAM` call (around line 86). Immediately after it (still before `printBanner`), add:
+
+```go
+	if err := app.ValidateCORS(cfg.CORS); err != nil {
+		slog.Error("CORS validation failed", "error", err)
+		os.Exit(1)
+	}
+	logCORSMode(cfg.CORS)
+```
+
+Add the `logCORSMode` helper at the bottom of `cmd/cyoda/main.go` (or in a new file `cmd/cyoda/cors_log.go` if you prefer; keeping it inline keeps the diff small):
+
+```go
+// logCORSMode emits a single startup line describing the resolved CORS
+// mode. The allowlist values themselves are logged only at DEBUG —
+// origins are operationally sensitive (internal hostnames, customer
+// subdomains in multi-tenant SaaS).
+func logCORSMode(c app.CORSConfig) {
+	switch c.Mode() {
+	case "disabled":
+		slog.Info("cors: disabled — no Access-Control-* headers will be emitted; configure CORS at your ingress/proxy layer", "pkg", "cors")
+	case "wildcard":
+		slog.Warn("cors: wildcard mode active (Access-Control-Allow-Origin: *)", "pkg", "cors")
+	case "loopback":
+		slog.Info("cors: loopback mode active — only http(s)://localhost, 127.0.0.1, [::1] are allowed; set CYODA_CORS_ALLOWED_ORIGINS to permit additional origins", "pkg", "cors")
+	case "allowlist":
+		slog.Info("cors: allowlist mode active", "pkg", "cors", "origin_count", len(c.AllowedOrigins))
+		slog.Debug("cors: allowlist contents", "pkg", "cors", "origins", c.AllowedOrigins)
+	}
+}
+```
+
+- [ ] **Step 2: Build the binary to confirm compilation**
+
+```bash
+go build -o /tmp/cyoda-cors-build ./cmd/cyoda && rm /tmp/cyoda-cors-build
+```
+
+Expected: no output (success).
+
+- [ ] **Step 3: Run all root-module tests to confirm no regression**
+
+```bash
+go test -short ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/cyoda/main.go
+git commit -m "feat(cmd): wire ValidateCORS and mode logging at startup (#196)
+
+Validation runs after slog init so log-level and structured fields are
+honoured. Allowlist values are only logged at DEBUG — counted at INFO.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Wire CORS middleware in `app/app.go`
+
+**Files:**
+- Modify: `app/app.go`.
+
+The middleware wraps `a.handler` **last** — outside both `outerMux` and the cluster-routing wrap.
+
+- [ ] **Step 1: Add the wrap at the end of `New()`**
+
+In `app/app.go`, find the cluster-routing wrap (around line 526-531):
+
+```go
+	if cfg.Cluster.Enabled {
+		a.handler = proxy.HTTPRouting(a.tokenSigner, a.nodeRegistry, cfg.Cluster.NodeID, cfg.Cluster.ProxyTimeout)(a.handler)
+	}
+```
+
+Immediately after that block (before the `gRPC server — uses inner handler` comment), add:
+
+```go
+	// CORS middleware — outermost wrapper. Sits outside cluster-routing
+	// so preflights short-circuit at the receiving node and never get
+	// proxied. Sits outside outerMux so /help, discovery, and the API
+	// surface are all covered by a single CORS policy. See spec
+	// docs/superpowers/specs/2026-05-01-issue-196-cors-design.md.
+	corsPolicy := middleware.NewCORSPolicy(cfg.CORS.Enabled, cfg.CORS.Wildcard, cfg.CORS.AllowedOrigins)
+	a.handler = middleware.CORS(corsPolicy)(a.handler)
+```
+
+If `middleware` is not already imported in `app/app.go`, add the import:
+
+```go
+	"github.com/cyoda-platform/cyoda-go/internal/api/middleware"
+```
+
+(The package may already be imported as `middleware`; check the existing imports — `middleware.Auth` and `middleware.Recovery` are referenced earlier in the file.)
+
+- [ ] **Step 2: Build to confirm compilation**
+
+```bash
+go build ./app/...
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Add a wired-up assertion test**
+
+Find an existing app-level test file (e.g. `app/app_test.go` if it exists) or create `app/app_cors_wired_test.go`:
+
+```bash
+ls /Users/paul/go-projects/cyoda-light/cyoda-go/.worktrees/issue-196-cors/app/*_test.go
+```
+
+If `app/app_cors_wired_test.go` does not exist, create it:
+
+```go
+package app_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/app"
+)
+
+// TestApp_CORSWiredUp_Preflight verifies that a fully-constructed
+// app.Handler() actually has the CORS middleware installed in the
+// chain. A future refactor that drops the install site would fail
+// this test loud (it would 405 instead of 204).
+func TestApp_CORSWiredUp_Preflight(t *testing.T) {
+	cfg := app.DefaultConfig()
+	cfg.CORS.Enabled = true
+	cfg.CORS.Wildcard = true
+	cfg.CORS.AllowedOrigins = nil
+	// Force an in-memory store so the test does not require Postgres.
+	cfg.StorageBackend = "memory"
+	cfg.Cluster.Enabled = false
+
+	a := app.New(cfg)
+	defer a.Close()
+
+	// Synthetic preflight against an arbitrary path. CORS middleware
+	// short-circuits before any router can 404/405 — so we should see
+	// 204 with the preflight headers regardless of whether the path
+	// is registered.
+	req := httptest.NewRequest(http.MethodOptions, "/api/entity/00000000-0000-0000-0000-000000000000", nil)
+	req.Header.Set("Origin", "https://x.example")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	rec := httptest.NewRecorder()
+	a.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204 (CORS middleware not installed?)", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got == "" {
+		t.Error("Access-Control-Allow-Methods missing — CORS middleware not installed?")
+	}
+}
+
+// TestApp_CORSWiredUp_DisabledNoHeaders verifies that with
+// CYODA_CORS_ENABLED=false the chain emits no CORS headers — the
+// identity-wrapper path. A regression here would silently re-enable
+// CORS in production deployments that opted out.
+func TestApp_CORSWiredUp_DisabledNoHeaders(t *testing.T) {
+	cfg := app.DefaultConfig()
+	cfg.CORS.Enabled = false
+	cfg.StorageBackend = "memory"
+	cfg.Cluster.Enabled = false
+
+	a := app.New(cfg)
+	defer a.Close()
+
+	req := httptest.NewRequest(http.MethodOptions, "/api/entity/00000000-0000-0000-0000-000000000000", nil)
+	req.Header.Set("Origin", "https://x.example")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	rec := httptest.NewRecorder()
+	a.Handler().ServeHTTP(rec, req)
+
+	// With CORS disabled, the chi router is reached and 405s the OPTIONS
+	// (no preflight handling, no preflight short-circuit).
+	if rec.Code == http.StatusNoContent {
+		t.Errorf("status = %d (204) — CORS middleware should NOT be installed when disabled", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty when disabled", got)
+	}
+	if got := rec.Header().Get("Vary"); got == "Origin" {
+		t.Errorf("Vary: Origin emitted while CORS is disabled")
+	}
+}
+```
+
+- [ ] **Step 4: Run the new tests**
+
+```bash
+go test -short ./app/ -run TestApp_CORSWiredUp -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run all root-module tests**
+
+```bash
+go test -short ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/app.go app/app_cors_wired_test.go
+git commit -m "feat(app): install CORS middleware as outermost wrapper (#196)
+
+Sits outside both outerMux and the cluster-routing wrap. Wired-up
+assertion tests verify (a) CORS short-circuits a synthetic preflight
+when enabled, and (b) no CORS headers appear when disabled — so a
+future refactor that drops the install site fails loud.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Remove inline CORS from `internal/api/help.go` and clean up tests
+
+**Files:**
+- Modify: `internal/api/help.go` (delete `handleHelpPreflight`, delete inline ACAO sets, change `Allow` header on 405).
+- Modify: `internal/api/help_test.go` (delete `TestCORSHeadersPresent`, `TestCORSPreflight_204`; update `TestNonGET_Returns405`).
+
+- [ ] **Step 1: Update `internal/api/help.go`**
+
+Read the existing file structure first. Make these edits:
+
+(a) Delete the entire `handleHelpPreflight` function (currently ~lines 22-35).
+
+(b) In both `RegisterHelpRoutes` handlers, remove the call to `handleHelpPreflight` and remove the explicit `Header().Set("Access-Control-Allow-Origin", "*")` lines.
+
+(c) On the 405 path, change the `Allow` header from `GET, OPTIONS` to `GET`. The handler no longer handles `OPTIONS` directly — preflights short-circuit upstream in CORS middleware, and unit tests of `RegisterHelpRoutes` in isolation (without the middleware) will see `OPTIONS` as a non-GET 405.
+
+The full updated `internal/api/help.go` should look like:
+
+```go
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/cyoda-platform/cyoda-go/cmd/cyoda/help"
+	"github.com/cyoda-platform/cyoda-go/cmd/cyoda/help/renderer"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+)
+
+// topicPathPattern accepts both . and / as topic-path separators.
+// Must start and end with alphanumeric; internal characters allow
+// letters, digits, underscore, hyphen, and the two separators (. and /).
+// Note: Go's http.ServeMux cleans consecutive slashes (cli//help → cli/help)
+// before the handler runs, so double-slash cannot be detected at this layer.
+var topicPathPattern = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9._/-]*[A-Za-z0-9])?$`)
+
+// RegisterHelpRoutes mounts GET {contextPath}/help and
+// GET {contextPath}/help/{topic} on the given mux. contextPath must NOT
+// have a trailing slash. An empty contextPath mounts at "/help".
+// version is closed over by the handlers and reported in the full-tree
+// payload. CORS for /help is handled by the unified middleware in
+// internal/api/middleware/cors.go — these handlers no longer manage CORS
+// themselves.
+func RegisterHelpRoutes(mux *http.ServeMux, tree *help.Tree, contextPath, version string) {
+	prefix := strings.TrimRight(contextPath, "/") + "/help"
+	mux.HandleFunc(prefix, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			common.WriteError(w, r, common.Operational(
+				http.StatusMethodNotAllowed,
+				common.ErrCodeBadRequest,
+				"method not allowed; GET only",
+			))
+			return
+		}
+		if r.URL.Path != prefix {
+			common.WriteError(w, r, common.Operational(
+				http.StatusNotFound,
+				common.ErrCodeHelpTopicNotFound,
+				"no such help topic at this path",
+			))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		if err := enc.Encode(renderer.HelpPayload{
+			Schema:  1,
+			Version: version,
+			Topics:  tree.WalkDescriptors(),
+		}); err != nil {
+			slog.Error("help: failed to encode response", "error", err, "path", r.URL.Path)
+		}
+	})
+	mux.HandleFunc(prefix+"/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", "GET")
+			common.WriteError(w, r, common.Operational(
+				http.StatusMethodNotAllowed,
+				common.ErrCodeBadRequest,
+				"method not allowed; GET only",
+			))
+			return
+		}
+		topic := strings.TrimPrefix(r.URL.Path, prefix+"/")
+		if !topicPathPattern.MatchString(topic) {
+			common.WriteError(w, r, common.Operational(
+				http.StatusBadRequest,
+				common.ErrCodeBadRequest,
+				"invalid topic path: contains disallowed characters",
+			))
+			return
+		}
+		// Normalise: / and . are equivalent separators. Split on either,
+		// then reject any empty segment (double separator, leading/trailing).
+		normalized := strings.ReplaceAll(topic, "/", ".")
+		segs := strings.Split(normalized, ".")
+		for _, s := range segs {
+			if s == "" {
+				common.WriteError(w, r, common.Operational(
+					http.StatusBadRequest,
+					common.ErrCodeBadRequest,
+					"invalid topic path: empty segment",
+				))
+				return
+			}
+		}
+		node := tree.Find(segs)
+		if node == nil {
+			common.WriteError(w, r, common.Operational(
+				http.StatusNotFound,
+				common.ErrCodeHelpTopicNotFound,
+				"no such help topic: "+topic,
+			))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		if err := enc.Encode(node.Descriptor()); err != nil {
+			slog.Error("help: failed to encode response", "error", err, "path", r.URL.Path)
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Update `internal/api/help_test.go`**
+
+(a) Delete `TestCORSHeadersPresent` (currently around lines 104-115).
+
+(b) Delete `TestCORSPreflight_204` (currently around lines 161-178).
+
+(c) Update `TestNonGET_Returns405` so the expected `Allow` header is `GET` (not `GET, OPTIONS`):
+
+Find the assertion:
+```go
+				if got := resp.Header.Get("Allow"); got != "GET, OPTIONS" {
+					t.Errorf("%s / : Allow = %q, want \"GET, OPTIONS\"", method, got)
+				}
+```
+
+Change to:
+```go
+				if got := resp.Header.Get("Allow"); got != "GET" {
+					t.Errorf("%s / : Allow = %q, want \"GET\"", method, got)
+				}
+```
+
+(d) `TestNonGET_Returns405` includes `OPTIONS` in the methods loop? Check: looking at the existing source it iterates `[]string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch}` — no `OPTIONS`. Good, no further change needed.
+
+- [ ] **Step 3: Run the help tests to confirm**
+
+```bash
+go test -short ./internal/api/ -run "TestGet|TestMalformed|TestNon|TestRespects" -v
+```
+
+Expected: PASS for all remaining help tests; the deleted CORS tests are gone.
+
+- [ ] **Step 4: Run all root-module tests**
+
+```bash
+go test -short ./...
+```
+
+Expected: PASS — including the wired-up assertion tests in Task 8 (which still confirm CORS works through the full stack).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/help.go internal/api/help_test.go
+git commit -m "refactor(help): remove inline CORS — unified middleware owns it (#196)
+
+Deletes handleHelpPreflight and the explicit Access-Control-Allow-Origin
+sets. Allow header on 405 changes from \"GET, OPTIONS\" to \"GET\" since
+the handler no longer manages OPTIONS — preflights short-circuit in the
+CORS middleware upstream.
+
+Deletes TestCORSHeadersPresent and TestCORSPreflight_204; the new E2E
+test in internal/e2e/cors_e2e_test.go (next task) covers /help through
+the full handler stack.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: E2E tests for CORS through the full handler stack
+
+**Files:**
+- Create: `internal/e2e/cors_e2e_test.go`
+
+The E2E suite already has `TestMain` that boots a Postgres testcontainer and an in-process `httptest.Server` with JWT auth. We add a self-contained CORS test file that constructs its own minimal `app.New(cfg)`-backed `httptest.Server` for each scenario (different `cfg.CORS` values per test).
+
+- [ ] **Step 1: Inspect the existing E2E TestMain to confirm helpers available**
+
+```bash
+ls /Users/paul/go-projects/cyoda-light/cyoda-go/.worktrees/issue-196-cors/internal/e2e/
+grep -l "TestMain\|memory" /Users/paul/go-projects/cyoda-light/cyoda-go/.worktrees/issue-196-cors/internal/e2e/*.go | head -3
+```
+
+Note: existing E2E tests share a Postgres container via `TestMain`. For CORS we want per-test config, so we'll spin up a small `httptest.Server` per scenario backed by an in-memory store (`cfg.StorageBackend = "memory"`) so we don't fight the shared container.
+
+- [ ] **Step 2: Create `internal/e2e/cors_e2e_test.go`**
+
+```go
+package e2e
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/app"
+)
+
+// newCORSTestServer builds a minimal app and wraps it in an httptest.Server.
+// Each test gets its own fresh server with the requested CORS config.
+func newCORSTestServer(t *testing.T, cors app.CORSConfig) (*httptest.Server, func()) {
+	t.Helper()
+	cfg := app.DefaultConfig()
+	cfg.CORS = cors
+	cfg.StorageBackend = "memory"
+	cfg.Cluster.Enabled = false
+
+	a := app.New(cfg)
+	srv := httptest.NewServer(a.Handler())
+	return srv, func() {
+		srv.Close()
+		_ = a.Close()
+	}
+}
+
+// representativeRoutes is one path per group covered by the unified
+// CORS middleware. We don't need the routes to actually succeed at
+// the data layer — preflight short-circuits before auth and routing,
+// and actual GETs / discovery / health may legitimately 200/401/404.
+// We assert on CORS headers, not on body or status of the underlying
+// handler.
+var representativeRoutes = []struct {
+	name   string
+	method string
+	path   string
+}{
+	{"entity-get", http.MethodGet, "/api/entity/00000000-0000-0000-0000-000000000000"},
+	{"search-post", http.MethodPost, "/api/entity/example/1/search"},
+	{"messaging-post", http.MethodPost, "/api/messaging/test"},
+	{"account-get", http.MethodGet, "/api/account"},
+	{"admin-post", http.MethodPost, "/api/admin/log-level"},
+	{"help-get", http.MethodGet, "/api/help"},
+	{"health-get", http.MethodGet, "/livez"},
+	{"oauth-token-post", http.MethodPost, "/oauth/token"},
+}
+
+func TestCORS_E2E_PreflightAcrossGroups_LoopbackMode(t *testing.T) {
+	srv, cleanup := newCORSTestServer(t, app.CORSConfig{Enabled: true})
+	defer cleanup()
+
+	for _, r := range representativeRoutes {
+		t.Run(r.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodOptions, srv.URL+r.path, nil)
+			req.Header.Set("Origin", "http://localhost:3000")
+			req.Header.Set("Access-Control-Request-Method", r.method)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusNoContent {
+				t.Errorf("status = %d, want 204", resp.StatusCode)
+			}
+			if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "http://localhost:3000" {
+				t.Errorf("ACAO = %q", got)
+			}
+			if got := resp.Header.Get("Access-Control-Allow-Methods"); got == "" {
+				t.Error("missing Access-Control-Allow-Methods")
+			}
+			if got := resp.Header.Get("Vary"); got != "Origin" {
+				t.Errorf("Vary = %q, want \"Origin\"", got)
+			}
+		})
+	}
+}
+
+func TestCORS_E2E_LoopbackRejectsRemoteOrigin(t *testing.T) {
+	srv, cleanup := newCORSTestServer(t, app.CORSConfig{Enabled: true})
+	defer cleanup()
+
+	// Actual (non-preflight) GET against /livez — public, no auth, easy
+	// to assert headers on.
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/livez", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("ACAO = %q, want empty (remote origin rejected in loopback mode)", got)
+	}
+	if got := resp.Header.Get("Vary"); got != "Origin" {
+		t.Errorf("Vary = %q, want \"Origin\"", got)
+	}
+}
+
+func TestCORS_E2E_AllowlistMode(t *testing.T) {
+	srv, cleanup := newCORSTestServer(t, app.CORSConfig{
+		Enabled:        true,
+		AllowedOrigins: []string{"https://admin.example.com"},
+	})
+	defer cleanup()
+
+	t.Run("allowed origin", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/livez", nil)
+		req.Header.Set("Origin", "https://admin.example.com")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://admin.example.com" {
+			t.Errorf("ACAO = %q", got)
+		}
+	})
+
+	t.Run("loopback not auto-allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/livez", nil)
+		req.Header.Set("Origin", "http://localhost:3000")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("ACAO = %q, want empty (allowlist mode, loopback not auto-allowed)", got)
+		}
+	})
+}
+
+func TestCORS_E2E_WildcardMode(t *testing.T) {
+	srv, cleanup := newCORSTestServer(t, app.CORSConfig{
+		Enabled:  true,
+		Wildcard: true,
+	})
+	defer cleanup()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/livez", nil)
+	req.Header.Set("Origin", "https://anything.example")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("ACAO = %q, want \"*\"", got)
+	}
+}
+
+func TestCORS_E2E_DisabledNoHeaders(t *testing.T) {
+	srv, cleanup := newCORSTestServer(t, app.CORSConfig{Enabled: false})
+	defer cleanup()
+
+	// Preflight against /api/help — would 204 if CORS were installed,
+	// must 405 (chi default) when disabled.
+	req, _ := http.NewRequest(http.MethodOptions, srv.URL+"/api/help", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent {
+		t.Errorf("status = 204, want non-204 (CORS disabled — no preflight short-circuit)")
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("ACAO = %q, want empty when disabled", got)
+	}
+	if got := resp.Header.Get("Vary"); got == "Origin" {
+		t.Errorf("Vary: Origin emitted while disabled")
+	}
+}
+```
+
+- [ ] **Step 3: Run the E2E tests**
+
+```bash
+go test ./internal/e2e/ -run TestCORS_E2E -v
+```
+
+Expected: PASS for every subtest.
+
+If any test fails because a route returns 404 (e.g. `/api/admin/log-level` mount differs), narrow the route or replace with one we are sure about — these tests are about CORS headers, not data correctness, so any registered route that exercises the chain works.
+
+- [ ] **Step 4: Run all E2E tests to confirm no regression**
+
+```bash
+go test ./internal/e2e/ -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/e2e/cors_e2e_test.go
+git commit -m "test(e2e): CORS coverage through the full handler stack (#196)
+
+Per-mode E2E tests (loopback, wildcard, allowlist, disabled) and
+per-group preflight tests covering entity, search, messaging,
+account, admin, help, health, oauth. Uses an in-memory store and
+spins up a fresh app per test for config isolation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Documentation — help topic, README, cli help
+
+**Files:**
+- Create: `cmd/cyoda/help/content/config/cors.md`
+- Modify: `README.md`
+- Modify: `cmd/cyoda/help/content/cli/help.md`
+
+- [ ] **Step 1: Create `cmd/cyoda/help/content/config/cors.md`**
+
+```markdown
+# CORS Configuration
+
+cyoda-go provides CORS support for every public HTTP endpoint. This
+topic documents the env vars, defaults, and the trade-offs between
+in-service CORS and ingress-level CORS.
+
+## Environment variables
+
+| Var | Default | Effect |
+|---|---|---|
+| `CYODA_CORS_ENABLED` | `true` | Master switch. `false` disables CORS entirely — no `Access-Control-*` headers emitted, `OPTIONS` returns chi default `405`. Use this when CORS is handled by an upstream ingress/proxy. |
+| `CYODA_CORS_ALLOWED_ORIGINS` | unset (= **loopback mode**) | Comma-separated exact-match allowlist per RFC 6454 origin. Set to `*` for wildcard mode. |
+
+## Modes
+
+### Loopback (default)
+
+When `CYODA_CORS_ALLOWED_ORIGINS` is unset, the middleware allows
+requests from the following origins automatically:
+
+- `http://localhost`, `http://localhost:PORT`
+- `https://localhost`, `https://localhost:PORT`
+- `http://127.0.0.1`, `http://127.0.0.1:PORT`
+- `https://127.0.0.1`, `https://127.0.0.1:PORT`
+- `http://[::1]`, `http://[::1]:PORT`
+- `https://[::1]`, `https://[::1]:PORT`
+
+Every other origin is rejected — `Access-Control-Allow-Origin` is
+omitted from the response, the browser blocks reading the body. The
+underlying request is still processed; only the cross-origin read is
+blocked by the browser.
+
+This mode is designed for local development (vite, webpack, docker
+compose with port-mapped SPAs) where zero configuration is desired.
+Production deployments that browse to non-loopback origins must
+configure either allowlist mode or wildcard mode.
+
+### Allowlist
+
+```
+CYODA_CORS_ALLOWED_ORIGINS=https://admin.example.com,https://docs.example.com
+```
+
+Exact-string match against the request `Origin` header. Loopback origins
+are **not** auto-allowed in allowlist mode — the deployer's list is
+authoritative.
+
+Each configured origin must satisfy:
+
+- Lowercase scheme (`http` or `https`) and host.
+- No path, query, fragment, or trailing slash.
+- No userinfo (no `user@` or `user:pass@` segments).
+- No default ports — write `https://x.com`, not `https://x.com:443`.
+- ASCII host only — IDN must be supplied in punycode form
+  (`xn--e1afmkfd.example`, not `пример.example`). Misconfiguration
+  produces a startup error: `cors: origin "..." has non-ASCII host;
+  convert to punycode (e.g. xn--…) before configuring`.
+- IPv6 literals require brackets: `https://[::1]:8443`.
+- The literal value `null` is **not** a valid allowlist entry. To
+  permit `file://` SPAs, use wildcard mode (or do not — `null` from
+  sandboxed iframes is materially riskier than `null` from `file://`).
+
+### Wildcard
+
+```
+CYODA_CORS_ALLOWED_ORIGINS=*
+```
+
+Emits `Access-Control-Allow-Origin: *` (literally, never reflective)
+on every cross-origin response. Triggers a startup `WARN`. Use only
+when the cyoda-go instance is genuinely public-readable.
+
+### Disabled
+
+```
+CYODA_CORS_ENABLED=false
+```
+
+No CORS headers, no preflight handling. `OPTIONS` returns `405`. Use
+this when the upstream ingress/proxy handles CORS — see "Deployment
+guidance" below.
+
+## Behaviour summary
+
+| Header | Loopback / Allowlist | Wildcard | Disabled |
+|---|---|---|---|
+| `Access-Control-Allow-Origin` | matched origin or omitted | literal `*` | not emitted |
+| `Access-Control-Allow-Methods` | `GET, POST, PUT, PATCH, DELETE, OPTIONS` (preflight only) | same | not emitted |
+| `Access-Control-Allow-Headers` | `Authorization, Content-Type, traceparent, tracestate` (preflight only) | same | not emitted |
+| `Access-Control-Max-Age` | `86400` (preflight only) | same | not emitted |
+| `Vary: Origin` | always | always | not emitted |
+
+`Access-Control-Allow-Credentials` is **not** emitted. cyoda-go uses
+bearer-in-`Authorization` auth, which does not require the credentials
+flag; enabling it would only add attack surface (subdomain takeover of
+an allowlisted origin, XSS in an allowlisted SPA).
+
+## CORS does not provide tenant isolation
+
+CORS is a browser-side defence against unauthorized cross-origin reads.
+It is **not** a tenant-isolation control. All tenant boundaries are
+enforced by JWT claims and per-request authorization. An allowlisted
+SPA serving multiple tenants relies entirely on the auth layer to
+prevent cross-tenant access.
+
+## Deployment guidance
+
+### Local development / docker compose
+
+Default loopback mode just works. No env vars needed. Both
+`http://localhost:3000` (vite/webpack/CRA) and `file://` (with
+`null` origin — note `file://` is **not** auto-allowed; use a
+local web server) variants are supported.
+
+### Behind an ingress with its own CORS support
+
+Set `CYODA_CORS_ENABLED=false`. Configure CORS at the ingress
+(nginx-ingress annotations, Envoy `cors` filter, AWS ALB CORS rules,
+GCP HTTPS LB, etc.). Ensure the ingress responds to `OPTIONS` preflights
+**before** they reach cyoda-go — most ingress controllers do this by
+default.
+
+Common foot-gun: **double `Access-Control-Allow-Origin` headers**. If
+both the ingress and cyoda-go emit the header, browsers reject the
+multi-valued response. Either the ingress strips the upstream header,
+or cyoda-go runs with `CYODA_CORS_ENABLED=false`.
+
+### Behind a reverse proxy with no CORS
+
+Set `CYODA_CORS_ALLOWED_ORIGINS=https://your.spa.host`. The proxy passes
+preflights through; cyoda-go answers them.
+
+### Browser SPA on a private network reaching cyoda-go on a public network
+
+cyoda-go does **not** handle Chrome's Private Network Access headers
+(`Access-Control-Request-Private-Network` /
+`Access-Control-Allow-Private-Network`). Configure PNA at your ingress.
+
+## CSRF
+
+CSRF is not a threat for bearer-in-`Authorization` auth — the SPA
+explicitly attaches the bearer on each request rather than relying on
+ambient credentials. cyoda-go does not require any anti-CSRF token and
+none will be added.
+
+## Toggling between enabled and disabled
+
+Toggling `CYODA_CORS_ENABLED` between `true` and `false` requires a
+**downstream-cache flush**. While disabled, cyoda-go does not emit
+`Vary: Origin`; responses cached during that period could be served to
+origins for which the post-toggle policy disagrees.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Browser logs "CORS request did not succeed" but cyoda-go logs the request as 200 | Origin rejected by allowlist | Add the origin to `CYODA_CORS_ALLOWED_ORIGINS` (exact match, no path, no default port). |
+| Browser logs "multi-valued Access-Control-Allow-Origin" | Ingress and cyoda-go both emit ACAO | Set `CYODA_CORS_ENABLED=false` and let the ingress own CORS. |
+| Startup logs `cors: wildcard mode active` and you do not want that | `CYODA_CORS_ALLOWED_ORIGINS=*` is set | Set it to a specific allowlist or unset to fall back to loopback mode. |
+| Startup fails with `convert to punycode` | Configured allowlist contains non-ASCII characters | Convert the host to its IDN punycode form (`xn--…`) and reconfigure. |
+| `https://x.com:443` rejected at startup | Default port included | Drop the `:443` — write `https://x.com`. |
+| Local SPA on `file://` cannot reach cyoda-go | `null` origin, not in loopback set | Serve the SPA from a local web server (`http://localhost`) — `file://` is not auto-allowed because sandboxed iframes also send `Origin: null`. |
+```
+
+- [ ] **Step 2: Update `cmd/cyoda/help/content/cli/help.md`**
+
+Find the existing CORS bullet (around line 47-48 — references CORS preflight on `/help`) and the CORS section (around line 140). Strike the help-only CORS coverage and link to `config/cors.md`.
+
+```bash
+grep -n "CORS\|preflight" cmd/cyoda/help/content/cli/help.md | head -10
+```
+
+Then make targeted edits:
+
+- Replace any text claiming `/help` is the only CORS-aware endpoint with a one-liner: "CORS is configured globally — see `cyoda help config/cors`."
+- Remove the lines listing `OPTIONS {CYODA_CONTEXT_PATH}/help` and `OPTIONS {CYODA_CONTEXT_PATH}/help/{topic}` as if they were unique to help. These now apply across the whole API.
+- Remove the `### CORS` section if it duplicates content now in `cors.md`.
+
+The exact edits depend on the file shape today; keep the change minimal and ensure the help-CLI page no longer claims CORS is help-specific.
+
+- [ ] **Step 3: Update `README.md`**
+
+Find the configuration table or env-var reference. Add two rows:
+
+```
+| `CYODA_CORS_ENABLED` | `true` | Master switch for CORS. `false` disables CORS — for ingress-driven setups. |
+| `CYODA_CORS_ALLOWED_ORIGINS` | unset (loopback) | Comma-separated allowlist or `*` for wildcard. See `cyoda help config/cors`. |
+```
+
+If the README references `/help` CORS specifically (e.g. as an example of what works for browsers), broaden the wording to reflect the API-wide policy.
+
+- [ ] **Step 4: Verify the help embed builds**
+
+The help content is embedded into the binary; the build step picks up the new `cors.md` automatically. Run:
+
+```bash
+go build -o /tmp/cyoda-help-build ./cmd/cyoda
+/tmp/cyoda-help-build help config/cors >/tmp/cors-help-out.txt
+head -10 /tmp/cors-help-out.txt
+rm /tmp/cyoda-help-build /tmp/cors-help-out.txt
+```
+
+Expected: the help topic prints (first 10 lines visible).
+
+- [ ] **Step 5: Run all tests to ensure nothing regressed**
+
+```bash
+go test -short ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/cyoda/help/content/config/cors.md cmd/cyoda/help/content/cli/help.md README.md
+git commit -m "docs: CORS configuration help topic and README/help-cli updates (#196)
+
+New cmd/cyoda/help/content/config/cors.md documents env vars, modes
+(loopback/allowlist/wildcard/disabled), behaviour summary, deployment
+guidance for ingress-driven setups, the explicit 'CORS is not tenant
+isolation' note, and troubleshooting.
+
+README and the help-CLI topic updated to reflect that CORS is now
+API-wide rather than help-only.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Final verification
+
+**Files:** none modified.
+
+This task is the Gate-5 verification per CLAUDE.md before claiming the work is done. Race detector runs once here per `.claude/rules/race-testing.md`.
+
+- [ ] **Step 1: Full test suite (root module)**
+
+```bash
+go test ./... -v 2>&1 | tail -40
+```
+
+Expected: every package PASS. If any fail, stop and address before proceeding.
+
+- [ ] **Step 2: Full test suite including plugin submodules (per CLAUDE.md)**
+
+```bash
+make test-all 2>&1 | tail -40
+```
+
+Expected: PASS. (Requires Docker for Postgres testcontainers.) If `make test-all` is unavailable, run each plugin manually:
+
+```bash
+( cd plugins/memory && go test ./... -v ) | tail -10
+( cd plugins/sqlite && go test ./... -v ) | tail -10
+( cd plugins/postgres && go test ./... -v ) | tail -10
+```
+
+- [ ] **Step 3: Static analysis**
+
+```bash
+go vet ./...
+```
+
+Expected: no output.
+
+```bash
+( cd plugins/memory && go vet ./... )
+( cd plugins/sqlite && go vet ./... )
+( cd plugins/postgres && go vet ./... )
+```
+
+Expected: no output for each.
+
+- [ ] **Step 4: Race detector (one-shot end-of-deliverable check)**
+
+```bash
+go test -race ./... 2>&1 | tail -40
+```
+
+Expected: PASS. (Slower — 2-10x — but a single sanity run before PR per `.claude/rules/race-testing.md`.)
+
+- [ ] **Step 5: Build the binary**
+
+```bash
+go build -o bin/cyoda ./cmd/cyoda
+ls -la bin/cyoda
+rm bin/cyoda
+```
+
+Expected: clean build.
+
+- [ ] **Step 6: Confirm the help binary surfaces the new topic**
+
+```bash
+go run ./cmd/cyoda help config/cors | head -10
+```
+
+Expected: the markdown content of the CORS help topic prints.
+
+- [ ] **Step 7: Confirm git status is clean**
+
+```bash
+git status
+```
+
+Expected: working tree clean (or only untracked files unrelated to this work).
+
+- [ ] **Step 8: Review the commit log**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected: 11 task commits + 2 spec commits = 13 commits on the branch, all conventional-commit-formatted with `(#196)` reference.
+
+---
+
+## Spec coverage check (self-review)
+
+Cross-checking the spec against this plan:
+
+- **Architecture / handler order** → Task 8 wires CORS as outermost; Task 6 strips Origin in proxy.
+- **Tenant isolation note** → Task 11 (cors.md) — explicit body section.
+- **Configuration env vars** → Task 1 (struct + reads), Task 2 (validate happy paths), Task 3 (validate rejection rules).
+- **Loopback matching contract** → Task 4 (`matchLoopback`) + Task 4 tests.
+- **Wildcard mode literal `*`, `null` in wildcard gets `*`** → Task 4 tests cover both.
+- **Allowlist normalization** → Task 3.
+- **Preflight detection (3-tuple), pass-through for non-preflight OPTIONS** → Task 4.
+- **Preflight response headers, `Vary: Origin` always** → Task 5.
+- **Actual request behaviour, `Vary: Origin` on no-Origin** → Task 5.
+- **`/_internal/*` excluded** → Task 5.
+- **No-Origin pass-through** → Task 5.
+- **Cluster proxy strip site (`internal/cluster/proxy/http.go:123`)** → Task 6.
+- **Validation step (`ValidateCORS`)** → Task 2-3 (function), Task 7 (wired in `cmd/cyoda/main.go` after slog init).
+- **Mode logs (INFO/WARN, no allowlist values above DEBUG)** → Task 7.
+- **Help endpoint unification (delete `handleHelpPreflight`, delete two CORS tests)** → Task 9.
+- **Toggling note (cache flush)** → Task 11 (cors.md).
+- **Wired-up assertion test** → Task 8.
+- **Punycode error message wording** → Task 3 test.
+- **OPTIONS without ACRM falls through to chi 405** → Task 4 test.
+- **E2E coverage one per group + each mode + disabled** → Task 10.
+- **Documentation** → Task 11.
+- **Race + vet + full test gate** → Task 12.
+- **No third-party CORS library** → Confirmed: only `net/http` + `net/url` + `strings` imports in cors.go.
+- **Per-Gate-6 in-flight defects** → No defects identified during planning. If any surface during implementation, fix red/green with new tasks rather than deferring per CLAUDE.md Gate 6.
+
+Every spec section has a task. No placeholders, no "TBD". Type names consistent: `CORSConfig`, `CORSPolicy`, `NewCORSPolicy`, `CORS`, `ValidateCORS`, `validateCORSOrigin`, `matchLoopback`, `loopbackHosts`, `makeProxyDirector`.
+
+---
+
+## Execution
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-02-issue-196-cors.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, two-stage review between tasks, fast iteration. Use `superpowers:subagent-driven-development`.
+
+**2. Inline Execution** — execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints for review.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-01-issue-196-cors-design.md
+++ b/docs/superpowers/specs/2026-05-01-issue-196-cors-design.md
@@ -1,9 +1,9 @@
 # Issue #196 — API-wide CORS support
 
-**Status:** Design v2 (post-review)
+**Status:** Design v2.1 (post-second-review)
 **Issue:** [#196](https://github.com/Cyoda-platform/cyoda-go/issues/196)
 **Branch:** `issue-196-cors`
-**Date:** 2026-05-02 (v2); 2026-05-01 (v1)
+**Date:** 2026-05-02 (v2, v2.1); 2026-05-01 (v1)
 
 ## Problem
 
@@ -45,6 +45,10 @@ The middleware covers:
 
 The internal `/_internal/*` cluster-dispatch surface is **explicitly excluded** from CORS by a path-prefix check at the top of the middleware: regardless of `Origin` presence, no `Access-Control-*` headers are emitted on requests whose path begins with `/_internal/`. This is defence-in-depth alongside the cluster proxy stripping `Origin` on outbound peer hops; either control alone would suffice, but together they prevent a forged peer-side request from eliciting a CORS response.
 
+### Tenant isolation
+
+CORS is a browser-side defence against unauthorized cross-origin reads; it is **not** a tenant-isolation control. All tenant boundaries are enforced by JWT claims and per-request authorization checks in the data path. An allowlisted SPA serving multiple tenants relies entirely on the auth layer, not CORS, to prevent cross-tenant access. This is load-bearing for Gate 3 and is repeated in the help topic, but is asserted here as a design principle: no CORS rule, however restrictive, is permitted to substitute for or displace JWT-based authz.
+
 Final handler order, outermost to innermost:
 
 ```
@@ -65,7 +69,7 @@ Two env vars, both `CYODA_CORS_*`:
 
 | Var | Default | Effect |
 |---|---|---|
-| `CYODA_CORS_ENABLED` | `true` | Master switch. When `false`, middleware is not installed; service emits no `Access-Control-*` headers and `OPTIONS` returns the chi default `405`. For deployments that handle CORS at an ingress/proxy layer. **Deployers must ensure their ingress handles `OPTIONS` preflights before requests reach cyoda-go in this mode.** |
+| `CYODA_CORS_ENABLED` | `true` | Master switch. When `false`, middleware is not installed; service emits no `Access-Control-*` headers (including `Vary: Origin`) and `OPTIONS` returns the chi default `405`. For deployments that handle CORS at an ingress/proxy layer. **Deployers must ensure their ingress handles `OPTIONS` preflights before requests reach cyoda-go in this mode.** **Toggling `CYODA_CORS_ENABLED` between `true` and `false` requires a downstream-cache flush** — responses cached during the disabled period lack `Vary: Origin` and could be served to origins for which the post-toggle policy disagrees. |
 | `CYODA_CORS_ALLOWED_ORIGINS` | unset (= **loopback mode**) | Comma-separated exact-match allowlist per RFC 6454 origin (scheme + host + port). When unset, only loopback origins are allowed (see "Loopback mode" below). The literal value `*` opts into wildcard mode. |
 
 `CYODA_CORS_ALLOW_CREDENTIALS` is **not part of v1** — see non-goals.
@@ -86,6 +90,24 @@ Any port (or no port) is accepted. The matched origin is echoed in `Access-Contr
 This gives zero-config dev ergonomics (vite/webpack/local docker SPAs all work) while remaining secure by default — a remote attacker hosting `evil.example.com` cannot read responses without explicit allowlist configuration. DNS rebinding does not bypass loopback mode: CORS keys on the `Origin` header (the attacker's actual domain), not the resolved destination IP.
 
 `file://` is not auto-allowed because `Origin: null` is also emitted by sandboxed iframes and certain redirect chains, materially widening the attack surface. Deployers explicitly needing `file://` access add `null` to the allowlist (the documentation calls this out as a footgun).
+
+#### Loopback matching contract
+
+The incoming `Origin` header is matched as follows:
+
+1. Parse with `net/url`. Reject (treat as no match) if `url.Parse` returns an error.
+2. Lowercase `u.Scheme` and `u.Hostname()`. Browsers already emit lowercase scheme and host; this normalization is a defensive belt-and-braces step.
+3. Reject (no match) unless **all** of the following hold:
+   - `u.Scheme` is exactly `http` or `https`.
+   - `u.Hostname()` is exactly one of the strings `localhost`, `127.0.0.1`, `::1` — string compare, not IP-equivalence. Non-canonical IPv4 (`127.0.0.0.1`, `127.000.000.001`, `127.1`, `0x7f000001`) does **not** match. Non-canonical IPv6 (`0:0:0:0:0:0:0:1`, `[0::1]`) does **not** match. The implementation uses `u.Hostname()` (which strips IPv6 brackets) — so the configured `[::1]` strings produce a hostname of `::1`, and incoming `Origin: http://[::1]:8080` parses to a hostname of `::1` — these compare equal.
+   - `u.User` is `nil` (no userinfo).
+   - `u.Path` is empty.
+   - `u.RawQuery` is empty.
+   - `u.Fragment` is empty.
+   - `u.Port()` may be empty or any decimal port number; both are accepted.
+4. If all checks pass, the matched origin is echoed in `Access-Control-Allow-Origin` exactly as received (so that `http://Localhost:3000` is echoed as `http://Localhost:3000`, not the lowercased form — this matches what the browser will be checking against).
+
+Concrete attacker examples this rejects: `http://localhost.evil.example` (hostname mismatch), `http://localhost@evil.example` (userinfo present), `http://127.0.0.0.1:3000` (host string mismatch), `http://xn--lcalhost-...` (host string mismatch — IDN homograph defeated by exact-string compare), `null` (`url.Parse` returns an empty scheme — fails check 3).
 
 ### Wildcard mode
 
@@ -110,7 +132,7 @@ Each origin in the comma-separated list is parsed with `net/url`, then normalize
 - **Reject literal `null`** — the `null` origin is never a valid allowlist entry. (Wildcard mode does not echo `null` either; in wildcard mode only the literal `*` is emitted.)
 - **`*` is mutually exclusive** — `CYODA_CORS_ALLOWED_ORIGINS=*` opts into wildcard mode. Any other value containing `*` is rejected (no glob semantics in v1).
 
-`r.Header.Get("Origin")` is used to read the incoming origin (canonical key). Comparison is byte-equal against the post-normalization allowlist, stored as `map[string]struct{}` built once in the constructor for O(1) lookup.
+`r.Header.Get("Origin")` is used to read the incoming origin (canonical key). **Incoming `Origin` is compared byte-equal verbatim** against the post-normalization allowlist, stored as `map[string]struct{}` built once in the constructor for O(1) lookup. No per-request URL parsing or normalization of the incoming `Origin` is performed in allowlist mode — browsers reliably emit lowercase scheme/host with non-default ports, so verbatim compare avoids a hot-path parse step. (Loopback mode requires URL parsing because the rules are structural, not string-equality; this only fires when no allowlist is configured.)
 
 ## Behaviour
 
@@ -122,7 +144,7 @@ A request is a CORS preflight iff:
 - Request carries an `Origin` header, AND
 - Request carries an `Access-Control-Request-Method` header.
 
-`OPTIONS` requests not meeting all three conditions are passed through unchanged. Today, chi will 405 them per-route; if a future chi version adds auto-`OPTIONS` behaviour, the middleware's pass-through still does the right thing. The middleware does not validate `Access-Control-Request-Method` or `Access-Control-Request-Headers` — preflight is a static yes/no based on `Origin` only. The actual request is method-checked by chi as today.
+`OPTIONS` requests not meeting all three conditions are passed through unchanged. Today, chi will 405 them per-route; if a future chi version adds auto-`OPTIONS` behaviour, the middleware's pass-through still does the right thing. Specifically, an `OPTIONS` request that carries `Origin` but no `Access-Control-Request-Method` (which browsers send only rarely, e.g. for non-CORS purposes) falls through to chi and 405s as today — this is intentional. The middleware does not validate `Access-Control-Request-Method` or `Access-Control-Request-Headers` — preflight is a static yes/no based on `Origin` only. The actual request is method-checked by chi as today.
 
 ### Preflight response
 
@@ -138,7 +160,9 @@ Short-circuits at the receiving node, never reaches Auth or any handler. Headers
 
 Status: `204 No Content`. Empty body.
 
-`Vary: Origin` is emitted on every CORS-middleware response — preflight and actual — regardless of mode. The middleware inspects `Origin` to make every decision; intermediate caches must therefore key by `Origin` per RFC 7234 §4.1. This is required even in wildcard mode (where the response value is constant) so that mode-flip during a deployment cannot cause a CDN to serve a stale `Origin`-specific response to a different origin.
+`Vary: Origin` is emitted on **every response** that passes through an installed CORS middleware — preflight, actual request, and even pass-throughs where `Origin` is absent. The middleware's *decision* depends on `Origin`; intermediate caches must therefore key by `Origin` per RFC 7234 §4.1. Always emitting (rather than only-when-`Origin`-is-present) prevents the inverse cache-poisoning vector: a CDN caching a no-`Origin` response without `Vary: Origin` and later serving it to an `Origin`-bearing request whose policy has changed. This is required even in wildcard mode (constant response value) so that a mode-flip during a deployment cannot cause a CDN to serve a stale `Origin`-specific response to a different origin.
+
+In wildcard mode, an `Origin: null` request also receives `Access-Control-Allow-Origin: *` — wildcard means literal `*` for every origin including `null`. This is consistent and correct: browsers do not honour `*` for credentialed reads, and credentials are off in v1.
 
 ### Actual request (non-preflight)
 
@@ -157,7 +181,9 @@ In loopback or allowlist mode, when the request `Origin` does not match: the mid
 
 ### Request without `Origin` header
 
-Middleware short-circuits — no CORS headers added (not even `Vary: Origin`), request continues unmodified. This is what makes server-to-server `curl` and the cluster proxy's outbound calls invisible to CORS, and what makes the `/_internal/*` peer-to-peer surface a no-op even before its path-prefix exclusion fires.
+The middleware adds `Vary: Origin` to the response (for the cache-poisoning reason given above) but emits no `Access-Control-*` headers. The request continues unmodified through the rest of the chain. This is what makes server-to-server `curl` and the cluster proxy's outbound calls invisible to CORS in terms of policy, while still leaving the cache-key signalling intact for any intermediary that might later receive an `Origin`-bearing request for the same URL.
+
+`/_internal/*` is the sole exception: no headers at all (not even `Vary: Origin`) are emitted on requests whose path begins with `/_internal/`, regardless of `Origin` presence. This is consistent with the path-prefix exclusion rule in §"Architecture" — the internal dispatch surface is peer-only, never browser-visible, and the spec deliberately keeps it free of any CORS-related response state.
 
 ## Cluster proxy interaction
 
@@ -180,7 +206,7 @@ A unit test on the proxy's outbound-headers helper asserts all three headers are
 
 `ValidateCORS(cfg.CORS) error` called from `cmd/cyoda/main.go` **after** slog initialization (so log-level config is honoured for any WARN/INFO emitted):
 
-- Any normalization rule violation (uppercase, default port, path/query/fragment/trailing-slash, userinfo, non-ASCII, empty entry, literal `null` in allowlist, `*` mixed with other values) → returned error; binary slogs and `os.Exit(1)`s. Error message names the offending value.
+- Any normalization rule violation (uppercase, default port, path/query/fragment/trailing-slash, userinfo, non-ASCII, empty entry, literal `null` in allowlist, `*` mixed with other values) → returned error; binary slogs and `os.Exit(1)`s. Error message names the offending value. The non-ASCII case binds a discoverable wording specifically: `cors: origin %q has non-ASCII host; convert to punycode (e.g. xn--…) before configuring`.
 - If `CYODA_CORS_ENABLED=true` and `CYODA_CORS_ALLOWED_ORIGINS=*` → log WARN once: `cors: wildcard mode active (Access-Control-Allow-Origin: *)`. `pkg=cors`.
 - If `CYODA_CORS_ENABLED=true` and an explicit allowlist is configured → log INFO once: `cors: allowlist mode active (N origins)` (count only, never the values; values logged only at DEBUG via `pkg=cors`).
 - If `CYODA_CORS_ENABLED=true` and no allowlist (loopback mode) → log INFO once: `cors: loopback mode active — only http(s)://localhost, 127.0.0.1, [::1] are allowed; set CYODA_CORS_ALLOWED_ORIGINS to permit additional origins`. `pkg=cors`.
@@ -213,10 +239,12 @@ After unification, `/help` in wildcard mode has the same externally-observable C
   - `OPTIONS` with `Origin` but no `Access-Control-Request-Method` → falls through.
   - `OPTIONS` without `Origin` → falls through.
   - `GET` with `Origin` → handled as actual request, not preflight.
-- No `Origin` header on any method: passes through untouched. Specifically, `Vary: Origin` is **not** emitted in this case (no header inspection occurred).
+- No `Origin` header on any method: `Vary: Origin` is emitted; no `Access-Control-*` headers are emitted; downstream handler runs normally.
 - `Vary: Origin` is **appended** via `w.Header().Add`, not overwritten — when a downstream handler also sets `Vary: Accept`, both values are preserved.
-- `/_internal/*` path: no CORS headers emitted regardless of `Origin` presence.
-- `CYODA_CORS_ENABLED=false`: middleware is not installed (constructor returns identity wrapper).
+- `/_internal/*` path: **no** headers emitted (not even `Vary: Origin`) regardless of `Origin` presence.
+- `CYODA_CORS_ENABLED=false`: middleware is not installed (constructor returns identity wrapper); no `Access-Control-*` and no `Vary: Origin` are emitted.
+- **Wired-up assertion test:** with `CYODA_CORS_ENABLED=true` and the full `app.Handler()` constructed, a synthetic preflight against an arbitrary registered route returns `204` with the preflight header set. This proves the middleware is actually installed in the chain (not merely that the middleware code is reachable in isolation). A future refactor that drops the install site would fail this test loud.
+- Wildcard mode + `Origin: null`: response carries `Access-Control-Allow-Origin: *`.
 - Config validation (table-driven):
   - Reject: uppercase character, default port (`:443`, `:80`), trailing slash, path, query, fragment, userinfo, non-ASCII host, empty entry, literal `null`, `*` mixed with other values, malformed URL.
   - Accept: `https://x.com`, `http://x.com:8080`, `https://[::1]:8443`, `https://xn--e1afmkfd.example`.
@@ -274,9 +302,11 @@ Per the documentation-hygiene gate, update together:
 - [ ] `/_internal/*` requests never carry CORS response headers regardless of `Origin`.
 - [ ] `CYODA_CORS_ENABLED=false` disables CORS everywhere, including `/help`.
 - [ ] Loopback mode is the default; wildcard mode requires explicit `=*` and emits a startup WARN.
+- [ ] Loopback mode matches `localhost`/`127.0.0.1`/`::1` exactly per the matching contract; rejects `localhost.evil.example`, non-canonical IPv4/IPv6 forms, userinfo-bearing origins, and IDN homographs.
+- [ ] Wired-up assertion: `CYODA_CORS_ENABLED=true` actually installs the middleware in `app.Handler()`, verified by a test that issues a synthetic preflight against the assembled handler.
 - [ ] Allowlist normalization rejects uppercase, default ports, path/query/fragment/trailing-slash, userinfo, non-ASCII, empty entries, literal `null`, `*` mixed with other values.
 - [ ] Wildcard mode emits literal `*`, never reflective of `Origin`.
-- [ ] `Vary: Origin` is appended (not overwritten) and present on every CORS-middleware response except no-`Origin` pass-throughs.
+- [ ] `Vary: Origin` is appended (not overwritten) and present on every response that passes through the installed CORS middleware, including no-`Origin` pass-throughs. Sole exception: `/_internal/*` paths.
 - [ ] Startup logs report mode at INFO/WARN and never log allowlist values above DEBUG.
 - [ ] Unit + E2E + cluster proxy tests cover all of the above.
 - [ ] `cmd/cyoda/help/content/config/cors.md`, `README.md`, `app/config.go` godoc, and `DefaultConfig()` updated together.

--- a/docs/superpowers/specs/2026-05-01-issue-196-cors-design.md
+++ b/docs/superpowers/specs/2026-05-01-issue-196-cors-design.md
@@ -1,0 +1,205 @@
+# Issue #196 — API-wide CORS support
+
+**Status:** Design
+**Issue:** [#196](https://github.com/Cyoda-platform/cyoda-go/issues/196)
+**Branch:** `issue-196-cors`
+**Date:** 2026-05-01
+
+## Problem
+
+cyoda-go ships CORS support only for the `/help` endpoints (`internal/api/help.go:22-35`). The rest of the API surface — entity, model, search, messaging, audit, account, admin, OAuth, discovery, health — has no CORS handling. From a browser on any other origin (including `file://`):
+
+- **Simple requests** (e.g. `GET /api/entity/{id}`): no `Access-Control-Allow-Origin` header in the response → browser blocks it.
+- **Non-simple requests** (POST/PUT/PATCH/DELETE for search, create, send-message, archive, etc.): browser sends an `OPTIONS` preflight first → chi returns `405 Method Not Allowed` (no `OPTIONS` handler registered) → browser blocks the actual request.
+
+Result: a SPA running anywhere other than the same origin as cyoda-go cannot make a single API call. This breaks any browser-based admin or inspector tool against a deployed instance.
+
+## Goal
+
+Make every cyoda-go HTTP endpoint reachable from a cross-origin browser SPA out of the box, with an opt-in tightening path for production deployments. Unify the existing `/help` CORS implementation under the new middleware so there is a single source of truth.
+
+## Non-goals (v1)
+
+- Glob/suffix wildcards for the allowlist (e.g. `https://*.example.com`). Punted to a follow-up issue if multi-tenant deployers ask. Can be added behind a separate `CYODA_CORS_ALLOWED_ORIGIN_SUFFIXES` knob with explicit suffix-match semantics.
+- Per-route CORS policy (e.g. different rules for `/admin/*` vs the API). A single global policy serves the use cases driving this issue.
+- `Access-Control-Expose-Headers`. No current need; add when a client surfaces a use case.
+- Dynamic config reload. Config is read at startup; changes require a restart. Matches the project's existing config-reload story.
+
+## Architecture
+
+A single CORS middleware applied **outermost** on the user-facing handler chain — outside cluster-routing, OTel, Recovery, and Auth. The same middleware covers:
+
+- The generated OpenAPI surface (entity, model, search, messaging, audit, account)
+- Admin endpoints (`/admin/log-level`, `/admin/trace-sampler`)
+- Entity transition routes (`/entity/{entityId}/transitions`, `/platform-api/entity/fetch/transitions`)
+- OAuth/auth endpoints (`/oauth/token`, `/.well-known/`, `/oauth/keys/*`, `/account/m2m/*`)
+- Discovery routes (`RegisterDiscoveryRoutes`)
+- Health routes (`RegisterHealthRoutes`)
+- Help routes (`/help`, `/help/{topic}`)
+
+The internal `/_internal/*` cluster-dispatch surface receives the middleware too, but it is a no-op there because peers do not send `Origin`.
+
+Final handler order, outermost to innermost:
+
+```
+CORS → cluster-routing → otelhttp → Recovery → Auth → handler
+```
+
+New file: `internal/api/middleware/cors.go`. Wired into `app/app.go`'s `Handler()` construction.
+
+## Configuration
+
+Three env vars, all `CYODA_CORS_*`:
+
+| Var | Default | Effect |
+|---|---|---|
+| `CYODA_CORS_ENABLED` | `true` | Master switch. When `false`, middleware is not installed; service emits no `Access-Control-*` headers and `OPTIONS` returns the chi default `405`. For deployments that handle CORS at an ingress/proxy layer. |
+| `CYODA_CORS_ALLOWED_ORIGINS` | unset (= wildcard mode) | Comma-separated exact-match allowlist per RFC 6454 origin (scheme + host + port). Default-port omission required (`https://x.com`, not `https://x.com:443`). Refuses to start if a configured origin contains path, query, fragment, or trailing slash. |
+| `CYODA_CORS_ALLOW_CREDENTIALS` | `false` | Opt-in for `Access-Control-Allow-Credentials: true`. Refuses to start if `true` while in wildcard mode (browser spec violation). |
+
+Loaded in `app/config.go`'s `DefaultConfig()` alongside other `CYODA_*` env reads. New `CORSConfig` struct mirrors the shape of existing config groups (`Auth`, `Bootstrap`, etc.).
+
+## Behaviour
+
+### Preflight detection
+
+A request is a CORS preflight iff:
+
+- Method is `OPTIONS`, AND
+- Request carries an `Origin` header, AND
+- Request carries an `Access-Control-Request-Method` header.
+
+`OPTIONS` requests not meeting all three conditions fall through to the next handler — chi will 405 them per-route as today.
+
+### Preflight response
+
+Short-circuits at the receiving node, never reaches Auth or any handler. Headers:
+
+| Header | Value |
+|---|---|
+| `Access-Control-Allow-Origin` | `*` in wildcard mode; the matched origin in allowlist mode; **omitted** in allowlist mode if origin not allowed |
+| `Access-Control-Allow-Methods` | `GET, POST, PUT, PATCH, DELETE, OPTIONS` (static) |
+| `Access-Control-Allow-Headers` | `Authorization, Content-Type, traceparent, tracestate` (static) |
+| `Access-Control-Max-Age` | `86400` |
+| `Access-Control-Allow-Credentials` | `true` only if configured AND in allowlist mode AND origin matched |
+| `Vary: Origin` | emitted whenever the response varies by origin (i.e. any time we are in allowlist mode) |
+
+Status: `204 No Content`. Empty body.
+
+### Actual request (non-preflight)
+
+Middleware does not block; sets headers on the `ResponseWriter` before calling next:
+
+| Header | Value |
+|---|---|
+| `Access-Control-Allow-Origin` | same matching rules as preflight; omitted if origin not allowed |
+| `Access-Control-Allow-Credentials` | `true` only if configured AND in allowlist mode AND origin matched |
+| `Vary: Origin` | emitted in allowlist mode |
+
+No other CORS headers on actual responses. The handler runs as today; the middleware does not interfere with status code or body.
+
+### Failure mode for unknown origins
+
+In allowlist mode, when the request `Origin` does not match any configured allowed origin: the middleware **omits** `Access-Control-Allow-Origin`. We do not send an error response. The browser will block the response and the deployer sees the misconfig in browser devtools. This matches the wider CORS ecosystem's behaviour and avoids leaking allowlist contents in error messages.
+
+### Request without `Origin` header
+
+Middleware short-circuits — no CORS headers added, request continues unmodified. This is what makes the `/_internal/*` peer-to-peer no-op work without a path-prefix special case, and also makes server-to-server `curl` and the cluster proxy's outbound calls invisible to CORS.
+
+## Cluster proxy interaction
+
+Two changes:
+
+1. **Strip `Origin` on outbound peer-to-peer requests.** Without this, a request proxied from node A to node B would cause node B's CORS middleware to also emit `Access-Control-Allow-Origin`, and depending on how the proxy merges response headers we risk a multi-valued header (browsers reject). Stripping `Origin` makes node B's CORS middleware a no-op on proxied requests, and node A's outermost middleware is the sole authority for what reaches the browser.
+2. **No special preflight handling needed.** Preflights short-circuit at node A's CORS middleware before cluster-routing is reached. Preflights never traverse the cluster proxy.
+
+The exact file path for the proxy change is determined during implementation; no behavioural surprise expected since the proxy already manipulates per-request headers (e.g. for AEAD signing).
+
+## Startup validation and logging
+
+In `DefaultConfig()` (or an explicit `cfg.Validate()` step):
+
+- If `CYODA_CORS_ALLOW_CREDENTIALS=true` and `CYODA_CORS_ALLOWED_ORIGINS` is unset → fatal startup error naming both vars.
+- If any configured origin contains a path, query, fragment, or trailing slash → fatal startup error naming the offending value.
+- If `CYODA_CORS_ENABLED=true` and no allowlist configured → log WARN once at startup: `cors: wildcard mode active (Access-Control-Allow-Origin: *) — set CYODA_CORS_ALLOWED_ORIGINS to restrict access`. `pkg=cors`.
+- If `CYODA_CORS_ENABLED=false` → log INFO once: `cors: disabled — no Access-Control-* headers will be emitted; configure CORS at your ingress/proxy layer`. `pkg=cors`.
+
+The startup WARN suppresses when the deployer has explicitly set `CYODA_CORS_ALLOWED_ORIGINS` (even if the value is the literal string `*` — a deliberate decision the deployer made and which we do not need to second-guess).
+
+All log lines use `log/slog` per the project's logging policy. No credentials or tokens appear in any CORS-related log line.
+
+## Help endpoint unification
+
+`internal/api/help.go` loses its inline CORS:
+
+- Delete `handleHelpPreflight` and the explicit `Header().Set("Access-Control-Allow-Origin", "*")` calls.
+- Help routes register only their `GET` handler; the unified middleware handles preflight and CORS headers.
+- Existing tests `TestCORSHeadersPresent` and `TestCORSPreflight_204` in `internal/api/help_test.go` move into the new middleware test or are restructured as integration tests against the wired-up server.
+
+This collapses two CORS implementations into one. Critically, it makes `CYODA_CORS_ENABLED=false` actually disable CORS everywhere — today the inline help CORS would still leak headers regardless of the new switch.
+
+## Testing strategy
+
+### Unit tests (`internal/api/middleware/cors_test.go`)
+
+- Wildcard mode, simple GET: response carries `Access-Control-Allow-Origin: *`, no `Allow-Credentials`, no `Vary`.
+- Allowlist mode, matched origin: response carries echoed origin and `Vary: Origin`.
+- Allowlist mode, unmatched origin: response carries no `Access-Control-Allow-Origin`, but `Vary: Origin` is still set (cache correctness).
+- Preflight short-circuits with `204` and the full preflight header set.
+- Preflight detection edge case: `OPTIONS` with `Origin` but no `Access-Control-Request-Method` falls through (not a preflight).
+- No `Origin` header on any method: passes through untouched.
+- `Allow-Credentials`: emitted only when configured AND allowlist mode AND origin matched. Never emitted in wildcard mode.
+- Config validation: refuses startup on `Credentials + wildcard`; refuses on origin with path/query/fragment/trailing-slash; accepts well-formed origins.
+- Static header values match the spec exactly (regression guard against accidental edits).
+
+### E2E tests (`internal/e2e/cors_e2e_test.go`)
+
+Through the full HTTP stack with auth middleware in the chain — proves preflight bypasses auth correctly and that the unified middleware reaches every group.
+
+- Preflight + actual request for one representative endpoint per group: entity (POST), search (POST), messaging (POST), account (GET), admin (POST), help (GET), discovery (GET), health (GET), oauth-token (POST).
+- One test in allowlist mode where the configured allowed origin matches and the response carries credentials when the corresponding env is set.
+- One test with a disallowed origin: response has no `Access-Control-Allow-Origin`; the underlying request still succeeds but the browser would block reading the body.
+- One test with `CYODA_CORS_ENABLED=false`: no `Access-Control-*` headers anywhere, including `/help`.
+
+### Cluster test
+
+- Multi-node fixture (or integration test if multi-node E2E fixtures don't currently support this scenario): a request proxied from node A → node B with `Origin` set asserts the response has exactly one `Access-Control-Allow-Origin` value, set by node A. Confirms the `Origin`-stripping change in the proxy.
+
+## Documentation
+
+Per the documentation-hygiene gate, update together:
+
+- New file `cmd/cyoda/help/content/config/cors.md` — full env-var reference, defaults, deployment guidance (in-service vs ingress), worked examples for dev / docker-compose / k8s-with-ingress, troubleshooting (wildcard + credentials, double-CORS-headers from ingress, origin-mismatch).
+- `README.md` — add a CORS row to the configuration table; brief note that wildcard is the default and allowlist is the production opt-in.
+- `app/config.go` — godoc on the new `CORSConfig` struct fields linking to the help topic.
+- `cmd/cyoda/help/content/cli/help.md` — strike the help-only CORS bullet and link to `config/cors.md`.
+
+## Files touched
+
+**New:**
+- `internal/api/middleware/cors.go`
+- `internal/api/middleware/cors_test.go`
+- `internal/e2e/cors_e2e_test.go`
+- `cmd/cyoda/help/content/config/cors.md`
+
+**Modified:**
+- `app/config.go` — `CORSConfig` struct, env reads, validation
+- `app/app.go` — install middleware in handler chain
+- `internal/cluster/proxy/...` — strip `Origin` on outbound (exact path determined during implementation)
+- `internal/api/help.go` — remove inline CORS
+- `internal/api/help_test.go` — move/restructure CORS tests
+- `README.md`
+- `cmd/cyoda/help/content/cli/help.md`
+
+## Acceptance
+
+- [ ] `OPTIONS` preflight returns `204` with the full preflight header set for every API endpoint, not just `/help`.
+- [ ] Every actual response carries `Access-Control-Allow-Origin` matching the configured policy (or omitted for unknown origins in allowlist mode).
+- [ ] Preflight is processed before auth middleware.
+- [ ] CORS applies through the cluster proxy layer with no duplicate headers.
+- [ ] `CYODA_CORS_ENABLED=false` disables CORS everywhere, including `/help`.
+- [ ] Wildcard mode emits a startup WARN; disabled mode emits an INFO; misconfigurations refuse to start.
+- [ ] Unit + E2E + cluster tests cover all of the above.
+- [ ] `cmd/cyoda/help/content/config/cors.md`, `README.md`, `app/config.go` godoc, and `DefaultConfig()` updated together.
+- [ ] `make test-all` and `go vet ./...` green.
+- [ ] `go test -race ./...` green as the end-of-deliverable sanity check.

--- a/docs/superpowers/specs/2026-05-01-issue-196-cors-design.md
+++ b/docs/superpowers/specs/2026-05-01-issue-196-cors-design.md
@@ -1,9 +1,9 @@
 # Issue #196 — API-wide CORS support
 
-**Status:** Design
+**Status:** Design v2 (post-review)
 **Issue:** [#196](https://github.com/Cyoda-platform/cyoda-go/issues/196)
 **Branch:** `issue-196-cors`
-**Date:** 2026-05-01
+**Date:** 2026-05-02 (v2); 2026-05-01 (v1)
 
 ## Problem
 
@@ -16,18 +16,24 @@ Result: a SPA running anywhere other than the same origin as cyoda-go cannot mak
 
 ## Goal
 
-Make every cyoda-go HTTP endpoint reachable from a cross-origin browser SPA out of the box, with an opt-in tightening path for production deployments. Unify the existing `/help` CORS implementation under the new middleware so there is a single source of truth.
+Make every cyoda-go HTTP endpoint reachable from a cross-origin browser SPA, secure by default, with zero-config developer ergonomics and an explicit opt-in for production deployments. Unify the existing `/help` CORS implementation under the new middleware so there is a single source of truth.
 
 ## Non-goals (v1)
 
-- Glob/suffix wildcards for the allowlist (e.g. `https://*.example.com`). Punted to a follow-up issue if multi-tenant deployers ask. Can be added behind a separate `CYODA_CORS_ALLOWED_ORIGIN_SUFFIXES` knob with explicit suffix-match semantics.
-- Per-route CORS policy (e.g. different rules for `/admin/*` vs the API). A single global policy serves the use cases driving this issue.
-- `Access-Control-Expose-Headers`. No current need; add when a client surfaces a use case.
-- Dynamic config reload. Config is read at startup; changes require a restart. Matches the project's existing config-reload story.
+- **`Access-Control-Allow-Credentials`.** Auth is bearer-token in the `Authorization` header; cookies/HTTP-auth/TLS client certs are not used. Enabling credentials mode adds attack surface (subdomain takeover of an allowlisted origin, XSS in an allowlisted SPA) without functional benefit. If a future change introduces cookie-based auth, that proposal owns its own credentials story.
+- **Glob/suffix wildcards** for the allowlist (e.g. `https://*.example.com`). Punted to a follow-up issue if multi-tenant deployers ask. Can be added behind a separate `CYODA_CORS_ALLOWED_ORIGIN_SUFFIXES` knob with explicit suffix-match semantics.
+- **Per-route CORS policy** (e.g. different rules for `/admin/*` vs the API). A single global policy serves the use cases driving this issue.
+- **`Access-Control-Expose-Headers`.** No current need.
+- **Dynamic config reload.** Config is read at startup; changes require a restart.
+- **Private Network Access (PNA).** cyoda-go does not handle the `Access-Control-Request-Private-Network` / `Access-Control-Allow-Private-Network` headers. Deployers needing browsers on a public origin to reach cyoda-go on a private network front us with an ingress that handles PNA.
+- **CSRF tokens.** CSRF is not a threat for bearer-in-header auth; the SPA explicitly attaches the bearer on each request rather than relying on ambient credentials. No anti-CSRF token is required and none will be added.
+- **Preflight route validation.** `OPTIONS /any/path` with valid preflight headers returns `204` regardless of whether the path is a registered route. Anything else would leak routing structure to unauthenticated callers.
 
 ## Architecture
 
-A single CORS middleware applied **outermost** on the user-facing handler chain — outside cluster-routing, OTel, Recovery, and Auth. The same middleware covers:
+A single CORS middleware applied **outside `outerMux`** (the topmost mux that wraps both the context-path-rooted API and the root-rooted help/discovery/dispatch routes), and outside the cluster-routing middleware. This is the only placement that covers every group: the existing chain has `Recovery`/`Auth` only over the inner `mux`, while help/discovery/dispatch are registered directly on `outerMux` and are *not* wrapped by `Recovery` or `Auth` today.
+
+The middleware covers:
 
 - The generated OpenAPI surface (entity, model, search, messaging, audit, account)
 - Admin endpoints (`/admin/log-level`, `/admin/trace-sampler`)
@@ -37,27 +43,74 @@ A single CORS middleware applied **outermost** on the user-facing handler chain 
 - Health routes (`RegisterHealthRoutes`)
 - Help routes (`/help`, `/help/{topic}`)
 
-The internal `/_internal/*` cluster-dispatch surface receives the middleware too, but it is a no-op there because peers do not send `Origin`.
+The internal `/_internal/*` cluster-dispatch surface is **explicitly excluded** from CORS by a path-prefix check at the top of the middleware: regardless of `Origin` presence, no `Access-Control-*` headers are emitted on requests whose path begins with `/_internal/`. This is defence-in-depth alongside the cluster proxy stripping `Origin` on outbound peer hops; either control alone would suffice, but together they prevent a forged peer-side request from eliciting a CORS response.
 
 Final handler order, outermost to innermost:
 
 ```
-CORS → cluster-routing → otelhttp → Recovery → Auth → handler
+CORS → cluster-routing → outerMux
+                         ├── /<contextPath>/* → mux → otelhttp → Recovery → Auth → genapi
+                         ├── /help, /help/{topic}        (no Recovery/Auth/otelhttp today)
+                         ├── /<discovery routes>          (no Recovery/Auth/otelhttp today)
+                         └── /_internal/*                (AEAD-auth, peer-only; CORS no-op)
 ```
 
-New file: `internal/api/middleware/cors.go`. Wired into `app/app.go`'s `Handler()` construction.
+The middleware writes CORS headers to `w.Header()` **before** calling `next.ServeHTTP`. It does not wrap the `ResponseWriter`, does not observe the downstream status code, and does not buffer the response — preserving `Flush`/`Hijack`/`CloseNotify` interfaces and avoiding any hidden interaction with `otelhttp` or chi.
+
+New file: `internal/api/middleware/cors.go`. Wired into `app/app.go`'s `Handler()` construction. Pure `net/http`; no third-party CORS library. Expected to be ~80 lines.
 
 ## Configuration
 
-Three env vars, all `CYODA_CORS_*`:
+Two env vars, both `CYODA_CORS_*`:
 
 | Var | Default | Effect |
 |---|---|---|
-| `CYODA_CORS_ENABLED` | `true` | Master switch. When `false`, middleware is not installed; service emits no `Access-Control-*` headers and `OPTIONS` returns the chi default `405`. For deployments that handle CORS at an ingress/proxy layer. |
-| `CYODA_CORS_ALLOWED_ORIGINS` | unset (= wildcard mode) | Comma-separated exact-match allowlist per RFC 6454 origin (scheme + host + port). Default-port omission required (`https://x.com`, not `https://x.com:443`). Refuses to start if a configured origin contains path, query, fragment, or trailing slash. |
-| `CYODA_CORS_ALLOW_CREDENTIALS` | `false` | Opt-in for `Access-Control-Allow-Credentials: true`. Refuses to start if `true` while in wildcard mode (browser spec violation). |
+| `CYODA_CORS_ENABLED` | `true` | Master switch. When `false`, middleware is not installed; service emits no `Access-Control-*` headers and `OPTIONS` returns the chi default `405`. For deployments that handle CORS at an ingress/proxy layer. **Deployers must ensure their ingress handles `OPTIONS` preflights before requests reach cyoda-go in this mode.** |
+| `CYODA_CORS_ALLOWED_ORIGINS` | unset (= **loopback mode**) | Comma-separated exact-match allowlist per RFC 6454 origin (scheme + host + port). When unset, only loopback origins are allowed (see "Loopback mode" below). The literal value `*` opts into wildcard mode. |
 
-Loaded in `app/config.go`'s `DefaultConfig()` alongside other `CYODA_*` env reads. New `CORSConfig` struct mirrors the shape of existing config groups (`Auth`, `Bootstrap`, etc.).
+`CYODA_CORS_ALLOW_CREDENTIALS` is **not part of v1** — see non-goals.
+
+### Loopback mode (default)
+
+When `CYODA_CORS_ALLOWED_ORIGINS` is unset, the middleware allows requests whose `Origin` header matches one of:
+
+- `http://localhost[:PORT]`
+- `https://localhost[:PORT]`
+- `http://127.0.0.1[:PORT]`
+- `https://127.0.0.1[:PORT]`
+- `http://[::1][:PORT]`
+- `https://[::1][:PORT]`
+
+Any port (or no port) is accepted. The matched origin is echoed in `Access-Control-Allow-Origin`; `Vary: Origin` is emitted. All other origins (including `null` from `file://`, sandboxed iframes, and arbitrary remote origins) are unmatched — `Access-Control-Allow-Origin` is omitted, the browser blocks the response.
+
+This gives zero-config dev ergonomics (vite/webpack/local docker SPAs all work) while remaining secure by default — a remote attacker hosting `evil.example.com` cannot read responses without explicit allowlist configuration. DNS rebinding does not bypass loopback mode: CORS keys on the `Origin` header (the attacker's actual domain), not the resolved destination IP.
+
+`file://` is not auto-allowed because `Origin: null` is also emitted by sandboxed iframes and certain redirect chains, materially widening the attack surface. Deployers explicitly needing `file://` access add `null` to the allowlist (the documentation calls this out as a footgun).
+
+### Wildcard mode
+
+Set `CYODA_CORS_ALLOWED_ORIGINS=*` to opt into wildcard. The middleware emits `Access-Control-Allow-Origin: *` literally — never reflective of the request `Origin`. A startup WARN announces wildcard mode is active.
+
+### Allowlist mode
+
+Set `CYODA_CORS_ALLOWED_ORIGINS=https://admin.example.com,https://docs.example.com` to opt into an exact-match allowlist. Loopback origins are **not** automatically included in this mode — the deployer's list is authoritative.
+
+### Allowlist normalization and validation
+
+Applied at config load by `ValidateCORS(cfg.CORS) error` (called from `cmd/cyoda/main.go` after slog init, returning an error that the binary slogs and `os.Exit(1)`s on). No `panic`, no `log.Fatal`, no `os.Exit` inside `app/`.
+
+Each origin in the comma-separated list is parsed with `net/url`, then normalized:
+
+- **Lowercase** scheme and host. Configured origins must already be lowercase; uppercase characters cause startup failure with a clear error naming the value (avoids surprises about case sensitivity on match).
+- **Strip default ports** — `https://x.com:443` and `http://x.com:80` are rejected at startup; configure as `https://x.com` / `http://x.com`.
+- **Reject path, query, fragment, trailing slash, userinfo** — these are not valid origin components per RFC 6454.
+- **Reject non-ASCII hosts** — IDN must be supplied in punycode form (`xn--...`); the error message points to this.
+- **IPv6** — bracketed form required (`https://[::1]`). The validator confirms `net/url` round-trips correctly.
+- **Reject empty entries** — leading/trailing commas, double commas, whitespace-only entries error out.
+- **Reject literal `null`** — the `null` origin is never a valid allowlist entry. (Wildcard mode does not echo `null` either; in wildcard mode only the literal `*` is emitted.)
+- **`*` is mutually exclusive** — `CYODA_CORS_ALLOWED_ORIGINS=*` opts into wildcard mode. Any other value containing `*` is rejected (no glob semantics in v1).
+
+`r.Header.Get("Origin")` is used to read the incoming origin (canonical key). Comparison is byte-equal against the post-normalization allowlist, stored as `map[string]struct{}` built once in the constructor for O(1) lookup.
 
 ## Behaviour
 
@@ -69,22 +122,23 @@ A request is a CORS preflight iff:
 - Request carries an `Origin` header, AND
 - Request carries an `Access-Control-Request-Method` header.
 
-`OPTIONS` requests not meeting all three conditions fall through to the next handler — chi will 405 them per-route as today.
+`OPTIONS` requests not meeting all three conditions are passed through unchanged. Today, chi will 405 them per-route; if a future chi version adds auto-`OPTIONS` behaviour, the middleware's pass-through still does the right thing. The middleware does not validate `Access-Control-Request-Method` or `Access-Control-Request-Headers` — preflight is a static yes/no based on `Origin` only. The actual request is method-checked by chi as today.
 
 ### Preflight response
 
-Short-circuits at the receiving node, never reaches Auth or any handler. Headers:
+Short-circuits at the receiving node, never reaches Auth or any handler. Headers (in all CORS-enabled modes):
 
 | Header | Value |
 |---|---|
-| `Access-Control-Allow-Origin` | `*` in wildcard mode; the matched origin in allowlist mode; **omitted** in allowlist mode if origin not allowed |
-| `Access-Control-Allow-Methods` | `GET, POST, PUT, PATCH, DELETE, OPTIONS` (static) |
-| `Access-Control-Allow-Headers` | `Authorization, Content-Type, traceparent, tracestate` (static) |
-| `Access-Control-Max-Age` | `86400` |
-| `Access-Control-Allow-Credentials` | `true` only if configured AND in allowlist mode AND origin matched |
-| `Vary: Origin` | emitted whenever the response varies by origin (i.e. any time we are in allowlist mode) |
+| `Access-Control-Allow-Origin` | wildcard mode: literal `*`. Loopback / allowlist mode: matched origin, or **omitted** if no match |
+| `Access-Control-Allow-Methods` | `GET, POST, PUT, PATCH, DELETE, OPTIONS` (static, package `const`) |
+| `Access-Control-Allow-Headers` | `Authorization, Content-Type, traceparent, tracestate` (static, package `const`) |
+| `Access-Control-Max-Age` | `86400` (static) |
+| `Vary` | `Origin` (always **appended** via `w.Header().Add`, never overwriting an existing `Vary`) |
 
 Status: `204 No Content`. Empty body.
+
+`Vary: Origin` is emitted on every CORS-middleware response — preflight and actual — regardless of mode. The middleware inspects `Origin` to make every decision; intermediate caches must therefore key by `Origin` per RFC 7234 §4.1. This is required even in wildcard mode (where the response value is constant) so that mode-flip during a deployment cannot cause a CDN to serve a stale `Origin`-specific response to a different origin.
 
 ### Actual request (non-preflight)
 
@@ -93,40 +147,46 @@ Middleware does not block; sets headers on the `ResponseWriter` before calling n
 | Header | Value |
 |---|---|
 | `Access-Control-Allow-Origin` | same matching rules as preflight; omitted if origin not allowed |
-| `Access-Control-Allow-Credentials` | `true` only if configured AND in allowlist mode AND origin matched |
-| `Vary: Origin` | emitted in allowlist mode |
+| `Vary` | `Origin` (appended) |
 
-No other CORS headers on actual responses. The handler runs as today; the middleware does not interfere with status code or body.
+No other CORS headers on actual responses. The handler runs as today; the middleware does not interfere with status code, body, or response writer wrapping.
 
 ### Failure mode for unknown origins
 
-In allowlist mode, when the request `Origin` does not match any configured allowed origin: the middleware **omits** `Access-Control-Allow-Origin`. We do not send an error response. The browser will block the response and the deployer sees the misconfig in browser devtools. This matches the wider CORS ecosystem's behaviour and avoids leaking allowlist contents in error messages.
+In loopback or allowlist mode, when the request `Origin` does not match: the middleware **omits** `Access-Control-Allow-Origin` (still emits `Vary: Origin`). No error response. The browser blocks reading the response and the deployer sees the misconfig in browser devtools. We do not log the rejected origin — that would create a noisy attack-tunable log channel.
 
 ### Request without `Origin` header
 
-Middleware short-circuits — no CORS headers added, request continues unmodified. This is what makes the `/_internal/*` peer-to-peer no-op work without a path-prefix special case, and also makes server-to-server `curl` and the cluster proxy's outbound calls invisible to CORS.
+Middleware short-circuits — no CORS headers added (not even `Vary: Origin`), request continues unmodified. This is what makes server-to-server `curl` and the cluster proxy's outbound calls invisible to CORS, and what makes the `/_internal/*` peer-to-peer surface a no-op even before its path-prefix exclusion fires.
 
 ## Cluster proxy interaction
 
-Two changes:
+Two changes in `internal/cluster/proxy/http.go`:
 
-1. **Strip `Origin` on outbound peer-to-peer requests.** Without this, a request proxied from node A to node B would cause node B's CORS middleware to also emit `Access-Control-Allow-Origin`, and depending on how the proxy merges response headers we risk a multi-valued header (browsers reject). Stripping `Origin` makes node B's CORS middleware a no-op on proxied requests, and node A's outermost middleware is the sole authority for what reaches the browser.
-2. **No special preflight handling needed.** Preflights short-circuit at node A's CORS middleware before cluster-routing is reached. Preflights never traverse the cluster proxy.
+1. **In the `httputil.ReverseProxy.Director` (`internal/cluster/proxy/http.go:123`)**, strip the following headers on every outbound peer-to-peer request:
+   - `Origin`
+   - `Access-Control-Request-Method`
+   - `Access-Control-Request-Headers`
 
-The exact file path for the proxy change is determined during implementation; no behavioural surprise expected since the proxy already manipulates per-request headers (e.g. for AEAD signing).
+   `req.Header.Del(...)` is idempotent. Stripping all three is defence-in-depth: the CORS middleware short-circuits preflights at node A so peer-B should never see a preflight, but a future refactor that moves CORS below cluster routing would otherwise leak preflight signalling to peers. A one-line code comment in the `Director` references the CORS middleware as the upstream owner of these headers.
+
+2. **No special preflight handling.** Preflights short-circuit at node A's CORS middleware before cluster-routing is reached. The `Director` strip is purely a guarantee, not a correctness dependency.
+
+`ReverseProxy` strips hop-by-hop headers automatically but does not strip CORS response headers. With `Origin` stripped on outbound and node B's CORS middleware no-opping when `Origin` is absent, peer-B never emits `Access-Control-*`. Node A's outermost middleware is the sole authority for what reaches the browser.
+
+A unit test on the proxy's outbound-headers helper asserts all three headers are removed, independent of any CORS-middleware test. This is in addition to the multi-node E2E test described under "Testing strategy".
 
 ## Startup validation and logging
 
-In `DefaultConfig()` (or an explicit `cfg.Validate()` step):
+`ValidateCORS(cfg.CORS) error` called from `cmd/cyoda/main.go` **after** slog initialization (so log-level config is honoured for any WARN/INFO emitted):
 
-- If `CYODA_CORS_ALLOW_CREDENTIALS=true` and `CYODA_CORS_ALLOWED_ORIGINS` is unset → fatal startup error naming both vars.
-- If any configured origin contains a path, query, fragment, or trailing slash → fatal startup error naming the offending value.
-- If `CYODA_CORS_ENABLED=true` and no allowlist configured → log WARN once at startup: `cors: wildcard mode active (Access-Control-Allow-Origin: *) — set CYODA_CORS_ALLOWED_ORIGINS to restrict access`. `pkg=cors`.
+- Any normalization rule violation (uppercase, default port, path/query/fragment/trailing-slash, userinfo, non-ASCII, empty entry, literal `null` in allowlist, `*` mixed with other values) → returned error; binary slogs and `os.Exit(1)`s. Error message names the offending value.
+- If `CYODA_CORS_ENABLED=true` and `CYODA_CORS_ALLOWED_ORIGINS=*` → log WARN once: `cors: wildcard mode active (Access-Control-Allow-Origin: *)`. `pkg=cors`.
+- If `CYODA_CORS_ENABLED=true` and an explicit allowlist is configured → log INFO once: `cors: allowlist mode active (N origins)` (count only, never the values; values logged only at DEBUG via `pkg=cors`).
+- If `CYODA_CORS_ENABLED=true` and no allowlist (loopback mode) → log INFO once: `cors: loopback mode active — only http(s)://localhost, 127.0.0.1, [::1] are allowed; set CYODA_CORS_ALLOWED_ORIGINS to permit additional origins`. `pkg=cors`.
 - If `CYODA_CORS_ENABLED=false` → log INFO once: `cors: disabled — no Access-Control-* headers will be emitted; configure CORS at your ingress/proxy layer`. `pkg=cors`.
 
-The startup WARN suppresses when the deployer has explicitly set `CYODA_CORS_ALLOWED_ORIGINS` (even if the value is the literal string `*` — a deliberate decision the deployer made and which we do not need to second-guess).
-
-All log lines use `log/slog` per the project's logging policy. No credentials or tokens appear in any CORS-related log line.
+All log lines use `log/slog`. No credentials, tokens, request headers, or rejected-origin values appear in any CORS-related log line.
 
 ## Help endpoint unification
 
@@ -134,43 +194,55 @@ All log lines use `log/slog` per the project's logging policy. No credentials or
 
 - Delete `handleHelpPreflight` and the explicit `Header().Set("Access-Control-Allow-Origin", "*")` calls.
 - Help routes register only their `GET` handler; the unified middleware handles preflight and CORS headers.
-- Existing tests `TestCORSHeadersPresent` and `TestCORSPreflight_204` in `internal/api/help_test.go` move into the new middleware test or are restructured as integration tests against the wired-up server.
+- **Delete** `TestCORSHeadersPresent` and `TestCORSPreflight_204` from `internal/api/help_test.go`. The E2E group-coverage test for `/help` (see "Testing strategy") subsumes them.
 
-This collapses two CORS implementations into one. Critically, it makes `CYODA_CORS_ENABLED=false` actually disable CORS everywhere — today the inline help CORS would still leak headers regardless of the new switch.
+After unification, `/help` in wildcard mode has the same externally-observable CORS behaviour as today's `/help`. In loopback or allowlist mode, `/help` is stricter than today — only loopback or explicitly allowed origins can read help content cross-origin. This is a deliberate behaviour change: a single CORS policy is the whole point of unification.
+
+`CYODA_CORS_ENABLED=false` now disables CORS on `/help` too — today's inline implementation would still leak headers; v2 honours the master switch.
 
 ## Testing strategy
 
 ### Unit tests (`internal/api/middleware/cors_test.go`)
 
-- Wildcard mode, simple GET: response carries `Access-Control-Allow-Origin: *`, no `Allow-Credentials`, no `Vary`.
-- Allowlist mode, matched origin: response carries echoed origin and `Vary: Origin`.
-- Allowlist mode, unmatched origin: response carries no `Access-Control-Allow-Origin`, but `Vary: Origin` is still set (cache correctness).
+- Loopback mode: matched origins (`http://localhost:3000`, `https://127.0.0.1:8080`, `http://[::1]:5173`) get echoed; unmatched (`https://evil.example`, `http://localhost.evil.example`, `null`) are omitted.
+- Wildcard mode: response carries literal `*` regardless of request `Origin`; never reflective. Explicit test that an `Origin: https://evil.example` request gets `*`, not echoed.
+- Allowlist mode, matched origin: echoed + `Vary: Origin`.
+- Allowlist mode, unmatched origin: no `Access-Control-Allow-Origin`, but `Vary: Origin` still set.
 - Preflight short-circuits with `204` and the full preflight header set.
-- Preflight detection edge case: `OPTIONS` with `Origin` but no `Access-Control-Request-Method` falls through (not a preflight).
-- No `Origin` header on any method: passes through untouched.
-- `Allow-Credentials`: emitted only when configured AND allowlist mode AND origin matched. Never emitted in wildcard mode.
-- Config validation: refuses startup on `Credentials + wildcard`; refuses on origin with path/query/fragment/trailing-slash; accepts well-formed origins.
-- Static header values match the spec exactly (regression guard against accidental edits).
+- Preflight detection edge cases:
+  - `OPTIONS` with `Origin` but no `Access-Control-Request-Method` → falls through.
+  - `OPTIONS` without `Origin` → falls through.
+  - `GET` with `Origin` → handled as actual request, not preflight.
+- No `Origin` header on any method: passes through untouched. Specifically, `Vary: Origin` is **not** emitted in this case (no header inspection occurred).
+- `Vary: Origin` is **appended** via `w.Header().Add`, not overwritten — when a downstream handler also sets `Vary: Accept`, both values are preserved.
+- `/_internal/*` path: no CORS headers emitted regardless of `Origin` presence.
+- `CYODA_CORS_ENABLED=false`: middleware is not installed (constructor returns identity wrapper).
+- Config validation (table-driven):
+  - Reject: uppercase character, default port (`:443`, `:80`), trailing slash, path, query, fragment, userinfo, non-ASCII host, empty entry, literal `null`, `*` mixed with other values, malformed URL.
+  - Accept: `https://x.com`, `http://x.com:8080`, `https://[::1]:8443`, `https://xn--e1afmkfd.example`.
+  - Single value `*` accepted as wildcard mode.
 
 ### E2E tests (`internal/e2e/cors_e2e_test.go`)
 
 Through the full HTTP stack with auth middleware in the chain — proves preflight bypasses auth correctly and that the unified middleware reaches every group.
 
 - Preflight + actual request for one representative endpoint per group: entity (POST), search (POST), messaging (POST), account (GET), admin (POST), help (GET), discovery (GET), health (GET), oauth-token (POST).
-- One test in allowlist mode where the configured allowed origin matches and the response carries credentials when the corresponding env is set.
-- One test with a disallowed origin: response has no `Access-Control-Allow-Origin`; the underlying request still succeeds but the browser would block reading the body.
+- One test in allowlist mode where the configured allowed origin matches.
+- One test with a disallowed origin: response has no `Access-Control-Allow-Origin`; the underlying request still succeeds but the browser would block reading the body. Asserts `Vary: Origin` is still present.
 - One test with `CYODA_CORS_ENABLED=false`: no `Access-Control-*` headers anywhere, including `/help`.
+- One test with default loopback mode: `Origin: http://localhost:3000` succeeds; `Origin: https://evil.example` is omitted.
 
-### Cluster test
+### Cluster proxy test
 
-- Multi-node fixture (or integration test if multi-node E2E fixtures don't currently support this scenario): a request proxied from node A → node B with `Origin` set asserts the response has exactly one `Access-Control-Allow-Origin` value, set by node A. Confirms the `Origin`-stripping change in the proxy.
+- Unit test on `internal/cluster/proxy/http.go`'s outbound `Director`: assert `Origin`, `Access-Control-Request-Method`, `Access-Control-Request-Headers` are all removed from the proxied request, regardless of input.
+- Multi-node integration test (or, if multi-node E2E fixtures don't currently support this scenario, an integration test against the proxy): a request proxied from node A → node B with `Origin` set asserts the response has exactly one `Access-Control-Allow-Origin` value, set by node A.
 
 ## Documentation
 
 Per the documentation-hygiene gate, update together:
 
-- New file `cmd/cyoda/help/content/config/cors.md` — full env-var reference, defaults, deployment guidance (in-service vs ingress), worked examples for dev / docker-compose / k8s-with-ingress, troubleshooting (wildcard + credentials, double-CORS-headers from ingress, origin-mismatch).
-- `README.md` — add a CORS row to the configuration table; brief note that wildcard is the default and allowlist is the production opt-in.
+- New file `cmd/cyoda/help/content/config/cors.md` — full env-var reference, defaults, deployment guidance (in-service vs ingress), worked examples for dev / docker-compose / k8s-with-ingress, troubleshooting (loopback-mode mismatch, double-CORS-headers from ingress, origin case sensitivity, `null` origin from `file://`, IDN/punycode), explicit "CORS does not provide tenant isolation — always JWT-gate" note, explicit "no PNA, no CSRF tokens" stance.
+- `README.md` — add a CORS row to the configuration table; brief note that loopback mode is the default and allowlist is the production opt-in.
 - `app/config.go` — godoc on the new `CORSConfig` struct fields linking to the help topic.
 - `cmd/cyoda/help/content/cli/help.md` — strike the help-only CORS bullet and link to `config/cors.md`.
 
@@ -183,23 +255,30 @@ Per the documentation-hygiene gate, update together:
 - `cmd/cyoda/help/content/config/cors.md`
 
 **Modified:**
-- `app/config.go` — `CORSConfig` struct, env reads, validation
-- `app/app.go` — install middleware in handler chain
-- `internal/cluster/proxy/...` — strip `Origin` on outbound (exact path determined during implementation)
+- `app/config.go` — `CORSConfig` struct, env reads, exported `ValidateCORS`
+- `cmd/cyoda/main.go` — call `ValidateCORS` after slog init, before `app.New`
+- `app/app.go` — install middleware outside `outerMux`, outside cluster-routing
+- `internal/cluster/proxy/http.go` — strip `Origin`, `Access-Control-Request-Method`, `Access-Control-Request-Headers` in the proxy `Director`
 - `internal/api/help.go` — remove inline CORS
-- `internal/api/help_test.go` — move/restructure CORS tests
+- `internal/api/help_test.go` — delete `TestCORSHeadersPresent`, `TestCORSPreflight_204`
 - `README.md`
 - `cmd/cyoda/help/content/cli/help.md`
 
 ## Acceptance
 
 - [ ] `OPTIONS` preflight returns `204` with the full preflight header set for every API endpoint, not just `/help`.
-- [ ] Every actual response carries `Access-Control-Allow-Origin` matching the configured policy (or omitted for unknown origins in allowlist mode).
+- [ ] Every actual response carries `Access-Control-Allow-Origin` matching the configured policy (or omitted for unmatched origins) and `Vary: Origin`.
 - [ ] Preflight is processed before auth middleware.
 - [ ] CORS applies through the cluster proxy layer with no duplicate headers.
+- [ ] Cluster proxy `Director` strips `Origin`, `Access-Control-Request-Method`, `Access-Control-Request-Headers` on outbound peer requests, with a unit test on the helper.
+- [ ] `/_internal/*` requests never carry CORS response headers regardless of `Origin`.
 - [ ] `CYODA_CORS_ENABLED=false` disables CORS everywhere, including `/help`.
-- [ ] Wildcard mode emits a startup WARN; disabled mode emits an INFO; misconfigurations refuse to start.
-- [ ] Unit + E2E + cluster tests cover all of the above.
+- [ ] Loopback mode is the default; wildcard mode requires explicit `=*` and emits a startup WARN.
+- [ ] Allowlist normalization rejects uppercase, default ports, path/query/fragment/trailing-slash, userinfo, non-ASCII, empty entries, literal `null`, `*` mixed with other values.
+- [ ] Wildcard mode emits literal `*`, never reflective of `Origin`.
+- [ ] `Vary: Origin` is appended (not overwritten) and present on every CORS-middleware response except no-`Origin` pass-throughs.
+- [ ] Startup logs report mode at INFO/WARN and never log allowlist values above DEBUG.
+- [ ] Unit + E2E + cluster proxy tests cover all of the above.
 - [ ] `cmd/cyoda/help/content/config/cors.md`, `README.md`, `app/config.go` godoc, and `DefaultConfig()` updated together.
 - [ ] `make test-all` and `go vet ./...` green.
 - [ ] `go test -race ./...` green as the end-of-deliverable sanity check.

--- a/docs/superpowers/specs/2026-05-01-issue-196-cors-design.md
+++ b/docs/superpowers/specs/2026-05-01-issue-196-cors-design.md
@@ -43,7 +43,7 @@ The middleware covers:
 - Health routes (`RegisterHealthRoutes`)
 - Help routes (`/help`, `/help/{topic}`)
 
-The internal `/_internal/*` cluster-dispatch surface is **explicitly excluded** from CORS by a path-prefix check at the top of the middleware: regardless of `Origin` presence, no `Access-Control-*` headers are emitted on requests whose path begins with `/_internal/`. This is defence-in-depth alongside the cluster proxy stripping `Origin` on outbound peer hops; either control alone would suffice, but together they prevent a forged peer-side request from eliciting a CORS response.
+The internal `/internal/dispatch/*` cluster-dispatch surface is **explicitly excluded** from CORS by a path-prefix check at the top of the middleware: regardless of `Origin` presence, no `Access-Control-*` headers are emitted on requests whose path begins with `/internal/dispatch/`. This is defence-in-depth alongside the cluster proxy stripping `Origin` on outbound peer hops; either control alone would suffice, but together they prevent a forged peer-side request from eliciting a CORS response.
 
 ### Tenant isolation
 
@@ -56,7 +56,7 @@ CORS → cluster-routing → outerMux
                          ├── /<contextPath>/* → mux → otelhttp → Recovery → Auth → genapi
                          ├── /help, /help/{topic}        (no Recovery/Auth/otelhttp today)
                          ├── /<discovery routes>          (no Recovery/Auth/otelhttp today)
-                         └── /_internal/*                (AEAD-auth, peer-only; CORS no-op)
+                         └── /internal/dispatch/*        (AEAD-auth, peer-only; CORS no-op)
 ```
 
 The middleware writes CORS headers to `w.Header()` **before** calling `next.ServeHTTP`. It does not wrap the `ResponseWriter`, does not observe the downstream status code, and does not buffer the response — preserving `Flush`/`Hijack`/`CloseNotify` interfaces and avoiding any hidden interaction with `otelhttp` or chi.
@@ -183,7 +183,7 @@ In loopback or allowlist mode, when the request `Origin` does not match: the mid
 
 The middleware adds `Vary: Origin` to the response (for the cache-poisoning reason given above) but emits no `Access-Control-*` headers. The request continues unmodified through the rest of the chain. This is what makes server-to-server `curl` and the cluster proxy's outbound calls invisible to CORS in terms of policy, while still leaving the cache-key signalling intact for any intermediary that might later receive an `Origin`-bearing request for the same URL.
 
-`/_internal/*` is the sole exception: no headers at all (not even `Vary: Origin`) are emitted on requests whose path begins with `/_internal/`, regardless of `Origin` presence. This is consistent with the path-prefix exclusion rule in §"Architecture" — the internal dispatch surface is peer-only, never browser-visible, and the spec deliberately keeps it free of any CORS-related response state.
+`/internal/dispatch/*` is the sole exception: no headers at all (not even `Vary: Origin`) are emitted on requests whose path begins with `/internal/dispatch/`, regardless of `Origin` presence. This is consistent with the path-prefix exclusion rule in §"Architecture" — the internal dispatch surface is peer-only, never browser-visible, and the spec deliberately keeps it free of any CORS-related response state.
 
 ## Cluster proxy interaction
 
@@ -241,7 +241,7 @@ After unification, `/help` in wildcard mode has the same externally-observable C
   - `GET` with `Origin` → handled as actual request, not preflight.
 - No `Origin` header on any method: `Vary: Origin` is emitted; no `Access-Control-*` headers are emitted; downstream handler runs normally.
 - `Vary: Origin` is **appended** via `w.Header().Add`, not overwritten — when a downstream handler also sets `Vary: Accept`, both values are preserved.
-- `/_internal/*` path: **no** headers emitted (not even `Vary: Origin`) regardless of `Origin` presence.
+- `/internal/dispatch/*` path: **no** headers emitted (not even `Vary: Origin`) regardless of `Origin` presence.
 - `CYODA_CORS_ENABLED=false`: middleware is not installed (constructor returns identity wrapper); no `Access-Control-*` and no `Vary: Origin` are emitted.
 - **Wired-up assertion test:** with `CYODA_CORS_ENABLED=true` and the full `app.Handler()` constructed, a synthetic preflight against an arbitrary registered route returns `204` with the preflight header set. This proves the middleware is actually installed in the chain (not merely that the middleware code is reachable in isolation). A future refactor that drops the install site would fail this test loud.
 - Wildcard mode + `Origin: null`: response carries `Access-Control-Allow-Origin: *`.
@@ -299,14 +299,14 @@ Per the documentation-hygiene gate, update together:
 - [ ] Preflight is processed before auth middleware.
 - [ ] CORS applies through the cluster proxy layer with no duplicate headers.
 - [ ] Cluster proxy `Director` strips `Origin`, `Access-Control-Request-Method`, `Access-Control-Request-Headers` on outbound peer requests, with a unit test on the helper.
-- [ ] `/_internal/*` requests never carry CORS response headers regardless of `Origin`.
+- [ ] `/internal/dispatch/*` requests never carry CORS response headers regardless of `Origin`.
 - [ ] `CYODA_CORS_ENABLED=false` disables CORS everywhere, including `/help`.
 - [ ] Loopback mode is the default; wildcard mode requires explicit `=*` and emits a startup WARN.
 - [ ] Loopback mode matches `localhost`/`127.0.0.1`/`::1` exactly per the matching contract; rejects `localhost.evil.example`, non-canonical IPv4/IPv6 forms, userinfo-bearing origins, and IDN homographs.
 - [ ] Wired-up assertion: `CYODA_CORS_ENABLED=true` actually installs the middleware in `app.Handler()`, verified by a test that issues a synthetic preflight against the assembled handler.
 - [ ] Allowlist normalization rejects uppercase, default ports, path/query/fragment/trailing-slash, userinfo, non-ASCII, empty entries, literal `null`, `*` mixed with other values.
 - [ ] Wildcard mode emits literal `*`, never reflective of `Origin`.
-- [ ] `Vary: Origin` is appended (not overwritten) and present on every response that passes through the installed CORS middleware, including no-`Origin` pass-throughs. Sole exception: `/_internal/*` paths.
+- [ ] `Vary: Origin` is appended (not overwritten) and present on every response that passes through the installed CORS middleware, including no-`Origin` pass-throughs. Sole exception: `/internal/dispatch/*` paths.
 - [ ] Startup logs report mode at INFO/WARN and never log allowlist values above DEBUG.
 - [ ] Unit + E2E + cluster proxy tests cover all of the above.
 - [ ] `cmd/cyoda/help/content/config/cors.md`, `README.md`, `app/config.go` godoc, and `DefaultConfig()` updated together.

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
-	github.com/gofrs/flock v0.12.1 // indirect
+	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang-migrate/migrate/v4 v4.19.1 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
@@ -57,8 +57,8 @@ require (
 	github.com/moby/moby/client v0.4.0 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/ncruces/go-sqlite3 v0.33.3 // indirect
-	github.com/ncruces/go-sqlite3-wasm v1.1.1-0.20260409221933-87e4b35a38d0 // indirect
+	github.com/ncruces/go-sqlite3 v0.34.0 // indirect
+	github.com/ncruces/go-sqlite3-wasm/v2 v2.1.35300 // indirect
 	github.com/ncruces/julianday v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
-github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
-github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang-migrate/migrate/v4 v4.19.1 h1:OCyb44lFuQfYXYLx1SCxPZQGU7mcaZ7gH9yH4jSFbBA=
 github.com/golang-migrate/migrate/v4 v4.19.1/go.mod h1:CTcgfjxhaUtsLipnLoQRWCrjYXycRz/g5+RWDuYgPrE=
@@ -294,10 +294,10 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/ncruces/go-sqlite3 v0.33.3 h1:6jCR3KuGvJSEwhaQrkHDGeIe2qCQ6nOUDNsPz7ZIotw=
-github.com/ncruces/go-sqlite3 v0.33.3/go.mod h1:t2Osfw0wcKzJTgv2EvrkTtVLqlbKTA5Yvwb2ypAlBcY=
-github.com/ncruces/go-sqlite3-wasm v1.1.1-0.20260409221933-87e4b35a38d0 h1:ymE9H30x1AyW5VfMNkJC9teuI2W1jjMsQS7kc6zl6Tg=
-github.com/ncruces/go-sqlite3-wasm v1.1.1-0.20260409221933-87e4b35a38d0/go.mod h1:/H3+JykPsfSlvKbOxNSx9kKwm3ecqQGzyCs1e9KkNsU=
+github.com/ncruces/go-sqlite3 v0.34.0 h1:q2I6wHTLWIoz6ehYkKdG5dGQc66eJv7ZGnekhvuMfK8=
+github.com/ncruces/go-sqlite3 v0.34.0/go.mod h1:qpBxsSdGPnO9K5OExuv5GEsrGQ7Rk6JsJFH6wn2DwwU=
+github.com/ncruces/go-sqlite3-wasm/v2 v2.1.35300 h1:cRdxCt3BDfMu0vfSdoqaAPD+dzIXPkGREjqyZMLN2Ak=
+github.com/ncruces/go-sqlite3-wasm/v2 v2.1.35300/go.mod h1:R2kJLPoSA/GBX/b8x7zwOq/KLAw6rLMY1l3Hi76SQIo=
 github.com/ncruces/julianday v1.0.0 h1:fH0OKwa7NWvniGQtxdJRxAgkBMolni2BjDHaWTxqt7M=
 github.com/ncruces/julianday v1.0.0/go.mod h1:Dusn2KvZrrovOMJuOt0TNXL6tB7U2E8kvza5fFc9G7g=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/internal/api/help.go
+++ b/internal/api/help.go
@@ -19,33 +19,18 @@ import (
 // before the handler runs, so double-slash cannot be detected at this layer.
 var topicPathPattern = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9._/-]*[A-Za-z0-9])?$`)
 
-// handleHelpPreflight writes a CORS preflight response and returns true if the
-// request was an OPTIONS preflight. The caller should return immediately when
-// this function returns true.
-func handleHelpPreflight(w http.ResponseWriter, r *http.Request) bool {
-	if r.Method != http.MethodOptions {
-		return false
-	}
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
-	w.Header().Set("Access-Control-Max-Age", "86400")
-	w.WriteHeader(http.StatusNoContent)
-	return true
-}
-
 // RegisterHelpRoutes mounts GET {contextPath}/help and
 // GET {contextPath}/help/{topic} on the given mux. contextPath must NOT
 // have a trailing slash. An empty contextPath mounts at "/help".
-// version is closed over by the handlers and reported in the full-tree payload.
+// version is closed over by the handlers and reported in the full-tree
+// payload. CORS for /help is handled by the unified middleware in
+// internal/api/middleware/cors.go — these handlers no longer manage CORS
+// themselves.
 func RegisterHelpRoutes(mux *http.ServeMux, tree *help.Tree, contextPath, version string) {
 	prefix := strings.TrimRight(contextPath, "/") + "/help"
 	mux.HandleFunc(prefix, func(w http.ResponseWriter, r *http.Request) {
-		if handleHelpPreflight(w, r) {
-			return
-		}
 		if r.Method != http.MethodGet {
-			w.Header().Set("Allow", "GET, OPTIONS")
+			w.Header().Set("Allow", "GET")
 			common.WriteError(w, r, common.Operational(
 				http.StatusMethodNotAllowed,
 				common.ErrCodeBadRequest,
@@ -53,7 +38,6 @@ func RegisterHelpRoutes(mux *http.ServeMux, tree *help.Tree, contextPath, versio
 			))
 			return
 		}
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 		if r.URL.Path != prefix {
 			common.WriteError(w, r, common.Operational(
 				http.StatusNotFound,
@@ -73,11 +57,8 @@ func RegisterHelpRoutes(mux *http.ServeMux, tree *help.Tree, contextPath, versio
 		}
 	})
 	mux.HandleFunc(prefix+"/", func(w http.ResponseWriter, r *http.Request) {
-		if handleHelpPreflight(w, r) {
-			return
-		}
 		if r.Method != http.MethodGet {
-			w.Header().Set("Allow", "GET, OPTIONS")
+			w.Header().Set("Allow", "GET")
 			common.WriteError(w, r, common.Operational(
 				http.StatusMethodNotAllowed,
 				common.ErrCodeBadRequest,
@@ -85,7 +66,6 @@ func RegisterHelpRoutes(mux *http.ServeMux, tree *help.Tree, contextPath, versio
 			))
 			return
 		}
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 		topic := strings.TrimPrefix(r.URL.Path, prefix+"/")
 		if !topicPathPattern.MatchString(topic) {
 			common.WriteError(w, r, common.Operational(

--- a/internal/api/help_test.go
+++ b/internal/api/help_test.go
@@ -101,18 +101,6 @@ func TestMalformedTopicPath_400(t *testing.T) {
 	}
 }
 
-func TestCORSHeadersPresent(t *testing.T) {
-	srv := helpTestServer(t, "/api")
-	defer srv.Close()
-	resp, err := http.Get(srv.URL + "/api/help")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	if resp.Header.Get("Access-Control-Allow-Origin") != "*" {
-		t.Errorf("CORS header missing: %q", resp.Header.Get("Access-Control-Allow-Origin"))
-	}
-}
 
 func TestMalformedTopicPath_400_LeadingDot(t *testing.T) {
 	srv := helpTestServer(t, "/api")
@@ -158,24 +146,6 @@ func TestMalformedTopicPath_BareDot_RedirectsToCanonical(t *testing.T) {
 	}
 }
 
-func TestCORSPreflight_204(t *testing.T) {
-	srv := helpTestServer(t, "/api")
-	defer srv.Close()
-	req, _ := http.NewRequest(http.MethodOptions, srv.URL+"/api/help", nil)
-	req.Header.Set("Origin", "https://example.com")
-	req.Header.Set("Access-Control-Request-Method", "GET")
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent {
-		t.Errorf("status = %d, want 204", resp.StatusCode)
-	}
-	if resp.Header.Get("Access-Control-Allow-Methods") == "" {
-		t.Error("missing Access-Control-Allow-Methods")
-	}
-}
 
 func TestNonGET_Returns405(t *testing.T) {
 	srv := helpTestServer(t, "/api")
@@ -191,8 +161,8 @@ func TestNonGET_Returns405(t *testing.T) {
 			if resp.StatusCode != http.StatusMethodNotAllowed {
 				t.Errorf("%s / : status = %d, want 405", method, resp.StatusCode)
 			}
-			if got := resp.Header.Get("Allow"); got != "GET, OPTIONS" {
-				t.Errorf("%s / : Allow = %q, want \"GET, OPTIONS\"", method, got)
+			if got := resp.Header.Get("Allow"); got != "GET" {
+				t.Errorf("%s / : Allow = %q, want \"GET\"", method, got)
 			}
 		})
 	}

--- a/internal/api/middleware/cors.go
+++ b/internal/api/middleware/cors.go
@@ -58,6 +58,20 @@ func CORS(p *CORSPolicy) func(http.Handler) http.Handler {
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// /_internal/* is excluded from CORS entirely — no headers, not
+			// even Vary: Origin. Defence-in-depth alongside the cluster
+			// proxy stripping Origin on outbound peer-to-peer requests.
+			if strings.HasPrefix(r.URL.Path, internalPrefix) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Vary: Origin always — even on no-Origin pass-through and
+			// even in wildcard mode. Closes the cache-poisoning vector
+			// where a CDN serves a no-Origin response (without Vary) to
+			// a later Origin-bearing request whose policy has changed.
+			w.Header().Add("Vary", "Origin")
+
 			origin := r.Header.Get("Origin")
 			allowed := p.match(origin)
 

--- a/internal/api/middleware/cors.go
+++ b/internal/api/middleware/cors.go
@@ -11,7 +11,7 @@ const (
 	corsAllowMethods = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
 	corsAllowHeaders = "Authorization, Content-Type, traceparent, tracestate"
 	corsMaxAge       = "86400"
-	internalPrefix   = "/_internal/"
+	internalPrefix   = "/internal/dispatch/"
 )
 
 // loopbackHosts is the set of host strings (post-Hostname()-extraction,
@@ -58,8 +58,8 @@ func CORS(p *CORSPolicy) func(http.Handler) http.Handler {
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// /_internal/* is excluded from CORS entirely — no headers, not
-			// even Vary: Origin. Defence-in-depth alongside the cluster
+			// /internal/dispatch/* is excluded from CORS entirely — no headers,
+			// not even Vary: Origin. Defence-in-depth alongside the cluster
 			// proxy stripping Origin on outbound peer-to-peer requests.
 			if strings.HasPrefix(r.URL.Path, internalPrefix) {
 				next.ServeHTTP(w, r)
@@ -125,15 +125,23 @@ func (p *CORSPolicy) match(origin string) string {
 // the three loopback names, scheme http or https, no userinfo/path/
 // query/fragment, any port permitted.
 func matchLoopback(origin string) bool {
+	// Pre-parse scheme-case check: url.Parse lowercases scheme before
+	// returning, so the only way to enforce raw-string lowercase is to
+	// inspect the bytes before Parse. Mirrors validateCORSOrigin's
+	// approach in app/config.go.
+	idx := strings.Index(origin, "://")
+	if idx <= 0 {
+		return false
+	}
+	rawScheme := origin[:idx]
+	if rawScheme != strings.ToLower(rawScheme) {
+		return false
+	}
 	u, err := url.Parse(origin)
 	if err != nil {
 		return false
 	}
-	scheme := u.Scheme
-	if scheme != strings.ToLower(scheme) {
-		return false
-	}
-	if scheme != "http" && scheme != "https" {
+	if u.Scheme != "http" && u.Scheme != "https" {
 		return false
 	}
 	host := u.Hostname()

--- a/internal/api/middleware/cors.go
+++ b/internal/api/middleware/cors.go
@@ -1,0 +1,136 @@
+package middleware
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Static preflight-response values per spec.
+const (
+	corsAllowMethods = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+	corsAllowHeaders = "Authorization, Content-Type, traceparent, tracestate"
+	corsMaxAge       = "86400"
+	internalPrefix   = "/_internal/"
+)
+
+// loopbackHosts is the set of host strings (post-Hostname()-extraction,
+// post-lowercase) that the default loopback mode allows. String compare
+// only — no IP-equivalence, so non-canonical forms like 127.000.000.001
+// or 0:0:0:0:0:0:0:1 do NOT match.
+var loopbackHosts = map[string]struct{}{
+	"localhost": {},
+	"127.0.0.1": {},
+	"::1":       {},
+}
+
+// CORSPolicy holds the validated, resolved CORS state derived from
+// CYODA_CORS_ENABLED and CYODA_CORS_ALLOWED_ORIGINS. Build once at
+// startup via NewCORSPolicy. The middleware closure captures the policy
+// pointer; per-request work is allocation-free apart from header writes.
+type CORSPolicy struct {
+	enabled  bool
+	wildcard bool
+	// allowed is non-nil iff !wildcard && len(allowedOrigins) > 0
+	// (allowlist mode). Nil in loopback mode and disabled mode.
+	allowed map[string]struct{}
+}
+
+// NewCORSPolicy builds a CORSPolicy. Inputs must already have been
+// validated by app.ValidateCORS — this constructor performs no
+// validation and assumes the caller is the app startup path.
+func NewCORSPolicy(enabled, wildcard bool, allowedOrigins []string) *CORSPolicy {
+	p := &CORSPolicy{enabled: enabled, wildcard: wildcard}
+	if !wildcard && len(allowedOrigins) > 0 {
+		p.allowed = make(map[string]struct{}, len(allowedOrigins))
+		for _, o := range allowedOrigins {
+			p.allowed[o] = struct{}{}
+		}
+	}
+	return p
+}
+
+// CORS returns the CORS middleware constructor. When the policy is
+// disabled, returns an identity wrapper (no-op).
+func CORS(p *CORSPolicy) func(http.Handler) http.Handler {
+	if !p.enabled {
+		return func(next http.Handler) http.Handler { return next }
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			allowed := p.match(origin)
+
+			isPreflight := r.Method == http.MethodOptions &&
+				origin != "" &&
+				r.Header.Get("Access-Control-Request-Method") != ""
+
+			if isPreflight {
+				if allowed != "" {
+					w.Header().Set("Access-Control-Allow-Origin", allowed)
+				}
+				w.Header().Set("Access-Control-Allow-Methods", corsAllowMethods)
+				w.Header().Set("Access-Control-Allow-Headers", corsAllowHeaders)
+				w.Header().Set("Access-Control-Max-Age", corsMaxAge)
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			if origin != "" && allowed != "" {
+				w.Header().Set("Access-Control-Allow-Origin", allowed)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// match returns the value to emit in Access-Control-Allow-Origin, or
+// "" if the origin is not allowed.
+func (p *CORSPolicy) match(origin string) string {
+	if p.wildcard {
+		return "*"
+	}
+	if origin == "" {
+		return ""
+	}
+	if p.allowed != nil {
+		if _, ok := p.allowed[origin]; ok {
+			return origin
+		}
+		return ""
+	}
+	// Loopback mode.
+	if matchLoopback(origin) {
+		return origin
+	}
+	return ""
+}
+
+// matchLoopback implements the spec's "Loopback matching contract":
+// parse with net/url, exact (lowercase) host string-equal to one of
+// the three loopback names, scheme http or https, no userinfo/path/
+// query/fragment, any port permitted.
+func matchLoopback(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	scheme := u.Scheme
+	if scheme != strings.ToLower(scheme) {
+		return false
+	}
+	if scheme != "http" && scheme != "https" {
+		return false
+	}
+	host := u.Hostname()
+	if host != strings.ToLower(host) {
+		return false
+	}
+	if _, ok := loopbackHosts[host]; !ok {
+		return false
+	}
+	if u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
+	return true
+}

--- a/internal/api/middleware/cors_test.go
+++ b/internal/api/middleware/cors_test.go
@@ -265,8 +265,16 @@ func TestCORS_VaryOriginAlwaysWhenEnabled(t *testing.T) {
 			req.Header.Set("Origin", "https://x.example")
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
-			if got := rec.Header().Get("Vary"); got != "Origin" {
-				t.Errorf("Vary = %q, want \"Origin\"", got)
+			vary := rec.Header().Values("Vary")
+			hasOrigin := false
+			for _, v := range vary {
+				if v == "Origin" {
+					hasOrigin = true
+					break
+				}
+			}
+			if !hasOrigin {
+				t.Errorf("Vary missing Origin: %v", vary)
 			}
 		})
 		t.Run(c.name+"/no-origin", func(t *testing.T) {
@@ -276,8 +284,16 @@ func TestCORS_VaryOriginAlwaysWhenEnabled(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
-			if got := rec.Header().Get("Vary"); got != "Origin" {
-				t.Errorf("Vary = %q, want \"Origin\" even on no-Origin requests", got)
+			vary := rec.Header().Values("Vary")
+			hasOrigin := false
+			for _, v := range vary {
+				if v == "Origin" {
+					hasOrigin = true
+					break
+				}
+			}
+			if !hasOrigin {
+				t.Errorf("Vary missing Origin: %v", vary)
 			}
 			if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
 				t.Errorf("ACAO = %q, want empty on no-Origin requests", got)
@@ -337,12 +353,46 @@ func TestCORS_InternalPrefixSkipped(t *testing.T) {
 	}
 }
 
+func TestCORS_InternalPrefixBoundaries(t *testing.T) {
+	// Pin the design decision that /_internal/ (with trailing slash) is the
+	// excluded prefix. Paths /_internal (no slash) and /_internalfoo are
+	// regular paths that get full CORS treatment. A future "cleanup" that
+	// drops the trailing slash from internalPrefix would silently change
+	// this behaviour.
+	p := NewCORSPolicy(true, true, nil)
+	h := CORS(p)(dummyHandler)
+
+	cases := []struct {
+		name       string
+		path       string
+		varyOrigin bool // true: Vary: Origin should be present
+	}{
+		{"with trailing slash (excluded)", "/_internal/", false},
+		{"under prefix (excluded)", "/_internal/dispatch", false},
+		{"no trailing slash (NOT excluded)", "/_internal", true},
+		{"prefix-like but distinct (NOT excluded)", "/_internalfoo", true},
+		{"middle of path (NOT excluded)", "/foo/_internal/bar", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req.Header.Set("Origin", "https://x.example")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			gotVary := rec.Header().Get("Vary") == "Origin"
+			if gotVary != tc.varyOrigin {
+				t.Errorf("Vary: Origin presence = %v, want %v", gotVary, tc.varyOrigin)
+			}
+		})
+	}
+}
+
 func TestCORS_InternalPrefixSkippedOnPreflight(t *testing.T) {
 	p := NewCORSPolicy(true, true, nil)
 	downstreamReached := false
 	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		downstreamReached = true
-		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.WriteHeader(http.StatusTeapot)
 	})
 	h := CORS(p)(downstream)
 
@@ -357,7 +407,7 @@ func TestCORS_InternalPrefixSkippedOnPreflight(t *testing.T) {
 	if !downstreamReached {
 		t.Error("downstream should have been reached for /_internal/ preflight")
 	}
-	if rec.Code != http.StatusMethodNotAllowed {
-		t.Errorf("status = %d, want 405 (downstream)", rec.Code)
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want %d (downstream sentinel)", rec.Code, http.StatusTeapot)
 	}
 }

--- a/internal/api/middleware/cors_test.go
+++ b/internal/api/middleware/cors_test.go
@@ -1,0 +1,250 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// dummyHandler returns 200 with body "ok" so we can confirm pass-through.
+var dummyHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+})
+
+func newCORSPolicy(t *testing.T, enabled, wildcard bool, allowed ...string) *CORSPolicy {
+	t.Helper()
+	return NewCORSPolicy(enabled, wildcard, allowed)
+}
+
+func TestCORS_DisabledIsIdentityWrapper(t *testing.T) {
+	p := newCORSPolicy(t, false, false)
+	h := CORS(p)(dummyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://anything.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want empty (disabled mode)", got)
+	}
+	if got := rec.Header().Get("Vary"); got != "" {
+		t.Errorf("Vary = %q, want empty (disabled mode)", got)
+	}
+}
+
+func TestCORS_WildcardActualRequest(t *testing.T) {
+	p := newCORSPolicy(t, true, true)
+	h := CORS(p)(dummyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want \"*\" (wildcard never reflects)", got)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestCORS_WildcardWithNullOrigin(t *testing.T) {
+	p := newCORSPolicy(t, true, true)
+	h := CORS(p)(dummyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "null")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	// Wildcard mode emits literal * for every origin including null.
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want \"*\" (null + wildcard)", got)
+	}
+}
+
+func TestCORS_LoopbackMatch(t *testing.T) {
+	cases := []string{
+		"http://localhost",
+		"http://localhost:3000",
+		"https://localhost:8443",
+		"http://127.0.0.1",
+		"http://127.0.0.1:5173",
+		"https://127.0.0.1:8080",
+		"http://[::1]",
+		"http://[::1]:8080",
+		"https://[::1]:8443",
+	}
+	p := newCORSPolicy(t, true, false) // loopback mode
+	h := CORS(p)(dummyHandler)
+	for _, origin := range cases {
+		t.Run(origin, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Origin", origin)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if got := rec.Header().Get("Access-Control-Allow-Origin"); got != origin {
+				t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, origin)
+			}
+		})
+	}
+}
+
+func TestCORS_LoopbackRejects(t *testing.T) {
+	cases := []string{
+		"https://evil.example",
+		"http://localhost.evil.example",       // suffix attack
+		"https://xn--lcalhost-ksb.example",    // IDN homograph
+		"http://localhost@evil.example",       // userinfo
+		"http://127.000.000.001:3000",         // non-canonical IPv4
+		"http://[0:0:0:0:0:0:0:1]",            // non-canonical IPv6
+		"null",                                // file://
+		"ftp://localhost",                     // wrong scheme
+		"http://localhost/admin",              // path component
+		"http://Localhost:3000",               // case (must be lowercase)
+	}
+	p := newCORSPolicy(t, true, false)
+	h := CORS(p)(dummyHandler)
+	for _, origin := range cases {
+		t.Run(origin, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Origin", origin)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+				t.Errorf("Access-Control-Allow-Origin = %q, want empty (rejected)", got)
+			}
+			// Underlying request must still succeed — only the header is omitted.
+			if rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200 (request still processed)", rec.Code)
+			}
+		})
+	}
+}
+
+func TestCORS_AllowlistMatch(t *testing.T) {
+	p := newCORSPolicy(t, true, false, "https://admin.example.com", "http://app.local:3000")
+	h := CORS(p)(dummyHandler)
+	t.Run("matched", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Origin", "https://admin.example.com")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://admin.example.com" {
+			t.Errorf("ACAO = %q, want match", got)
+		}
+	})
+	t.Run("unmatched", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Origin", "https://other.example.com")
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("ACAO = %q, want empty (not in allowlist)", got)
+		}
+	})
+	t.Run("loopback not auto-allowed in allowlist mode", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Origin", "http://localhost:3000") // not in the list
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("ACAO = %q, want empty (allowlist mode does not auto-allow loopback)", got)
+		}
+	})
+}
+
+func TestCORS_PreflightShortCircuit(t *testing.T) {
+	p := newCORSPolicy(t, true, false, "https://admin.example.com")
+	// downstream that would 200 if reached — preflight must NOT reach it
+	downstreamReached := false
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstreamReached = true
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CORS(p)(downstream)
+
+	req := httptest.NewRequest(http.MethodOptions, "/anything", nil)
+	req.Header.Set("Origin", "https://admin.example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if downstreamReached {
+		t.Error("downstream should not have been reached on preflight")
+	}
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://admin.example.com" {
+		t.Errorf("ACAO = %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got != "GET, POST, PUT, PATCH, DELETE, OPTIONS" {
+		t.Errorf("Allow-Methods = %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Headers"); got != "Authorization, Content-Type, traceparent, tracestate" {
+		t.Errorf("Allow-Headers = %q", got)
+	}
+	if got := rec.Header().Get("Access-Control-Max-Age"); got != "86400" {
+		t.Errorf("Max-Age = %q", got)
+	}
+}
+
+func TestCORS_PreflightWithoutACRMFallsThrough(t *testing.T) {
+	// OPTIONS with Origin but no Access-Control-Request-Method is NOT a preflight.
+	p := newCORSPolicy(t, true, true)
+	downstreamCode := http.StatusTeapot
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(downstreamCode)
+	})
+	h := CORS(p)(downstream)
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "https://x.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want %d (downstream); CORS must not short-circuit non-preflight OPTIONS", rec.Code, downstreamCode)
+	}
+}
+
+func TestCORS_PreflightWithoutOriginFallsThrough(t *testing.T) {
+	// OPTIONS with ACRM but no Origin: also not a preflight.
+	p := newCORSPolicy(t, true, true)
+	downstreamCode := http.StatusTeapot
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(downstreamCode)
+	})
+	h := CORS(p)(downstream)
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want %d", rec.Code, downstreamCode)
+	}
+}
+
+func TestCORS_PreflightUnmatchedOriginInAllowlist(t *testing.T) {
+	// Preflight is still 204, but Access-Control-Allow-Origin is omitted.
+	p := newCORSPolicy(t, true, false, "https://allowed.example.com")
+	h := CORS(p)(dummyHandler)
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "https://forbidden.example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("ACAO = %q, want empty (origin not allowed)", got)
+	}
+}

--- a/internal/api/middleware/cors_test.go
+++ b/internal/api/middleware/cors_test.go
@@ -247,6 +247,20 @@ func TestCORS_PreflightUnmatchedOriginInAllowlist(t *testing.T) {
 	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
 		t.Errorf("ACAO = %q, want empty (origin not allowed)", got)
 	}
+
+	// Static preflight headers must be emitted regardless of origin match.
+	// Only Access-Control-Allow-Origin is conditionally omitted. Pinning
+	// this prevents a regression where a future refactor moves the static
+	// header writes inside the "if allowed != \"\"" gate.
+	if got := rec.Header().Get("Access-Control-Allow-Methods"); got == "" {
+		t.Error("Access-Control-Allow-Methods missing on rejected-origin preflight")
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Headers"); got == "" {
+		t.Error("Access-Control-Allow-Headers missing on rejected-origin preflight")
+	}
+	if got := rec.Header().Get("Access-Control-Max-Age"); got == "" {
+		t.Error("Access-Control-Max-Age missing on rejected-origin preflight")
+	}
 }
 
 func TestCORS_VaryOriginAlwaysWhenEnabled(t *testing.T) {

--- a/internal/api/middleware/cors_test.go
+++ b/internal/api/middleware/cors_test.go
@@ -98,7 +98,7 @@ func TestCORS_LoopbackRejects(t *testing.T) {
 		"https://evil.example",
 		"http://localhost.evil.example",       // suffix attack
 		"https://xn--lcalhost-ksb.example",    // IDN homograph
-		"http://localhost@evil.example",       // userinfo
+		"http://localhost@evil.example",       // hostname injection via userinfo syntax — host is evil.example, not localhost
 		"http://127.000.000.001:3000",         // non-canonical IPv4
 		"http://[0:0:0:0:0:0:0:1]",            // non-canonical IPv6
 		"null",                                // file://
@@ -246,5 +246,118 @@ func TestCORS_PreflightUnmatchedOriginInAllowlist(t *testing.T) {
 	}
 	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
 		t.Errorf("ACAO = %q, want empty (origin not allowed)", got)
+	}
+}
+
+func TestCORS_VaryOriginAlwaysWhenEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		p    *CORSPolicy
+	}{
+		{"wildcard", NewCORSPolicy(true, true, nil)},
+		{"loopback (default)", NewCORSPolicy(true, false, nil)},
+		{"allowlist", NewCORSPolicy(true, false, []string{"https://x.example"})},
+	}
+	for _, c := range cases {
+		t.Run(c.name+"/with-origin", func(t *testing.T) {
+			h := CORS(c.p)(dummyHandler)
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("Origin", "https://x.example")
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if got := rec.Header().Get("Vary"); got != "Origin" {
+				t.Errorf("Vary = %q, want \"Origin\"", got)
+			}
+		})
+		t.Run(c.name+"/no-origin", func(t *testing.T) {
+			// Vary: Origin must be present even when Origin is absent
+			// (cache-poisoning protection on mode-flip).
+			h := CORS(c.p)(dummyHandler)
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if got := rec.Header().Get("Vary"); got != "Origin" {
+				t.Errorf("Vary = %q, want \"Origin\" even on no-Origin requests", got)
+			}
+			if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+				t.Errorf("ACAO = %q, want empty on no-Origin requests", got)
+			}
+		})
+	}
+}
+
+func TestCORS_VaryAppendedNotOverwritten(t *testing.T) {
+	// A downstream handler that also sets Vary: Accept must coexist with
+	// Vary: Origin — both values present, neither overwritten.
+	p := NewCORSPolicy(true, true, nil)
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Vary", "Accept")
+		w.WriteHeader(http.StatusOK)
+	})
+	h := CORS(p)(downstream)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://x.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	vary := rec.Header().Values("Vary")
+	hasOrigin, hasAccept := false, false
+	for _, v := range vary {
+		if v == "Origin" {
+			hasOrigin = true
+		}
+		if v == "Accept" {
+			hasAccept = true
+		}
+	}
+	if !hasOrigin {
+		t.Errorf("Vary missing Origin: %v", vary)
+	}
+	if !hasAccept {
+		t.Errorf("Vary missing Accept: %v", vary)
+	}
+}
+
+func TestCORS_InternalPrefixSkipped(t *testing.T) {
+	p := NewCORSPolicy(true, true, nil) // wildcard — would otherwise emit *
+	h := CORS(p)(dummyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/_internal/dispatch", nil)
+	req.Header.Set("Origin", "https://anything.example")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("ACAO = %q, want empty on /_internal/", got)
+	}
+	if got := rec.Header().Get("Vary"); got != "" {
+		t.Errorf("Vary = %q, want empty on /_internal/", got)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("downstream not reached on /_internal/")
+	}
+}
+
+func TestCORS_InternalPrefixSkippedOnPreflight(t *testing.T) {
+	p := NewCORSPolicy(true, true, nil)
+	downstreamReached := false
+	downstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		downstreamReached = true
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
+	h := CORS(p)(downstream)
+
+	// A preflight-shaped request to /_internal/ must NOT short-circuit;
+	// it must reach downstream so peer-side AEAD-auth can reject it.
+	req := httptest.NewRequest(http.MethodOptions, "/_internal/dispatch", nil)
+	req.Header.Set("Origin", "https://anything.example")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if !downstreamReached {
+		t.Error("downstream should have been reached for /_internal/ preflight")
+	}
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405 (downstream)", rec.Code)
 	}
 }

--- a/internal/api/middleware/cors_test.go
+++ b/internal/api/middleware/cors_test.go
@@ -105,6 +105,7 @@ func TestCORS_LoopbackRejects(t *testing.T) {
 		"ftp://localhost",                     // wrong scheme
 		"http://localhost/admin",              // path component
 		"http://Localhost:3000",               // case (must be lowercase)
+		"HTTP://localhost:3000",               // uppercase scheme
 	}
 	p := newCORSPolicy(t, true, false)
 	h := CORS(p)(dummyHandler)
@@ -261,6 +262,9 @@ func TestCORS_PreflightUnmatchedOriginInAllowlist(t *testing.T) {
 	if got := rec.Header().Get("Access-Control-Max-Age"); got == "" {
 		t.Error("Access-Control-Max-Age missing on rejected-origin preflight")
 	}
+	if got := rec.Header().Get("Vary"); got != "Origin" {
+		t.Errorf("Vary = %q, want \"Origin\" (must be present even for rejected origins)", got)
+	}
 }
 
 func TestCORS_VaryOriginAlwaysWhenEnabled(t *testing.T) {
@@ -351,28 +355,28 @@ func TestCORS_VaryAppendedNotOverwritten(t *testing.T) {
 func TestCORS_InternalPrefixSkipped(t *testing.T) {
 	p := NewCORSPolicy(true, true, nil) // wildcard — would otherwise emit *
 	h := CORS(p)(dummyHandler)
-	req := httptest.NewRequest(http.MethodGet, "/_internal/dispatch", nil)
+	req := httptest.NewRequest(http.MethodGet, "/internal/dispatch/processor", nil)
 	req.Header.Set("Origin", "https://anything.example")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
 	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
-		t.Errorf("ACAO = %q, want empty on /_internal/", got)
+		t.Errorf("ACAO = %q, want empty on /internal/dispatch/", got)
 	}
 	if got := rec.Header().Get("Vary"); got != "" {
-		t.Errorf("Vary = %q, want empty on /_internal/", got)
+		t.Errorf("Vary = %q, want empty on /internal/dispatch/", got)
 	}
 	if rec.Code != http.StatusOK {
-		t.Errorf("downstream not reached on /_internal/")
+		t.Errorf("downstream not reached on /internal/dispatch/")
 	}
 }
 
 func TestCORS_InternalPrefixBoundaries(t *testing.T) {
-	// Pin the design decision that /_internal/ (with trailing slash) is the
-	// excluded prefix. Paths /_internal (no slash) and /_internalfoo are
-	// regular paths that get full CORS treatment. A future "cleanup" that
-	// drops the trailing slash from internalPrefix would silently change
-	// this behaviour.
+	// Pin the design decision that /internal/dispatch/ (with trailing slash)
+	// is the excluded prefix. Paths /internal/dispatch (no slash) and
+	// /internal/dispatchfoo are regular paths that get full CORS treatment.
+	// A future "cleanup" that drops the trailing slash from internalPrefix
+	// would silently change this behaviour.
 	p := NewCORSPolicy(true, true, nil)
 	h := CORS(p)(dummyHandler)
 
@@ -381,11 +385,11 @@ func TestCORS_InternalPrefixBoundaries(t *testing.T) {
 		path       string
 		varyOrigin bool // true: Vary: Origin should be present
 	}{
-		{"with trailing slash (excluded)", "/_internal/", false},
-		{"under prefix (excluded)", "/_internal/dispatch", false},
-		{"no trailing slash (NOT excluded)", "/_internal", true},
-		{"prefix-like but distinct (NOT excluded)", "/_internalfoo", true},
-		{"middle of path (NOT excluded)", "/foo/_internal/bar", true},
+		{"with trailing slash (excluded)", "/internal/dispatch/", false},
+		{"under prefix (excluded)", "/internal/dispatch/processor", false},
+		{"no trailing slash (NOT excluded)", "/internal/dispatch", true},
+		{"prefix-like but distinct (NOT excluded)", "/internal/dispatchfoo", true},
+		{"middle of path (NOT excluded)", "/foo/internal/dispatch/bar", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -410,9 +414,9 @@ func TestCORS_InternalPrefixSkippedOnPreflight(t *testing.T) {
 	})
 	h := CORS(p)(downstream)
 
-	// A preflight-shaped request to /_internal/ must NOT short-circuit;
+	// A preflight-shaped request to /internal/dispatch/ must NOT short-circuit;
 	// it must reach downstream so peer-side AEAD-auth can reject it.
-	req := httptest.NewRequest(http.MethodOptions, "/_internal/dispatch", nil)
+	req := httptest.NewRequest(http.MethodOptions, "/internal/dispatch/processor", nil)
 	req.Header.Set("Origin", "https://anything.example")
 	req.Header.Set("Access-Control-Request-Method", "POST")
 	rec := httptest.NewRecorder()

--- a/internal/cluster/proxy/director_test.go
+++ b/internal/cluster/proxy/director_test.go
@@ -1,0 +1,53 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestDirector_StripsCORSPreflightHeaders(t *testing.T) {
+	target, _ := url.Parse("http://peer-b:8080")
+	director := makeProxyDirector(target)
+
+	req, err := http.NewRequest(http.MethodPost, "http://peer-a/path", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Origin", "https://browser.example")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "Authorization")
+	req.Header.Set("Authorization", "Bearer xyz")
+
+	director(req)
+
+	for _, h := range []string{"Origin", "Access-Control-Request-Method", "Access-Control-Request-Headers"} {
+		if got := req.Header.Get(h); got != "" {
+			t.Errorf("%s should be stripped, got %q", h, got)
+		}
+	}
+	// Authorization (and other unrelated headers) must NOT be stripped.
+	if got := req.Header.Get("Authorization"); got != "Bearer xyz" {
+		t.Errorf("Authorization should be preserved, got %q", got)
+	}
+	// Director must rewrite scheme/host/Host onto the target.
+	if req.URL.Scheme != "http" || req.URL.Host != "peer-b:8080" {
+		t.Errorf("URL not rewritten: scheme=%q host=%q", req.URL.Scheme, req.URL.Host)
+	}
+	if req.Host != "peer-b:8080" {
+		t.Errorf("Host not rewritten: %q", req.Host)
+	}
+}
+
+func TestDirector_StripsAreIdempotent(t *testing.T) {
+	target, _ := url.Parse("http://peer-b:8080")
+	director := makeProxyDirector(target)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://peer-a/x", nil)
+	// No headers set. Strip should not panic and request should remain valid.
+	director(req)
+
+	if req.URL.Host != "peer-b:8080" {
+		t.Errorf("URL not rewritten: %q", req.URL.Host)
+	}
+}

--- a/internal/cluster/proxy/director_test.go
+++ b/internal/cluster/proxy/director_test.go
@@ -1,5 +1,10 @@
 package proxy
 
+// director_test.go uses package proxy (white-box) rather than the existing
+// http_test.go's package proxy_test (black-box) because makeProxyDirector is
+// unexported. The two test files coexist; tests in this file exercise the
+// helper directly, while http_test.go covers the public HTTPRouting surface.
+
 import (
 	"net/http"
 	"net/url"
@@ -18,6 +23,9 @@ func TestDirector_StripsCORSPreflightHeaders(t *testing.T) {
 	req.Header.Set("Access-Control-Request-Method", "POST")
 	req.Header.Set("Access-Control-Request-Headers", "Authorization")
 	req.Header.Set("Authorization", "Bearer xyz")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Request-ID", "abc-123")
+	req.Header.Set("X-Tx-Token", "transaction-token")
 
 	director(req)
 
@@ -29,6 +37,16 @@ func TestDirector_StripsCORSPreflightHeaders(t *testing.T) {
 	// Authorization (and other unrelated headers) must NOT be stripped.
 	if got := req.Header.Get("Authorization"); got != "Bearer xyz" {
 		t.Errorf("Authorization should be preserved, got %q", got)
+	}
+	preserved := map[string]string{
+		"Content-Type": "application/json",
+		"X-Request-ID": "abc-123",
+		"X-Tx-Token":   "transaction-token",
+	}
+	for h, want := range preserved {
+		if got := req.Header.Get(h); got != want {
+			t.Errorf("%s should be preserved as %q, got %q", h, want, got)
+		}
 	}
 	// Director must rewrite scheme/host/Host onto the target.
 	if req.URL.Scheme != "http" || req.URL.Host != "peer-b:8080" {

--- a/internal/cluster/proxy/http.go
+++ b/internal/cluster/proxy/http.go
@@ -120,11 +120,7 @@ func proxyTo(w http.ResponseWriter, r *http.Request, addr string, transport http
 	// Caching was considered but rejected: an unbounded cache leaks memory as
 	// nodes join/leave during rolling updates.
 	rp := &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL.Scheme = target.Scheme
-			req.URL.Host = target.Host
-			req.Host = target.Host
-		},
+		Director:  makeProxyDirector(target),
 		Transport: transport,
 		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
 			slog.Error("proxy request failed",
@@ -141,4 +137,23 @@ func proxyTo(w http.ResponseWriter, r *http.Request, addr string, transport http
 	}
 
 	rp.ServeHTTP(w, r)
+}
+
+// makeProxyDirector returns the Director that the per-request
+// httputil.ReverseProxy uses to rewrite an outbound peer-to-peer
+// request. It rewrites the URL onto the target node and strips any
+// CORS-related request headers — those are the responsibility of the
+// outermost CORS middleware on the receiving node, not the destination
+// peer. See spec §"Cluster proxy interaction".
+func makeProxyDirector(target *url.URL) func(*http.Request) {
+	return func(req *http.Request) {
+		req.URL.Scheme = target.Scheme
+		req.URL.Host = target.Host
+		req.Host = target.Host
+		// Strip CORS request headers — see spec §"Cluster proxy
+		// interaction". Owned by the outermost CORS middleware.
+		req.Header.Del("Origin")
+		req.Header.Del("Access-Control-Request-Method")
+		req.Header.Del("Access-Control-Request-Headers")
+	}
 }

--- a/internal/cluster/proxy/http.go
+++ b/internal/cluster/proxy/http.go
@@ -144,7 +144,7 @@ func proxyTo(w http.ResponseWriter, r *http.Request, addr string, transport http
 // request. It rewrites the URL onto the target node and strips any
 // CORS-related request headers — those are the responsibility of the
 // outermost CORS middleware on the receiving node, not the destination
-// peer. See spec §"Cluster proxy interaction".
+// peer. See docs/superpowers/specs/2026-05-01-issue-196-cors-design.md §"Cluster proxy interaction".
 func makeProxyDirector(target *url.URL) func(*http.Request) {
 	return func(req *http.Request) {
 		req.URL.Scheme = target.Scheme

--- a/internal/cluster/proxy/http_test.go
+++ b/internal/cluster/proxy/http_test.go
@@ -196,3 +196,60 @@ func TestHTTPProxy_ExpiredToken_Returns400(t *testing.T) {
 		t.Fatalf("expected 400, got %d", rec.Code)
 	}
 }
+
+// TestHTTPProxy_RoundTrip_SingleACAO verifies that when a request with an
+// Origin header is proxied from node A to a peer (node B) that itself emits
+// Access-Control-Allow-Origin, the final response contains exactly one
+// Access-Control-Allow-Origin value. The proxy's director strips Origin from
+// the outbound request so the peer never fires its own CORS logic, meaning
+// the ACAO seen by the browser is exactly the one set by node A's outermost
+// CORS middleware — not a double-valued header that browsers reject.
+//
+// Placed in http_test.go (black-box package proxy_test) rather than
+// director_test.go because it exercises the full HTTPRouting middleware
+// surface including the httputil.ReverseProxy round-trip, not just the
+// director helper in isolation. The scaffolding (fakeRegistry, mustNewSigner,
+// httptest.NewServer) already exists here and maps cleanly onto the scenario.
+func TestHTTPProxy_RoundTrip_SingleACAO(t *testing.T) {
+	// Fake peer (node B) that emits ACAO as if it ran its own CORS middleware.
+	// In production this would never fire because the director strips Origin,
+	// but a misbehaving or misconfigured peer might still emit this header.
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "https://emitted-by-peer.example")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "peer-body")
+	}))
+	defer peer.Close()
+
+	signer := mustNewSigner([]byte("test-secret-key-at-least-32-bytes!"))
+	reg := newFakeRegistry(
+		contract.NodeInfo{NodeID: "node-1", Addr: "http://localhost:9999", Alive: true},
+		contract.NodeInfo{NodeID: "node-2", Addr: peer.URL, Alive: true},
+	)
+
+	tok, err := signer.Issue("node-2", "tx-acao-roundtrip", time.Now().Add(5*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mw := proxy.HTTPRouting(signer, reg, "node-1", 5*time.Second)
+	handler := mw(localHandler())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set(proxy.TxTokenHeader, tok)
+	req.Header.Set("Origin", "https://browser.example")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	// Browsers reject responses with more than one Access-Control-Allow-Origin
+	// value. The proxy must not create a double-header by letting node B's ACAO
+	// pass through alongside any ACAO set by node A's middleware.
+	vals := rec.Header().Values("Access-Control-Allow-Origin")
+	if len(vals) > 1 {
+		t.Errorf("got %d Access-Control-Allow-Origin values %v, want at most 1 (browsers reject multi-valued ACAO)", len(vals), vals)
+	}
+}

--- a/internal/e2e/cors_e2e_test.go
+++ b/internal/e2e/cors_e2e_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"github.com/cyoda-platform/cyoda-go/app"
@@ -85,8 +86,9 @@ func TestCORS_E2E_PreflightAcrossGroups_LoopbackMode(t *testing.T) {
 			if got := resp.Header.Get("Access-Control-Max-Age"); got == "" {
 				t.Error("missing Access-Control-Max-Age")
 			}
-			if got := resp.Header.Get("Vary"); got != "Origin" {
-				t.Errorf("Vary = %q, want \"Origin\"", got)
+			vary := resp.Header.Values("Vary")
+			if !slices.Contains(vary, "Origin") {
+				t.Errorf("Vary missing Origin: %v", vary)
 			}
 		})
 	}
@@ -109,8 +111,9 @@ func TestCORS_E2E_LoopbackRejectsRemoteOrigin(t *testing.T) {
 	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
 		t.Errorf("ACAO = %q, want empty (remote origin rejected in loopback mode)", got)
 	}
-	if got := resp.Header.Get("Vary"); got != "Origin" {
-		t.Errorf("Vary = %q, want \"Origin\"", got)
+	vary := resp.Header.Values("Vary")
+	if !slices.Contains(vary, "Origin") {
+		t.Errorf("Vary missing Origin: %v", vary)
 	}
 }
 

--- a/internal/e2e/cors_e2e_test.go
+++ b/internal/e2e/cors_e2e_test.go
@@ -6,9 +6,6 @@ import (
 	"testing"
 
 	"github.com/cyoda-platform/cyoda-go/app"
-
-	// Register stock storage plugins so spi.GetPlugin("memory") resolves.
-	_ "github.com/cyoda-platform/cyoda-go/plugins/memory"
 )
 
 // newCORSTestServer builds a minimal app and wraps it in an httptest.Server.
@@ -55,6 +52,7 @@ var representativeRoutes = []struct {
 	{"admin-post", http.MethodPost, "/api/admin/log-level"},
 	{"help-get", http.MethodGet, "/api/help"},
 	{"health-get", http.MethodGet, "/api/health"},
+	{"discovery-get", http.MethodGet, "/api/openapi.json"},
 }
 
 func TestCORS_E2E_PreflightAcrossGroups_LoopbackMode(t *testing.T) {
@@ -80,6 +78,12 @@ func TestCORS_E2E_PreflightAcrossGroups_LoopbackMode(t *testing.T) {
 			}
 			if got := resp.Header.Get("Access-Control-Allow-Methods"); got == "" {
 				t.Error("missing Access-Control-Allow-Methods")
+			}
+			if got := resp.Header.Get("Access-Control-Allow-Headers"); got == "" {
+				t.Error("missing Access-Control-Allow-Headers")
+			}
+			if got := resp.Header.Get("Access-Control-Max-Age"); got == "" {
+				t.Error("missing Access-Control-Max-Age")
 			}
 			if got := resp.Header.Get("Vary"); got != "Origin" {
 				t.Errorf("Vary = %q, want \"Origin\"", got)

--- a/internal/e2e/cors_e2e_test.go
+++ b/internal/e2e/cors_e2e_test.go
@@ -1,0 +1,191 @@
+package e2e_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/app"
+
+	// Register stock storage plugins so spi.GetPlugin("memory") resolves.
+	_ "github.com/cyoda-platform/cyoda-go/plugins/memory"
+)
+
+// newCORSTestServer builds a minimal app and wraps it in an httptest.Server.
+// Each test gets its own fresh server with the requested CORS config.
+// Uses an in-memory store and disables cluster so no external infra is needed.
+func newCORSTestServer(t *testing.T, cors app.CORSConfig) (*httptest.Server, func()) {
+	t.Helper()
+	cfg := app.DefaultConfig()
+	cfg.CORS = cors
+	cfg.StorageBackend = "memory"
+	cfg.Cluster.Enabled = false
+
+	a := app.New(cfg)
+	srv := httptest.NewServer(a.Handler())
+	return srv, func() {
+		srv.Close()
+		a.Shutdown()
+		_ = a.Close()
+	}
+}
+
+// representativeRoutes is one path per group covered by the unified
+// CORS middleware. Routes are chosen from those definitely registered
+// in mock-IAM / memory-backend mode. We assert on CORS headers, not
+// on the body or status of the underlying handler — preflights
+// short-circuit before auth and routing; actual GETs may legitimately
+// 200/401/404.
+//
+// Context: DefaultConfig has ContextPath="/api", so all API routes
+// have the /api prefix. Health is registered on the inner mux and is
+// accessible at /api/health after context-path stripping.
+// The /oauth/token endpoint is only registered in jwt mode (authSvc !=
+// nil); in default mock mode it is absent, so we cover that group via
+// /api/account instead.
+var representativeRoutes = []struct {
+	name   string
+	method string
+	path   string
+}{
+	{"entity-get", http.MethodGet, "/api/entity/00000000-0000-0000-0000-000000000000"},
+	{"search-post", http.MethodPost, "/api/search/direct/example/1"},
+	{"messaging-post", http.MethodPost, "/api/message/new/test"},
+	{"account-get", http.MethodGet, "/api/account"},
+	{"admin-post", http.MethodPost, "/api/admin/log-level"},
+	{"help-get", http.MethodGet, "/api/help"},
+	{"health-get", http.MethodGet, "/api/health"},
+}
+
+func TestCORS_E2E_PreflightAcrossGroups_LoopbackMode(t *testing.T) {
+	srv, cleanup := newCORSTestServer(t, app.CORSConfig{Enabled: true})
+	defer cleanup()
+
+	for _, r := range representativeRoutes {
+		t.Run(r.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodOptions, srv.URL+r.path, nil)
+			req.Header.Set("Origin", "http://localhost:3000")
+			req.Header.Set("Access-Control-Request-Method", r.method)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusNoContent {
+				t.Errorf("status = %d, want 204", resp.StatusCode)
+			}
+			if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "http://localhost:3000" {
+				t.Errorf("ACAO = %q", got)
+			}
+			if got := resp.Header.Get("Access-Control-Allow-Methods"); got == "" {
+				t.Error("missing Access-Control-Allow-Methods")
+			}
+			if got := resp.Header.Get("Vary"); got != "Origin" {
+				t.Errorf("Vary = %q, want \"Origin\"", got)
+			}
+		})
+	}
+}
+
+func TestCORS_E2E_LoopbackRejectsRemoteOrigin(t *testing.T) {
+	srv, cleanup := newCORSTestServer(t, app.CORSConfig{Enabled: true})
+	defer cleanup()
+
+	// Actual (non-preflight) GET against /api/help — unauthenticated,
+	// easy to assert headers on.
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/help", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("ACAO = %q, want empty (remote origin rejected in loopback mode)", got)
+	}
+	if got := resp.Header.Get("Vary"); got != "Origin" {
+		t.Errorf("Vary = %q, want \"Origin\"", got)
+	}
+}
+
+func TestCORS_E2E_AllowlistMode(t *testing.T) {
+	srv, cleanup := newCORSTestServer(t, app.CORSConfig{
+		Enabled:        true,
+		AllowedOrigins: []string{"https://admin.example.com"},
+	})
+	defer cleanup()
+
+	t.Run("allowed origin", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/help", nil)
+		req.Header.Set("Origin", "https://admin.example.com")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://admin.example.com" {
+			t.Errorf("ACAO = %q", got)
+		}
+	})
+
+	t.Run("loopback not auto-allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/help", nil)
+		req.Header.Set("Origin", "http://localhost:3000")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+			t.Errorf("ACAO = %q, want empty (allowlist mode, loopback not auto-allowed)", got)
+		}
+	})
+}
+
+func TestCORS_E2E_WildcardMode(t *testing.T) {
+	srv, cleanup := newCORSTestServer(t, app.CORSConfig{
+		Enabled:  true,
+		Wildcard: true,
+	})
+	defer cleanup()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/api/help", nil)
+	req.Header.Set("Origin", "https://anything.example")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("ACAO = %q, want \"*\"", got)
+	}
+}
+
+func TestCORS_E2E_DisabledNoHeaders(t *testing.T) {
+	srv, cleanup := newCORSTestServer(t, app.CORSConfig{Enabled: false})
+	defer cleanup()
+
+	// Preflight against /api/help — would 204 if CORS were installed,
+	// must NOT 204 when disabled (no preflight short-circuit).
+	req, _ := http.NewRequest(http.MethodOptions, srv.URL+"/api/help", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNoContent {
+		t.Errorf("status = 204, want non-204 (CORS disabled — no preflight short-circuit)")
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("ACAO = %q, want empty when disabled", got)
+	}
+	if got := resp.Header.Get("Vary"); got == "Origin" {
+		t.Errorf("Vary: Origin emitted while disabled")
+	}
+}


### PR DESCRIPTION
## Summary

Adds CORS support to every cyoda-go HTTP endpoint. Closes #196.

- **New CORS middleware** at `internal/api/middleware/cors.go` (pure `net/http`, no third-party library) wraps the entire handler chain as the outermost layer.
- **Loopback-by-default** mode: `http(s)://localhost`, `127.0.0.1`, `[::1]` on any port — zero-config dev ergonomics, secure-by-default in production. Wildcard requires explicit `CYODA_CORS_ALLOWED_ORIGINS=*` (with startup WARN). Allowlist mode for production deployments. Master switch `CYODA_CORS_ENABLED` for ingress-driven setups.
- **`/_internal/*` excluded** from CORS at the middleware. Cluster proxy `Director` strips `Origin` and `Access-Control-Request-{Method,Headers}` on outbound peer-to-peer requests (defence-in-depth).
- **`Vary: Origin` always emitted** when middleware is installed (cache-poisoning protection on mode-flip).
- **`Access-Control-Allow-Credentials` deliberately not in v1** — bearer-in-`Authorization` auth doesn't need it.
- **Help endpoint inline CORS removed** and unified under the new middleware.
- **Strict allowlist validation** at startup: lowercase scheme/host, no userinfo/path/query/fragment/trailing-slash, no default ports, ASCII hosts only (with punycode hint), port range 1–65535, no glob/regex in v1.

Implementation followed superpowers workflow: brainstorming (with two security audits and one Go-idiomatic review) → spec v2.1 → 12-task plan → subagent-driven execution with per-task spec + code-quality reviews → final holistic review.

## Test Plan

- [ ] `make test-all` green (root module + memory/sqlite/postgres plugins)
- [ ] `go test -race ./...` green
- [ ] `go vet ./...` clean
- [ ] `cyoda help config cors` returns the operator topic
- [ ] Locally: SPA on `http://localhost:3000` can call `/api/entity/...` without CORS errors out of the box
- [ ] Locally: SPA on `https://evil.example` is blocked (no `Access-Control-Allow-Origin` emitted in default loopback mode)
- [ ] With `CYODA_CORS_ALLOWED_ORIGINS=https://admin.example.com`: that origin echoed; loopback origins NOT auto-allowed in allowlist mode
- [ ] With `CYODA_CORS_ENABLED=false`: no `Access-Control-*` headers anywhere, including `/help`
- [ ] Cluster mode: a request proxied A→B with `Origin` header set produces a single-valued `Access-Control-Allow-Origin` in the response (no double-header browser rejection)

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-01-issue-196-cors-design.md` (v2.1)
- Plan: `docs/superpowers/plans/2026-05-02-issue-196-cors.md` (12 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)