### PR TITLE
fix(memory): tx.OpMu coverage for Savepoint/RollbackToSavepoint/Join + tenant isolation (#199 PR-A)

### DIFF
--- a/docs/audits/2026-05-memory-plugin-tx-locking.md
+++ b/docs/audits/2026-05-memory-plugin-tx-locking.md
@@ -1,0 +1,109 @@
+# Memory Plugin — `*spi.TransactionState` Locking Audit
+
+Issue #199 PR-A. Enumerates every method in `plugins/memory/` that touches
+fields on `*spi.TransactionState`, what it touches, the locking it currently
+holds, the locking required by the design, and the verdict.
+
+## Locking model recap
+
+- `m.mu` (per-`TransactionManager`) — protects the `m.active`,
+  `m.committedLog`, `m.committing`, `m.submitTimes`, `m.savepoints` maps.
+  Brief hold; never held across slow I/O.
+- `tx.OpMu` (per-transaction `sync.RWMutex`, lives in `*spi.TransactionState`)
+  — separates the in-flight-op class from the closure class:
+  - In-flight ops on tx state (Save, CompareAndSave, Get, GetAll, GetAsAt,
+    Delete, DeleteAll, Exists, Count, Savepoint) hold `tx.OpMu.RLock` so
+    multiple readers can run.
+  - Closure / structural-mutation ops (Commit, Rollback, RollbackToSavepoint)
+    hold `tx.OpMu.Lock` so they wait for in-flight ops to drain and then run
+    exclusive.
+- `m.factory.entityMu` — protects the committed entity store. Lock order is
+  always `tx.OpMu` before `m.factory.entityMu` (matching `Commit`'s flush).
+- The application is responsible per `TransactionManager.Join`'s godoc for
+  not firing concurrent ops on the same tx; `tx.OpMu` does **not** mutually
+  exclude RLock-holders from each other (that is the application's job).
+
+## Method-level audit
+
+### `entity_store.go` — tx-path entity ops
+
+| Method (line) | Tx-state fields touched | Current locking | Required | Verdict |
+|---|---|---|---|---|
+| `Save` (99–116) | reads `tx.RolledBack`; writes `tx.Buffer[id]`, `tx.WriteSet[id]` | `tx.OpMu.RLock` + entityMu.RLock (lock order: OpMu before entityMu) | `tx.OpMu.RLock` | ✅ correct (PR #153 + #198) |
+| `CompareAndSave` (124–161) | reads `tx.RolledBack`; writes `tx.Buffer[id]`, `tx.WriteSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (PR #153) |
+| `Get` (246–268) | reads `tx.RolledBack`, `tx.Deletes`, `tx.Buffer`, `tx.SnapshotTime`; writes `tx.ReadSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+| `GetAsAt` (287–298) | reads `tx.RolledBack`; writes `tx.ReadSet[id]` | `tx.OpMu.RLock` (conditional on tx) + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+| `GetAll` (341–377) | reads `tx.RolledBack`, `tx.Deletes`, `tx.SnapshotTime`, iterates `tx.Buffer`; writes `tx.ReadSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+| `Count` (delegates to `GetAll`) | inherits | inherits | inherits | ✅ correct (#176 / PR #198) |
+| `Delete` (443–476) | reads `tx.RolledBack`, `tx.Buffer`; writes `tx.Deletes[id]`, deletes from `tx.Buffer`, writes `tx.WriteSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+| `DeleteAll` (506–547) | reads `tx.RolledBack`, `tx.SnapshotTime`; iterates and mutates `tx.Buffer`, writes `tx.Deletes`, `tx.WriteSet` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+| `Exists` (582–601) | reads `tx.RolledBack`, `tx.Deletes`, `tx.Buffer`, `tx.SnapshotTime` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+
+### `txmanager.go` — transaction lifecycle
+
+| Method (line) | Tx-state fields touched | Current locking | Required | Verdict |
+|---|---|---|---|---|
+| `Begin` (75–103) | constructs new `tx`; writes `m.active[txID]` | `m.mu` (brief, only for `m.active` write) | `m.mu` | ✅ correct (no contention before tx is published) |
+| `Join` (109–139) | reads `tx.RolledBack`, `tx.Closed`, `tx.TenantID` | `m.mu` (brief, for `m.active` lookup) + `tx.OpMu.RLock` (IIFE) for flag reads (PR-A) | `m.mu` for lookup; `tx.OpMu.RLock` for flag reads | ✅ **fixed by PR-A (#199)** |
+| `Commit` (133–283) | reads `tx.SnapshotTime`, `tx.ReadSet`, `tx.WriteSet`, `tx.TenantID`; iterates `tx.Buffer`, `tx.Deletes`; writes `tx.Closed` (defer) | `tx.OpMu.Lock` + entityMu.Lock + `m.mu` (brief, multiple sections) | `tx.OpMu.Lock` | ✅ correct |
+| `Rollback` (286–314) | reads `tx.TenantID`; writes `tx.RolledBack` (under `m.mu`), `tx.Closed` (defer, under `tx.OpMu.Lock`) | `tx.OpMu.Lock` + `m.mu` (brief) | `tx.OpMu.Lock` | ✅ correct |
+| `GetSubmitTime` (318–331) | reads `m.active`, `m.submitTimes`; does not access `tx.*` fields on active txs (early-exits) | `m.mu` | `m.mu` | ✅ correct |
+| `CommittedLogLen` (335–339) | reads `m.committedLog` only | `m.mu` | `m.mu` | ✅ correct |
+| **`Savepoint` (343–399)** | reads `tx.RolledBack`, `tx.Closed`, `tx.Buffer`, `tx.ReadSet`, `tx.WriteSet`, `tx.Deletes` (deep-copy snapshot) | **`tx.OpMu.RLock` + `m.mu` for `m.savepoints` write (PR-A)** | `tx.OpMu.RLock` | ✅ **fixed by PR-A (#199)** |
+| **`RollbackToSavepoint` (403–449)** | reads `tx.RolledBack`, `tx.Closed`; writes `tx.Buffer`, `tx.ReadSet`, `tx.WriteSet`, `tx.Deletes` (replace) | **`tx.OpMu.Lock` + `m.mu` for `m.savepoints` write (PR-A)** | `tx.OpMu.Lock` | ✅ **fixed by PR-A (#199)** |
+| `ReleaseSavepoint` (459–479) | does not access any `tx.*` field — only mutates `m.savepoints` | `m.mu` | `m.mu` | ✅ correct (no tx-state to coordinate) |
+
+## Other gaps surfaced by this audit
+
+### `Join` — unsynchronised reads of `tx.RolledBack` and `tx.Closed` (FIXED)
+
+**File:** `plugins/memory/txmanager.go:117` (pre-fix)
+
+**Pattern (pre-fix):**
+```go
+m.mu.Lock()
+tx, ok := m.active[txID]
+m.mu.Unlock()
+// ...
+if tx.RolledBack || tx.Closed {  // ← unsynchronised read
+    return nil, fmt.Errorf("transaction already closed: %s", txID)
+}
+```
+
+**Why it raced:**
+- `Rollback` writes `tx.RolledBack` inside its `m.mu` critical section
+  (txmanager.go:307–312). `Join` read it **outside** the brief `m.mu` lookup
+  region. The `m.mu`-Unlock/Lock sequence does not establish happens-before
+  for code outside the critical sections.
+- `Commit` and `Rollback` both write `tx.Closed` in a defer that runs under
+  `tx.OpMu.Lock` only — never under `m.mu`. `Join` did not hold `tx.OpMu`
+  when reading `tx.Closed`, so the read was fully unsynchronised against
+  that write.
+
+**Effect:** Per Go's memory model, a data race. Race detector flagged it via
+`TestJoin_VsRollback_NoRace`. Semantically the read was benign (TOCTOU
+regardless), but the unsynchronised access pattern was unsafe.
+
+**Fix (PR-A):** Wrap the flag reads in an IIFE that holds `tx.OpMu.RLock`,
+matching the discipline of every other tx-path method post-#176.
+
+```go
+closed := func() bool {
+    tx.OpMu.RLock()
+    defer tx.OpMu.RUnlock()
+    return tx.RolledBack || tx.Closed
+}()
+```
+
+Regression test: `plugins/memory/concurrency_savepoint_test.go::TestJoin_VsRollback_NoRace`.
+
+## Summary
+
+| Status | Count | Methods |
+|---|---|---|
+| ✅ Correct | 13 | All entity-store ops (9), `Begin`, `Commit`, `Rollback`, `GetSubmitTime`, `CommittedLogLen`, `ReleaseSavepoint` |
+| ✅ Fixed by PR-A | 3 | `Savepoint`, `RollbackToSavepoint`, `Join` |
+
+After PR-A merges, the memory plugin has zero outstanding tx-state locking
+gaps. Every method touching `*spi.TransactionState` holds the appropriate
+lock for the field-access pattern it performs.

--- a/docs/audits/2026-05-memory-plugin-tx-locking.md
+++ b/docs/audits/2026-05-memory-plugin-tx-locking.md
@@ -110,6 +110,19 @@ against `tx.TenantID`. A caller authenticated as tenant A who learned a
 tenant B txID could record/rollback/release savepoints on tenant B's
 tx-state. `Commit` and `Rollback` already had this protection.
 
+**Pre-fix severity (security-auditor assessment):** the most severe path
+was `RollbackToSavepoint(ctxA, txBID, spID)` from tenant A —
+**destructive integrity loss on tenant B's tx-state**, replacing tenant
+B's `Buffer`/`ReadSet`/`WriteSet`/`Deletes` with a snapshot tenant A
+controlled. `Savepoint` from the wrong tenant produced a savepointID for
+tenant B's state (information disclosure on tenant B's tx-namespace
+keying); `ReleaseSavepoint` was an availability-impact path (clearing
+tenant B's snapshot). Mitigated in practice by 128-bit txID entropy
+(infeasible to enumerate), but a tenant A caller who *learned* a tenant B
+txID by any means (logs, support channels, side channels) could exploit
+this without authentication bypass. Pre-fix this gap was a high-severity
+tenant-isolation flaw on the savepoint surface.
+
 **Fixed by PR-A (#199 review I-1):** all three methods now resolve the
 caller's `UserContext` and reject mismatched-tenant calls with a
 `"tenant mismatch"` error. Regression tests at

--- a/docs/audits/2026-05-memory-plugin-tx-locking.md
+++ b/docs/audits/2026-05-memory-plugin-tx-locking.md
@@ -27,31 +27,35 @@ holds, the locking required by the design, and the verdict.
 
 ### `entity_store.go` — tx-path entity ops
 
-| Method (line) | Tx-state fields touched | Current locking | Required | Verdict |
+Line numbers omitted from this table — they go stale on every refactor.
+Cross-reference by method name in `plugins/memory/entity_store.go`.
+
+| Method | Tx-state fields touched | Current locking | Required | Verdict |
 |---|---|---|---|---|
-| `Save` (99–116) | reads `tx.RolledBack`; writes `tx.Buffer[id]`, `tx.WriteSet[id]` | `tx.OpMu.RLock` + entityMu.RLock (lock order: OpMu before entityMu) | `tx.OpMu.RLock` | ✅ correct (PR #153 + #198) |
-| `CompareAndSave` (124–161) | reads `tx.RolledBack`; writes `tx.Buffer[id]`, `tx.WriteSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (PR #153) |
-| `Get` (246–268) | reads `tx.RolledBack`, `tx.Deletes`, `tx.Buffer`, `tx.SnapshotTime`; writes `tx.ReadSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
-| `GetAsAt` (287–298) | reads `tx.RolledBack`; writes `tx.ReadSet[id]` | `tx.OpMu.RLock` (conditional on tx) + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
-| `GetAll` (341–377) | reads `tx.RolledBack`, `tx.Deletes`, `tx.SnapshotTime`, iterates `tx.Buffer`; writes `tx.ReadSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+| `Save` | reads `tx.RolledBack`; writes `tx.Buffer[id]`, `tx.WriteSet[id]` | `tx.OpMu.RLock` + entityMu.RLock (lock order: OpMu before entityMu) | `tx.OpMu.RLock` | ✅ correct (PR #153 + #198) |
+| `CompareAndSave` | reads `tx.RolledBack`; writes `tx.Buffer[id]`, `tx.WriteSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (PR #153) |
+| `Get` | reads `tx.RolledBack`, `tx.Deletes`, `tx.Buffer`, `tx.SnapshotTime`; writes `tx.ReadSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+| `GetAsAt` | reads `tx.RolledBack`; writes `tx.ReadSet[id]` | `tx.OpMu.RLock` (conditional on tx) + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+| `GetAll` | reads `tx.RolledBack`, `tx.Deletes`, `tx.SnapshotTime`, iterates `tx.Buffer`; writes `tx.ReadSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
 | `Count` (delegates to `GetAll`) | inherits | inherits | inherits | ✅ correct (#176 / PR #198) |
-| `Delete` (443–476) | reads `tx.RolledBack`, `tx.Buffer`; writes `tx.Deletes[id]`, deletes from `tx.Buffer`, writes `tx.WriteSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
-| `DeleteAll` (506–547) | reads `tx.RolledBack`, `tx.SnapshotTime`; iterates and mutates `tx.Buffer`, writes `tx.Deletes`, `tx.WriteSet` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
-| `Exists` (582–601) | reads `tx.RolledBack`, `tx.Deletes`, `tx.Buffer`, `tx.SnapshotTime` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+| `CountByState` (delegates to `GetAll`) | inherits | inherits | inherits | ✅ correct (#176 / PR #198) |
+| `Delete` | reads `tx.RolledBack`, `tx.Buffer`; writes `tx.Deletes[id]`, deletes from `tx.Buffer`, writes `tx.WriteSet[id]` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+| `DeleteAll` | reads `tx.RolledBack`, `tx.SnapshotTime`; iterates and mutates `tx.Buffer`, writes `tx.Deletes`, `tx.WriteSet` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
+| `Exists` | reads `tx.RolledBack`, `tx.Deletes`, `tx.Buffer`, `tx.SnapshotTime` | `tx.OpMu.RLock` + entityMu.RLock | `tx.OpMu.RLock` | ✅ correct (#176 / PR #198) |
 
 ### `txmanager.go` — transaction lifecycle
 
-| Method (line) | Tx-state fields touched | Current locking | Required | Verdict |
+| Method | Tx-state fields touched | Current locking | Required | Verdict |
 |---|---|---|---|---|
-| `Begin` (75–103) | constructs new `tx`; writes `m.active[txID]` | `m.mu` (brief, only for `m.active` write) | `m.mu` | ✅ correct (no contention before tx is published) |
-| `Join` (109–139) | reads `tx.RolledBack`, `tx.Closed`, `tx.TenantID` | `m.mu` (brief, for `m.active` lookup) + `tx.OpMu.RLock` (IIFE) for flag reads (PR-A) | `m.mu` for lookup; `tx.OpMu.RLock` for flag reads | ✅ **fixed by PR-A (#199)** |
-| `Commit` (133–283) | reads `tx.SnapshotTime`, `tx.ReadSet`, `tx.WriteSet`, `tx.TenantID`; iterates `tx.Buffer`, `tx.Deletes`; writes `tx.Closed` (defer) | `tx.OpMu.Lock` + entityMu.Lock + `m.mu` (brief, multiple sections) | `tx.OpMu.Lock` | ✅ correct |
-| `Rollback` (286–314) | reads `tx.TenantID`; writes `tx.RolledBack` (under `m.mu`), `tx.Closed` (defer, under `tx.OpMu.Lock`) | `tx.OpMu.Lock` + `m.mu` (brief) | `tx.OpMu.Lock` | ✅ correct |
-| `GetSubmitTime` (318–331) | reads `m.active`, `m.submitTimes`; does not access `tx.*` fields on active txs (early-exits) | `m.mu` | `m.mu` | ✅ correct |
-| `CommittedLogLen` (335–339) | reads `m.committedLog` only | `m.mu` | `m.mu` | ✅ correct |
-| **`Savepoint` (343–399)** | reads `tx.RolledBack`, `tx.Closed`, `tx.Buffer`, `tx.ReadSet`, `tx.WriteSet`, `tx.Deletes` (deep-copy snapshot) | **`tx.OpMu.RLock` + `m.mu` for `m.savepoints` write (PR-A)** | `tx.OpMu.RLock` | ✅ **fixed by PR-A (#199)** |
-| **`RollbackToSavepoint` (403–449)** | reads `tx.RolledBack`, `tx.Closed`; writes `tx.Buffer`, `tx.ReadSet`, `tx.WriteSet`, `tx.Deletes` (replace) | **`tx.OpMu.Lock` + `m.mu` for `m.savepoints` write (PR-A)** | `tx.OpMu.Lock` | ✅ **fixed by PR-A (#199)** |
-| `ReleaseSavepoint` (459–479) | does not access any `tx.*` field — only mutates `m.savepoints` | `m.mu` | `m.mu` | ✅ correct (no tx-state to coordinate) |
+| `Begin` | constructs new `tx`; writes `m.active[txID]` | `m.mu` (brief, only for `m.active` write) | `m.mu` | ✅ correct (no contention before tx is published) |
+| `Join` | reads `tx.RolledBack`, `tx.Closed`, `tx.TenantID` | `m.mu` (brief, for `m.active` lookup) + `tx.OpMu.RLock` (IIFE) for flag reads (PR-A) | `m.mu` for lookup; `tx.OpMu.RLock` for flag reads | ✅ **fixed by PR-A (#199)** |
+| `Commit` | reads `tx.SnapshotTime`, `tx.ReadSet`, `tx.WriteSet`, `tx.TenantID`; iterates `tx.Buffer`, `tx.Deletes`; writes `tx.Closed` (defer) | `tx.OpMu.Lock` + entityMu.Lock + `m.mu` (brief, multiple sections) | `tx.OpMu.Lock` | ✅ correct |
+| `Rollback` | reads `tx.TenantID`; writes `tx.RolledBack` (under `m.mu`), `tx.Closed` (defer, under `tx.OpMu.Lock`) | `tx.OpMu.Lock` + `m.mu` (brief) | `tx.OpMu.Lock` | ✅ correct |
+| `GetSubmitTime` | reads `m.active`, `m.submitTimes`; does not access `tx.*` fields on active txs (early-exits) | `m.mu` | `m.mu` | ✅ correct |
+| `CommittedLogLen` | reads `m.committedLog` only | `m.mu` | `m.mu` | ✅ correct |
+| **`Savepoint`** | reads `tx.RolledBack`, `tx.Closed`, `tx.Buffer`, `tx.ReadSet`, `tx.WriteSet`, `tx.Deletes` (deep-copy snapshot); reads `tx.TenantID` for tenant check | **`tx.OpMu.RLock` + `m.mu` for `m.savepoints` write (PR-A); tenant check from ctx (PR-A I-1)** | `tx.OpMu.RLock` + tenant check | ✅ **fixed by PR-A (#199)** |
+| **`RollbackToSavepoint`** | reads `tx.RolledBack`, `tx.Closed`, `tx.TenantID`; writes `tx.Buffer`, `tx.ReadSet`, `tx.WriteSet`, `tx.Deletes` (replace) | **`tx.OpMu.Lock` + `m.mu` for `m.savepoints` write (PR-A); tenant check from ctx (PR-A I-1)** | `tx.OpMu.Lock` + tenant check | ✅ **fixed by PR-A (#199)** |
+| **`ReleaseSavepoint`** | reads `tx.TenantID` for tenant check; does not access any other `tx.*` field — only mutates `m.savepoints` | **`m.mu` + tenant check from ctx (PR-A I-1)** | `m.mu` + tenant check | ✅ **tenant check added by PR-A (#199); locking unchanged (no tx-state to coordinate)** |
 
 ## Other gaps surfaced by this audit
 
@@ -97,13 +101,31 @@ closed := func() bool {
 
 Regression test: `plugins/memory/concurrency_savepoint_test.go::TestJoin_VsRollback_NoRace`.
 
+## Tenant isolation finding (review I-1)
+
+The audit also surfaced a tenant-isolation gap in the three savepoint
+methods (`Savepoint`, `RollbackToSavepoint`, `ReleaseSavepoint`): pre-fix
+they took `_ context.Context` and never compared the caller's tenant
+against `tx.TenantID`. A caller authenticated as tenant A who learned a
+tenant B txID could record/rollback/release savepoints on tenant B's
+tx-state. `Commit` and `Rollback` already had this protection.
+
+**Fixed by PR-A (#199 review I-1):** all three methods now resolve the
+caller's `UserContext` and reject mismatched-tenant calls with a
+`"tenant mismatch"` error. Regression tests at
+`plugins/memory/txmanager_test.go::TestSavepoint_RejectsCrossTenant`,
+`TestRollbackToSavepoint_RejectsCrossTenant`,
+`TestReleaseSavepoint_RejectsCrossTenant`.
+
 ## Summary
 
 | Status | Count | Methods |
 |---|---|---|
-| ✅ Correct | 13 | All entity-store ops (9), `Begin`, `Commit`, `Rollback`, `GetSubmitTime`, `CommittedLogLen`, `ReleaseSavepoint` |
-| ✅ Fixed by PR-A | 3 | `Savepoint`, `RollbackToSavepoint`, `Join` |
+| ✅ Correct | 13 | All entity-store ops (10, including `CountByState`), `Begin`, `Commit`, `Rollback`, `GetSubmitTime`, `CommittedLogLen` |
+| ✅ Fixed by PR-A (locking) | 3 | `Savepoint`, `RollbackToSavepoint`, `Join` |
+| ✅ Fixed by PR-A (tenant isolation, review I-1) | 3 | `Savepoint`, `RollbackToSavepoint`, `ReleaseSavepoint` |
 
 After PR-A merges, the memory plugin has zero outstanding tx-state locking
-gaps. Every method touching `*spi.TransactionState` holds the appropriate
-lock for the field-access pattern it performs.
+gaps and zero outstanding tenant-isolation gaps in the savepoint surface.
+Every method touching `*spi.TransactionState` holds the appropriate lock
+for the field-access pattern it performs and rejects cross-tenant callers.

--- a/plugins/memory/concurrency_savepoint_test.go
+++ b/plugins/memory/concurrency_savepoint_test.go
@@ -10,23 +10,46 @@ import (
 	"github.com/cyoda-platform/cyoda-go/plugins/memory"
 )
 
-// Locking-discipline race tests for Savepoint and RollbackToSavepoint in
-// plugins/memory/txmanager.go. Issue #199 surfaces that both methods mutate
-// tx-state under m.mu only, never tx.OpMu — so they race against in-flight
-// tx-path ops (Save/Get/Delete) and against Commit's flush phase, which
-// iterates tx.Buffer / tx.Deletes outside m.mu but under tx.OpMu.Lock.
+// Locking-discipline race tests for Savepoint, RollbackToSavepoint, and
+// Join in plugins/memory/txmanager.go. Issue #199 surfaces that Savepoint
+// and RollbackToSavepoint mutate tx-state under m.mu only, never tx.OpMu —
+// so they race against Commit's flush phase, which iterates tx.Buffer /
+// tx.Deletes outside m.mu but under tx.OpMu.Lock. The PR-A audit also
+// surfaced an unsynchronised flag-read in Join.
 //
-// The race shape:
+// Two classes of tests in this file:
+//
+//  1. **Race reproducers** — fail under -race against pre-fix code, pass
+//     after. The race detector's success/failure is the test signal:
+//       - TestRollbackToSavepoint_VsCommit_NoRace
+//       - TestRollbackToSavepoint_VsSave_NoRace
+//       - TestJoin_VsRollback_NoRace
+//
+//  2. **Contract-pin sentinels** — pass under -race both before AND after
+//     the fix because Savepoint=RLock and Commit/Rollback=Lock are
+//     mutually exclusive (no race shape exists for the detector to flag,
+//     regardless of whether the lock is correct or not). Their value is
+//     regression discipline: any future contributor who removes the OpMu
+//     pairing OR adds a new tx-state mutation in Savepoint/Commit gets
+//     caught:
+//       - TestSavepoint_VsCommit_NoRace
+//       - TestSavepoint_VsRollback_NoRace
+//
+// The race shape for the reproducers:
 //   - Savepoint reads tx.Buffer / tx.ReadSet / tx.WriteSet / tx.Deletes.
 //     Required posture: tx.OpMu.RLock — serialises against Commit/Rollback
 //     (Lock) without blocking other readers (Save/Get also take RLock).
 //   - RollbackToSavepoint replaces tx.Buffer / tx.ReadSet / tx.WriteSet /
 //     tx.Deletes. Required posture: tx.OpMu.Lock — exclusive against every
 //     other tx-path op.
+//   - Join reads tx.RolledBack / tx.Closed. Required posture: tx.OpMu.RLock
+//     (in an IIFE) — Commit and Rollback both write tx.Closed in their defer
+//     under tx.OpMu.Lock only, never under m.mu.
 //
-// Tolerated errors mirror the existing concurrency tests: a tx that closed
-// mid-op is a legitimate outcome, not a defect. Sentinel errors land via
-// #200; until then we match by substring.
+// TODO(#200): replace substring matches on tolerated errors ("not found",
+// "rolled back", "already closed", "already completed", "already being
+// committed") with errors.Is against sentinel error types once they land.
+// Until then a closed-mid-op tx is a legitimate outcome, not a defect.
 //
 // These tests are intended to be run with `go test -race`. Without `-race`
 // they still verify the tolerated-error contract.

--- a/plugins/memory/concurrency_savepoint_test.go
+++ b/plugins/memory/concurrency_savepoint_test.go
@@ -1,0 +1,434 @@
+package memory_test
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/memory"
+)
+
+// Locking-discipline race tests for Savepoint and RollbackToSavepoint in
+// plugins/memory/txmanager.go. Issue #199 surfaces that both methods mutate
+// tx-state under m.mu only, never tx.OpMu — so they race against in-flight
+// tx-path ops (Save/Get/Delete) and against Commit's flush phase, which
+// iterates tx.Buffer / tx.Deletes outside m.mu but under tx.OpMu.Lock.
+//
+// The race shape:
+//   - Savepoint reads tx.Buffer / tx.ReadSet / tx.WriteSet / tx.Deletes.
+//     Required posture: tx.OpMu.RLock — serialises against Commit/Rollback
+//     (Lock) without blocking other readers (Save/Get also take RLock).
+//   - RollbackToSavepoint replaces tx.Buffer / tx.ReadSet / tx.WriteSet /
+//     tx.Deletes. Required posture: tx.OpMu.Lock — exclusive against every
+//     other tx-path op.
+//
+// Tolerated errors mirror the existing concurrency tests: a tx that closed
+// mid-op is a legitimate outcome, not a defect. Sentinel errors land via
+// #200; until then we match by substring.
+//
+// These tests are intended to be run with `go test -race`. Without `-race`
+// they still verify the tolerated-error contract.
+
+const savepointRaceIterations = 50
+
+var savepointModelRef = spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+// TestSavepoint_VsCommit_NoRace is a contract-pin test: it ensures that
+// Savepoint completes cleanly when concurrent with Commit, and that
+// Savepoint takes tx.OpMu.RLock so Commit's tx.OpMu.Lock blocks any
+// in-flight Savepoint from running during Commit's flush phase.
+//
+// This test does NOT fire the race detector in red-phase pre-fix. Both
+// Savepoint and Commit's flush phase are read-only on tx.Buffer (Savepoint
+// deep-copies via copyEntity; Commit iterates and copies into entityData
+// without mutating tx.Buffer entries). Read-vs-read is not a Go race.
+//
+// The test's value is regression discipline: any future contributor who
+// removes tx.OpMu.RLock from Savepoint, or accidentally introduces a
+// tx.Buffer mutation in Savepoint, breaks this test's "no error" contract
+// even if -race stays clean. It also gives the Commit-as-contender pairing
+// runtime exercise so that if future code adds a tx-state mutation in
+// either method (e.g. Savepoint reading tx.RolledBack on entry) the race
+// detector starts catching it.
+func TestSavepoint_VsCommit_NoRace(t *testing.T) {
+	for iter := 0; iter < savepointRaceIterations; iter++ {
+		func() {
+			factory := memory.NewStoreFactory()
+			defer factory.Close()
+			uuids := newTestUUIDGenerator()
+			txMgr := factory.NewTransactionManager(uuids)
+
+			ctx := ctxWithTenant("tenant-A")
+			store, err := factory.EntityStore(ctx)
+			if err != nil {
+				t.Fatalf("EntityStore failed: %v", err)
+			}
+
+			txID, txCtx, err := txMgr.Begin(ctx)
+			if err != nil {
+				t.Fatalf("Begin failed: %v", err)
+			}
+
+			// Seed tx.Buffer with one entry (sequential, before contention)
+			// so Commit's flush actually iterates a non-empty map. The
+			// seed Save runs to completion before the race goroutines
+			// spawn — so it does NOT introduce app-contract-violation
+			// concurrency with Savepoint.
+			e := &spi.Entity{
+				Meta: spi.EntityMeta{
+					ID:       "e-sp-vs-commit",
+					TenantID: "tenant-A",
+					ModelRef: savepointModelRef,
+					State:    "NEW",
+				},
+				Data: []byte(`{}`),
+			}
+			if _, serr := store.Save(txCtx, e); serr != nil {
+				t.Fatalf("seed Save failed: %v", serr)
+			}
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if _, sperr := txMgr.Savepoint(ctx, txID); sperr != nil {
+					msg := sperr.Error()
+					if strings.Contains(msg, "not found") ||
+						strings.Contains(msg, "already completed") ||
+						strings.Contains(msg, "rolled back") ||
+						strings.Contains(msg, "already closed") {
+						return
+					}
+					t.Errorf("Savepoint failed: %v", sperr)
+				}
+			}()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if cerr := txMgr.Commit(ctx, txID); cerr != nil {
+					if errors.Is(cerr, spi.ErrConflict) || errors.Is(cerr, spi.ErrNotFound) {
+						return
+					}
+					msg := cerr.Error()
+					if strings.Contains(msg, "already being committed") ||
+						strings.Contains(msg, "not found") {
+						return
+					}
+					t.Errorf("Commit failed: %v", cerr)
+				}
+			}()
+
+			close(start)
+			wg.Wait()
+		}()
+	}
+}
+
+// TestSavepoint_VsRollback_NoRace is a contract-pin test paralleling
+// TestSavepoint_VsCommit_NoRace. Like that test, it does NOT fire the race
+// detector in red-phase: current Savepoint pre-fix doesn't read
+// tx.RolledBack (the only field Rollback writes), so the field-level
+// access pattern has no race shape regardless of OpMu usage. Post-fix,
+// Savepoint reads tx.RolledBack/Closed under tx.OpMu.RLock and Rollback
+// writes those fields under tx.OpMu.Lock — mutually exclusive.
+//
+// The test pins the contract: Savepoint and Rollback must complete cleanly
+// when fired concurrently, with appropriate error returns when the tx is
+// already closed.
+func TestSavepoint_VsRollback_NoRace(t *testing.T) {
+	for iter := 0; iter < savepointRaceIterations; iter++ {
+		func() {
+			factory := memory.NewStoreFactory()
+			defer factory.Close()
+			uuids := newTestUUIDGenerator()
+			txMgr := factory.NewTransactionManager(uuids)
+
+			ctx := ctxWithTenant("tenant-A")
+			_, err := factory.EntityStore(ctx)
+			if err != nil {
+				t.Fatalf("EntityStore failed: %v", err)
+			}
+
+			txID, _, err := txMgr.Begin(ctx)
+			if err != nil {
+				t.Fatalf("Begin failed: %v", err)
+			}
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if _, sperr := txMgr.Savepoint(ctx, txID); sperr != nil {
+					msg := sperr.Error()
+					if strings.Contains(msg, "not found") ||
+						strings.Contains(msg, "already completed") ||
+						strings.Contains(msg, "rolled back") ||
+						strings.Contains(msg, "already closed") {
+						return
+					}
+					t.Errorf("Savepoint failed: %v", sperr)
+				}
+			}()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				_ = txMgr.Rollback(ctx, txID)
+			}()
+
+			close(start)
+			wg.Wait()
+		}()
+	}
+}
+
+// TestRollbackToSavepoint_VsCommit_NoRace pins that RollbackToSavepoint
+// takes tx.OpMu.Lock so its overwrite of tx.Buffer / tx.ReadSet /
+// tx.WriteSet / tx.Deletes is serialised against Commit's flush iteration
+// of those maps under tx.OpMu.Lock.
+//
+// Without tx.OpMu.Lock on RollbackToSavepoint, the race detector flags
+// RollbackToSavepoint's writes of those four fields against Commit's
+// reads/iterations.
+func TestRollbackToSavepoint_VsCommit_NoRace(t *testing.T) {
+	for iter := 0; iter < savepointRaceIterations; iter++ {
+		func() {
+			factory := memory.NewStoreFactory()
+			defer factory.Close()
+			uuids := newTestUUIDGenerator()
+			txMgr := factory.NewTransactionManager(uuids)
+
+			ctx := ctxWithTenant("tenant-A")
+			store, err := factory.EntityStore(ctx)
+			if err != nil {
+				t.Fatalf("EntityStore failed: %v", err)
+			}
+
+			txID, txCtx, err := txMgr.Begin(ctx)
+			if err != nil {
+				t.Fatalf("Begin failed: %v", err)
+			}
+
+			// Take a savepoint we can roll back to. Add an entity AFTER so
+			// tx.Buffer is non-empty when Commit fires; the snapshot will
+			// roll the buffer back to empty.
+			spID, err := txMgr.Savepoint(ctx, txID)
+			if err != nil {
+				t.Fatalf("Savepoint failed: %v", err)
+			}
+
+			e := &spi.Entity{
+				Meta: spi.EntityMeta{
+					ID:       "e-rts-vs-commit",
+					TenantID: "tenant-A",
+					ModelRef: savepointModelRef,
+					State:    "NEW",
+				},
+				Data: []byte(`{}`),
+			}
+			if _, serr := store.Save(txCtx, e); serr != nil {
+				t.Fatalf("seed Save failed: %v", serr)
+			}
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if rerr := txMgr.RollbackToSavepoint(ctx, txID, spID); rerr != nil {
+					msg := rerr.Error()
+					if strings.Contains(msg, "not found") ||
+						strings.Contains(msg, "already completed") ||
+						strings.Contains(msg, "rolled back") ||
+						strings.Contains(msg, "already closed") {
+						return
+					}
+					t.Errorf("RollbackToSavepoint failed: %v", rerr)
+				}
+			}()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if cerr := txMgr.Commit(ctx, txID); cerr != nil {
+					if errors.Is(cerr, spi.ErrConflict) || errors.Is(cerr, spi.ErrNotFound) {
+						return
+					}
+					msg := cerr.Error()
+					if strings.Contains(msg, "already being committed") ||
+						strings.Contains(msg, "not found") {
+						return
+					}
+					t.Errorf("Commit failed: %v", cerr)
+				}
+			}()
+
+			close(start)
+			wg.Wait()
+		}()
+	}
+}
+
+// TestRollbackToSavepoint_VsSave_NoRace pins that RollbackToSavepoint takes
+// tx.OpMu.Lock so its replacement of tx.Buffer / tx.WriteSet is serialised
+// against concurrent Save (which mutates the same maps under tx.OpMu.RLock).
+//
+// Per the Join() godoc the application must coordinate concurrent ops on a
+// single tx itself — but tx.OpMu IS what enforces that contract from the
+// plugin side. This test pins the invariant: even if a contributor
+// accidentally fires Save and RollbackToSavepoint concurrently, the race
+// detector must stay clean.
+//
+// Without tx.OpMu.Lock on RollbackToSavepoint, the race detector flags the
+// pointer-replacement of tx.Buffer against Save's tx.Buffer[id] = entity
+// write.
+func TestRollbackToSavepoint_VsSave_NoRace(t *testing.T) {
+	for iter := 0; iter < savepointRaceIterations; iter++ {
+		func() {
+			factory := memory.NewStoreFactory()
+			defer factory.Close()
+			uuids := newTestUUIDGenerator()
+			txMgr := factory.NewTransactionManager(uuids)
+
+			ctx := ctxWithTenant("tenant-A")
+			store, err := factory.EntityStore(ctx)
+			if err != nil {
+				t.Fatalf("EntityStore failed: %v", err)
+			}
+
+			txID, txCtx, err := txMgr.Begin(ctx)
+			if err != nil {
+				t.Fatalf("Begin failed: %v", err)
+			}
+
+			spID, err := txMgr.Savepoint(ctx, txID)
+			if err != nil {
+				t.Fatalf("Savepoint failed: %v", err)
+			}
+
+			e := &spi.Entity{
+				Meta: spi.EntityMeta{
+					ID:       "e-rts-vs-save",
+					TenantID: "tenant-A",
+					ModelRef: savepointModelRef,
+					State:    "NEW",
+				},
+				Data: []byte(`{}`),
+			}
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if _, serr := store.Save(txCtx, e); serr != nil {
+					msg := serr.Error()
+					if strings.Contains(msg, "rolled back") ||
+						strings.Contains(msg, "already completed") ||
+						strings.Contains(msg, "not found") {
+						return
+					}
+					t.Errorf("Save failed: %v", serr)
+				}
+			}()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if rerr := txMgr.RollbackToSavepoint(ctx, txID, spID); rerr != nil {
+					msg := rerr.Error()
+					if strings.Contains(msg, "not found") ||
+						strings.Contains(msg, "already completed") ||
+						strings.Contains(msg, "rolled back") ||
+						strings.Contains(msg, "already closed") {
+						return
+					}
+					t.Errorf("RollbackToSavepoint failed: %v", rerr)
+				}
+			}()
+
+			close(start)
+			wg.Wait()
+		}()
+	}
+}
+
+// TestJoin_VsRollback_NoRace flags the missing tx.OpMu.RLock around Join's
+// reads of tx.RolledBack and tx.Closed.
+//
+// Surfaced by the memory-plugin tx-locking audit during PR-A (#199): Join
+// reads tx.RolledBack and tx.Closed outside any lock at txmanager.go:117.
+// Rollback writes tx.RolledBack inside m.mu only, and Commit/Rollback both
+// write tx.Closed in their defer under tx.OpMu.Lock only — never under m.mu.
+// The m.mu critical section in Join's lookup does not establish
+// happens-before for the subsequent flag reads, so the race detector flags
+// Join's read against Rollback's tx.RolledBack write.
+//
+// The fix takes tx.OpMu.RLock (via IIFE per .claude/rules/go-mutex-discipline.md)
+// for the flag reads.
+func TestJoin_VsRollback_NoRace(t *testing.T) {
+	for iter := 0; iter < savepointRaceIterations; iter++ {
+		func() {
+			factory := memory.NewStoreFactory()
+			defer factory.Close()
+			uuids := newTestUUIDGenerator()
+			txMgr := factory.NewTransactionManager(uuids)
+
+			ctx := ctxWithTenant("tenant-A")
+			_, err := factory.EntityStore(ctx)
+			if err != nil {
+				t.Fatalf("EntityStore failed: %v", err)
+			}
+
+			txID, _, err := txMgr.Begin(ctx)
+			if err != nil {
+				t.Fatalf("Begin failed: %v", err)
+			}
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if _, jerr := txMgr.Join(ctx, txID); jerr != nil {
+					msg := jerr.Error()
+					if strings.Contains(msg, "not found") ||
+						strings.Contains(msg, "already closed") ||
+						strings.Contains(msg, "rolled back") {
+						return
+					}
+					t.Errorf("Join failed: %v", jerr)
+				}
+			}()
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				_ = txMgr.Rollback(ctx, txID)
+			}()
+
+			close(start)
+			wg.Wait()
+		}()
+	}
+}

--- a/plugins/memory/txmanager.go
+++ b/plugins/memory/txmanager.go
@@ -106,6 +106,12 @@ func (m *TransactionManager) Begin(ctx context.Context) (string, context.Context
 // transaction. This allows multiple goroutines to participate in the same
 // transaction. Callers must coordinate access to the transaction's Buffer,
 // ReadSet, WriteSet, and Deletes maps.
+//
+// Locking discipline (issue #199 audit): Rollback writes tx.RolledBack
+// inside m.mu only; Commit and Rollback both write tx.Closed in their
+// defer under tx.OpMu.Lock only. Reading those fields requires
+// tx.OpMu.RLock to be synchronised against the Closed-write — m.mu alone
+// is not sufficient because Commit's defer runs outside the m.mu region.
 func (m *TransactionManager) Join(ctx context.Context, txID string) (context.Context, error) {
 	m.mu.Lock()
 	tx, ok := m.active[txID]
@@ -114,7 +120,13 @@ func (m *TransactionManager) Join(ctx context.Context, txID string) (context.Con
 	if !ok {
 		return nil, fmt.Errorf("transaction not found: %s", txID)
 	}
-	if tx.RolledBack || tx.Closed {
+
+	closed := func() bool {
+		tx.OpMu.RLock()
+		defer tx.OpMu.RUnlock()
+		return tx.RolledBack || tx.Closed
+	}()
+	if closed {
 		return nil, fmt.Errorf("transaction already closed: %s", txID)
 	}
 
@@ -340,18 +352,39 @@ func (m *TransactionManager) CommittedLogLen() int {
 
 // Savepoint creates a named savepoint within the given transaction by
 // deep-copying the transaction's buffer maps.
+//
+// Locking discipline (issue #199): Savepoint reads tx.Buffer / tx.ReadSet /
+// tx.WriteSet / tx.Deletes — the same fields Commit's flush phase iterates
+// under tx.OpMu.Lock and that other tx-path ops (Save, Get, Delete, ...)
+// mutate under tx.OpMu.RLock. Savepoint must therefore hold tx.OpMu.RLock
+// across those reads. The lock interleaving with m.mu follows Commit's
+// pattern: drop m.mu before taking tx.OpMu, re-take m.mu briefly for the
+// m.savepoints update.
 func (m *TransactionManager) Savepoint(_ context.Context, txID string) (string, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	tx, ok := m.active[txID]
+	m.mu.Unlock()
 	if !ok {
 		return "", fmt.Errorf("Savepoint: transaction %s not found", txID)
 	}
 
+	tx.OpMu.RLock()
+	defer tx.OpMu.RUnlock()
+
+	// Commit and Rollback set tx.Closed/RolledBack inside their tx.OpMu.Lock
+	// region; once we hold tx.OpMu.RLock those flags are stable and reading
+	// them tells us whether the tx was closed during our OpMu acquisition.
+	if tx.RolledBack || tx.Closed {
+		return "", fmt.Errorf("Savepoint: transaction %s already closed", txID)
+	}
+
 	spID := uuid.UUID(m.uuids.NewTimeUUID()).String()
 
-	// Deep-copy the buffer maps.
+	// Deep-copy the buffer maps under tx.OpMu.RLock so we are serialised
+	// against Commit/Rollback (Lock). Per the Join() godoc the application
+	// is responsible for serialising its own concurrent ops on a single tx,
+	// so concurrent Save+Savepoint is an application contract violation,
+	// not a plugin defect — RLock here intentionally allows other readers.
 	bufCopy := make(map[string]*spi.Entity, len(tx.Buffer))
 	for k, v := range tx.Buffer {
 		bufCopy[k] = copyEntity(v)
@@ -369,6 +402,8 @@ func (m *TransactionManager) Savepoint(_ context.Context, txID string) (string, 
 		delCopy[k] = v
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.savepoints[txID] == nil {
 		m.savepoints[txID] = make(map[string]savepointSnapshot)
 	}
@@ -383,14 +418,28 @@ func (m *TransactionManager) Savepoint(_ context.Context, txID string) (string, 
 
 // RollbackToSavepoint restores the transaction's buffer maps from the snapshot
 // captured when the savepoint was created, then removes the snapshot.
+//
+// Locking discipline (issue #199): RollbackToSavepoint replaces tx.Buffer /
+// tx.ReadSet / tx.WriteSet / tx.Deletes — exclusive against every other
+// tx-path op. Holds tx.OpMu.Lock (write) for the duration of the field
+// replacement. Lock interleaving with m.mu follows Commit's pattern.
 func (m *TransactionManager) RollbackToSavepoint(_ context.Context, txID string, savepointID string) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	tx, ok := m.active[txID]
+	m.mu.Unlock()
 	if !ok {
 		return fmt.Errorf("RollbackToSavepoint: transaction %s not found", txID)
 	}
+
+	tx.OpMu.Lock()
+	defer tx.OpMu.Unlock()
+
+	if tx.RolledBack || tx.Closed {
+		return fmt.Errorf("RollbackToSavepoint: transaction %s already closed", txID)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	txSavepoints, ok := m.savepoints[txID]
 	if !ok {
@@ -412,6 +461,11 @@ func (m *TransactionManager) RollbackToSavepoint(_ context.Context, txID string,
 
 // ReleaseSavepoint releases a savepoint. The work done since the savepoint is
 // already in the parent transaction's buffer, so this just removes the snapshot.
+//
+// Locking discipline (issue #199): ReleaseSavepoint does not read or write
+// tx.Buffer / tx.ReadSet / tx.WriteSet / tx.Deletes — it only mutates
+// m.savepoints. Holds m.mu only; tx.OpMu is not required because there is
+// no tx-state field to coordinate against Commit/Rollback.
 func (m *TransactionManager) ReleaseSavepoint(_ context.Context, txID string, savepointID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/plugins/memory/txmanager.go
+++ b/plugins/memory/txmanager.go
@@ -360,12 +360,22 @@ func (m *TransactionManager) CommittedLogLen() int {
 // across those reads. The lock interleaving with m.mu follows Commit's
 // pattern: drop m.mu before taking tx.OpMu, re-take m.mu briefly for the
 // m.savepoints update.
-func (m *TransactionManager) Savepoint(_ context.Context, txID string) (string, error) {
+//
+// Tenant isolation (issue #199 PR-A review I-1): rejects callers whose
+// UserContext tenant does not match the transaction's tenant, mirroring
+// Commit/Rollback. Without this guard a caller authenticated as tenant A
+// who learned a tenant B txID could record a snapshot against tenant B's
+// tx-state.
+func (m *TransactionManager) Savepoint(ctx context.Context, txID string) (string, error) {
+	uc := spi.GetUserContext(ctx)
 	m.mu.Lock()
 	tx, ok := m.active[txID]
 	m.mu.Unlock()
 	if !ok {
 		return "", fmt.Errorf("Savepoint: transaction %s not found", txID)
+	}
+	if uc == nil || uc.Tenant.ID != tx.TenantID {
+		return "", fmt.Errorf("Savepoint: tenant mismatch on transaction %s", txID)
 	}
 
 	tx.OpMu.RLock()
@@ -423,12 +433,19 @@ func (m *TransactionManager) Savepoint(_ context.Context, txID string) (string, 
 // tx.ReadSet / tx.WriteSet / tx.Deletes — exclusive against every other
 // tx-path op. Holds tx.OpMu.Lock (write) for the duration of the field
 // replacement. Lock interleaving with m.mu follows Commit's pattern.
-func (m *TransactionManager) RollbackToSavepoint(_ context.Context, txID string, savepointID string) error {
+//
+// Tenant isolation (issue #199 PR-A review I-1): rejects cross-tenant
+// callers — RollbackToSavepoint is destructive on tx-state.
+func (m *TransactionManager) RollbackToSavepoint(ctx context.Context, txID string, savepointID string) error {
+	uc := spi.GetUserContext(ctx)
 	m.mu.Lock()
 	tx, ok := m.active[txID]
 	m.mu.Unlock()
 	if !ok {
 		return fmt.Errorf("RollbackToSavepoint: transaction %s not found", txID)
+	}
+	if uc == nil || uc.Tenant.ID != tx.TenantID {
+		return fmt.Errorf("RollbackToSavepoint: tenant mismatch on transaction %s", txID)
 	}
 
 	tx.OpMu.Lock()
@@ -466,12 +483,20 @@ func (m *TransactionManager) RollbackToSavepoint(_ context.Context, txID string,
 // tx.Buffer / tx.ReadSet / tx.WriteSet / tx.Deletes — it only mutates
 // m.savepoints. Holds m.mu only; tx.OpMu is not required because there is
 // no tx-state field to coordinate against Commit/Rollback.
-func (m *TransactionManager) ReleaseSavepoint(_ context.Context, txID string, savepointID string) error {
+//
+// Tenant isolation (issue #199 PR-A review I-1): rejects cross-tenant
+// callers — m.savepoints is tenant-scoped state.
+func (m *TransactionManager) ReleaseSavepoint(ctx context.Context, txID string, savepointID string) error {
+	uc := spi.GetUserContext(ctx)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if _, ok := m.active[txID]; !ok {
+	tx, ok := m.active[txID]
+	if !ok {
 		return fmt.Errorf("ReleaseSavepoint: transaction %s not found", txID)
+	}
+	if uc == nil || uc.Tenant.ID != tx.TenantID {
+		return fmt.Errorf("ReleaseSavepoint: tenant mismatch on transaction %s", txID)
 	}
 
 	txSavepoints, ok := m.savepoints[txID]

--- a/plugins/memory/txmanager_test.go
+++ b/plugins/memory/txmanager_test.go
@@ -2,6 +2,7 @@ package memory_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -538,4 +539,83 @@ func TestSavepoint_WrongTxIDRejected(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected tx1 to rollback to its own savepoint, got: %v", err)
 	}
+}
+
+// TestSavepoint_RejectsCrossTenant verifies that Savepoint refuses to operate
+// on a transaction belonging to a different tenant. Surfaced by the issue
+// #199 audit / PR-A code review (Item I-1): pre-fix, the three savepoint
+// methods discarded the caller's tenant context entirely (took _ context.Context),
+// allowing tenant A to manipulate tenant B's tx-state if the txID was known.
+// Mirrors Commit/Rollback's existing tenant-mismatch protection.
+func TestSavepoint_RejectsCrossTenant(t *testing.T) {
+	_, tm := newTxManager(t)
+	ctxA := ctxWithTenant("tenant-A")
+	ctxB := ctxWithTenant("tenant-B")
+
+	txAID, _, err := tm.Begin(ctxA)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	if _, err := tm.Savepoint(ctxB, txAID); err == nil {
+		t.Fatal("expected error when tenant B takes savepoint on tenant A's tx")
+	} else if !strings.Contains(err.Error(), "tenant mismatch") {
+		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	}
+
+	_ = tm.Rollback(ctxA, txAID)
+}
+
+// TestRollbackToSavepoint_RejectsCrossTenant verifies that RollbackToSavepoint
+// refuses to operate on another tenant's transaction. Critical because
+// RollbackToSavepoint is destructive on tx-state — without tenant verification,
+// an authenticated tenant A caller could roll back tenant B's tx-state.
+func TestRollbackToSavepoint_RejectsCrossTenant(t *testing.T) {
+	_, tm := newTxManager(t)
+	ctxA := ctxWithTenant("tenant-A")
+	ctxB := ctxWithTenant("tenant-B")
+
+	txAID, _, err := tm.Begin(ctxA)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+	spID, err := tm.Savepoint(ctxA, txAID)
+	if err != nil {
+		t.Fatalf("Savepoint failed: %v", err)
+	}
+
+	if err := tm.RollbackToSavepoint(ctxB, txAID, spID); err == nil {
+		t.Fatal("expected error when tenant B rolls back tenant A's savepoint")
+	} else if !strings.Contains(err.Error(), "tenant mismatch") {
+		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	}
+
+	_ = tm.Rollback(ctxA, txAID)
+}
+
+// TestReleaseSavepoint_RejectsCrossTenant verifies that ReleaseSavepoint
+// refuses to operate on another tenant's transaction. Less destructive than
+// RollbackToSavepoint (only removes the snapshot record from m.savepoints)
+// but still tenant-scoped state — enforces the consistent isolation contract.
+func TestReleaseSavepoint_RejectsCrossTenant(t *testing.T) {
+	_, tm := newTxManager(t)
+	ctxA := ctxWithTenant("tenant-A")
+	ctxB := ctxWithTenant("tenant-B")
+
+	txAID, _, err := tm.Begin(ctxA)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+	spID, err := tm.Savepoint(ctxA, txAID)
+	if err != nil {
+		t.Fatalf("Savepoint failed: %v", err)
+	}
+
+	if err := tm.ReleaseSavepoint(ctxB, txAID, spID); err == nil {
+		t.Fatal("expected error when tenant B releases tenant A's savepoint")
+	} else if !strings.Contains(err.Error(), "tenant mismatch") {
+		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	}
+
+	_ = tm.Rollback(ctxA, txAID)
 }


### PR DESCRIPTION
## Summary

Closes #199 PR-A. Fixes the remaining `tx.OpMu` locking-discipline gaps in `plugins/memory/` after PR #198 (closed #176): `Savepoint`, `RollbackToSavepoint`, and (surfaced by the audit) `Join`. Also closes a tenant-isolation gap in the three savepoint methods that the audit lens surfaced through the same review.

- **`Savepoint`** now takes `tx.OpMu.RLock` (read on tx state — serialised against `Commit`/`Rollback`'s `tx.OpMu.Lock`). Lock interleaving with `m.mu` follows `Commit`'s pattern (drop `m.mu` before `tx.OpMu`, re-take briefly for `m.savepoints` write).
- **`RollbackToSavepoint`** now takes `tx.OpMu.Lock` (write on tx state — exclusive against every other tx-path op).
- **`Join`** now reads `tx.RolledBack`/`tx.Closed` under a brief `tx.OpMu.RLock` IIFE — pre-fix the reads were unsynchronised against `Rollback`'s `m.mu`-only write of `tx.RolledBack` and `Commit`/`Rollback`'s defer-OpMu-only write of `tx.Closed`.
- **`Savepoint`/`RollbackToSavepoint`/`ReleaseSavepoint`** now reject cross-tenant callers via `uc.Tenant.ID == tx.TenantID` checks, mirroring the existing `Commit`/`Rollback` pattern. Pre-fix they took `_ context.Context` and never compared tenants.

`ReleaseSavepoint`'s locking discipline audited and unchanged — it touches no `tx.*` field, only `m.savepoints` under `m.mu`.

## Test plan

- [x] **Race tests** in `plugins/memory/concurrency_savepoint_test.go` — 5 new race tests covering Savepoint/RollbackToSavepoint/Join. 3 are real race reproducers (fail under `-race` against pre-fix code, pass after); 2 are mutual-exclusion contract pins (Savepoint=RLock vs Commit/Rollback=Lock are mutually exclusive — no race shape exists for the detector to flag, but the tests pin the pairing).
- [x] **Tenant-isolation regression tests** in `plugins/memory/txmanager_test.go` — `TestSavepoint_RejectsCrossTenant`, `TestRollbackToSavepoint_RejectsCrossTenant`, `TestReleaseSavepoint_RejectsCrossTenant`. Each writes a tx as tenant A, attempts the savepoint op as tenant B, expects `"tenant mismatch"`. All three FAIL pre-fix and PASS post-fix.
- [x] `go test ./...` green (root module, including E2E).
- [x] `go test -race ./...` green (root + memory + sqlite plugin submodules; full e2e race in 288s).
- [x] `go vet ./...` clean (root + plugins).
- [x] Memory-plugin audit table at `docs/audits/2026-05-memory-plugin-tx-locking.md` enumerates every method touching `*spi.TransactionState`.

## Audit summary

After PR-A merges:
- ✅ Locking-correct (13): all entity-store ops (10), `Begin`, `Commit`, `Rollback`, `GetSubmitTime`, `CommittedLogLen`
- ✅ Fixed-by-PR-A locking (3): `Savepoint`, `RollbackToSavepoint`, `Join`
- ✅ Fixed-by-PR-A tenant isolation (3): `Savepoint`, `RollbackToSavepoint`, `ReleaseSavepoint`

Zero outstanding tx-state locking gaps and zero outstanding tenant-isolation gaps in the savepoint surface.

## Out of scope

- PR-B (SPI godoc contract + `.claude/rules/` checklist) — separate PR per #199 decomposition.
- PR-C (`docs/architecture/concurrency-model.md` + audits of postgres/sqlite/cluster/workflow) — separate PR per #199 decomposition.
- Sentinel error types — tracked at #200 for v0.8.0; race tests use substring matching with a `TODO(#200)` breadcrumb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)