### PR TITLE
fix(memory): apply tx.OpMu locking discipline to remaining 6 in-tx ops (#176)

### DIFF
--- a/plugins/memory/concurrency_inreadops_test.go
+++ b/plugins/memory/concurrency_inreadops_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/plugins/memory"
@@ -205,6 +206,128 @@ func TestCount_VsRollback_NoRace(t *testing.T) {
 		func(txCtx context.Context, store spi.EntityStore) error {
 			_, err := store.Count(txCtx, raceModelRef)
 			return err
+		},
+	)
+}
+
+// TestGetAsAt_VsRollback_NoRace flags the missing tx.OpMu.RLock in
+// GetAsAt's tx-path. Surfaced by code review on PR #198 as the same
+// race-shape defect issue #176 fixes for the six core ops: GetAsAt
+// reads tx.RolledBack and writes tx.ReadSet inside an entityMu.RLock
+// region without tx.OpMu.RLock, AND has an inverted lock order
+// (entityMu before tx.OpMu). The fix takes tx.OpMu.RLock first when a
+// tx is present, then entityMu.RLock — matching every other tx-path
+// method.
+func TestGetAsAt_VsRollback_NoRace(t *testing.T) {
+	runOpVsRollback(t, "GetAsAt",
+		func(t *testing.T, ctx context.Context, store spi.EntityStore) {
+			raceSeedOne(t, ctx, store, "e-asat")
+		},
+		func(txCtx context.Context, store spi.EntityStore) error {
+			_, err := store.GetAsAt(txCtx, "e-asat", time.Now())
+			return err
+		},
+	)
+}
+
+// runOpVsCommit is the Commit-as-contender variant of runOpVsRollback.
+// Commit iterates tx.Buffer (txmanager.go flush) and tx.Deletes under
+// tx.OpMu.Lock; an in-flight op that mutates those maps without
+// tx.OpMu.RLock races against the iteration. This contender exposes
+// races that runOpVsRollback (which only writes tx.RolledBack/Closed)
+// does not.
+func runOpVsCommit(
+	t *testing.T,
+	name string,
+	setup func(t *testing.T, ctx context.Context, store spi.EntityStore),
+	op func(txCtx context.Context, store spi.EntityStore) error,
+) {
+	t.Helper()
+	for iter := 0; iter < inReadOpsRaceIterations; iter++ {
+		func() {
+			factory := memory.NewStoreFactory()
+			defer factory.Close()
+			uuids := newTestUUIDGenerator()
+			txMgr := factory.NewTransactionManager(uuids)
+
+			ctx := ctxWithTenant("tenant-A")
+			store, err := factory.EntityStore(ctx)
+			if err != nil {
+				t.Fatalf("%s: EntityStore failed: %v", name, err)
+			}
+
+			if setup != nil {
+				setup(t, ctx, store)
+			}
+
+			txID, txCtx, err := txMgr.Begin(ctx)
+			if err != nil {
+				t.Fatalf("%s: Begin failed: %v", name, err)
+			}
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if oerr := op(txCtx, store); oerr != nil {
+					if errors.Is(oerr, spi.ErrConflict) || errors.Is(oerr, spi.ErrNotFound) {
+						return
+					}
+					msg := oerr.Error()
+					if strings.Contains(msg, "rolled back") ||
+						strings.Contains(msg, "already completed") ||
+						strings.Contains(msg, "not found") ||
+						strings.Contains(msg, "already being committed") {
+						return
+					}
+					t.Errorf("%s: op failed: %v", name, oerr)
+				}
+			}()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				_ = txMgr.Commit(ctx, txID)
+			}()
+
+			close(start)
+			wg.Wait()
+		}()
+	}
+}
+
+// TestDelete_VsCommit_NoRace pairs Delete against Commit. Commit's
+// flush iterates tx.Buffer and tx.Deletes under tx.OpMu.Lock; Delete
+// writes both maps. Without tx.OpMu.RLock on Delete, the writes race
+// against Commit's iteration. The Rollback-paired test catches the
+// tx.RolledBack-flag race only; this test catches the map-mutation
+// race directly.
+func TestDelete_VsCommit_NoRace(t *testing.T) {
+	runOpVsCommit(t, "Delete",
+		func(t *testing.T, ctx context.Context, store spi.EntityStore) {
+			raceSeedOne(t, ctx, store, "e-del-vs-commit")
+		},
+		func(txCtx context.Context, store spi.EntityStore) error {
+			return store.Delete(txCtx, "e-del-vs-commit")
+		},
+	)
+}
+
+// TestDeleteAll_VsCommit_NoRace pairs DeleteAll against Commit for
+// the same reason as TestDelete_VsCommit_NoRace: DeleteAll iterates
+// AND writes tx.Buffer / tx.Deletes / tx.WriteSet, all of which Commit
+// also touches under tx.OpMu.Lock during flush.
+func TestDeleteAll_VsCommit_NoRace(t *testing.T) {
+	runOpVsCommit(t, "DeleteAll",
+		func(t *testing.T, ctx context.Context, store spi.EntityStore) {
+			raceSeedOne(t, ctx, store, "e-delall-vs-commit")
+		},
+		func(txCtx context.Context, store spi.EntityStore) error {
+			return store.DeleteAll(txCtx, raceModelRef)
 		},
 	)
 }

