### PR TITLE
feat(fixtureutil): add LaunchCyodaClusterAndComputeWithBinaries (#157)

### DIFF
--- a/e2e/parity/fixtureutil/cluster_with_binaries_test.go
+++ b/e2e/parity/fixtureutil/cluster_with_binaries_test.go
@@ -1,0 +1,81 @@
+package fixtureutil_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/fixtureutil"
+)
+
+// TestLaunchCyodaClusterAndComputeWithBinaries — issue #157.
+//
+// Out-of-tree consumers (plugins maintained in their own repos, e.g.
+// cyoda-go-cassandra) need to drive the shared parity scenario suite
+// against *their* cmd/cyoda-go binary that blank-imports their backend.
+// The single-node analogue LaunchCyodaAndComputeWithBinaries already
+// exists; this test pins the cluster symmetry.
+//
+// The function must accept caller-supplied binary paths and otherwise
+// reuse the same cluster-bootstrap logic as LaunchCyodaClusterAndCompute
+// (port allocation × 4 per node, gossip-seed CSV, HMAC secret derivation,
+// concurrent health probing, compute-client wiring to node 0).
+func TestLaunchCyodaClusterAndComputeWithBinaries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cluster launch under -short")
+	}
+
+	cyodaBin, err := fixtureutil.BuildCyodaBinary()
+	if err != nil {
+		t.Fatalf("BuildCyodaBinary: %v", err)
+	}
+	computeBin, err := fixtureutil.BuildComputeBinary()
+	if err != nil {
+		t.Fatalf("BuildComputeBinary: %v", err)
+	}
+
+	ks, err := fixtureutil.GenerateJWTKeySet()
+	if err != nil {
+		t.Fatalf("GenerateJWTKeySet: %v", err)
+	}
+
+	const n = 2
+	result, cleanup, err := fixtureutil.LaunchCyodaClusterAndComputeWithBinaries(
+		cyodaBin, computeBin, ks, n,
+		[]string{"CYODA_STORAGE_BACKEND=memory"},
+	)
+	if err != nil {
+		t.Fatalf("LaunchCyodaClusterAndComputeWithBinaries: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	if got := len(result.BaseURLs); got != n {
+		t.Fatalf("BaseURLs: got %d entries, want %d", got, n)
+	}
+	if result.GRPCEndpoint == "" {
+		t.Errorf("GRPCEndpoint is empty")
+	}
+	if len(result.CyodaCmds) != n {
+		t.Errorf("CyodaCmds: got %d, want %d", len(result.CyodaCmds), n)
+	}
+	if result.ComputeCmd == nil {
+		t.Errorf("ComputeCmd is nil")
+	}
+
+	// Each node should be reachable on /api/health. Compute-client and
+	// node-0 readiness are already verified internally before the launcher
+	// returns; confirm the *other* nodes too so cluster-mode bootstrap
+	// (gossip seed CSV, HMAC sharing) actually succeeded for them.
+	client := &http.Client{Timeout: 2 * time.Second}
+	for i, baseURL := range result.BaseURLs {
+		resp, err := client.Get(baseURL + "/api/health")
+		if err != nil {
+			t.Errorf("node %d health: %v", i, err)
+			continue
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("node %d health: got status %d, want 200", i, resp.StatusCode)
+		}
+	}
+}

--- a/e2e/parity/fixtureutil/fixtureutil.go
+++ b/e2e/parity/fixtureutil/fixtureutil.go
@@ -534,12 +534,16 @@ const gossipSettleDelay = 1 * time.Second
 
 // LaunchCyodaClusterAndCompute builds the stock cyoda + compute
 // binaries and launches n cyoda-go subprocesses sharing the supplied
-// backing storage (carried in extraEnv). Cluster bootstrap envs
-// (CYODA_CLUSTER_ENABLED, CYODA_NODE_ID, CYODA_NODE_ADDR,
-// CYODA_GOSSIP_ADDR, CYODA_SEED_NODES, CYODA_HMAC_SECRET) are added
-// per node by this function — callers MUST NOT supply them. extraEnv
-// is for backend wiring only (e.g. CYODA_STORAGE_BACKEND=postgres,
-// CYODA_POSTGRES_URL=...).
+// backing storage (carried in extraEnv). Use this from in-tree parity
+// tests. For out-of-tree consumers (e.g. cyoda-go-cassandra's full
+// binary) that need to inject their own pre-built cyoda binary, use
+// LaunchCyodaClusterAndComputeWithBinaries.
+//
+// Cluster bootstrap envs (CYODA_CLUSTER_ENABLED, CYODA_NODE_ID,
+// CYODA_NODE_ADDR, CYODA_GOSSIP_ADDR, CYODA_SEED_NODES,
+// CYODA_HMAC_SECRET) are added per node by this function — callers
+// MUST NOT supply them. extraEnv is for backend wiring only (e.g.
+// CYODA_STORAGE_BACKEND=postgres, CYODA_POSTGRES_URL=...).
 //
 // Allocates n × 4 free ports (HTTP, gRPC, gossip, admin) for per-node
 // isolation.
