### PR TITLE
feat(release): cosign keyless signatures on archives + verify in install.sh (#47)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -162,6 +162,37 @@ docker_signs:
       - "--yes"
       - "${artifact}"
 
+signs:
+  # Issue #47 — keyless cosign signatures on archive and checksum
+  # artifacts. Uses Sigstore + GitHub Actions OIDC; release.yml already
+  # sets `id-token: write` and installs cosign. Produces sibling .sig
+  # and .pem files alongside each archive and SHA256SUMS so consumers
+  # can run `cosign verify-blob --certificate=...pem --signature=...sig`
+  # without trusting any long-lived key. install.sh auto-verifies when
+  # cosign is on PATH.
+  - id: archives
+    cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--yes"
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+    artifacts: archive
+  - id: checksum
+    cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--yes"
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+    artifacts: checksum
+
 sboms:
   - artifacts: archive
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ Installs to `~/.local/bin/cyoda` and runs `cyoda init`. Override the
 install directory with `CYODA_INSTALL_DIR=~/bin curl ... | sh`. Pin a
 specific version with `CYODA_VERSION=v0.2.0 curl ... | sh`.
 
+The installer SHA256-verifies the archive against `SHA256SUMS` from the
+release, and — if [`cosign`](https://docs.sigstore.dev/cosign/installation/)
+is on `PATH` — additionally verifies a Sigstore keyless signature
+issued by our GitHub Actions release workflow. Force-fail when cosign
+is missing with `CYODA_COSIGN_VERIFY=required`; opt out with
+`CYODA_COSIGN_VERIFY=false` (not recommended).
+
 ### Debian or Ubuntu
 
 ```bash

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # cyoda installer — downloads the latest (or pinned) release for the
-# current OS/arch, verifies SHA256, installs to ~/.local/bin/cyoda,
-# and runs 'cyoda init' to enable sqlite persistence.
+# current OS/arch, verifies SHA256 (and cosign keyless signature when
+# cosign is available), installs to ~/.local/bin/cyoda, and runs
+# 'cyoda init' to enable sqlite persistence.
 #
 # Usage:
 #   curl -fsSL https://github.com/cyoda-platform/cyoda-go/releases/latest/download/install.sh | sh
@@ -11,11 +12,25 @@
 #
 # Pin a different install directory:
 #   CYODA_INSTALL_DIR=~/bin curl -fsSL ... | sh
+#
+# Cosign verification (issue #47):
+#   - Auto-on when `cosign` is on PATH. Verifies the archive and
+#     SHA256SUMS against keyless Sigstore signatures issued by the
+#     cyoda-platform/cyoda-go release workflow.
+#   - Disable explicitly: CYODA_COSIGN_VERIFY=false curl ... | sh
+#   - Force-fail-without-cosign: CYODA_COSIGN_VERIFY=required curl ... | sh
+#     (Aborts if cosign is missing rather than falling back to SHA256-only.)
 
 set -eu
 
 REPO="cyoda-platform/cyoda-go"
 INSTALL_DIR="${CYODA_INSTALL_DIR:-$HOME/.local/bin}"
+# Cosign keyless verification expects the signing identity to come from
+# this OIDC issuer (GitHub Actions) and the cert subject to match a
+# workflow path under our org+repo. The release.yml workflow runs with
+# `id-token: write` and is the only ref that can mint a matching cert.
+COSIGN_OIDC_ISSUER="https://token.actions.githubusercontent.com"
+COSIGN_IDENTITY_REGEX="^https://github.com/cyoda-platform/cyoda-go/"
 
 err() { printf 'install.sh: error: %s\n' "$*" >&2; }
 warn() { printf 'install.sh: warning: %s\n' "$*" >&2; }
@@ -75,6 +90,56 @@ resolve_version() {
         | head -n1
 }
 
+# cosign_verify runs keyless Sigstore verification of the archive and
+# SHA256SUMS using sibling .sig + .pem assets published by GoReleaser
+# (issue #47). Default behaviour:
+#   - cosign on PATH AND CYODA_COSIGN_VERIFY != "false" → verify; abort on failure.
+#   - cosign missing AND CYODA_COSIGN_VERIFY = "required" → abort.
+#   - otherwise → skip with a hint about how to enable.
+cosign_verify() {
+    cv_tmp=$1
+    cv_archive=$2
+    cv_version=$3
+
+    cv_mode="${CYODA_COSIGN_VERIFY:-auto}"
+    case "$cv_mode" in
+        false|0|no) info "Skipping cosign verification (CYODA_COSIGN_VERIFY=$cv_mode)"; return 0 ;;
+    esac
+
+    if ! command -v cosign >/dev/null 2>&1; then
+        if [ "$cv_mode" = "required" ]; then
+            err "CYODA_COSIGN_VERIFY=required but cosign is not on PATH. Install: https://docs.sigstore.dev/cosign/installation/"
+            exit 1
+        fi
+        warn "cosign is not on PATH; skipping signature verification (SHA256-only). Install cosign for keyless Sigstore verification: https://docs.sigstore.dev/cosign/installation/"
+        return 0
+    fi
+
+    info "Verifying cosign signatures (keyless)"
+    for cv_target in "$cv_archive" SHA256SUMS; do
+        cv_sig_url="https://github.com/$REPO/releases/download/$cv_version/${cv_target}.sig"
+        cv_pem_url="https://github.com/$REPO/releases/download/$cv_version/${cv_target}.pem"
+        if ! curl -fsSL -o "$cv_tmp/${cv_target}.sig" "$cv_sig_url"; then
+            err "could not download signature: $cv_sig_url"
+            exit 1
+        fi
+        if ! curl -fsSL -o "$cv_tmp/${cv_target}.pem" "$cv_pem_url"; then
+            err "could not download certificate: $cv_pem_url"
+            exit 1
+        fi
+        if ! cosign verify-blob \
+            --certificate="$cv_tmp/${cv_target}.pem" \
+            --signature="$cv_tmp/${cv_target}.sig" \
+            --certificate-identity-regexp="$COSIGN_IDENTITY_REGEX" \
+            --certificate-oidc-issuer="$COSIGN_OIDC_ISSUER" \
+            "$cv_tmp/$cv_target" >/dev/null 2>&1; then
+            err "cosign verification FAILED for $cv_target — refusing to install."
+            err "Re-run with CYODA_COSIGN_VERIFY=false to skip (not recommended)."
+            exit 1
+        fi
+    done
+}
+
 main() {
     os=$(detect_os)
     arch=$(detect_arch)
@@ -109,6 +174,8 @@ main() {
         err "SHA256 verification failed for $archive"
         exit 1
     fi
+
+    cosign_verify "$tmp" "$archive" "$version"
 
     info "Extracting"
     tar -xzf "$tmp/$archive" -C "$tmp"


### PR DESCRIPTION
Closes #47.

Extends the existing cosign-keyless setup (already in place for docker images via \`docker_signs\`) to cover release archives and the \`SHA256SUMS\` file, and teaches \`install.sh\` to verify those signatures when cosign is on \`PATH\`.

## Trust model

**Before:** HTTPS to github.com + SHA256 match between archive and \`SHA256SUMS\`. But \`SHA256SUMS\` itself was not signed — a compromised release path could serve a malicious archive plus a matching malicious \`SHA256SUMS\` and the verification still passes.

**After:** archives and \`SHA256SUMS\` each have keyless Sigstore signatures (\`.sig\` + \`.pem\`) issued by the cyoda-platform/cyoda-go release workflow under GitHub Actions OIDC. Consumers with cosign installed verify end-to-end; consumers without cosign get SHA256-only with a warning — same posture as before, no regression.

## Changes

- **\`.goreleaser.yaml\`** — new \`signs:\` block with two stanzas: \`archives\` → \`archive.tar.gz.sig\` + \`.pem\`; \`checksum\` → \`SHA256SUMS.sig\` + \`SHA256SUMS.pem\`. \`release.yml\` already sets \`id-token: write\` and installs cosign, so no workflow changes needed.
- **\`scripts/install.sh\`** — new \`cosign_verify()\` helper invoked after SHA256. Auto-on when cosign is on PATH; \`CYODA_COSIGN_VERIFY=false\` opts out; \`CYODA_COSIGN_VERIFY=required\` force-fails when cosign is missing. Verifies both archive and SHA256SUMS against the GitHub Actions OIDC issuer + a \`^https://github.com/cyoda-platform/cyoda-go/\` certificate identity.
- **\`README.md\`** — Install section documents the verification behaviour and the override envs.

## Out of scope (per #47)

- Key-based cosign (stays keyless with OIDC).
- Migration to Sigstore-bundle format — follow-up.

## Verification

- [x] \`goreleaser check\` validates the config
- [x] \`sh -n scripts/install.sh\` syntactically clean *(local shellcheck unavailable in this worktree; the CI shellcheck job runs on the eventual main merge)*
- [x] \`go test -short ./...\` green
- [x] \`go vet ./...\` clean
- [ ] **End-to-end signing exercised at the next \`v*\` tag** — \`release-smoke\` runs goreleaser with \`--skip=sign\` (no OIDC in PR context), so the \`signs:\` stanza only fires on the real release. The first \`v0.7.0-rc\` or \`v0.7.0\` tag will be the executable proof; if the sign step fails, we ship a rollback PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)