### PR TITLE
fix(release): publish install.sh as a release asset + adopt stable URL (#49)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -171,3 +171,7 @@ release:
   extra_files:
     - glob: ./.release-extras/cyoda_help_*.tar.gz
     - glob: ./.release-extras/cyoda_help_*.json
+    # Publish install.sh as a release asset so the canonical install URL
+    # is `/releases/latest/download/install.sh` — pinned per-release rather
+    # than tracking `main` (issue #49).
+    - glob: ./scripts/install.sh

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ without an on-disk config. Homebrew does not auto-init because its
 ### Any Unix via curl
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cyoda-platform/cyoda-go/main/scripts/install.sh | sh
+curl -fsSL https://github.com/cyoda-platform/cyoda-go/releases/latest/download/install.sh | sh
 ```
 
 Installs to `~/.local/bin/cyoda` and runs `cyoda init`. Override the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@
 # and runs 'cyoda init' to enable sqlite persistence.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/cyoda-platform/cyoda-go/main/scripts/install.sh | sh
+#   curl -fsSL https://github.com/cyoda-platform/cyoda-go/releases/latest/download/install.sh | sh
 #
 # Pin a version:
 #   CYODA_VERSION=v0.2.0 curl -fsSL ... | sh


### PR DESCRIPTION
Closes #49.

Promotes the canonical installer URL from
\`raw.githubusercontent.com/cyoda-platform/cyoda-go/main/scripts/install.sh\`
to \`github.com/cyoda-platform/cyoda-go/releases/latest/download/install.sh\`.

## Why

The raw-on-main URL is a moving target — every commit to \`main\` that touches \`scripts/install.sh\` goes live immediately for every new \`curl | sh\` user. The release-asset URL is pinned per-release, so the bytes a user pipes to \`sh\` match the release they install. (See #49's full risk analysis.)

## Changes

- \`.goreleaser.yaml\` — add \`scripts/install.sh\` to \`release.extra_files\` so it ships as \`install.sh\` on every release.
- \`README.md\` — install one-liner uses the release-asset URL.
- \`scripts/install.sh\` — update the usage-comment URL to match.

## Backward compatibility

The raw-on-main URL keeps working — \`scripts/install.sh\` stays in the repo. Old documentation, blog posts, etc., continue to function unchanged. No redirect needed; just promotion of the better URL.

## Acceptance from #49

- [x] README Install section uses \`/releases/latest/download/install.sh\` URL
- [x] GoReleaser config attaches \`install.sh\` as a release asset on every release
- [ ] *Optional: cosign signature on the installer* — out of scope here, will be picked up by #47
- [x] CODEOWNERS / branch protection covers \`scripts/install.sh\` — repo currently has no \`CODEOWNERS\` file; \`main\` branch protection already requires PR review for any change. No additional file needed unless we want narrower per-path ownership (separate decision)

## Test plan

- [x] \`goreleaser check\` validates the config
- [ ] \`release-smoke\` CI job exercises a full snapshot release on this PR — verifies \`install.sh\` is staged for release-asset upload
- [x] \`go vet ./...\` clean
- [x] \`go test -short ./...\` green (no Go code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)