### PR TITLE
test(parity): unblock #150/#152 skips — server-side fixes already delivered

### DIFF
--- a/e2e/parity/externalapi/negative_validation.go
+++ b/e2e/parity/externalapi/negative_validation.go
@@ -144,17 +144,11 @@ func RunExternalAPI_12_04_GetEntityAtTimeBeforeCreation(t *testing.T, fixture pa
 
 // RunExternalAPI_12_05_GetEntityWithBogusTransactionID — dictionary 12/neg/05.
 // Dictionary expects HTTP 404 + EntityNotFoundException for a bogus
-// transactionId.
-//
-// worse: cyoda-go's GetOneEntity handler currently does not honor the
-// transactionId query param — server returns the current entity (HTTP
-// 200) regardless of the transactionId supplied. Server-side wiring
-// tracked by #150; the parity-client surface (delivered via #132) is
-// in place. Test body below is ready for when #150 lands; remove the
-// t.Skip then.
+// transactionId. equiv_or_better: cyoda-go's GetOneEntity scans the
+// version history for the supplied transactionId and returns
+// ENTITY_NOT_FOUND@404 on miss, matching the dictionary expectation.
 func RunExternalAPI_12_05_GetEntityWithBogusTransactionID(t *testing.T, fixture parity.BackendFixture) {
 	t.Helper()
-	t.Skip("pending #150 (worse): GetOneEntity ignores transactionId query param. Parity-client surface delivered via #132; close this skip when #150 lands.")
 	d := driver.NewInProcess(t, fixture)
 	if err := d.CreateModelFromSample("neg5", 1, `{"k":1}`); err != nil {
 		t.Fatalf("create: %v", err)

--- a/e2e/parity/externalapi/point_in_time.go
+++ b/e2e/parity/externalapi/point_in_time.go
@@ -76,13 +76,10 @@ func RunExternalAPI_07_01_GetEntityAtPointInTime(t *testing.T, fixture parity.Ba
 // RunExternalAPI_07_02_GetEntityByTransactionID — dictionary 07/02.
 // Dictionary expects GET /entity/{id}?transactionId=<tx> to return the
 // entity envelope as it stood at that transaction.
-//
-// Status: parity-client surface (GetEntityByTransactionID) is in place
-// per #132. The underlying GetOneEntity handler currently ignores the
-// transactionId query parameter (server-side gap tracked by #150) and
-// returns the latest entity instead of the at-tx snapshot. The body
-// below probes for that gap and skips with a #150 reference until the
-// server-side wiring lands.
+// equiv_or_better: cyoda-go's GetOneEntity routes the transactionId
+// param into the service, which scans the entity's version history
+// and returns the matching version's envelope (or ENTITY_NOT_FOUND@404
+// on a miss — exercised by 12/neg/05).
 func RunExternalAPI_07_02_GetEntityByTransactionID(t *testing.T, fixture parity.BackendFixture) {
 	t.Helper()
 	d := driver.NewInProcess(t, fixture)
@@ -118,14 +115,8 @@ func RunExternalAPI_07_02_GetEntityByTransactionID(t *testing.T, fixture parity.
 	if err != nil {
 		t.Fatalf("GetEntityByTransactionID: %v", err)
 	}
-	// worse: cyoda-go's GetOneEntity handler does not yet honor the
-	// transactionId query param (it parses pointInTime only). The server
-	// returns the latest entity instead of the at-transaction snapshot.
-	// Until the handler routes transactionId, this assertion documents
-	// the divergence: the dictionary expects k=1 (the createTxID
-	// snapshot), but cyoda-go currently returns the latest k=3.
 	if v, _ := got.Data["k"].(float64); v != float64(1) {
-		t.Skipf("pending #150 (worse): GET ?transactionId=<createTxID> returned k=%v want 1; transactionId silently dropped by GetOneEntity handler. Parity-client surface delivered via #132; close this skip when #150 lands.", got.Data["k"])
+		t.Errorf("data.k: got %v, want 1 (the createTxID snapshot, before subsequent updates)", got.Data["k"])
 	}
 	if got.Meta.TransactionID != createTxID {
 		t.Errorf("meta.transactionId: got %q want %q", got.Meta.TransactionID, createTxID)


### PR DESCRIPTION
Closes #150.
Closes #152.

While preparing the v0.7.0 milestone backlog I discovered that both \`GetOneEntity\` (transactionId) and \`GetEntityChangesMetadata\` (pointInTime) handler-param drops have **already been fixed server-side** — likely as part of PR #195's broad OpenAPI conformance reconciliation. The handler at \`internal/domain/entity/handler.go:326-358\` routes \`params.TransactionId\` into the service input, the service scans version history and returns \`ENTITY_NOT_FOUND@404\` on a miss; \`GetEntityChangesMetadata\` truncates the returned slice to \`timeOfChange <= pointInTime\`.

The parity scenarios were left skip-gated with \`#150\`/\`#152\` references. This PR removes the gates and tightens the assertions.

## Changes

| File | Change |
|---|---|
| \`e2e/parity/externalapi/point_in_time.go\` | \`07_02_GetEntityByTransactionID\`: drop conditional \`t.Skipf\` → hard assertion that \`data.k == 1\` (the at-tx snapshot, not the latest) |
| \`e2e/parity/externalapi/negative_validation.go\` | \`12_05_GetEntityWithBogusTransactionID\`: drop unconditional \`t.Skip\` → exercise that bogus tx returns \`ENTITY_NOT_FOUND@404\` |

\`07_04_ChangeHistoryAtPointInTime\` (#152) was already running with no skip gate, just confirmed it stays green.

## Test plan

- [x] \`go test ./e2e/parity/memory/... -run TestParity/ExternalAPI_07_02|TestParity/ExternalAPI_07_04|TestParity/ExternalAPI_12_05\` — all PASS
- [x] Same on \`./e2e/parity/sqlite/...\` and \`./e2e/parity/postgres/...\` — all PASS
- [x] \`go test -short ./...\` (root) green
- [x] \`go test -race -short ./...\` green
- [x] \`go vet ./...\` clean

## Note on #176-style hygiene

Like #176 and #199, the work for #150/#152 landed in PRs that targeted \`release/v0.7.0\`, so GitHub's auto-close did not fire. Closing manually at merge time per the release-branch issue-closure protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)