--- a/plugins/memory/concurrency_inreadops_test.go
+++ b/plugins/memory/concurrency_inreadops_test.go
@@ -1,0 +1,210 @@
+package memory_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/memory"
+)
+
+// Locking-discipline race tests for the remaining six tx-path operations
+// in plugins/memory/entity_store.go. PR #153 (v0.6.3) fixed Save and
+// CompareAndSave; issue #176 covers Get, GetAll, Delete, DeleteAll,
+// Exists, and Count.
+//
+// Each operation reads tx.RolledBack and at least one of
+// tx.Buffer / tx.WriteSet / tx.Deletes / tx.ReadSet. Commit and Rollback
+// take tx.OpMu.Lock and write to those fields; in-flight ops must take
+// tx.OpMu.RLock to be serialised against them. Without the RLock, the
+// race detector flags the in-flight read of tx.RolledBack against
+// Rollback's write of the same field.
+//
+// Each test runs many iterations to give the scheduler chances to
+// interleave the in-flight op with Rollback. Tolerated errors are the
+// legitimate outcomes of a tx that closed mid-op:
+//   - "rolled back"
+//   - "already completed"
+//   - "not found"
+//
+// These tests are intended to be run with `go test -race`. Without
+// `-race`, they will not exercise the data-race detector but still
+// verify the tolerated-error contract.
+
+const inReadOpsRaceIterations = 50
+
+var raceModelRef = spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+// runOpVsRollback drives the standard pattern: spawn a goroutine that
+// calls op against the tx context, spawn a goroutine that Rolls Back
+// the tx, release both at once. If op returns a non-tolerated error,
+// fail. The setup callback runs before the goroutines spawn — use it
+// to seed entities the op needs to find.
+func runOpVsRollback(
+	t *testing.T,
+	name string,
+	setup func(t *testing.T, ctx context.Context, store spi.EntityStore),
+	op func(txCtx context.Context, store spi.EntityStore) error,
+) {
+	t.Helper()
+	for iter := 0; iter < inReadOpsRaceIterations; iter++ {
+		func() {
+			factory := memory.NewStoreFactory()
+			defer factory.Close()
+			uuids := newTestUUIDGenerator()
+			txMgr := factory.NewTransactionManager(uuids)
+
+			ctx := ctxWithTenant("tenant-A")
+			store, err := factory.EntityStore(ctx)
+			if err != nil {
+				t.Fatalf("%s: EntityStore failed: %v", name, err)
+			}
+
+			if setup != nil {
+				setup(t, ctx, store)
+			}
+
+			txID, txCtx, err := txMgr.Begin(ctx)
+			if err != nil {
+				t.Fatalf("%s: Begin failed: %v", name, err)
+			}
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if oerr := op(txCtx, store); oerr != nil {
+					if errors.Is(oerr, spi.ErrConflict) || errors.Is(oerr, spi.ErrNotFound) {
+						return
+					}
+					msg := oerr.Error()
+					if strings.Contains(msg, "rolled back") ||
+						strings.Contains(msg, "already completed") ||
+						strings.Contains(msg, "not found") {
+						return
+					}
+					t.Errorf("%s: op failed: %v", name, oerr)
+				}
+			}()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				_ = txMgr.Rollback(ctx, txID)
+			}()
+
+			close(start)
+			wg.Wait()
+		}()
+	}
+}
+
+func raceSeedOne(t *testing.T, ctx context.Context, store spi.EntityStore, id string) {
+	t.Helper()
+	e := &spi.Entity{
+		Meta: spi.EntityMeta{
+			ID:       id,
+			TenantID: "tenant-A",
+			ModelRef: raceModelRef,
+			State:    "NEW",
+		},
+		Data: []byte(`{}`),
+	}
+	if _, err := store.Save(ctx, e); err != nil {
+		t.Fatalf("seed Save failed: %v", err)
+	}
+}
+
+// TestGet_VsRollback_NoRace flags the missing tx.OpMu.RLock around
+// Get's reads of tx.RolledBack, tx.Deletes, tx.Buffer, and write to
+// tx.ReadSet.
+func TestGet_VsRollback_NoRace(t *testing.T) {
+	runOpVsRollback(t, "Get",
+		func(t *testing.T, ctx context.Context, store spi.EntityStore) {
+			raceSeedOne(t, ctx, store, "e-get")
+		},
+		func(txCtx context.Context, store spi.EntityStore) error {
+			_, err := store.Get(txCtx, "e-get")
+			return err
+		},
+	)
+}
+
+// TestGetAll_VsRollback_NoRace flags the missing tx.OpMu.RLock around
+// GetAll's reads of tx.RolledBack, tx.Buffer, tx.Deletes, and writes
+// to tx.ReadSet.
+func TestGetAll_VsRollback_NoRace(t *testing.T) {
+	runOpVsRollback(t, "GetAll",
+		func(t *testing.T, ctx context.Context, store spi.EntityStore) {
+			raceSeedOne(t, ctx, store, "e-getall")
+		},
+		func(txCtx context.Context, store spi.EntityStore) error {
+			_, err := store.GetAll(txCtx, raceModelRef)
+			return err
+		},
+	)
+}
+
+// TestDelete_VsRollback_NoRace flags the missing tx.OpMu.RLock around
+// Delete's read of tx.RolledBack and writes to tx.Deletes / tx.Buffer
+// / tx.WriteSet.
+func TestDelete_VsRollback_NoRace(t *testing.T) {
+	runOpVsRollback(t, "Delete",
+		func(t *testing.T, ctx context.Context, store spi.EntityStore) {
+			raceSeedOne(t, ctx, store, "e-del")
+		},
+		func(txCtx context.Context, store spi.EntityStore) error {
+			return store.Delete(txCtx, "e-del")
+		},
+	)
+}
+
+// TestDeleteAll_VsRollback_NoRace flags the missing tx.OpMu.RLock
+// around DeleteAll's read of tx.RolledBack, iteration of tx.Buffer,
+// and writes to tx.Deletes / tx.Buffer / tx.WriteSet.
+func TestDeleteAll_VsRollback_NoRace(t *testing.T) {
+	runOpVsRollback(t, "DeleteAll",
+		func(t *testing.T, ctx context.Context, store spi.EntityStore) {
+			raceSeedOne(t, ctx, store, "e-delall")
+		},
+		func(txCtx context.Context, store spi.EntityStore) error {
+			return store.DeleteAll(txCtx, raceModelRef)
+		},
+	)
+}
+
+// TestExists_VsRollback_NoRace flags the missing tx.OpMu.RLock around
+// Exists's reads of tx.RolledBack, tx.Deletes, tx.Buffer.
+func TestExists_VsRollback_NoRace(t *testing.T) {
+	runOpVsRollback(t, "Exists",
+		func(t *testing.T, ctx context.Context, store spi.EntityStore) {
+			raceSeedOne(t, ctx, store, "e-exists")
+		},
+		func(txCtx context.Context, store spi.EntityStore) error {
+			_, err := store.Exists(txCtx, "e-exists")
+			return err
+		},
+	)
+}
+
+// TestCount_VsRollback_NoRace flags the missing tx.OpMu.RLock in
+// Count's tx-path. Count delegates to GetAll, so the race lives in
+// GetAll; this test pins that delegation correctness.
+func TestCount_VsRollback_NoRace(t *testing.T) {
+	runOpVsRollback(t, "Count",
+		func(t *testing.T, ctx context.Context, store spi.EntityStore) {
+			raceSeedOne(t, ctx, store, "e-count")
+		},
+		func(txCtx context.Context, store spi.EntityStore) error {
+			_, err := store.Count(txCtx, raceModelRef)
+			return err
+		},
+	)
+}