@@ -548,10 +552,6 @@ const gossipSettleDelay = 1 * time.Second
 // cleanup function kills all subprocesses; the caller is responsible
 // for any external resource (e.g. the postgres testcontainer).
 func LaunchCyodaClusterAndCompute(ks *JWTKeySet, n int, extraEnv []string, opts ...LaunchOpts) (*ClusterLaunchResult, func(), error) {
-	if n < 1 {
-		return nil, nil, fmt.Errorf("LaunchCyodaClusterAndCompute: n must be >= 1, got %d", n)
-	}
-
 	cyodaBin, err := BuildCyodaBinary()
 	if err != nil {
 		return nil, nil, err
@@ -560,7 +560,26 @@ func LaunchCyodaClusterAndCompute(ks *JWTKeySet, n int, extraEnv []string, opts 
 	if err != nil {
 		return nil, nil, err
 	}
+	return LaunchCyodaClusterAndComputeWithBinaries(cyodaBin, computeBin, ks, n, extraEnv, opts...)
+}
 
+// LaunchCyodaClusterAndComputeWithBinaries is the binary-path-explicit
+// variant of LaunchCyodaClusterAndCompute. Out-of-tree consumers
+// maintaining their own backend plugin (e.g. cyoda-go-cassandra) build
+// a cmd/cyoda-go binary that blank-imports their plugin, then drive the
+// shared parity scenario suite against that binary by passing its path
+// here. Issue #157 — symmetric to LaunchCyodaAndComputeWithBinaries.
+//
+// cyodaBin and computeBin must be absolute paths to already-built
+// executables. All cluster-bootstrap logic (port allocation, gossip
+// seed CSV, HMAC derivation, health probing, compute-client wiring to
+// node 0) is plugin-agnostic and lives here.
+func LaunchCyodaClusterAndComputeWithBinaries(cyodaBin, computeBin string, ks *JWTKeySet, n int, extraEnv []string, opts ...LaunchOpts) (*ClusterLaunchResult, func(), error) {
+	if n < 1 {
+		return nil, nil, fmt.Errorf("LaunchCyodaClusterAndComputeWithBinaries: n must be >= 1, got %d", n)
+	}
+
+	var err error
 	var opt LaunchOpts
 	if len(opts) > 0 {
 		opt = opts[0]


### PR DESCRIPTION
Closes #157.

Adds the \`…WithBinaries\` cluster-launcher symmetric to the existing single-node \`LaunchCyodaAndComputeWithBinaries\`. Out-of-tree consumers (plugins maintained in their own repos, e.g. \`cyoda-go-cassandra\`) need to drive the shared parity scenario suite against *their* \`cmd/cyoda-go\` binary that blank-imports their backend. The single-node analogue already supports this; the cluster launcher did not, so the multinode parity package introduced in #120 was only usable by in-tree backends.

## Mechanics

All cluster-bootstrap logic (port allocation × 4 per node, gossip seed CSV, HMAC secret derivation, concurrent health probing, compute-client wiring to node 0) is plugin-agnostic — stays in fixtureutil. Only binary acquisition moves out.

\`LaunchCyodaClusterAndCompute\` is now a thin wrapper that builds the in-tree binaries via \`BuildCyodaBinary\` / \`BuildComputeBinary\` and delegates, mirroring how \`LaunchCyodaAndCompute\` wraps \`LaunchCyodaAndComputeWithBinaries\`.

## TDD

- RED: \`TestLaunchCyodaClusterAndComputeWithBinaries\` references the new symbol → test binary fails to compile (\`undefined: fixtureutil.LaunchCyodaClusterAndComputeWithBinaries\`).
- GREEN: implement the function and refactor the wrapper. Test passes (~13s for a 2-node memory cluster).

## Test plan

- [x] New \`TestLaunchCyodaClusterAndComputeWithBinaries\` — builds in-tree binaries, launches a 2-node memory-backed cluster, asserts every node reaches \`/api/health@200\`. PASS.
- [x] \`TestMultiNode\` (postgres backend) — confirms the wrapper delegation path is regression-free. PASS.
- [x] \`go test -short ./...\` green
- [x] \`go test -race -short ./...\` clean
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)