### PR TITLE
docs(chart): dedicated guides for Ingress→Gateway migration + Gateway API policies (#57 #58)

### DIFF
--- a/deploy/helm/cyoda/README.md
+++ b/deploy/helm/cyoda/README.md
@@ -214,61 +214,24 @@ store (Vault, AWS Secrets Manager, etc.) into the Secret names.
 
 ## Migrating from ingress-nginx
 
-`ingress-nginx` was retired by SIG Network in March 2026. Use the
-`ingress` values block in this chart as a transitional affordance
-until you've migrated to Gateway API. For migration tooling, see
-[Ingress2Gateway 1.0](https://kubernetes.io/blog/2026/03/20/ingress2gateway-1-0-release/).
+`ingress-nginx` was retired by SIG Network in March 2026. The chart
+ships `ingress.enabled=true` as a transitional affordance and
+`gateway.enabled=true` (default) for Gateway API. For step-by-step
+migration using [Ingress2Gateway 1.0][i2g], see
+[`docs/migrating-from-ingress.md`](./docs/migrating-from-ingress.md).
 
-Suggested migration path:
-
-1. **Start on this chart with `ingress.enabled=true`.** The rendered
-   `Ingress` objects carry the `nginx.ingress.kubernetes.io/backend-protocol: GRPC`
-   annotation on the gRPC path so ingress-nginx-compatible controllers
-   still route correctly.
-2. **Install a Gateway API implementation** in a platform namespace
-   (Envoy Gateway, Contour, or Cilium — all three ship production-ready
-   `HTTPRoute` + `GRPCRoute` support).
-3. **Run Ingress2Gateway** against the chart's rendered Ingress objects
-   to produce equivalent `HTTPRoute` + `GRPCRoute` skeletons. Treat the
-   output as a hint — the chart's own Gateway API templates render the
-   canonical shape, so once you have a Gateway in place you flip the
-   chart's values:
-
-   ```bash
-   helm upgrade cyoda cyoda/cyoda -n cyoda --reuse-values \
-     --set ingress.enabled=false \
-     --set gateway.enabled=true \
-     --set 'gateway.parentRefs[0].name=platform-gateway' \
-     --set 'gateway.parentRefs[0].namespace=gateway-system' \
-     --set gateway.http.hostnames[0]=cyoda.example.com \
-     --set gateway.grpc.hostnames[0]=grpc.cyoda.example.com
-   ```
-
-4. **Delete the old ingress-nginx controller deployment** once cutover
-   is stable. The transitional `Ingress` templates in this chart can be
-   retired from a future chart major.
+[i2g]: https://kubernetes.io/blog/2026/03/20/ingress2gateway-1-0-release/
 
 ## Gateway API policy attachments (rate limiting, auth, WAF)
 
 Gateway API 1.2 exposes per-controller policy attachments rather than
 cross-controller annotations. The chart renders only `HTTPRoute` and
 `GRPCRoute` — policy objects are deliberately operator-owned because
-their shape and semantics differ by implementation. Reference pointers:
-
-- **Envoy Gateway:** `BackendTrafficPolicy` for rate limiting, retries,
-  timeouts; `SecurityPolicy` for JWT authn, OIDC, CORS, IP allow-list.
-  Attach via `targetRefs` pointing at this chart's HTTPRoute/GRPCRoute.
-  See [Envoy Gateway docs](https://gateway.envoyproxy.io/docs/tasks/).
-- **Cilium Gateway:** `CiliumEnvoyConfig` for advanced per-route
-  Envoy config; L7 policy can also ride `CiliumNetworkPolicy`.
-- **Contour:** `HTTPProxy` (Contour's predecessor CRD) is orthogonal;
-  for Gateway API policies, attach `BackendTLSPolicy` directly to the
-  chart-rendered HTTPRoute.
-
-These are out of scope for the chart because a rendered
-`BackendTrafficPolicy` that targets a wrong controller's CRD would be
-silently inert — worse than no rendering. Operators add their own
-policies in the namespace alongside the chart-rendered routes.
+their shape and semantics differ by implementation. For concrete
+`BackendTrafficPolicy` (rate limiting, retries) and `SecurityPolicy`
+(JWT, CORS, IP allow-list) examples per controller (Envoy Gateway,
+Cilium, Contour), see
+[`docs/gateway-api-policies.md`](./docs/gateway-api-policies.md).
 
 ## Values reference
 

--- a/deploy/helm/cyoda/docs/gateway-api-policies.md
+++ b/deploy/helm/cyoda/docs/gateway-api-policies.md
@@ -1,0 +1,220 @@
+# Gateway API policy attachments
+
+The cyoda chart renders `HTTPRoute` and `GRPCRoute` resources that
+attach to an operator-managed `Gateway`. **Policy objects** —
+rate-limiting, JWT authn, CORS, IP allow-listing, retries, timeouts —
+are deliberately **not** rendered by the chart. They differ in shape
+and semantics across Gateway controllers; rendering one
+controller's flavour would be silently inert under another.
+
+This guide gives concrete `BackendTrafficPolicy` and `SecurityPolicy`
+examples for the most common controllers, applied in the operator's
+namespace alongside the chart-rendered routes.
+
+## Envoy Gateway
+
+[Envoy Gateway][eg] is the most common choice for cyoda deployments.
+It exposes two policy CRDs that target Gateway API resources via
+`targetRefs`:
+
+- `BackendTrafficPolicy` — rate limiting, retries, timeouts, fault
+  injection, circuit breakers.
+- `SecurityPolicy` — JWT authn, OIDC, CORS, IP allow-list, basic
+  auth, ext-authz.
+
+[eg]: https://gateway.envoyproxy.io/docs/
+
+### Rate limiting (BackendTrafficPolicy)
+
+Limit the cyoda HTTP route to 100 requests per minute per client IP:
+
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: cyoda-http-ratelimit
+  namespace: cyoda
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: cyoda          # the chart-rendered HTTPRoute name
+  rateLimit:
+    type: Local
+    local:
+      rules:
+        - limit:
+            requests: 100
+            unit: Minute
+          clientSelectors:
+            - sourceCIDR:
+                value: 0.0.0.0/0
+                type: Distinct
+```
+
+`type: Local` rate-limits per Envoy proxy instance (no external Redis
+needed). For cluster-wide enforcement use `type: Global` and supply a
+`backendRefs` to a Redis instance.
+
+### JWT auth (SecurityPolicy)
+
+Require an RS256 JWT signed by your IdP for every request to the HTTP
+route, with `aud` claim matching `cyoda-api`:
+
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: cyoda-http-jwt
+  namespace: cyoda
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: cyoda
+  jwt:
+    providers:
+      - name: idp
+        issuer: https://idp.example.com/
+        audiences:
+          - cyoda-api
+        remoteJWKS:
+          uri: https://idp.example.com/.well-known/jwks.json
+```
+
+`Authorization: Bearer …` requests with a missing or invalid token
+get a `401`. The cyoda binary's own JWT validation runs on top — set
+`CYODA_REQUIRE_JWT=true` and the trusted-key registry to enforce
+defense in depth.
+
+### CORS (SecurityPolicy)
+
+Allow the cyoda admin UI origin to call the API:
+
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: cyoda-http-cors
+  namespace: cyoda
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: cyoda
+  cors:
+    allowOrigins:
+      - https://admin.cyoda.example.com
+    allowMethods:
+      - GET
+      - POST
+      - PUT
+      - DELETE
+    allowHeaders:
+      - Authorization
+      - Content-Type
+    maxAge: 600s
+```
+
+The cyoda binary also has its own CORS middleware
+(`CYODA_CORS_ALLOWED_ORIGINS`) — only one layer needs to set CORS
+headers, so disable the binary's via `CYODA_CORS_ENABLED=false` if
+you handle CORS at the gateway.
+
+## Cilium Gateway
+
+Cilium Gateway implements Gateway API natively but exposes per-route
+Envoy customisation via `CiliumEnvoyConfig`. For most policies,
+prefer `CiliumNetworkPolicy` at L7:
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cyoda-l7-policy
+  namespace: cyoda
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: cyoda
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            "k8s:io.kubernetes.pod.namespace": gateway-system
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+          rules:
+            http:
+              - method: "GET"
+                path: "/api/.*"
+              - method: "POST"
+                path: "/api/.*"
+```
+
+For richer policy (JWT, OIDC, ext-authz), Cilium recommends Envoy
+Gateway in front. Don't try to attach Envoy Gateway's CRDs to Cilium —
+the `targetRefs` won't resolve.
+
+## Contour
+
+Contour supports Gateway API natively and provides `BackendTLSPolicy`
+for upstream TLS:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: cyoda-backend-tls
+  namespace: cyoda
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: cyoda
+  validation:
+    caCertificateRefs:
+      - kind: ConfigMap
+        name: cyoda-ca-bundle
+    hostname: cyoda.cyoda.svc.cluster.local
+```
+
+For richer policies (rate limiting, auth filters), Contour
+recommends `HTTPProxy` (its predecessor CRD) attached to the same
+backend `Service`. Note that `HTTPProxy` and `HTTPRoute` cannot
+coexist on the same backend — pick one.
+
+## Pattern: separate routes per concern
+
+If a single policy needs to apply to a subset of paths only (e.g.
+rate-limit `/api/entity/*` but not `/api/health`), split into two
+chart-rendered `HTTPRoute`s by extending `gateway.http.routes` in
+values. Each can carry its own `BackendTrafficPolicy` /
+`SecurityPolicy` via `targetRefs`.
+
+The chart's default rendering is a single route per protocol; the
+`gateway.http.routes` extension point allows per-path-prefix routes.
+See the chart `values.yaml` for the schema.
+
+## Pitfalls
+
+- **`targetRefs` to a non-existent route.** The policy is silently
+  inert. `kubectl get backendtrafficpolicy -o yaml | yq .status` —
+  the `Accepted` condition shows the resolution error.
+- **Mixing controllers.** A `BackendTrafficPolicy` from Envoy Gateway
+  attached to a route owned by Contour will not apply. Match
+  controller and policy CRD.
+- **Rate limit unit too coarse.** `Hour`-scoped buckets fill up in
+  bursts and stall the client. Use `Minute` or `Second` for
+  user-facing APIs.
+
+## See also
+
+- [Envoy Gateway tasks](https://gateway.envoyproxy.io/docs/tasks/) —
+  comprehensive reference.
+- [Gateway API policy attachment][gw-policy] — upstream specification.
+- [`migrating-from-ingress.md`](./migrating-from-ingress.md) — moving
+  off ingress-nginx.
+
+[gw-policy]: https://gateway-api.sigs.k8s.io/reference/policy-attachment/

--- a/deploy/helm/cyoda/docs/migrating-from-ingress.md
+++ b/deploy/helm/cyoda/docs/migrating-from-ingress.md
@@ -1,0 +1,189 @@
+# Migrating from ingress-nginx to Gateway API
+
+`ingress-nginx` was retired by SIG Network in March 2026. The cyoda
+chart ships both `ingress.enabled=true` (transitional) and
+`gateway.enabled=true` (recommended, default ON) so operators can
+adopt Gateway API on their own timeline. This guide walks through the
+migration end-to-end using the [Ingress2Gateway 1.0][i2g] tool.
+
+[i2g]: https://kubernetes.io/blog/2026/03/20/ingress2gateway-1-0-release/
+
+## Prerequisites
+
+Before starting, you need:
+
+- A Kubernetes 1.31+ cluster with Gateway API CRDs installed
+  (`kubectl get crd | grep gateway.networking.k8s.io` returns at least
+  `gatewayclasses`, `gateways`, `httproutes`, `grpcroutes`).
+- A Gateway API implementation deployed in a platform namespace —
+  Envoy Gateway, Contour, Cilium, or Istio. All four ship
+  production-ready `HTTPRoute` + `GRPCRoute` support.
+- The Ingress2Gateway 1.0 binary on your PATH:
+  ```bash
+  go install sigs.k8s.io/ingress2gateway/cmd/ingress2gateway@latest
+  ```
+
+## Step 1 — Render the existing Ingress objects
+
+If you're already running cyoda with `ingress.enabled=true`, dump the
+rendered `Ingress` objects so Ingress2Gateway can convert them:
+
+```bash
+helm template cyoda cyoda/cyoda -n cyoda --reuse-values \
+  --show-only templates/ingress.yaml \
+  --show-only templates/ingress-grpc.yaml \
+  > /tmp/cyoda-ingress.yaml
+```
+
+These are what your in-cluster `Ingress` resources look like today —
+including the `nginx.ingress.kubernetes.io/backend-protocol: GRPC`
+annotation on the gRPC path that ingress-nginx-compatible controllers
+need.
+
+## Step 2 — Install a Gateway API implementation
+
+Pick one of the supported controllers. Envoy Gateway is the most
+common choice for cyoda deployments:
+
+```bash
+helm repo add eg https://gateway.envoyproxy.io/charts
+helm install eg eg/gateway-helm -n envoy-gateway-system --create-namespace
+```
+
+Once installed, create a `Gateway` in a platform namespace that the
+cyoda routes will attach to:
+
+```yaml
+# platform/gateway.yaml — operator-managed, NOT chart-rendered
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: platform-gateway
+  namespace: gateway-system
+spec:
+  gatewayClassName: eg
+  listeners:
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: grpc
+      port: 8080
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+```
+
+`kubectl apply -f platform/gateway.yaml`. Verify:
+
+```bash
+kubectl -n gateway-system get gateway platform-gateway -o yaml | yq .status
+```
+
+The `Programmed` condition should read `True`.
+
+## Step 3 — Convert with Ingress2Gateway
+
+Run Ingress2Gateway against the dumped Ingress resources. This is a
+**hint generator**, not the source of truth — the chart's own Gateway
+API templates render the canonical shape. Use the output to confirm
+your understanding of what the cyoda chart will render:
+
+```bash
+ingress2gateway print --input-file /tmp/cyoda-ingress.yaml \
+  --providers ingress-nginx > /tmp/cyoda-routes.yaml
+```
+
+Inspect `/tmp/cyoda-routes.yaml`. You'll see two route resources:
+
+- An `HTTPRoute` carrying the cyoda HTTP API paths.
+- A `GRPCRoute` (translated from the `backend-protocol: GRPC`
+  annotation) for the gRPC service.
+
+Compare against `helm template cyoda cyoda/cyoda --set
+gateway.enabled=true --show-only templates/httproute.yaml` to see the
+chart's canonical shape. Differences are usually:
+
+- The chart attaches via `parentRefs` you supply via values — adjust
+  `gateway.parentRefs[]` to match your `Gateway` name and namespace.
+- The chart sets `hostnames` separately for HTTP and gRPC — populate
+  `gateway.http.hostnames` and `gateway.grpc.hostnames`.
+
+## Step 4 — Flip the chart values
+
+With the Gateway in place, switch the chart from `ingress` to
+`gateway`:
+
+```bash
+helm upgrade cyoda cyoda/cyoda -n cyoda --reuse-values \
+  --set ingress.enabled=false \
+  --set gateway.enabled=true \
+  --set 'gateway.parentRefs[0].name=platform-gateway' \
+  --set 'gateway.parentRefs[0].namespace=gateway-system' \
+  --set gateway.http.hostnames[0]=cyoda.example.com \
+  --set gateway.grpc.hostnames[0]=grpc.cyoda.example.com
+```
+
+The chart now renders `HTTPRoute` and `GRPCRoute` resources that
+attach to your platform Gateway. The old `Ingress` resources are
+deleted on this upgrade.
+
+## Step 5 — Verify routing end-to-end
+
+```bash
+# HTTP
+curl -fsSL https://cyoda.example.com/api/health
+# expected: 200 OK
+
+# gRPC (via grpcurl)
+grpcurl -insecure grpc.cyoda.example.com:443 list
+# expected: cyoda's gRPC services listed
+```
+
+If either fails, check:
+
+- `kubectl -n cyoda get httproute,grpcroute -o yaml | yq .status` —
+  the `Accepted` and `ResolvedRefs` conditions should both be `True`.
+- `kubectl -n gateway-system get gateway platform-gateway -o yaml`
+  for listener-level errors.
+- Controller logs (varies by implementation —
+  `kubectl -n envoy-gateway-system logs deploy/envoy-gateway` for
+  Envoy Gateway).
+
+## Step 6 — Decommission ingress-nginx
+
+Once routing is stable for at least one full deploy cycle:
+
+```bash
+helm uninstall ingress-nginx -n ingress-nginx
+kubectl delete namespace ingress-nginx
+```
+
+The transitional `Ingress` templates can stay in this chart's values
+schema for any other workloads still mid-migration; cyoda itself no
+longer needs them.
+
+## Common pitfalls
+
+- **Forgot to install Gateway API CRDs.** The chart fails to install
+  with `no matches for kind "HTTPRoute"`. Install the CRDs from
+  `https://github.com/kubernetes-sigs/gateway-api/releases`.
+- **Cross-namespace `parentRefs` blocked by `ReferenceGrant`.** Some
+  Gateway implementations require an explicit `ReferenceGrant` in the
+  Gateway's namespace pointing back at cyoda's namespace. Render the
+  policy alongside the Gateway, not from this chart.
+- **gRPC routing returns HTTP 200 with empty body.** Almost always a
+  protocol-mismatch — confirm the `Service` port targeting gRPC is
+  named `grpc` and the route is a `GRPCRoute`, not `HTTPRoute`.
+
+## See also
+
+- [Gateway API project](https://gateway-api.sigs.k8s.io/) — official
+  spec and documentation.
+- [`gateway-api-policies.md`](./gateway-api-policies.md) — recommended
+  `BackendTrafficPolicy` / `SecurityPolicy` overlays per controller.
+- The chart's [`README.md`](../README.md) for the full values
+  reference.


### PR DESCRIPTION
Closes #57.
Closes #58.

The chart README already carried inline sections on both topics, but the issues specifically asked for:
- **#57**: a dedicated file at \`deploy/helm/cyoda/docs/migrating-from-ingress.md\` (separate from the README).
- **#58**: documented policy overlays — the existing inline section had pointers but no concrete YAML.

This PR promotes both topics to dedicated docs under \`deploy/helm/cyoda/docs/\` and slims the README sections to summaries with links.

## New files

- **\`deploy/helm/cyoda/docs/migrating-from-ingress.md\`** — six-step walkthrough using Ingress2Gateway 1.0: prerequisites → render current Ingress → install Gateway API impl → run conversion → flip chart values → verify routing → decommission. Covers common pitfalls (missing CRDs, \`ReferenceGrant\`, gRPC misrouting).
- **\`deploy/helm/cyoda/docs/gateway-api-policies.md\`** — concrete \`BackendTrafficPolicy\` (rate limit) and \`SecurityPolicy\` (JWT, CORS) YAML for Envoy Gateway; Cilium L7 policy example via \`CiliumNetworkPolicy\`; Contour \`BackendTLSPolicy\` example. Pattern guidance + pitfalls.

## Changed files

- **\`deploy/helm/cyoda/README.md\`** — \"Migrating from ingress-nginx\" and \"Gateway API policy attachments\" sections trimmed to one-paragraph summaries with links to the new dedicated docs.

## No code changes

Chart templates and values schema unchanged. \`helm-chart-ci\` job (CT lint/install) should pass — chart structure is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)