--- a/plugins/memory/entity_store.go
+++ b/plugins/memory/entity_store.go
@@ -347,10 +347,16 @@ func (s *EntityStore) GetAll(ctx context.Context, modelRef spi.ModelRef) ([]*spi
 		if tx.RolledBack {
 			return nil, fmt.Errorf("transaction has been rolled back")
 		}
-		// Combine: snapshot of main store + buffer - deletes.
-		s.factory.entityMu.RLock()
-		mainEntities := s.getAllSnapshotUnlocked(modelRef, tx.SnapshotTime)
-		s.factory.entityMu.RUnlock()
+		// Combine: snapshot of main store + buffer - deletes. Wrap the
+		// entityMu hold in an IIFE so the unlock runs via defer (per
+		// .claude/rules/go-mutex-discipline.md — bare Unlock is not the
+		// right answer).
+		var mainEntities []*spi.Entity
+		func() {
+			s.factory.entityMu.RLock()
+			defer s.factory.entityMu.RUnlock()
+			mainEntities = s.getAllSnapshotUnlocked(modelRef, tx.SnapshotTime)
+		}()
 
 		result := make(map[string]*spi.Entity)
 		for _, e := range mainEntities {
@@ -443,11 +449,15 @@ func (s *EntityStore) Delete(ctx context.Context, entityID string) error {
 		if tx.RolledBack {
 			return fmt.Errorf("transaction has been rolled back")
 		}
-		// Check existence: buffer first, then committed store.
+		// Check existence: buffer first, then committed store. Wrap the
+		// entityMu hold in an IIFE so the unlock runs via defer.
 		if _, inBuffer := tx.Buffer[entityID]; !inBuffer {
-			s.factory.entityMu.RLock()
-			versions := s.factory.entityData[s.tenant][entityID]
-			s.factory.entityMu.RUnlock()
+			var versions []entityVersion
+			func() {
+				s.factory.entityMu.RLock()
+				defer s.factory.entityMu.RUnlock()
+				versions = s.factory.entityData[s.tenant][entityID]
+			}()
 			if len(versions) == 0 {
 				return fmt.Errorf("entity %s: %w", entityID, spi.ErrNotFound)
 			}
@@ -502,10 +512,15 @@ func (s *EntityStore) DeleteAll(ctx context.Context, modelRef spi.ModelRef) erro
 		if tx.RolledBack {
 			return fmt.Errorf("transaction has been rolled back")
 		}
-		// Get all entities for the model (snapshot), mark each as deleted in tx.
-		s.factory.entityMu.RLock()
-		mainEntities := s.getAllSnapshotUnlocked(modelRef, tx.SnapshotTime)
-		s.factory.entityMu.RUnlock()
+		// Get all entities for the model (snapshot), mark each as deleted
+		// in tx. Wrap the entityMu hold in an IIFE so the unlock runs via
+		// defer.
+		var mainEntities []*spi.Entity
+		func() {
+			s.factory.entityMu.RLock()
+			defer s.factory.entityMu.RUnlock()
+			mainEntities = s.getAllSnapshotUnlocked(modelRef, tx.SnapshotTime)
+		}()
 
 		for _, e := range mainEntities {
 			tx.Deletes[e.Meta.ID] = true

--- a/plugins/memory/entity_store.go
+++ b/plugins/memory/entity_store.go
@@ -284,16 +284,22 @@ func (s *EntityStore) Get(ctx context.Context, entityID string) (*spi.Entity, er
 }
 
 func (s *EntityStore) GetAsAt(ctx context.Context, entityID string, asAt time.Time) (*spi.Entity, error) {
-	s.factory.entityMu.RLock()
-	defer s.factory.entityMu.RUnlock()
-
-	// Historical query: always reads committed data. Track in read set if in tx.
+	// Take tx.OpMu BEFORE factory.entityMu to preserve the lock order
+	// established by Save/CompareAndSave and txmanager.Commit. Historical
+	// queries always read committed data, but the in-tx tx.RolledBack
+	// read and tx.ReadSet write must be serialised against Commit/Rollback
+	// (which take tx.OpMu.Lock).
 	if tx := spi.GetTransaction(ctx); tx != nil {
+		tx.OpMu.RLock()
+		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
 			return nil, fmt.Errorf("transaction has been rolled back")
 		}
 		tx.ReadSet[entityID] = true
 	}
+
+	s.factory.entityMu.RLock()
+	defer s.factory.entityMu.RUnlock()
 
 	versions, ok := s.factory.entityData[s.tenant][entityID]
 	if !ok || len(versions) == 0 {

--- a/plugins/memory/entity_store.go
+++ b/plugins/memory/entity_store.go
@@ -243,6 +243,12 @@ func (s *EntityStore) saveUnlocked(entity *spi.Entity) (int64, error) {
 func (s *EntityStore) Get(ctx context.Context, entityID string) (*spi.Entity, error) {
 	tx := spi.GetTransaction(ctx)
 	if tx != nil {
+		// Hold tx.OpMu.RLock for the duration of the tx-state reads and
+		// the ReadSet write so Commit/Rollback (which take tx.OpMu.Lock)
+		// cannot race with us. Lock order matches txmanager.Commit:
+		// tx.OpMu before factory.entityMu.
+		tx.OpMu.RLock()
+		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
 			return nil, fmt.Errorf("transaction has been rolled back")
 		}
@@ -326,6 +332,12 @@ func (s *EntityStore) GetAsAt(ctx context.Context, entityID string, asAt time.Ti
 func (s *EntityStore) GetAll(ctx context.Context, modelRef spi.ModelRef) ([]*spi.Entity, error) {
 	tx := spi.GetTransaction(ctx)
 	if tx != nil {
+		// Hold tx.OpMu.RLock for the duration of the tx-state reads and
+		// the ReadSet writes so Commit/Rollback (which take tx.OpMu.Lock)
+		// cannot race with our iteration of tx.Buffer / tx.Deletes.
+		// Lock order: tx.OpMu before factory.entityMu.
+		tx.OpMu.RLock()
+		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
 			return nil, fmt.Errorf("transaction has been rolled back")
 		}
@@ -416,6 +428,12 @@ func (s *EntityStore) GetAllAsAt(ctx context.Context, modelRef spi.ModelRef, asA
 func (s *EntityStore) Delete(ctx context.Context, entityID string) error {
 	tx := spi.GetTransaction(ctx)
 	if tx != nil {
+		// Hold tx.OpMu.RLock for the duration of the existence check and
+		// the tx.Deletes / tx.Buffer / tx.WriteSet mutations so Commit/
+		// Rollback (which take tx.OpMu.Lock) cannot race with us. Lock
+		// order: tx.OpMu before factory.entityMu.
+		tx.OpMu.RLock()
+		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
 			return fmt.Errorf("transaction has been rolled back")
 		}
@@ -469,6 +487,12 @@ func (s *EntityStore) Delete(ctx context.Context, entityID string) error {
 func (s *EntityStore) DeleteAll(ctx context.Context, modelRef spi.ModelRef) error {
 	tx := spi.GetTransaction(ctx)
 	if tx != nil {
+		// Hold tx.OpMu.RLock for the duration of the snapshot read and
+		// the iteration/mutation of tx.Buffer / tx.Deletes / tx.WriteSet
+		// so Commit/Rollback (which take tx.OpMu.Lock) cannot race with
+		// us. Lock order: tx.OpMu before factory.entityMu.
+		tx.OpMu.RLock()
+		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
 			return fmt.Errorf("transaction has been rolled back")
 		}
@@ -534,6 +558,11 @@ func (s *EntityStore) DeleteAll(ctx context.Context, modelRef spi.ModelRef) erro
 func (s *EntityStore) Exists(ctx context.Context, entityID string) (bool, error) {
 	tx := spi.GetTransaction(ctx)
 	if tx != nil {
+		// Hold tx.OpMu.RLock for the duration of the tx-state reads so
+		// Commit/Rollback (which take tx.OpMu.Lock) cannot race with us.
+		// Lock order: tx.OpMu before factory.entityMu.
+		tx.OpMu.RLock()
+		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
 			return false, fmt.Errorf("transaction has been rolled back")
 		}


### PR DESCRIPTION
## Summary

Closes #176. Completes the locking-discipline audit of the memory plugin's transaction-aware operations that PR #153 started.

PR #153 (v0.6.3) fixed \`Save\` and \`CompareAndSave\` — both take \`tx.OpMu.RLock()\` so \`Commit\`/\`Rollback\` (which hold \`tx.OpMu.Lock\`) cannot race with their reads/writes of \`tx.RolledBack\`/\`tx.Buffer\`/\`tx.WriteSet\`. PR #153 explicitly flagged the other six tx-path ops (\`Get\`, \`GetAll\`, \`Delete\`, \`DeleteAll\`, \`Exists\`, \`Count\`) as having the same defect; this PR addresses them.

### Changes

- **\`Get\`, \`GetAll\`, \`Delete\`, \`DeleteAll\`, \`Exists\`** all now acquire \`tx.OpMu.RLock()\` + \`defer tx.OpMu.RUnlock()\` at the top of their tx-branch, immediately before the \`tx.RolledBack\` check. Lock order matches Save/CompareAndSave: \`tx.OpMu\` before \`factory.entityMu\`.
- **\`Count\`** is unchanged. It delegates to \`GetAll\` for the tx-path; adding RLock here too would risk a deadlock with a concurrent writer queued between the two RLock acquisitions (\`sync.RWMutex.RLock\` is not safely reentrant). \`Count\` inherits the fix transparently. \`CountByState\` follows the same delegation pattern.

### Tests

Six race-conditional regression tests in \`plugins/memory/concurrency_inreadops_test.go\`, one per method:

- \`TestGet_VsRollback_NoRace\`
- \`TestGetAll_VsRollback_NoRace\`
- \`TestDelete_VsRollback_NoRace\`
- \`TestDeleteAll_VsRollback_NoRace\`
- \`TestExists_VsRollback_NoRace\`
- \`TestCount_VsRollback_NoRace\`

Each pairs the operation against \`txMgr.Rollback\` and runs 50 iterations to maximise scheduler interleavings. The reader's read of \`tx.RolledBack\` races with Rollback's write of the same field; the race detector flags it on the pre-fix code, all six pass green after.

The first commit lands the RED tests; the second commit applies the locking fix and turns them all GREEN — easy to review the discipline.

## Test plan

- [x] \`go test -race -count=1 ./plugins/memory/...\` — all six new tests flag FAIL pre-fix and pass post-fix; full suite green
- [x] \`cd plugins/memory && go vet ./...\` — clean
- [x] \`go test -short ./...\` from repo root — green
- [x] All 6 critical-section reads/writes are immediately preceded by \`tx.OpMu.RLock()\` and \`defer tx.OpMu.RUnlock()\` per \`.claude/rules/go-mutex-discipline.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)