### PR TITLE
refactor(common): separate (status, code, retryable) axes in 4xx errors (#140)

### DIFF
--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -47,7 +47,30 @@ func (e *AppError) Error() string { return e.Message }
 
 func (e *AppError) Unwrap() error { return e.Err }
 
+// AsRetryable flips the retryable bit on a 4xx error and returns the
+// receiver for fluent chaining. Use for the rare case a 4xx is
+// retry-eligible — typically SERIALIZABLE transaction aborts
+// (40001/40P01) or optimistic-lock failures triggered by concurrent
+// writers, where naive retry without a state change can succeed.
+//
+// Permanent business-logic conflicts (locked-state mismatches, ETag
+// mismatches, cardinality precondition failures) MUST NOT be flagged
+// retryable — calling those retryable causes pointless backoff and
+// 5x request amplification on the parity client side.
+//
+// Issue #140 — separates the (status, code, retryable) axes that
+// were previously bundled into specialized helpers (Conflict /
+// RetryableConflict, removed). Retryable is now opt-in on top of
+// any (status, code) pair via Operational(...).AsRetryable().
+func (e *AppError) AsRetryable() *AppError {
+	e.Retryable = true
+	return e
+}
+
 // Operational creates a client error (4xx). No internal detail is captured.
+//
+// Default is non-retryable; for the rare retry-eligible 4xx (e.g. a
+// SERIALIZABLE transaction abort), chain .AsRetryable().
 func Operational(status int, code string, message string) *AppError {
 	return &AppError{
 		Level:   LevelOperational,
@@ -57,52 +80,15 @@ func Operational(status int, code string, message string) *AppError {
 	}
 }
 
-// Conflict creates a 409 Conflict error for a permanent, non-retryable
-// business-logic conflict (e.g. "model already locked", ETag mismatch on
-// If-Match, "cannot delete: entities exist"). Retrying the same request
-// without a state change will never succeed, so retryable defaults to false.
-//
-// For transient conflicts that ARE expected to succeed on retry (e.g.
-// SERIALIZABLE 40001/40P01 transaction aborts) use RetryableConflict.
-func Conflict(message string) *AppError {
-	return &AppError{
-		Level:     LevelOperational,
-		Status:    http.StatusConflict,
-		Code:      ErrCodeConflict,
-		Message:   fmt.Sprintf("%s: %s", ErrCodeConflict, message),
-		Retryable: false,
-	}
-}
-
-// RetryableConflict creates a 409 Conflict error that the parity HTTP client
-// (e2e/parity/client/http.go isRetryableConflict) is allowed to retry. Use it
-// only for transient conflicts that depend on concurrent state and may
-// succeed on a fresh attempt — typically SERIALIZABLE transaction aborts and
-// optimistic-lock failures triggered by concurrent writers.
-//
-// Permanent business conflicts (locked-state mismatches, ETag mismatches,
-// cardinality precondition failures) MUST use Conflict — calling those
-// retryable causes pointless backoff and 5x request amplification on the
-// client side.
-func RetryableConflict(message string) *AppError {
-	return &AppError{
-		Level:     LevelOperational,
-		Status:    http.StatusConflict,
-		Code:      ErrCodeConflict,
-		Message:   fmt.Sprintf("%s: %s", ErrCodeConflict, message),
-		Retryable: true,
-	}
-}
-
 // Internal creates a 500 error with internal detail from the wrapped error.
 //
 // If the wrapped error is (or wraps) spi.ErrConflict, the result is routed to
-// RetryableConflict instead — a serialization abort (40001/40P01) that fully
+// a retryable 409 instead — a serialization abort (40001/40P01) that fully
 // rolled back is retryable, not a server error. This keeps every call site
 // honest without forcing each to reason about pgx error codes.
 func Internal(message string, err error) *AppError {
 	if err != nil && errors.Is(err, spi.ErrConflict) {
-		return RetryableConflict("transaction conflict — retry")
+		return Operational(http.StatusConflict, ErrCodeConflict, "transaction conflict — retry").AsRetryable()
 	}
 	detail := ""
 	if err != nil {

--- a/internal/common/errors_test.go
+++ b/internal/common/errors_test.go
@@ -294,38 +294,53 @@ func TestErrCodeSearchResultLimit(t *testing.T) {
 	}
 }
 
-// TestConflict_NotRetryableByDefault pins the behavior change for #126:
-// a plain Conflict represents a permanent business-logic conflict (e.g.
-// "model already locked", ETag mismatch on If-Match). The parity HTTP
-// client retries on properties.retryable=true; if Conflict were retryable
-// every permanent conflict would burn 5 attempts × 30+ms backoff before
-// surfacing to the caller.
-func TestConflict_NotRetryableByDefault(t *testing.T) {
-	err := common.Conflict("model already locked")
+// TestOperational_NotRetryableByDefault pins that 4xx errors from the
+// primitive Operational constructor are non-retryable by default —
+// retryable is opt-in via AsRetryable(). A permanent business-logic
+// conflict ("model already locked", ETag mismatch on If-Match) must
+// not advertise retryable; the parity HTTP client retries on
+// properties.retryable=true and would burn 5 attempts × 30+ms backoff
+// per permanent conflict otherwise.
+func TestOperational_NotRetryableByDefault(t *testing.T) {
+	err := common.Operational(http.StatusConflict, common.ErrCodeModelAlreadyLocked, "model already locked")
 	if err.Status != http.StatusConflict {
 		t.Errorf("status = %d, want 409", err.Status)
 	}
 	if err.Retryable {
-		t.Error("Conflict() must default to retryable=false (permanent business conflict)")
+		t.Error("Operational() must default to retryable=false")
 	}
 	if err.Level != common.LevelOperational {
 		t.Errorf("level = %v, want Operational", err.Level)
 	}
 }
 
-// TestRetryableConflict_RetryableTrue pins the new constructor's contract:
-// transient transaction-abort style conflicts must opt in via this helper
-// so the parity client retry loop can engage.
-func TestRetryableConflict_RetryableTrue(t *testing.T) {
-	err := common.RetryableConflict("transaction conflict — retry")
+// TestOperational_AsRetryable_FlipsRetryableBit pins #140's contract:
+// the three axes (status, code, retryable) are independent and any
+// 4xx with any code can be flagged retryable via the fluent
+// AsRetryable() opt-in. A retryable conflict with a specific
+// dictionary code (e.g. retryable TX_CONFLICT — distinct from the
+// generic CONFLICT) was previously unreachable without bare-field
+// mutation; AsRetryable() closes that gap.
+func TestOperational_AsRetryable_FlipsRetryableBit(t *testing.T) {
+	err := common.Operational(http.StatusConflict, common.ErrCodeConflict, "transaction conflict — retry").AsRetryable()
 	if err.Status != http.StatusConflict {
 		t.Errorf("status = %d, want 409", err.Status)
 	}
 	if !err.Retryable {
-		t.Error("RetryableConflict() must set retryable=true")
+		t.Error("AsRetryable() must set retryable=true")
 	}
 	if err.Code != common.ErrCodeConflict {
 		t.Errorf("code = %q, want %q", err.Code, common.ErrCodeConflict)
+	}
+}
+
+// TestOperational_AsRetryable_ReturnsSameInstance pins that the
+// fluent helper returns the receiver — chains compose without
+// allocating, and the returned pointer equals the input.
+func TestOperational_AsRetryable_ReturnsSameInstance(t *testing.T) {
+	err := common.Operational(http.StatusConflict, common.ErrCodeConflict, "x")
+	if got := err.AsRetryable(); got != err {
+		t.Errorf("AsRetryable() returned %p, want receiver %p", got, err)
 	}
 }
 
@@ -338,7 +353,7 @@ func TestWriteError_PermanentConflict_NoRetryableProperty(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("POST", "/test", nil)
 
-	common.WriteError(w, r, common.Conflict("model already locked"))
+	common.WriteError(w, r, common.Operational(http.StatusConflict, common.ErrCodeModelAlreadyLocked, "model already locked"))
 
 	if w.Code != http.StatusConflict {
 		t.Errorf("status = %d, want 409", w.Code)
@@ -364,7 +379,7 @@ func TestWriteError_RetryableConflict_AdvertisesRetryable(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("POST", "/test", nil)
 
-	common.WriteError(w, r, common.RetryableConflict("transaction conflict — retry"))
+	common.WriteError(w, r, common.Operational(http.StatusConflict, common.ErrCodeConflict, "transaction conflict — retry").AsRetryable())
 
 	var pd map[string]any
 	if err := json.NewDecoder(w.Body).Decode(&pd); err != nil {

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -235,7 +235,7 @@ func (h *Handler) CreateEntity(ctx context.Context, input CreateEntityInput) (*E
 	// Commit transaction.
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.RetryableConflict("transaction conflict — retry")
+			return nil, common.Operational(http.StatusConflict, common.ErrCodeConflict, "transaction conflict — retry").AsRetryable()
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}
@@ -526,7 +526,7 @@ func (h *Handler) DeleteEntity(ctx context.Context, entityID string) (*deleteEnt
 	// Commit transaction.
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.RetryableConflict("transaction conflict — retry")
+			return nil, common.Operational(http.StatusConflict, common.ErrCodeConflict, "transaction conflict — retry").AsRetryable()
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}
@@ -663,7 +663,7 @@ func (h *Handler) DeleteAllEntities(ctx context.Context, entityName string, mode
 	// Commit transaction.
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.RetryableConflict("transaction conflict — retry")
+			return nil, common.Operational(http.StatusConflict, common.ErrCodeConflict, "transaction conflict — retry").AsRetryable()
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}
@@ -853,7 +853,7 @@ func (h *Handler) CreateEntityCollection(ctx context.Context, items []Collection
 	// Commit transaction.
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.RetryableConflict("transaction conflict — retry")
+			return nil, common.Operational(http.StatusConflict, common.ErrCodeConflict, "transaction conflict — retry").AsRetryable()
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}
@@ -1000,7 +1000,7 @@ func (h *Handler) UpdateEntity(ctx context.Context, input UpdateEntityInput) (*E
 	// Commit transaction.
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.RetryableConflict("transaction conflict — retry")
+			return nil, common.Operational(http.StatusConflict, common.ErrCodeConflict, "transaction conflict — retry").AsRetryable()
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}
@@ -1136,7 +1136,7 @@ func (h *Handler) UpdateEntityCollection(ctx context.Context, items []UpdateColl
 
 	if err := h.txMgr.Commit(txCtx, txID); err != nil {
 		if errors.Is(err, spi.ErrConflict) {
-			return nil, common.RetryableConflict("transaction conflict — retry")
+			return nil, common.Operational(http.StatusConflict, common.ErrCodeConflict, "transaction conflict — retry").AsRetryable()
 		}
 		return nil, common.Internal("failed to commit transaction", err)
 	}


### PR DESCRIPTION
Closes #140.

Decouples the three orthogonal axes — HTTP status, dictionary error code, retryability — that were previously bundled into specialised helpers (\`Conflict\` / \`RetryableConflict\`).

## API change

| Before                            | After                                                  |
|-----------------------------------|--------------------------------------------------------|
| \`Conflict(msg)\`                 | \`Operational(409, ErrCodeConflict, msg)\`             |
| \`RetryableConflict(msg)\`        | \`Operational(409, ErrCodeConflict, msg).AsRetryable()\` |
| *(no path)* retryable + specific code | \`Operational(status, code, msg).AsRetryable()\`   |

\`Operational\` stays the primitive. \`AsRetryable()\` is a fluent opt-in that flips the \`Retryable\` bit and returns the receiver. The previously-unreachable cell — *retryable 4xx with a specific dictionary code* (e.g. retryable \`TX_CONFLICT\` distinct from generic \`CONFLICT\`) — is now expressible without bare-field mutation.

## Migrated

- \`Internal()\`'s \`spi.ErrConflict\` auto-route now uses \`Operational(409, ErrCodeConflict, ...).AsRetryable()\` — same wire semantics, no longer routed through a removed helper.
- Six \`entity/service.go\` sites that called \`RetryableConflict(...)\`.
- \`errors_test.go\` reorganised: \`TestOperational_NotRetryableByDefault\` (primitive default), \`TestOperational_AsRetryable_FlipsRetryableBit\`, new \`TestOperational_AsRetryable_ReturnsSameInstance\` pins the chainable receiver-return contract.

## Removed

\`Conflict()\` and \`RetryableConflict()\` constructors. No production callers remain — \`Conflict()\` had been fully migrated by #128; \`RetryableConflict()\` is migrated here.

## Behaviour

- Wire shape unchanged. Same status, same code, same \`retryable\` flag, same WriteError JSON output.
- Retryable classifications unchanged at every call site. This is purely the API refactor — does not change which errors retry, only the constructor used to express them.

## Out of scope (per #140)

The cascade-aware retryability question for the entity-service TX-commit sites is a separate audit; it should be raised independently if observed misbehaviour motivates it.

## TDD

- RED: new tests reference \`AsRetryable()\` → test binary fails to compile (\`undefined: ... AsRetryable\`).
- GREEN: implement method, migrate call sites, remove deprecated helpers. All tests green.

## Test plan

- [x] \`go test ./internal/common/...\` green (new + adapted tests)
- [x] \`go test -short ./...\` green
- [x] \`go test ./internal/e2e/...\` green
- [x] \`go test -race -short ./...\` clean
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)