### PR TITLE
chore(deps): bump cyoda-go-spi to v0.6.1 (#199 PR-B)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/charmbracelet/glamour v1.0.0
-	github.com/cyoda-platform/cyoda-go-spi v0.6.0
+	github.com/cyoda-platform/cyoda-go-spi v0.6.1
 	github.com/getkin/kin-openapi v0.137.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GK
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
-github.com/cyoda-platform/cyoda-go-spi v0.6.0 h1:h6Bj0xckmlwYlKt37uLgvE63SaNQ6BvJXREN798KLEc=
-github.com/cyoda-platform/cyoda-go-spi v0.6.0/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.6.1 h1:4rbecqHg8Q22tGcKAXdNgclBHTbiljpcOOufGV/xqjg=
+github.com/cyoda-platform/cyoda-go-spi v0.6.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/plugins/memory/go.mod
+++ b/plugins/memory/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/memory
 go 1.26.2
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.6.0
+	github.com/cyoda-platform/cyoda-go-spi v0.6.1
 	github.com/google/uuid v1.6.0
 )
 

--- a/plugins/memory/go.sum
+++ b/plugins/memory/go.sum
@@ -1,6 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.6.0 h1:h6Bj0xckmlwYlKt37uLgvE63SaNQ6BvJXREN798KLEc=
-github.com/cyoda-platform/cyoda-go-spi v0.6.0/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.6.1 h1:4rbecqHg8Q22tGcKAXdNgclBHTbiljpcOOufGV/xqjg=
+github.com/cyoda-platform/cyoda-go-spi v0.6.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/plugins/postgres/go.mod
+++ b/plugins/postgres/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/postgres
 go 1.26.2
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.6.0
+	github.com/cyoda-platform/cyoda-go-spi v0.6.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa

--- a/plugins/postgres/go.sum
+++ b/plugins/postgres/go.sum
@@ -9,8 +9,8 @@ github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.6.0 h1:h6Bj0xckmlwYlKt37uLgvE63SaNQ6BvJXREN798KLEc=
-github.com/cyoda-platform/cyoda-go-spi v0.6.0/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.6.1 h1:4rbecqHg8Q22tGcKAXdNgclBHTbiljpcOOufGV/xqjg=
+github.com/cyoda-platform/cyoda-go-spi v0.6.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/plugins/sqlite/go.mod
+++ b/plugins/sqlite/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/sqlite
 go 1.26.2
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.6.0
+	github.com/cyoda-platform/cyoda-go-spi v0.6.1
 	github.com/gofrs/flock v0.13.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0

--- a/plugins/sqlite/go.sum
+++ b/plugins/sqlite/go.sum
@@ -1,6 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.6.0 h1:h6Bj0xckmlwYlKt37uLgvE63SaNQ6BvJXREN798KLEc=
-github.com/cyoda-platform/cyoda-go-spi v0.6.0/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.6.1 h1:4rbecqHg8Q22tGcKAXdNgclBHTbiljpcOOufGV/xqjg=
+github.com/cyoda-platform/cyoda-go-spi v0.6.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=


### PR DESCRIPTION
## Summary

Bumps the SPI dependency to v0.6.1, which carries the formalised tx-state OpMu locking discipline + tenant isolation contract from cyoda-go-spi PR #6 (merged). Documentation-only SPI release — no API or behavioural change. cyoda-go's memory plugin already conforms via #199 PR-A (#201).

This is the second half of #199 PR-B; the SPI repo half landed at https://github.com/Cyoda-platform/cyoda-go-spi/pull/6.

Bumped across root module + all three plugin submodules (memory/sqlite/postgres) so the SPI godoc and the new \`.claude/rules/tx-state-locking.md\` propagate to every plugin author's checkout.

## Test plan

- [x] \`go build ./...\` clean (root)
- [x] \`go test ./...\` clean (root, including E2E)
- [x] \`go test -short\` clean for memory + sqlite plugin submodules
- [x] All four \`go.mod\` / \`go.sum\` files updated; \`go mod tidy\` clean

## What's NOT in this PR

- PR-C (architectural concurrency-model doc) — separate PR, may benefit from brainstorming first per #199 decomposition.

## References

- cyoda-go issue #199: https://github.com/Cyoda-platform/cyoda-go/issues/199
- cyoda-go-spi PR #6 (merged): https://github.com/Cyoda-platform/cyoda-go-spi/pull/6
- cyoda-go PR #201 (merged, PR-A): https://github.com/Cyoda-platform/cyoda-go/pull/201

🤖 Generated with [Claude Code](https://claude.com/claude-code)