### PR TITLE
fix(postgres): tenant isolation across TM lifecycle surface (#199 PR-C2)

### DIFF
--- a/docs/audits/2026-05-postgres-plugin-tx-locking.md
+++ b/docs/audits/2026-05-postgres-plugin-tx-locking.md
@@ -1,0 +1,219 @@
+# Postgres Plugin — `*spi.TransactionState` Locking + Tenant Isolation Audit
+
+Issue #199 PR-C2. Parallels the memory and sqlite audits but covers a
+plugin with a fundamentally different concurrency model. Documents what
+the SPI v0.6.1 OpMu contract requires, why postgres trivially satisfies
+it without any OpMu acquisition, and the tenant-isolation gap PR-C2
+closes.
+
+## Why this audit was needed
+
+cyoda-go-spi v0.6.1 (PR-B, merged) formalised the tx-state OpMu contract
+for plugin authors. PR-A closed the memory plugin's gaps; PR-C1 closed
+the sqlite plugin's. The natural completion of the audit pass was
+postgres — but two findings during the deep-dive made PR-C2 substantially
+larger than the originally-planned "audit only, no code change":
+
+1. **Postgres uses a different concurrency model entirely.** The OpMu
+   contract is satisfied trivially because the protected fields are
+   unused.
+2. **Postgres lacked application-layer tenant isolation on its TM
+   lifecycle methods.** Memory and sqlite have always had it on
+   Commit/Rollback (PR-A/PR-C1 extended it to Savepoint/etc.); postgres
+   relied solely on RLS, which doesn't extend to lifecycle commands.
+
+PR-C2 closes both — formally documents (1), fixes (2).
+
+## How postgres' concurrency model differs from memory/sqlite
+
+Memory and sqlite are **in-process SI+FCW** plugins. They maintain:
+- An in-memory `committedLog` window for conflict detection.
+- A per-tx `Buffer` map staging writes until commit.
+- A per-tx `OpMu` (`sync.RWMutex` on `*spi.TransactionState`) separating
+  in-flight tx-path ops from closure ops.
+
+Postgres delegates SI+FCW to PostgreSQL's MVCC engine plus an
+application-layer read-set validation:
+- `Begin` opens a real `pgx.Tx` via `pool.BeginTx(ctx, IsoLevel: RepeatableRead)`.
+  PostgreSQL handles the snapshot.
+- Writes go directly to the database via SQL inside the pgx.Tx — there
+  is no application-layer Buffer.
+- Reads execute SQL inside the pgx.Tx — RLS-bound to the tx's tenant
+  via `set_config('app.current_tenant', $1, true)`.
+- Read-set validation at commit time (`txstate.ValidateReadSet`) is the
+  only application-layer FCW check; write-write conflicts are caught by
+  PostgreSQL's tuple-level locks (`SQLSTATE 40001`).
+
+**Consequence for the SPI OpMu contract:** the postgres TM never reads
+or writes `tx.Buffer`/`tx.ReadSet`/`tx.WriteSet`/`tx.Deletes`/
+`tx.RolledBack`/`tx.Closed` on `*spi.TransactionState`. The
+`spi.TransactionState` value postgres exposes via Begin/Join carries
+ONLY `ID` and `TenantID` — the rest of the struct's fields are
+unread/unwritten. The OpMu contract therefore holds vacuously: there
+are no fields whose access requires OpMu.
+
+Per-tx bookkeeping for FCW lives in a separate internal `txState` struct
+(`plugins/postgres/txstate.go`) with its own `sync.Mutex`. That mutex is
+fully encapsulated inside the postgres plugin and is invisible at the
+SPI surface.
+
+## OpMu posture per method (postgres)
+
+| Method | Touches `*spi.TransactionState` mutable fields? | OpMu posture |
+|---|---|---|
+| `Begin` | No (only writes immutable `ID`/`TenantID`). | N/A |
+| `Commit` | No. Reads internal `txState` (separate struct, own mutex). | N/A |
+| `Rollback` | No. | N/A |
+| `Join` | No (constructs new `*spi.TransactionState` with `ID`/`TenantID` only). | N/A |
+| `GetSubmitTime` | No. | N/A |
+| `Savepoint` | No. Operates on internal `txState.savepoints`. | N/A |
+| `RollbackToSavepoint` | No. | N/A |
+| `ReleaseSavepoint` | No. | N/A |
+| All `EntityStore` ops (`Save`, `CompareAndSave`, `Get`, `GetAll`, `GetAsAt`, `Delete`, `DeleteAll`, `Exists`, `Count`, `CountByState`) | No. Use `tm.recordReadIfInTx` / `tm.recordWriteIfInTx` which target internal `txState`. | N/A |
+
+The OpMu contract is **trivially satisfied** for the postgres plugin
+because no plugin code path accesses any of the OpMu-protected fields.
+A future plugin contributor must NOT add OpMu acquisitions speculatively
+to the postgres plugin — the contract is satisfied by the structural
+property that those fields are unused, and any added OpMu would be
+spurious.
+
+## Internal locks postgres uses (for completeness)
+
+These are plugin-internal locks; they are NOT the SPI's OpMu contract.
+
+| Mutex | File:line | Protects | Notes |
+|---|---|---|---|
+| `TransactionManager.mu` | `transaction_manager.go:30` | `submitTimes`, `tenants` maps | Brief holds, multiple critical sections |
+| `TransactionManager.txStatesMu` | `transaction_manager.go:38` (RWMutex) | `txStates` map keying internal txState by txID | RLock for lookup, Lock for insert/delete |
+| `txState.mu` | `txstate.go:30` | `readSet`, `writeSet`, `savepoints` slice — per-tx FCW bookkeeping | One per active tx |
+| `txRegistry.mu` (internal) | `txregistry.go` | `txID → pgx.Tx` map | Single source of truth for the pgx.Tx handle |
+| `pgxpool.Pool` (vendored) | n/a | connection pool | Managed by pgx |
+
+Lock order across the postgres plugin is bounded by acquire-and-release
+discipline — every method acquires a lock briefly, does its bookkeeping,
+releases. Manager-side mutexes are never held across slow operations
+(SQL, network). No nested or composite lock acquisitions exist that
+could create cycles.
+
+## Tenant isolation finding (PR-C2)
+
+### Pre-fix gap
+
+Pre-PR-C2, the postgres TM lifecycle methods (`Commit`, `Rollback`,
+`Join`, `Savepoint`, `RollbackToSavepoint`, `ReleaseSavepoint`) did not
+verify the caller's `UserContext` tenant against the transaction's
+tenant. Memory and sqlite plugins always had this check on
+Commit/Rollback (and PR-A/PR-C1 extended it to the savepoint trio);
+postgres lacked it across the entire surface.
+
+### Why RLS does NOT cover this
+
+PostgreSQL's row-level security is a **row-level** check. It enforces
+policies on `SELECT`/`INSERT`/`UPDATE`/`DELETE` against tables. RLS does
+NOT extend to:
+
+- Transaction lifecycle commands (`BEGIN`, `COMMIT`, `ROLLBACK`,
+  `SAVEPOINT`, `ROLLBACK TO SAVEPOINT`, `RELEASE SAVEPOINT`). These are
+  connection/session-level operations. They access no row. They trigger
+  no policy.
+- Session variables and `set_config`. `app.current_tenant` is set once
+  at Begin time on the pgx.Tx connection. It does not change based on
+  who's calling `pgxTx.Commit()` later.
+- The Go-level `pgx.Tx` handle. Postgres has no concept of "who is the
+  current Go-level caller" — it sees only the connection that owns the
+  tx.
+
+So a caller authenticated as tenant A who learned a tenant B txID could
+trigger:
+- `Commit(ctxA, txBID)` — commits tenant B's tx prematurely.
+- `Rollback(ctxA, txBID)` — aborts tenant B's in-flight work.
+- `Savepoint(ctxA, txBID)` — creates a SAVEPOINT inside tenant B's tx.
+- `RollbackToSavepoint(ctxA, txBID, spID)` — destructively undoes
+  tenant B's DML state to the savepoint.
+- `ReleaseSavepoint(ctxA, txBID, spID)` — drops tenant B's savepoint.
+- `Join(ctxA, txBID)` — receives a context driving tenant B's tx.
+
+RLS continues to enforce data-path isolation correctly throughout —
+DML inside the pgx.Tx is RLS-scoped to tenant B (the tenant set at
+Begin time). But the lifecycle disruption is real.
+
+### Why this isn't covered by "RLS is intrinsic"
+
+The "RLS is intrinsic by design, application-layer is defense-in-depth"
+framing in `docs/plugins/POSTGRES.md` is correct **for data-path
+operations.** It is structurally not extendable to lifecycle: PostgreSQL
+has no row-level identity to compare against for lifecycle commands.
+Application-layer tenant gating is the only enforcement mechanism for
+lifecycle, across all three plugins (memory, sqlite, postgres).
+
+Pre-PR-C2, postgres was uniquely vulnerable on lifecycle despite having
+the strongest data-path protection.
+
+### Fix (PR-C2)
+
+A new `verifyTenant` helper in `transaction_manager.go` compares
+`uc.Tenant.ID` against the transaction's tenant (from
+`txState.tenantID` or `tm.tenants[txID]`). Every TM lifecycle method
+now calls it before performing any state mutation.
+
+```go
+func verifyTenant(ctx context.Context, txTenantID spi.TenantID, op string, txID string) error {
+    uc := spi.GetUserContext(ctx)
+    if uc == nil || uc.Tenant.ID != txTenantID {
+        return fmt.Errorf("%s: tenant mismatch on transaction %s", op, txID)
+    }
+    return nil
+}
+```
+
+This brings postgres to parity with memory and sqlite on lifecycle
+gating. RLS continues to provide defense-in-depth on the data path —
+it's not redundant with the lifecycle check, it's complementary.
+
+## Summary
+
+| Status | Methods |
+|---|---|
+| ✅ OpMu contract trivially satisfied (no OpMu-protected fields touched) | All TM methods, all EntityStore methods |
+| ✅ Tenant isolation present (already, before PR-C2) | `Begin` (resolves tenant from ctx) |
+| ✅ Tenant isolation added by PR-C2 | `Commit`, `Rollback`, `Join`, `Savepoint`, `RollbackToSavepoint`, `ReleaseSavepoint` |
+
+After PR-C2, the postgres plugin has zero outstanding tenant-isolation
+gaps on its TM lifecycle surface — same end-state as memory (post-PR-A)
+and sqlite (post-PR-C1). The OpMu contract is trivially satisfied due
+to postgres' fundamentally different concurrency model.
+
+## Pre-fix severity (security lens)
+
+`RollbackToSavepoint(ctxA, txBID, spID)` from tenant A was a
+**destructive integrity-loss path on tenant B's tx-state** at the
+PostgreSQL transaction level. RLS protected the data layer but not the
+lifecycle layer. Same blast radius as the parallel gaps PR-A and PR-C1
+closed in memory and sqlite. Mitigated in practice by 128-bit txID
+entropy, but a tenant A caller who learned a tenant B txID via
+logs/support channels could have exploited this without any auth
+bypass.
+
+## Regression tests
+
+`plugins/postgres/transaction_manager_tenant_test.go` — 6 tests, one per
+lifecycle method:
+- `TestPostgresCommit_RejectsCrossTenant`
+- `TestPostgresRollback_RejectsCrossTenant`
+- `TestPostgresJoin_RejectsCrossTenant`
+- `TestPostgresSavepoint_RejectsCrossTenant`
+- `TestPostgresRollbackToSavepoint_RejectsCrossTenant`
+- `TestPostgresReleaseSavepoint_RejectsCrossTenant`
+
+All FAIL pre-fix (verified by red-phase TDD), PASS post-fix. Require
+`CYODA_TEST_DB_URL` to point at a running PostgreSQL.
+
+## Pre-existing test cleanup
+
+PR-C2 also fixed one pre-existing test (`fcw_test.go:544`) that passed
+`context.Background()` to `tm.Commit`. With the new tenant gate this
+returns "tenant mismatch" (because `context.Background()` has no
+UserContext); the test now passes the test's own `ctx` (which has
+UserContext set up at the top), making it consistent with the contract
+that memory and sqlite have always enforced on Commit/Rollback.

