### PR TITLE
chore(deps): bump docker/setup-buildx-action from 3 to 4

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -31,7 +31,7 @@ jobs:
           go-version-file: go.mod
 
       - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Tag a non-prerelease snapshot version
         run: git tag v0.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         uses: docker/login-action@v4


### PR DESCRIPTION
Recreates dependabot PR #189 against `release/v0.7.0`. The original PR's `release-smoke` was failing because the dependabot branch is based on `main`, where root `go.sum` still references the pre-bump `gofrs/flock v0.12.1` / `ncruces/go-sqlite3 v0.33.3` — versions that no longer match `plugins/sqlite/go.mod`. `release/v0.7.0` already has the corrected indirect deps, so smoke can actually exercise `setup-buildx-action@v4` here.

Closes #189.

## Smoke check
- [ ] `release-smoke` passes (the actual exercise of `setup-buildx-action@v4`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)