### PR TITLE
fix(search): single-node invalidation + cross-tenant isolation in path cache (#174 #175)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -160,12 +160,13 @@ func New(cfg Config) *App {
 	if gossipReg != nil {
 		cacheBroadcaster = gossipReg
 	}
-	a.storeFactory = modelcache.NewCachingStoreFactory(
+	cachingStoreFactory := modelcache.NewCachingStoreFactory(
 		factory,
 		cacheBroadcaster,
 		nil, // wall clock
 		cfg.ModelCacheLease,
 	)
+	a.storeFactory = cachingStoreFactory
 
 	// Startable plugins (cassandra, etc.) must complete Start BEFORE the
 	// factory can serve TransactionManager: the initial takeover / shard-
@@ -302,11 +303,17 @@ func New(cfg Config) *App {
 			"error", err.Error())
 		os.Exit(1)
 	}
-	// Negative cache for pre-execution field-path validation. Shares
-	// the model.invalidate gossip topic with the descriptor cache so a
-	// single schema-change event drops both layers in lock step. The
-	// cache is bounded; otter's S3-FIFO eviction handles overflow.
-	pathValidationCache := search.NewPathValidationCache(cacheBroadcaster)
+	// Negative cache for pre-execution field-path validation. Wired
+	// to the descriptor cache via SubscribeLocal: every model
+	// invalidation (local mutation OR gossip-received event) drops
+	// the corresponding negative-cache bucket. This works on
+	// single-node and multi-node alike (issue #174 — pre-fix the
+	// cache subscribed to the broadcaster directly, so single-node
+	// deployments where the broadcaster is nil never received any
+	// invalidations). Per-(tenant, ref) bucketed otter caches isolate
+	// cross-tenant eviction (issue #175).
+	pathValidationCache := search.NewPathValidationCache()
+	cachingStoreFactory.SubscribeLocal(pathValidationCache.InvalidateRef)
 	a.searchService = search.
 		NewSearchService(a.storeFactory, common.NewDefaultUUIDGenerator(), searchStore).
 		WithPathValidationCache(pathValidationCache)

--- a/internal/cluster/modelcache/cache.go
+++ b/internal/cluster/modelcache/cache.go
@@ -39,6 +39,15 @@ type CachingModelStore struct {
 	jitterRand *rand.Rand // guarded by mu
 
 	flight singleflight.Group
+
+	// localSubMu guards localSubs. Issue #174 — downstream caches
+	// (e.g. the path-validation negative cache) register here to
+	// receive an in-process notification on every invalidation,
+	// regardless of whether a cluster broadcaster is wired up. On
+	// single-node deployments this is the only invalidation channel
+	// available; on multi-node it fires alongside the gossip path.
+	localSubMu sync.RWMutex
+	localSubs  []func(tenant string, ref spi.ModelRef)
 }
 
 type cacheKey struct {
@@ -224,6 +233,7 @@ func (c *CachingModelStore) evict(key cacheKey) {
 func (c *CachingModelStore) invalidate(ctx context.Context, ref spi.ModelRef) {
 	key := cacheKey{tenant: tenantOf(ctx), ref: ref}
 	c.evict(key)
+	c.notifyLocalSubscribers(key.tenant, ref)
 	if c.broadcaster != nil {
 		payload, err := EncodeInvalidation(key.tenant, ref)
 		if err == nil {
@@ -238,6 +248,33 @@ func (c *CachingModelStore) handleInvalidation(payload []byte) {
 		return
 	}
 	c.evict(cacheKey{tenant: tenant, ref: ref})
+	c.notifyLocalSubscribers(tenant, ref)
+}
+
+// SubscribeLocal registers an in-process invalidation handler. The
+// handler fires for every invalidation seen by this store —
+// originating from a local mutation (Save/Lock/Unlock/SetChangeLevel/
+// Delete/ExtendSchema) AND from gossip events received from peer
+// nodes. Downstream caches keyed off the same (tenant, ref) tuple
+// (e.g. the path-validation negative cache) use this to stay in lock
+// step with the descriptor cache regardless of cluster topology.
+//
+// Issue #174 — pre-fix the path-validation cache subscribed to the
+// gossip broadcaster directly, so single-node deployments (where the
+// broadcaster is nil) never received any invalidation events.
+func (c *CachingModelStore) SubscribeLocal(h func(tenant string, ref spi.ModelRef)) {
+	c.localSubMu.Lock()
+	defer c.localSubMu.Unlock()
+	c.localSubs = append(c.localSubs, h)
+}
+
+func (c *CachingModelStore) notifyLocalSubscribers(tenant string, ref spi.ModelRef) {
+	c.localSubMu.RLock()
+	subs := append([]func(string, spi.ModelRef){}, c.localSubs...)
+	c.localSubMu.RUnlock()
+	for _, h := range subs {
+		h(tenant, ref)
+	}
 }
 
 // jitteredLeaseLocked returns lease ± 10 %. MUST be called with c.mu

--- a/internal/cluster/modelcache/factory.go
+++ b/internal/cluster/modelcache/factory.go
@@ -76,6 +76,15 @@ func (f *CachingStoreFactory) TransactionManager(ctx context.Context) (spi.Trans
 }
 func (f *CachingStoreFactory) Close() error { return f.inner.Close() }
 
+// SubscribeLocal registers an in-process invalidation handler on the
+// shared CachingModelStore. The handler receives (tenant, ref) for
+// every model invalidation — local mutations and gossip-received
+// events alike. Downstream caches use this to stay in lock step
+// regardless of cluster topology (issue #174).
+func (f *CachingStoreFactory) SubscribeLocal(h func(tenant string, ref spi.ModelRef)) {
+	f.cache.SubscribeLocal(h)
+}
+
 // requestScopedStore is returned by CachingStoreFactory.ModelStore.
 // It delegates reads through the shared cache and writes directly to
 // the per-request inner store. The tenant is implicit in inner — the

--- a/internal/cluster/modelcache/local_subscriber_test.go
+++ b/internal/cluster/modelcache/local_subscriber_test.go
@@ -1,0 +1,151 @@
+package modelcache_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/cluster/modelcache"
+)
+
+// TestSubscribeLocal_FiresOnLocalMutation pins issue #174's contract.
+//
+// On a single-node deployment the broadcaster is nil — there is no
+// gossip channel to relay schema-change events. Downstream caches
+// (e.g. the path-validation negative cache) that needed those events
+// were silently never notified, so an ExtendSchema on the local node
+// did not invalidate them.
+//
+// Fix: CachingModelStore exposes SubscribeLocal so downstream caches
+// can register a handler that fires for every invalidation —
+// regardless of whether a broadcaster is present.
+func TestSubscribeLocal_FiresOnLocalMutation(t *testing.T) {
+	inner := newStubInner()
+	c := modelcache.New(inner, nil /* no broadcaster — single-node */, nil, time.Minute)
+
+	var notifications atomic.Int64
+	var lastTenant atomic.Value
+	var lastRef atomic.Value
+	c.SubscribeLocal(func(tenant string, ref spi.ModelRef) {
+		notifications.Add(1)
+		lastTenant.Store(tenant)
+		lastRef.Store(ref)
+	})
+
+	ref := spi.ModelRef{EntityName: "ord", ModelVersion: "1"}
+	ctx := tenantCtx("tenant-A")
+	if err := c.ExtendSchema(ctx, ref, spi.SchemaDelta(`[]`)); err != nil {
+		t.Fatalf("ExtendSchema: %v", err)
+	}
+
+	if got := notifications.Load(); got != 1 {
+		t.Fatalf("subscriber notifications: got %d, want 1", got)
+	}
+	if got := lastTenant.Load().(string); got != "tenant-A" {
+		t.Errorf("tenant: got %q, want tenant-A", got)
+	}
+	if got := lastRef.Load().(spi.ModelRef); got != ref {
+		t.Errorf("ref: got %+v, want %+v", got, ref)
+	}
+}
+
+// TestSubscribeLocal_FiresOnGossipReceive pins that subscribers
+// receive notifications for invalidations driven by remote gossip
+// too — not just local mutations. So in multi-node mode the
+// downstream cache reacts to peer ExtendSchema as well as local.
+func TestSubscribeLocal_FiresOnGossipReceive(t *testing.T) {
+	inner := newStubInner()
+	bc := newFakeBroadcasterMC()
+	c := modelcache.New(inner, bc, nil, time.Minute)
+
+	var notifications atomic.Int64
+	c.SubscribeLocal(func(tenant string, ref spi.ModelRef) {
+		notifications.Add(1)
+	})
+
+	ref := spi.ModelRef{EntityName: "ord", ModelVersion: "1"}
+	payload, err := modelcache.EncodeInvalidation("tenant-B", ref)
+	if err != nil {
+		t.Fatalf("EncodeInvalidation: %v", err)
+	}
+	bc.Broadcast("model.invalidate", payload)
+
+	if got := notifications.Load(); got != 1 {
+		t.Fatalf("subscriber notifications on gossip receive: got %d, want 1", got)
+	}
+}
+
+// TestSubscribeLocal_MultipleSubscribers pins fan-out — every
+// registered handler receives every event, in registration order.
+func TestSubscribeLocal_MultipleSubscribers(t *testing.T) {
+	inner := newStubInner()
+	c := modelcache.New(inner, nil, nil, time.Minute)
+
+	var aCount, bCount atomic.Int64
+	c.SubscribeLocal(func(string, spi.ModelRef) { aCount.Add(1) })
+	c.SubscribeLocal(func(string, spi.ModelRef) { bCount.Add(1) })
+
+	ref := spi.ModelRef{EntityName: "ord", ModelVersion: "1"}
+	if err := c.ExtendSchema(tenantCtx("tenant-A"), ref, spi.SchemaDelta(`[]`)); err != nil {
+		t.Fatalf("ExtendSchema: %v", err)
+	}
+
+	if a, b := aCount.Load(), bCount.Load(); a != 1 || b != 1 {
+		t.Errorf("subscribers: a=%d b=%d, want a=1 b=1", a, b)
+	}
+}
+
+// --- helpers ----------------------------------------------------------
+
+type stubInnerMC struct{}
+
+func newStubInner() *stubInnerMC { return &stubInnerMC{} }
+
+func (s *stubInnerMC) Get(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	return nil, nil
+}
+func (s *stubInnerMC) RefreshAndGet(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	return nil, nil
+}
+func (s *stubInnerMC) Save(context.Context, *spi.ModelDescriptor) error { return nil }
+func (s *stubInnerMC) GetAll(context.Context) ([]spi.ModelRef, error)   { return nil, nil }
+func (s *stubInnerMC) Delete(context.Context, spi.ModelRef) error       { return nil }
+func (s *stubInnerMC) Lock(context.Context, spi.ModelRef) error         { return nil }
+func (s *stubInnerMC) Unlock(context.Context, spi.ModelRef) error       { return nil }
+func (s *stubInnerMC) IsLocked(context.Context, spi.ModelRef) (bool, error) {
+	return true, nil
+}
+func (s *stubInnerMC) SetChangeLevel(context.Context, spi.ModelRef, spi.ChangeLevel) error {
+	return nil
+}
+func (s *stubInnerMC) ExtendSchema(context.Context, spi.ModelRef, spi.SchemaDelta) error {
+	return nil
+}
+
+var _ spi.ModelStore = (*stubInnerMC)(nil)
+
+type fakeBroadcasterMC struct {
+	handlers map[string][]func([]byte)
+}
+
+func newFakeBroadcasterMC() *fakeBroadcasterMC {
+	return &fakeBroadcasterMC{handlers: make(map[string][]func([]byte))}
+}
+func (b *fakeBroadcasterMC) Broadcast(topic string, payload []byte) {
+	for _, h := range b.handlers[topic] {
+		h(payload)
+	}
+}
+func (b *fakeBroadcasterMC) Subscribe(topic string, h func([]byte)) {
+	b.handlers[topic] = append(b.handlers[topic], h)
+}
+
+var _ spi.ClusterBroadcaster = (*fakeBroadcasterMC)(nil)
+
+func tenantCtx(tenant string) context.Context {
+	return spi.WithUserContext(context.Background(), &spi.UserContext{
+		Tenant: spi.Tenant{ID: spi.TenantID(tenant)},
+	})
+}

--- a/internal/domain/search/path_validation_cache.go
+++ b/internal/domain/search/path_validation_cache.go
@@ -6,37 +6,27 @@ import (
 	"github.com/maypok86/otter/v2"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
-	"github.com/cyoda-platform/cyoda-go/internal/cluster/modelcache"
 )
 
-// pathValidationCacheTopic is the gossip topic the path-validation
-// negative cache subscribes to. It is the same topic used by the
-// model-descriptor cache (internal/cluster/modelcache) so a single
-// schema-change event drops both the descriptor and the negative
-// path entries derived from it.
-const pathValidationCacheTopic = "model.invalidate"
+// pathValidationBucketCapacity bounds the number of distinct
+// negative-cache entries the cache holds for any single (tenant, ref)
+// model. Otter's S3-FIFO eviction handles overflow within the bucket.
+//
+// Issue #175 — pre-fix the cache used a single global otter cache
+// with MaximumSize=10000; an adversarial tenant could fill it with
+// 10001 distinct random fieldPaths under their own (tenant, ref) and
+// S3-FIFO-evict every other tenant's legitimate entries. Per-bucket
+// capacity isolates eviction within a single (tenant, ref): a
+// flooding tenant only evicts their own data.
+//
+// 100 entries per bucket is conservative — most production workloads
+// see a small set of repeatedly-queried unknown paths per model, not
+// thousands. Tune up if observability shows benign workloads hitting
+// the cap.
+const pathValidationBucketCapacity = 100
 
-// pathValidationCacheCapacity bounds the negative cache size. Otter's
-// S3-FIFO eviction handles overflow automatically — this bound is the
-// memory ceiling, not a TTL: a hot unknown path stays cached as long as
-// it keeps being queried (or until an invalidation event fires for its
-// model).
-const pathValidationCacheCapacity = 10000
-
-// pathCacheKey identifies a single (tenant, modelRef, fieldPath) tuple
-// in the negative cache. Otter requires comparable keys; the struct is
-// comparable by value so it works directly without a hash function.
-type pathCacheKey struct {
-	tenant       string
-	entityName   string
-	modelVersion string
-	fieldPath    string
-}
-
-// modelRefKey is the (tenant, modelRef) generation-bucket key. A single
-// schema-change event for one model bumps its generation, which causes
-// every cached path under that model to be treated as stale on the next
-// lookup. Otter's S3-FIFO eviction reaps the stale entries naturally.
+// modelRefKey is the (tenant, modelRef) bucket key. One otter cache
+// per bucket; entire-bucket eviction handled by InvalidateRef.
 type modelRefKey struct {
 	tenant       string
 	entityName   string
@@ -46,93 +36,71 @@ type modelRefKey struct {
 // PathValidationCache is a loading-cache-style negative cache for the
 // search-service's pre-execution field-path validation. It records
 // "this path was confirmed absent from this (tenant, modelRef)'s
-// schema FieldsMap as of generation N". A serial flood of validation
-// requests for the same unknown path collapses into a single inner-
-// store Get + RefreshAndGet pair instead of one pair per request.
+// schema FieldsMap". A serial flood of validation requests for the
+// same unknown path collapses into a single inner-store Get +
+// RefreshAndGet pair instead of one pair per request.
 //
-// Invalidation is event-driven: the cache subscribes to the cluster
-// broadcaster's "model.invalidate" topic. When an event arrives for
-// (tenant, modelRef), the generation for that bucket is bumped so
-// subsequent lookups treat any prior negative entry as stale. This
-// preserves the issue #77 contract — a peer extending the schema
-// must not be hidden behind a stale negative entry.
+// Invalidation is driven externally — call InvalidateRef(tenant, ref)
+// when a schema change for that model lands. The cache holds no
+// reference to the descriptor cache or the cluster broadcaster
+// directly: app wiring connects it to either or both via
+// modelcache.CachingStoreFactory.SubscribeLocal (issue #174 — local
+// mutations AND gossip events both reach this cache, on every
+// cluster topology).
 //
-// The cache is bounded (10000 entries by default); otter's S3-FIFO
-// policy evicts cold entries automatically, so unbounded memory growth
-// is impossible even under adversarial traffic.
+// Each (tenant, ref) lives in its own bounded otter cache (issue #175
+// — per-bucket capacity isolates cross-tenant eviction). InvalidateRef
+// drops the bucket entirely.
 //
 // The zero value is not safe — use NewPathValidationCache.
 type PathValidationCache struct {
-	cache *otter.Cache[pathCacheKey, uint64]
-
-	mu          sync.RWMutex
-	generations map[modelRefKey]uint64
+	mu      sync.Mutex
+	buckets map[modelRefKey]*otter.Cache[string, struct{}]
 }
 
-// NewPathValidationCache constructs a PathValidationCache. broadcaster
-// may be nil for single-node deployments; when non-nil the cache
-// subscribes to the cluster invalidation topic and drops affected
-// entries on every received event.
-func NewPathValidationCache(broadcaster spi.ClusterBroadcaster) *PathValidationCache {
-	c := otter.Must(&otter.Options[pathCacheKey, uint64]{
-		MaximumSize: pathValidationCacheCapacity,
-	})
-	pvc := &PathValidationCache{
-		cache:       c,
-		generations: make(map[modelRefKey]uint64),
+// NewPathValidationCache constructs an empty PathValidationCache.
+// Callers wire invalidation externally via
+// modelcache.CachingStoreFactory.SubscribeLocal.
+func NewPathValidationCache() *PathValidationCache {
+	return &PathValidationCache{
+		buckets: make(map[modelRefKey]*otter.Cache[string, struct{}]),
 	}
-	if broadcaster != nil {
-		broadcaster.Subscribe(pathValidationCacheTopic, pvc.handleInvalidation)
-	}
-	return pvc
 }
 
-// IsAbsent reports whether the (tenant, ref, path) tuple has a current
-// negative-cache entry — i.e. the path was previously confirmed absent
-// from the model's FieldsMap and no schema-change event has fired for
-// that model since. A cached entry whose generation is below the
-// current bucket generation is treated as a miss (and will be reaped
-// by S3-FIFO eviction in time).
+// IsAbsent reports whether the (tenant, ref, path) tuple has a
+// current negative-cache entry — i.e. the path was previously
+// confirmed absent from the model's FieldsMap and no schema-change
+// invalidation has fired for that model since.
 func (c *PathValidationCache) IsAbsent(tenant string, ref spi.ModelRef, path string) bool {
 	if c == nil {
 		return false
 	}
-	key := pathCacheKey{
+	bucket := c.bucketFor(modelRefKey{
 		tenant:       tenant,
 		entityName:   ref.EntityName,
 		modelVersion: ref.ModelVersion,
-		fieldPath:    path,
-	}
-	cached, ok := c.cache.GetIfPresent(key)
-	if !ok {
+	}, false /* createIfMissing */)
+	if bucket == nil {
 		return false
 	}
-	current := c.currentGeneration(modelRefKey{
-		tenant:       tenant,
-		entityName:   ref.EntityName,
-		modelVersion: ref.ModelVersion,
-	})
-	return cached == current
+	_, ok := bucket.GetIfPresent(path)
+	return ok
 }
 
-// MarkAbsent records the (tenant, ref, path) tuple as confirmed absent
-// at the current generation. Subsequent IsAbsent calls return true
-// until the next invalidation event for that (tenant, ref).
+// MarkAbsent records the (tenant, ref, path) tuple as confirmed
+// absent. Subsequent IsAbsent calls return true until either the
+// path's bucket is invalidated via InvalidateRef or otter's S3-FIFO
+// eviction reaps the entry under bucket-internal pressure.
 func (c *PathValidationCache) MarkAbsent(tenant string, ref spi.ModelRef, path string) {
 	if c == nil {
 		return
 	}
-	gen := c.currentGeneration(modelRefKey{
+	bucket := c.bucketFor(modelRefKey{
 		tenant:       tenant,
 		entityName:   ref.EntityName,
 		modelVersion: ref.ModelVersion,
-	})
-	c.cache.Set(pathCacheKey{
-		tenant:       tenant,
-		entityName:   ref.EntityName,
-		modelVersion: ref.ModelVersion,
-		fieldPath:    path,
-	}, gen)
+	}, true /* createIfMissing */)
+	bucket.Set(path, struct{}{})
 }
 
 // MarkPresent removes any negative cache entry for the (tenant, ref,
@@ -144,48 +112,50 @@ func (c *PathValidationCache) MarkPresent(tenant string, ref spi.ModelRef, path 
 	if c == nil {
 		return
 	}
-	c.cache.Invalidate(pathCacheKey{
+	bucket := c.bucketFor(modelRefKey{
 		tenant:       tenant,
 		entityName:   ref.EntityName,
 		modelVersion: ref.ModelVersion,
-		fieldPath:    path,
-	})
+	}, false)
+	if bucket == nil {
+		return
+	}
+	bucket.Invalidate(path)
 }
 
-// InvalidateRef bumps the generation for (tenant, ref) so every
-// previously-cached negative entry under that model is treated as
-// stale. The entries themselves are not eagerly removed; otter's S3-
-// FIFO eviction handles cold reaping as new traffic arrives. This
-// design avoids holding a per-bucket index of paths solely for the
-// invalidation path, at the cost of a small amount of dead-but-stale
-// space in the cache between events.
+// InvalidateRef drops every cached negative entry for (tenant, ref).
+// The whole bucket is removed from the map; the next MarkAbsent for
+// that bucket allocates a fresh otter cache.
+//
+// This is the public hook wired up by app.go to
+// modelcache.CachingStoreFactory.SubscribeLocal so the cache reacts
+// to local mutations AND remote gossip events alike.
 func (c *PathValidationCache) InvalidateRef(tenant string, ref spi.ModelRef) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.generations[modelRefKey{
+	delete(c.buckets, modelRefKey{
 		tenant:       tenant,
 		entityName:   ref.EntityName,
 		modelVersion: ref.ModelVersion,
-	}]++
+	})
 }
 
-func (c *PathValidationCache) currentGeneration(k modelRefKey) uint64 {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.generations[k]
-}
-
-// handleInvalidation is the gossip-topic subscriber. Decoded payloads
-// reuse the modelcache encoding so the descriptor cache and the
-// negative cache react to the same schema-change broadcasts in lock
-// step.
-func (c *PathValidationCache) handleInvalidation(payload []byte) {
-	tenant, ref, ok := modelcache.DecodeInvalidation(payload)
-	if !ok {
-		return
+func (c *PathValidationCache) bucketFor(k modelRefKey, createIfMissing bool) *otter.Cache[string, struct{}] {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	b, ok := c.buckets[k]
+	if ok {
+		return b
 	}
-	c.InvalidateRef(tenant, ref)
+	if !createIfMissing {
+		return nil
+	}
+	b = otter.Must(&otter.Options[string, struct{}]{
+		MaximumSize: pathValidationBucketCapacity,
+	})
+	c.buckets[k] = b
+	return b
 }

--- a/internal/domain/search/path_validation_cache_test.go
+++ b/internal/domain/search/path_validation_cache_test.go
@@ -8,7 +8,6 @@ import (
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go-spi/predicate"
-	"github.com/cyoda-platform/cyoda-go/internal/cluster/modelcache"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
 	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
 	"github.com/cyoda-platform/cyoda-go/plugins/memory"
@@ -72,7 +71,7 @@ func TestSearch_NegativeCache_CollapsesSerialFloodForUnknownPath(t *testing.T) {
 	uuids := common.NewTestUUIDGenerator()
 	searchStore, _ := base.AsyncSearchStore(context.Background())
 
-	cache := search.NewPathValidationCache(nil)
+	cache := search.NewPathValidationCache()
 	svc := search.NewSearchService(factory, uuids, searchStore).
 		WithPathValidationCache(cache)
 
@@ -99,13 +98,20 @@ func TestSearch_NegativeCache_CollapsesSerialFloodForUnknownPath(t *testing.T) {
 	}
 }
 
-// TestSearch_NegativeCache_InvalidatedOnSchemaChangeBroadcast asserts that
-// after a schema-change invalidation event for the (tenant, ref) is
-// broadcast, the previously-cached negative entry is dropped: the next
-// validation re-consults the inner store. Required to preserve the issue
-// #77 "fresh-after-extend" contract — a peer extending the model must not
-// be hidden behind a stale negative cache.
-func TestSearch_NegativeCache_InvalidatedOnSchemaChangeBroadcast(t *testing.T) {
+// TestSearch_NegativeCache_InvalidatedOnSchemaChange asserts that after
+// InvalidateRef fires for a (tenant, ref), the previously-cached
+// negative entry is dropped: the next validation re-consults the inner
+// store. Required to preserve the issue #77 "fresh-after-extend"
+// contract — a peer extending the model must not be hidden behind a
+// stale negative cache.
+//
+// Issue #174 — pre-fix the cache subscribed to a gossip broadcaster
+// directly, so this contract did not hold on single-node deployments.
+// After the redesign, app.go wires modelcache.SubscribeLocal to
+// pathValidationCache.InvalidateRef so every invalidation (local OR
+// gossip) reaches the cache regardless of cluster topology. Tests
+// drive InvalidateRef directly, decoupled from the wiring layer.
+func TestSearch_NegativeCache_InvalidatedOnSchemaChange(t *testing.T) {
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 	desc := buildSearchDescriptor(t, ref, "a")
 	ms := &countingModelStore{descriptor: desc}
@@ -117,8 +123,7 @@ func TestSearch_NegativeCache_InvalidatedOnSchemaChangeBroadcast(t *testing.T) {
 	uuids := common.NewTestUUIDGenerator()
 	searchStore, _ := base.AsyncSearchStore(context.Background())
 
-	bc := newFakePathBroadcaster()
-	cache := search.NewPathValidationCache(bc)
+	cache := search.NewPathValidationCache()
 	svc := search.NewSearchService(factory, uuids, searchStore).
 		WithPathValidationCache(cache)
 
@@ -145,14 +150,9 @@ func TestSearch_NegativeCache_InvalidatedOnSchemaChangeBroadcast(t *testing.T) {
 			ms.getCount.Load()-getsBefore, ms.refreshCount.Load()-refreshesBefore)
 	}
 
-	// Broadcast schema-change invalidation — peer's ExtendSchema would
-	// look like this from this node's view. The negative cache must
-	// drop the entry so the next request goes back to the inner store.
-	payload, err := modelcache.EncodeInvalidation("tenant-1", ref)
-	if err != nil {
-		t.Fatalf("EncodeInvalidation: %v", err)
-	}
-	bc.Broadcast("model.invalidate", payload)
+	// Invalidate the (tenant, ref) — the negative cache must drop the
+	// entry so the next request goes back to the inner store.
+	cache.InvalidateRef("tenant-1", ref)
 
 	// Third request: cache invalidated, inner Get must fire again.
 	if _, err := svc.Search(ctx, ref, cond, search.SearchOptions{}); err == nil {
@@ -164,9 +164,9 @@ func TestSearch_NegativeCache_InvalidatedOnSchemaChangeBroadcast(t *testing.T) {
 }
 
 // TestSearch_NegativeCache_ConcurrentMissAndInvalidation drives 100
-// concurrent validation requests interleaved with a single broadcast
-// invalidation. The contract: no panics, no races, all requests return
-// the expected 4xx error. Run with -race once before PR.
+// concurrent validation requests interleaved with a single InvalidateRef.
+// The contract: no panics, no races, all requests return the expected
+// 4xx error. Run with -race once before PR.
 func TestSearch_NegativeCache_ConcurrentMissAndInvalidation(t *testing.T) {
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 	desc := buildSearchDescriptor(t, ref, "a")
@@ -179,8 +179,7 @@ func TestSearch_NegativeCache_ConcurrentMissAndInvalidation(t *testing.T) {
 	uuids := common.NewTestUUIDGenerator()
 	searchStore, _ := base.AsyncSearchStore(context.Background())
 
-	bc := newFakePathBroadcaster()
-	cache := search.NewPathValidationCache(bc)
+	cache := search.NewPathValidationCache()
 	svc := search.NewSearchService(factory, uuids, searchStore).
 		WithPathValidationCache(cache)
 
@@ -199,8 +198,7 @@ func TestSearch_NegativeCache_ConcurrentMissAndInvalidation(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			if i == concurrency/2 {
-				payload, _ := modelcache.EncodeInvalidation("tenant-1", ref)
-				bc.Broadcast("model.invalidate", payload)
+				cache.InvalidateRef("tenant-1", ref)
 			}
 			_, err := svc.Search(ctx, ref, cond, search.SearchOptions{})
 			errs <- err
@@ -215,32 +213,3 @@ func TestSearch_NegativeCache_ConcurrentMissAndInvalidation(t *testing.T) {
 		}
 	}
 }
-
-// fakePathBroadcaster mirrors fakeBroadcaster but lives in the search
-// package's test scope. Synchronous delivery to every subscriber so
-// invalidation events take effect before the next request.
-type fakePathBroadcaster struct {
-	mu       sync.Mutex
-	handlers map[string][]func([]byte)
-}
-
-func newFakePathBroadcaster() *fakePathBroadcaster {
-	return &fakePathBroadcaster{handlers: make(map[string][]func([]byte))}
-}
-
-func (b *fakePathBroadcaster) Broadcast(topic string, payload []byte) {
-	b.mu.Lock()
-	hs := append([]func([]byte){}, b.handlers[topic]...)
-	b.mu.Unlock()
-	for _, h := range hs {
-		h(payload)
-	}
-}
-
-func (b *fakePathBroadcaster) Subscribe(topic string, h func([]byte)) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.handlers[topic] = append(b.handlers[topic], h)
-}
-
-var _ spi.ClusterBroadcaster = (*fakePathBroadcaster)(nil)

--- a/internal/domain/search/path_validation_cross_tenant_test.go
+++ b/internal/domain/search/path_validation_cross_tenant_test.go
@@ -1,0 +1,73 @@
+package search_test
+
+import (
+	"fmt"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
+)
+
+// TestPathValidationCache_CrossTenantNoisyNeighborSurvives pins
+// issue #175. Pre-fix the cache used a single global otter cache
+// with MaximumSize=10000 — a tenant-A flooder spamming distinct
+// random fieldPaths against `(tenantA, refX)` could S3-FIFO-evict
+// every legitimate `(tenantB, refY)` entry from tenant B.
+//
+// The fix partitions the cache into per-(tenant, ref) buckets with a
+// fixed bucket capacity. Eviction within tenant A's bucket cannot
+// affect tenant B's bucket. This test asserts that contract: tenant
+// B's previously-cached negative entry survives a flood of tenant A
+// entries far exceeding the old global capacity.
+func TestPathValidationCache_CrossTenantNoisyNeighborSurvives(t *testing.T) {
+	cache := search.NewPathValidationCache()
+
+	refA := spi.ModelRef{EntityName: "x", ModelVersion: "1"}
+	refB := spi.ModelRef{EntityName: "y", ModelVersion: "1"}
+
+	// Tenant B's legitimate negative entry — must remain cached after
+	// the flood.
+	cache.MarkAbsent("tenant-B", refB, "$.legit.path")
+	if !cache.IsAbsent("tenant-B", refB, "$.legit.path") {
+		t.Fatalf("setup: tenant B's entry not stored")
+	}
+
+	// Tenant A floods its own bucket far past the per-bucket capacity
+	// (and well past the previous global 10000 limit).
+	const floodSize = 12000
+	for i := 0; i < floodSize; i++ {
+		cache.MarkAbsent("tenant-A", refA, fmt.Sprintf("$.flood.%d", i))
+	}
+
+	if !cache.IsAbsent("tenant-B", refB, "$.legit.path") {
+		t.Errorf("tenant B's entry was evicted by tenant A's flood — cross-tenant isolation broken")
+	}
+}
+
+// TestPathValidationCache_PerBucketCapacityIsolatesWithinTenant pins
+// the second half of #175's contract — eviction inside tenant A's
+// bucket only affects tenant A's own entries within that (tenant, ref).
+// The flood evicts tenant A's own earlier entries, but does not reach
+// across the (tenant, ref) partition into tenant B's data.
+func TestPathValidationCache_PerBucketCapacityIsolatesWithinTenant(t *testing.T) {
+	cache := search.NewPathValidationCache()
+
+	refA := spi.ModelRef{EntityName: "x", ModelVersion: "1"}
+	refB := spi.ModelRef{EntityName: "y", ModelVersion: "1"}
+
+	cache.MarkAbsent("tenant-B", refB, "$.b.legit")
+
+	// Within tenant-A's (tenant, ref) bucket, generate enough
+	// distinct paths to exhaust the per-bucket capacity. Internal
+	// otter S3-FIFO will reap the oldest entries within this bucket;
+	// other buckets are untouched.
+	const overflow = 10000
+	for i := 0; i < overflow; i++ {
+		cache.MarkAbsent("tenant-A", refA, fmt.Sprintf("$.path.%d", i))
+	}
+
+	// Tenant B's bucket is unaffected.
+	if !cache.IsAbsent("tenant-B", refB, "$.b.legit") {
+		t.Errorf("tenant B's bucket affected by tenant A's overflow")
+	}
+}


### PR DESCRIPTION
Closes #174.
Closes #175.

Two related defects in the path-validation negative cache; one fix touches both.

## #174 — Single-node ExtendSchema lost path-cache invalidation

The path-validation cache subscribed directly to the cluster broadcaster. On single-node deployments the broadcaster is nil, so no invalidation events ever reached the cache: after \`ExtendSchema\` added a new field to the schema, the cache continued to serve a stale "absent" entry until otter S3-FIFO reaped it. Search/condition queries against the new path returned \`INVALID_FIELD_PATH@400\` in the meantime.

## #175 — Single global otter cache → cross-tenant noisy-neighbor

Pre-fix the cache used a single global otter cache with \`MaximumSize=10000\`. A flooding tenant could spam 10001 distinct random fieldPaths under their own \`(tenant, ref)\` and S3-FIFO-evict every other tenant's legitimate negative entries. Correctness was preserved (keys included tenant) but cross-tenant latency degraded.

## Fix

- **\`modelcache.CachingModelStore.SubscribeLocal(handler)\`** — new in-process subscriber list that fires for every invalidation regardless of cluster topology. Both the local-mutation path (\`Save\`/\`Lock\`/\`Unlock\`/\`SetChangeLevel\`/\`Delete\`/\`ExtendSchema\`) and the gossip-receive path call \`notifyLocalSubscribers()\`.
- **\`modelcache.CachingStoreFactory.SubscribeLocal\`** — forwards to the shared cache so app wiring can subscribe without a concrete-type reference.
- **\`search.PathValidationCache\` restructure** — per-(tenant, ref) bucket map of bounded otter caches (100 entries each). \`InvalidateRef\` drops the entire bucket. Cross-tenant flooding is contained to the attacker's own bucket.
- **\`search.NewPathValidationCache()\`** — no longer takes a broadcaster. Constructor parameter removed.
- **\`app.go\`** — captures the concrete \`*modelcache.CachingStoreFactory\` locally to call \`SubscribeLocal\`, then assigns to \`a.storeFactory\` as before. Wires \`pathValidationCache.InvalidateRef\` as the \`SubscribeLocal\` handler.

## TDD

- modelcache: \`TestSubscribeLocal_FiresOnLocalMutation\`, \`TestSubscribeLocal_FiresOnGossipReceive\`, \`TestSubscribeLocal_MultipleSubscribers\` — three RED tests covering the new method's contract; all GREEN after implementation.
- search: \`TestPathValidationCache_CrossTenantNoisyNeighborSurvives\`, \`TestPathValidationCache_PerBucketCapacityIsolatesWithinTenant\` — RED before per-bucket restructure; GREEN after.
- Existing search tests adapted from broadcaster-driven to direct \`InvalidateRef\` calls (the wiring layer now lives in app.go, not in the cache itself).

## Test plan

- [x] \`go test ./internal/cluster/modelcache/... ./internal/domain/search/...\` green
- [x] \`go test -short ./...\` green
- [x] \`go test ./internal/e2e/...\` green
- [x] \`go test -race -short ./...\` clean
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)