--- a/docs/audits/2026-05-postgres-plugin-tx-locking.md
+++ b/docs/audits/2026-05-postgres-plugin-tx-locking.md
@@ -217,3 +217,24 @@ returns "tenant mismatch" (because `context.Background()` has no
 UserContext); the test now passes the test's own `ctx` (which has
 UserContext set up at the top), making it consistent with the contract
 that memory and sqlite have always enforced on Commit/Rollback.
+
+## Cross-plugin Join parity (review L-3)
+
+The PR-C2 code review surfaced an asymmetry: postgres' new `verifyTenant`
+is uniformly strict (rejects `uc == nil`), while memory and sqlite's
+`Join` was permissive on nil UC (`if uc != nil && tx.TenantID != "" &&
+uc.Tenant.ID != tx.TenantID`). Memory/sqlite Commit/Rollback have always
+been strict; only Join was the outlier.
+
+PR-C2 folds in the parity fix: memory and sqlite `Join` now use the
+strict pattern (`uc == nil || uc.Tenant.ID != tx.TenantID`), matching
+the rest of the SPI surface. Pre-fix, a caller that bypassed the auth
+middleware (or an internal helper that forgot to thread the request
+context) could Join an arbitrary active tx without any tenant check.
+Post-fix the gate is uniform across all three plugins.
+
+Regression tests:
+- `plugins/memory/txmanager_join_test.go::TestJoinRejectsNilUserContext`
+- `plugins/sqlite/savepoint_tenant_test.go::TestSqliteJoin_RejectsNilUserContext`
+
+Both FAIL pre-fix, PASS post-fix.

--- a/plugins/memory/txmanager.go
+++ b/plugins/memory/txmanager.go
@@ -130,9 +130,12 @@ func (m *TransactionManager) Join(ctx context.Context, txID string) (context.Con
 		return nil, fmt.Errorf("transaction already closed: %s", txID)
 	}
 
-	// Verify tenant matches if UserContext is available.
+	// Verify tenant matches. Strict — rejects nil UserContext to match
+	// Commit/Rollback's gate (#199 PR-C2 review L-3). Pre-PR-C2 this was
+	// permissive on nil UC, allowing any caller without a UserContext to
+	// Join an arbitrary active tx.
 	uc := spi.GetUserContext(ctx)
-	if uc != nil && tx.TenantID != "" && uc.Tenant.ID != tx.TenantID {
+	if uc == nil || uc.Tenant.ID != tx.TenantID {
 		return nil, fmt.Errorf("tenant mismatch on transaction join")
 	}
 

--- a/plugins/memory/txmanager_join_test.go
+++ b/plugins/memory/txmanager_join_test.go
@@ -204,3 +204,31 @@ func TestJoinConcurrentOperationAndCommit(t *testing.T) {
 	wg.Wait()
 	<-operationDone
 }
+
+// TestJoinRejectsNilUserContext verifies that Join rejects callers with no
+// UserContext (#199 PR-C2 review L-3). Memory's Join was permissive on
+// nil UC pre-fix: it accepted any caller as long as no tenant mismatch
+// could be detected. That's a tenant-isolation gap because a caller that
+// somehow bypassed authentication middleware (or an internal helper that
+// forgot to thread the request context) could Join into any active tx.
+//
+// Post-fix Join is uniformly strict, matching Commit/Rollback's existing
+// pattern (uc == nil OR mismatch -> reject).
+func TestJoinRejectsNilUserContext(t *testing.T) {
+	_, tm := newTxManager(t)
+	ctx := ctxWithTenant("tenant-A")
+
+	txID, _, err := tm.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	// Pass a context with NO UserContext — Join must reject.
+	if _, err := tm.Join(spi.WithTransaction(t.Context(), nil), txID); err == nil {
+		t.Fatal("expected error when joining without UserContext")
+	} else if !strings.Contains(err.Error(), "tenant mismatch") {
+		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	}
+
+	_ = tm.Rollback(ctx, txID)
+}

--- a/plugins/postgres/fcw_test.go
+++ b/plugins/postgres/fcw_test.go
@@ -12,7 +12,6 @@ package postgres_test
 //   - Write-write: caught by postgres native tuple-level DML locks (SQLSTATE 40001).
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -541,7 +540,10 @@ func TestFCW_PureReadSetConflict_NoWriteOverlap(t *testing.T) {
 		_ = tm.Rollback(txCtxB, txB)
 		t.Fatalf("Tx B update prs-x: %v", err)
 	}
-	if err := tm.Commit(context.Background(), txB); err != nil {
+	// Use ctx (which carries the test tenant) so the post-#199 PR-C2 tenant
+	// gate accepts this commit. context.Background() has no UserContext and
+	// would be rejected with a "tenant mismatch" error.
+	if err := tm.Commit(ctx, txB); err != nil {
 		t.Fatalf("Tx B Commit: %v", err)
 	}
 

--- a/plugins/postgres/transaction_manager.go
+++ b/plugins/postgres/transaction_manager.go
@@ -104,6 +104,14 @@ func (tm *TransactionManager) Begin(ctx context.Context) (string, context.Contex
 // Returns spi.ErrConflict on serialization failure (PostgreSQL error 40001)
 // or when the application-layer first-committer-wins validation detects a
 // stale read or write set.
+//
+// Tenant isolation (issue #199 PR-C2): rejects callers whose UserContext
+// tenant does not match the transaction's tenant. RLS protects data-path
+// access (every DML is row-level filtered) but does not extend to
+// transaction-lifecycle commands (BEGIN/COMMIT/ROLLBACK/SAVEPOINT/etc.) —
+// those operate on connections and don't trigger any policy. So the
+// application-layer tenant gate is the only protection against a caller
+// authenticated as tenant A committing tenant B's in-flight work.
 func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
@@ -112,6 +120,9 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 	state, ok := tm.lookupTxState(txID)
 	if !ok {
 		return fmt.Errorf("Commit: tx state for %s not found", txID)
+	}
+	if err := verifyTenant(ctx, state.tenantID, "Commit", txID); err != nil {
+		return err
 	}
 
 	// --- First-committer-wins validation (read-set) ---
@@ -195,10 +206,21 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 }
 
 // Rollback aborts the transaction.
+//
+// Tenant isolation (issue #199 PR-C2): rejects mismatched-tenant callers.
+// See Commit's godoc for the design rationale.
 func (tm *TransactionManager) Rollback(ctx context.Context, txID string) error {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
 		return fmt.Errorf("Rollback: transaction %s not found", txID)
+	}
+
+	tenantID, ok := tm.lookupTenant(txID)
+	if !ok {
+		return fmt.Errorf("Rollback: transaction %s not found", txID)
+	}
+	if err := verifyTenant(ctx, tenantID, "Rollback", txID); err != nil {
+		return err
 	}
 
 	err := pgxTx.Rollback(ctx)
@@ -212,18 +234,23 @@ func (tm *TransactionManager) Rollback(ctx context.Context, txID string) error {
 
 // Join attaches to an existing transaction, returning a context carrying its
 // TransactionState.
+//
+// Tenant isolation (issue #199 PR-C2): rejects mismatched-tenant callers.
+// Returning a context for another tenant's tx would let the joining caller
+// drive arbitrary lifecycle operations on that tx — see Commit's godoc.
 func (tm *TransactionManager) Join(ctx context.Context, txID string) (context.Context, error) {
 	_, ok := tm.registry.Lookup(txID)
 	if !ok {
 		return nil, fmt.Errorf("Join: transaction %s not found", txID)
 	}
 
-	var tenantID spi.TenantID
-	func() {
-		tm.mu.Lock()
-		defer tm.mu.Unlock()
-		tenantID = tm.tenants[txID]
-	}()
+	tenantID, ok := tm.lookupTenant(txID)
+	if !ok {
+		return nil, fmt.Errorf("Join: transaction %s not found", txID)
+	}
+	if err := verifyTenant(ctx, tenantID, "Join", txID); err != nil {
+		return nil, err
+	}
 
 	txState := &spi.TransactionState{
 		ID:       txID,
@@ -283,6 +310,8 @@ func (tm *TransactionManager) lookupTxState(txID string) (*txState, bool) {
 
 // Savepoint creates a named savepoint within the given PostgreSQL transaction
 // and pushes a snapshot of the current readSet/writeSet onto the txState stack.
+//
+// Tenant isolation (issue #199 PR-C2): rejects mismatched-tenant callers.
 func (tm *TransactionManager) Savepoint(ctx context.Context, txID string) (string, error) {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
@@ -291,6 +320,9 @@ func (tm *TransactionManager) Savepoint(ctx context.Context, txID string) (strin
 	state, ok := tm.lookupTxState(txID)
 	if !ok {
 		return "", fmt.Errorf("Savepoint: tx state for %s not found", txID)
+	}
+	if err := verifyTenant(ctx, state.tenantID, "Savepoint", txID); err != nil {
+		return "", err
 	}
 	spID := uuid.UUID(tm.uuids.NewTimeUUID()).String()
 	spName := "sp_" + spID
@@ -303,6 +335,9 @@ func (tm *TransactionManager) Savepoint(ctx context.Context, txID string) (strin
 
 // RollbackToSavepoint rolls back all work done since the named savepoint and
 // restores the txState readSet/writeSet to the snapshot captured at that savepoint.
+//
+// Tenant isolation (issue #199 PR-C2): rejects mismatched-tenant callers —
+// destructive on tx-state.
 func (tm *TransactionManager) RollbackToSavepoint(ctx context.Context, txID string, savepointID string) error {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
@@ -311,6 +346,9 @@ func (tm *TransactionManager) RollbackToSavepoint(ctx context.Context, txID stri
 	state, ok := tm.lookupTxState(txID)
 	if !ok {
 		return fmt.Errorf("RollbackToSavepoint: tx state for %s not found", txID)
+	}
+	if err := verifyTenant(ctx, state.tenantID, "RollbackToSavepoint", txID); err != nil {
+		return err
 	}
 	spName := "sp_" + savepointID
 	if _, err := pgxTx.Exec(ctx, "ROLLBACK TO SAVEPOINT "+pgx.Identifier{spName}.Sanitize()); err != nil {
@@ -324,6 +362,8 @@ func (tm *TransactionManager) RollbackToSavepoint(ctx context.Context, txID stri
 
 // ReleaseSavepoint releases a savepoint, merging its work into the parent transaction.
 // The txState snapshot for this savepoint is dropped; work done after the push is kept.
+//
+// Tenant isolation (issue #199 PR-C2): rejects mismatched-tenant callers.
 func (tm *TransactionManager) ReleaseSavepoint(ctx context.Context, txID string, savepointID string) error {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
@@ -333,12 +373,45 @@ func (tm *TransactionManager) ReleaseSavepoint(ctx context.Context, txID string,
 	if !ok {
 		return fmt.Errorf("ReleaseSavepoint: tx state for %s not found", txID)
 	}
+	if err := verifyTenant(ctx, state.tenantID, "ReleaseSavepoint", txID); err != nil {
+		return err
+	}
 	spName := "sp_" + savepointID
 	if _, err := pgxTx.Exec(ctx, "RELEASE SAVEPOINT "+pgx.Identifier{spName}.Sanitize()); err != nil {
 		return fmt.Errorf("ReleaseSavepoint: %w", err)
 	}
 	if err := state.ReleaseSavepoint(savepointID); err != nil {
 		return fmt.Errorf("ReleaseSavepoint: %w", err)
+	}
+	return nil
+}
+
+// lookupTenant returns the tenant recorded for a transaction, or false if
+// the txID is not active. Used by Rollback / Join where a txState lookup
+// is not otherwise needed.
+func (tm *TransactionManager) lookupTenant(txID string) (spi.TenantID, bool) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	tenantID, ok := tm.tenants[txID]
+	return tenantID, ok
+}
+
+// verifyTenant compares the caller's UserContext tenant against the
+// transaction's tenant. Returns a "tenant mismatch" error on mismatch
+// or when no UserContext is present. Mirrors the pattern used by the
+// memory and sqlite plugins for application-layer tenant gating on
+// TM lifecycle methods.
+//
+// RLS (PostgreSQL row-level security) protects data-path access but does
+// NOT extend to transaction-lifecycle commands (BEGIN/COMMIT/ROLLBACK/
+// SAVEPOINT/etc.) — those operate on connections and don't trigger any
+// policy. The application-layer check is the only enforcement against a
+// caller authenticated as tenant A driving lifecycle operations on
+// tenant B's in-flight transaction.
+func verifyTenant(ctx context.Context, txTenantID spi.TenantID, op string, txID string) error {
+	uc := spi.GetUserContext(ctx)
+	if uc == nil || uc.Tenant.ID != txTenantID {
+		return fmt.Errorf("%s: tenant mismatch on transaction %s", op, txID)
 	}
 	return nil
 }

--- a/plugins/postgres/transaction_manager_tenant_test.go
+++ b/plugins/postgres/transaction_manager_tenant_test.go
@@ -1,0 +1,150 @@
+package postgres_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// Tenant-isolation regression tests for the postgres plugin's TM lifecycle
+// methods. Issue #199 PR-C2: the postgres TM relied solely on PostgreSQL's
+// row-level security (RLS) for tenant isolation. RLS is row-level and does
+// NOT extend to transaction-lifecycle commands (BEGIN/COMMIT/ROLLBACK/
+// SAVEPOINT/etc.) — those operate on connections and don't trigger any
+// policy. So a caller authenticated as tenant A who learned a tenant B
+// txID could:
+//
+//   - Commit(ctxA, txBID) — commit tenant B's tx prematurely.
+//   - Rollback(ctxA, txBID) — abort tenant B's in-flight work.
+//   - Join(ctxA, txBID) — receive a context driving tenant B's tx.
+//   - Savepoint/RollbackToSavepoint/ReleaseSavepoint(ctxA, txBID, ...) —
+//     manipulate tenant B's tx state.
+//
+// All operations remained RLS-bound at the data layer (any DML inside the
+// pgxTx still ran with app.current_tenant=B, set at Begin), but the
+// lifecycle disruption is real. PR-C2 closes the gap by adding
+// application-layer tenant verification on every TM lifecycle method,
+// matching the memory and sqlite plugins.
+//
+// These tests require Docker (testcontainers-go for PostgreSQL).
+
+func TestPostgresCommit_RejectsCrossTenant(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctxA := ctxWithTenant("tenant-A")
+	ctxB := ctxWithTenant("tenant-B")
+
+	txAID, _, err := tm.Begin(ctxA)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+
+	if err := tm.Commit(ctxB, txAID); err == nil {
+		t.Fatal("expected error when tenant B commits tenant A's tx")
+	} else if !strings.Contains(err.Error(), "tenant mismatch") {
+		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	}
+
+	_ = tm.Rollback(ctxA, txAID)
+}
+
+func TestPostgresRollback_RejectsCrossTenant(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctxA := ctxWithTenant("tenant-A")
+	ctxB := ctxWithTenant("tenant-B")
+
+	txAID, _, err := tm.Begin(ctxA)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+
+	if err := tm.Rollback(ctxB, txAID); err == nil {
+		t.Fatal("expected error when tenant B rolls back tenant A's tx")
+	} else if !strings.Contains(err.Error(), "tenant mismatch") {
+		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	}
+
+	_ = tm.Rollback(ctxA, txAID)
+}
+
+func TestPostgresJoin_RejectsCrossTenant(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctxA := ctxWithTenant("tenant-A")
+	ctxB := ctxWithTenant("tenant-B")
+
+	txAID, _, err := tm.Begin(ctxA)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+
+	if _, err := tm.Join(ctxB, txAID); err == nil {
+		t.Fatal("expected error when tenant B joins tenant A's tx")
+	} else if !strings.Contains(err.Error(), "tenant mismatch") {
+		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	}
+
+	_ = tm.Rollback(ctxA, txAID)
+}
+
+func TestPostgresSavepoint_RejectsCrossTenant(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctxA := ctxWithTenant("tenant-A")
+	ctxB := ctxWithTenant("tenant-B")
+
+	txAID, _, err := tm.Begin(ctxA)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+
+	if _, err := tm.Savepoint(ctxB, txAID); err == nil {
+		t.Fatal("expected error when tenant B takes savepoint on tenant A's tx")
+	} else if !strings.Contains(err.Error(), "tenant mismatch") {
+		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	}
+
+	_ = tm.Rollback(ctxA, txAID)
+}
+
+func TestPostgresRollbackToSavepoint_RejectsCrossTenant(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctxA := ctxWithTenant("tenant-A")
+	ctxB := ctxWithTenant("tenant-B")
+
+	txAID, _, err := tm.Begin(ctxA)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	spID, err := tm.Savepoint(ctxA, txAID)
+	if err != nil {
+		t.Fatalf("Savepoint: %v", err)
+	}
+
+	if err := tm.RollbackToSavepoint(ctxB, txAID, spID); err == nil {
+		t.Fatal("expected error when tenant B rolls back tenant A's savepoint")
+	} else if !strings.Contains(err.Error(), "tenant mismatch") {
+		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	}
+
+	_ = tm.Rollback(ctxA, txAID)
+}
+
+func TestPostgresReleaseSavepoint_RejectsCrossTenant(t *testing.T) {
+	tm, _ := newTestTxManager(t)
+	ctxA := ctxWithTenant("tenant-A")
+	ctxB := ctxWithTenant("tenant-B")
+
+	txAID, _, err := tm.Begin(ctxA)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	spID, err := tm.Savepoint(ctxA, txAID)
+	if err != nil {
+		t.Fatalf("Savepoint: %v", err)
+	}
+
+	if err := tm.ReleaseSavepoint(ctxB, txAID, spID); err == nil {
+		t.Fatal("expected error when tenant B releases tenant A's savepoint")
+	} else if !strings.Contains(err.Error(), "tenant mismatch") {
+		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	}
+
+	_ = tm.Rollback(ctxA, txAID)
+}

--- a/plugins/sqlite/savepoint_tenant_test.go
+++ b/plugins/sqlite/savepoint_tenant_test.go
@@ -101,3 +101,29 @@ func TestSqliteReleaseSavepoint_RejectsCrossTenant(t *testing.T) {
 
 	_ = tm.Rollback(ctxA, txAID)
 }
+
+// TestSqliteJoin_RejectsNilUserContext mirrors the memory plugin's
+// TestJoinRejectsNilUserContext (#199 PR-C2 review L-3). Sqlite's Join
+// was permissive on nil UC pre-fix, allowing any caller without a
+// UserContext to Join an arbitrary active tx. Post-fix Join is uniformly
+// strict, matching Commit/Rollback.
+func TestSqliteJoin_RejectsNilUserContext(t *testing.T) {
+	factory, ctxA := newTxMgrForTenantTest(t)
+	tm, err := factory.TransactionManager(ctxA)
+	if err != nil {
+		t.Fatalf("TransactionManager failed: %v", err)
+	}
+
+	txAID, _, err := tm.Begin(ctxA)
+	if err != nil {
+		t.Fatalf("Begin failed: %v", err)
+	}
+
+	if _, err := tm.Join(context.Background(), txAID); err == nil {
+		t.Fatal("expected error when joining without UserContext")
+	} else if !strings.Contains(err.Error(), "tenant mismatch") {
+		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	}
+
+	_ = tm.Rollback(ctxA, txAID)
+}

--- a/plugins/sqlite/txmanager.go
+++ b/plugins/sqlite/txmanager.go
@@ -130,9 +130,12 @@ func (m *transactionManager) Join(ctx context.Context, txID string) (context.Con
 		return nil, fmt.Errorf("transaction already closed: %s", txID)
 	}
 
-	// Verify tenant matches if UserContext is available.
+	// Verify tenant matches. Strict — rejects nil UserContext to match
+	// Commit/Rollback's gate (#199 PR-C2 review L-3). Pre-PR-C2 this was
+	// permissive on nil UC, allowing any caller without a UserContext to
+	// Join an arbitrary active tx.
 	uc := spi.GetUserContext(ctx)
-	if uc != nil && tx.TenantID != "" && uc.Tenant.ID != tx.TenantID {
+	if uc == nil || uc.Tenant.ID != tx.TenantID {
 		return nil, fmt.Errorf("tenant mismatch on transaction join")
 	}
 


### PR DESCRIPTION
## Summary

PR-C2 of #199. Originally scoped as audit-only. The deep-dive during the audit surfaced a substantial pre-existing tenant-isolation gap that grew PR-C2 into a code-fixing PR.

**Pre-PR-C2 gap:** the postgres TM lifecycle methods (`Commit`, `Rollback`, `Join`, `Savepoint`, `RollbackToSavepoint`, `ReleaseSavepoint`) did not verify the caller's `UserContext` tenant against the transaction's tenant. Memory and sqlite plugins always had this check on Commit/Rollback (and PR-A/PR-C1 extended it to the savepoint trio); postgres lacked it across the entire surface.

## Why RLS doesn't cover this

The `docs/plugins/POSTGRES.md` framing — "RLS is intrinsic by design, application-layer is defense-in-depth" — is correct **for data-path operations.** Every DML against `entities`/`entity_versions`/etc. is RLS-bound to the tx's tenant via `set_config('app.current_tenant')`.

But RLS is structurally **row-level**. It does NOT extend to transaction-lifecycle commands (`BEGIN`/`COMMIT`/`ROLLBACK`/`SAVEPOINT`/`ROLLBACK TO SAVEPOINT`/`RELEASE SAVEPOINT`). Those operate on connections, access no row, and trigger no policy. PostgreSQL has no concept of "who is the current Go-level caller" — it sees only the connection that owns the tx.

So a caller authenticated as tenant A who learned a tenant B txID could:
- `Commit(ctxA, txBID)` — commit tenant B's tx prematurely.
- `Rollback(ctxA, txBID)` — abort tenant B's in-flight work.
- `RollbackToSavepoint(ctxA, txBID, spID)` — destructively undo tenant B's DML state to a savepoint.

RLS continues to enforce data-path isolation correctly throughout, but the lifecycle disruption is real. Pre-PR-C2, postgres was uniquely vulnerable on lifecycle despite having the strongest data-path protection.

## What changed

- **`plugins/postgres/transaction_manager.go`:** added `verifyTenant` helper (compares `uc.Tenant.ID` against `txState.tenantID` or `tm.tenants[txID]`); called from every TM lifecycle method before any state mutation. Added `lookupTenant` helper for paths that don't otherwise need a `txState` lookup (Rollback, Join).
- **`plugins/postgres/transaction_manager_tenant_test.go`:** new file, 6 regression tests (one per lifecycle method). All FAIL pre-fix, PASS post-fix.
- **`plugins/postgres/fcw_test.go:544`:** pre-existing test passing `context.Background()` to `tm.Commit` updated to pass the test's `ctx` (which has UserContext set up at the top). `context.Background()` has no UserContext and is now rejected, matching memory/sqlite behavior.
- **`docs/audits/2026-05-postgres-plugin-tx-locking.md`:** new audit doc covering both the OpMu trivial-satisfaction story (postgres uses a different concurrency model — the SPI fields are unused) and the tenant-isolation fix.

## OpMu contract — trivially satisfied

Postgres delegates SI to PostgreSQL's MVCC engine. Per-tx FCW bookkeeping lives in an internal `txState` struct (`plugins/postgres/txstate.go`) entirely separate from `*spi.TransactionState`. The SPI v0.6.1 OpMu contract protects fields (`Buffer`/`ReadSet`/`WriteSet`/`Deletes`/`RolledBack`/`Closed`) that postgres simply doesn't touch — `spi.TransactionState` carries only `ID` and `TenantID` for postgres.

The contract holds vacuously. The audit doc captures this so a future contributor doesn't add `tx.OpMu.RLock()` speculatively.

## Test plan

- [x] **Tenant-isolation regression tests** (6) — `Commit`, `Rollback`, `Join`, `Savepoint`, `RollbackToSavepoint`, `ReleaseSavepoint`. All FAIL pre-fix, PASS post-fix. Verified via TDD red-then-green.
- [x] **Full postgres test suite** green (~20s with a real PG via Docker). 
- [x] **`go vet ./plugins/postgres/...`** clean.
- [x] **Memory + sqlite** plugin tests still green (no cross-plugin impact).
- [x] **Root module short tests** green.

## Pre-fix severity (security)

Same blast radius as the parallel gaps PR-A and PR-C1 closed in memory and sqlite — `RollbackToSavepoint(ctxA, txBID, spID)` was a destructive integrity-loss path on tenant B's tx-state at the PostgreSQL transaction level. Mitigated in practice by 128-bit txID entropy. Not introduced by #199 — pre-existing across the entire history of the postgres plugin.

## What's next

- PR-C3: \`docs/CONCURRENCY.md\` — the original PR-C deliverable; per-node lock inventory, state-scope table, cluster-routing failure modes. Cross-links to ARCHITECTURE.md §4 and CONSISTENCY.md.

After PR-C2 + PR-C3, issue #199 is fully complete.

## References

- cyoda-go #199: https://github.com/Cyoda-platform/cyoda-go/issues/199
- PR #201 (memory plugin, merged): https://github.com/Cyoda-platform/cyoda-go/pull/201
- PR #202 (SPI v0.6.1 bump, merged): https://github.com/Cyoda-platform/cyoda-go/pull/202
- PR #203 (sqlite plugin, merged): https://github.com/Cyoda-platform/cyoda-go/pull/203
- cyoda-go-spi PR #6 (godoc contract, merged): https://github.com/Cyoda-platform/cyoda-go-spi/pull/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)