### PR TITLE
fix(release/v0.7.0): code-review findings on #210/#211/#213

### DIFF
--- a/internal/common/errors.go
+++ b/internal/common/errors.go
@@ -58,6 +58,11 @@ func (e *AppError) Unwrap() error { return e.Err }
 // retryable — calling those retryable causes pointless backoff and
 // 5x request amplification on the parity client side.
 //
+// AsRetryable mutates the receiver. The intended call shape is
+// Operational(...).AsRetryable() on a freshly-constructed *AppError
+// — do NOT call on an aliased or shared *AppError, since the flip
+// is observable from every other reference to the same instance.
+//
 // Issue #140 — separates the (status, code, retryable) axes that
 // were previously bundled into specialized helpers (Conflict /
 // RetryableConflict, removed). Retryable is now opt-in on top of

--- a/internal/domain/search/path_validation_cache.go
+++ b/internal/domain/search/path_validation_cache.go
@@ -71,11 +71,20 @@ func NewPathValidationCache() *PathValidationCache {
 // current negative-cache entry — i.e. the path was previously
 // confirmed absent from the model's FieldsMap and no schema-change
 // invalidation has fired for that model since.
+//
+// The lookup AND the otter GetIfPresent call run under c.mu so a
+// concurrent InvalidateRef cannot drop the bucket between the two
+// steps (review #211 — TOCTOU concern). otter.Cache is internally
+// thread-safe; the mutex is about preserving the "operate on the
+// bucket I just resolved from c.buckets" invariant, not about
+// otter's own concurrency.
 func (c *PathValidationCache) IsAbsent(tenant string, ref spi.ModelRef, path string) bool {
 	if c == nil {
 		return false
 	}
-	bucket := c.bucketFor(modelRefKey{
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	bucket := c.bucketLocked(modelRefKey{
 		tenant:       tenant,
 		entityName:   ref.EntityName,
 		modelVersion: ref.ModelVersion,
@@ -91,11 +100,17 @@ func (c *PathValidationCache) IsAbsent(tenant string, ref spi.ModelRef, path str
 // absent. Subsequent IsAbsent calls return true until either the
 // path's bucket is invalidated via InvalidateRef or otter's S3-FIFO
 // eviction reaps the entry under bucket-internal pressure.
+//
+// Lock held across both bucket allocation and Set so a concurrent
+// InvalidateRef can't drop the bucket out from under us — without
+// the lock the Set would land in an orphaned bucket (review #211).
 func (c *PathValidationCache) MarkAbsent(tenant string, ref spi.ModelRef, path string) {
 	if c == nil {
 		return
 	}
-	bucket := c.bucketFor(modelRefKey{
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	bucket := c.bucketLocked(modelRefKey{
 		tenant:       tenant,
 		entityName:   ref.EntityName,
 		modelVersion: ref.ModelVersion,
@@ -112,7 +127,9 @@ func (c *PathValidationCache) MarkPresent(tenant string, ref spi.ModelRef, path 
 	if c == nil {
 		return
 	}
-	bucket := c.bucketFor(modelRefKey{
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	bucket := c.bucketLocked(modelRefKey{
 		tenant:       tenant,
 		entityName:   ref.EntityName,
 		modelVersion: ref.ModelVersion,
@@ -143,9 +160,11 @@ func (c *PathValidationCache) InvalidateRef(tenant string, ref spi.ModelRef) {
 	})
 }
 
-func (c *PathValidationCache) bucketFor(k modelRefKey, createIfMissing bool) *otter.Cache[string, struct{}] {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+// bucketLocked returns the bucket for k. Caller MUST hold c.mu — the
+// returned otter.Cache pointer is only safe to operate on while c.mu
+// is held, since InvalidateRef may delete the map entry concurrently
+// otherwise (review #211).
+func (c *PathValidationCache) bucketLocked(k modelRefKey, createIfMissing bool) *otter.Cache[string, struct{}] {
 	b, ok := c.buckets[k]
 	if ok {
 		return b

--- a/internal/domain/search/path_validation_concurrent_test.go
+++ b/internal/domain/search/path_validation_concurrent_test.go
@@ -1,0 +1,117 @@
+package search_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
+)
+
+// TestPathValidationCache_ConcurrentMarkAbsentAndInvalidateRef stresses
+// the per-bucket invalidation path against the reviewer's TOCTOU
+// concern (#211 review feedback). Pre-fix, MarkAbsent acquired c.mu
+// briefly (in bucketFor) to obtain a *otter.Cache pointer, released
+// the lock, then called bucket.Set without holding c.mu. A concurrent
+// InvalidateRef could delete(c.buckets, k) between those two steps
+// and the subsequent Set would land in an orphaned bucket (still
+// correct end-state, but only by accident — a tail of pre-invalidation
+// writes could end up in the dropped bucket while readers used the
+// fresh one).
+//
+// Post-fix bucketFor holds c.mu across both lookup AND cache op so the
+// "operate on the bucket I just fetched" sequence is atomic relative
+// to InvalidateRef. This test runs heavy concurrent MarkAbsent +
+// InvalidateRef + IsAbsent + MarkPresent traffic on a small set of
+// (tenant, ref) keys; under -race any inconsistency would surface.
+//
+// We don't (and can't reliably) assert the orphan-write bug
+// deterministically — the timing window is microseconds and the
+// orphan is unobservable from outside. The test's value is: it runs
+// the post-fix code through a contention pattern that the existing
+// tests don't, and a future regression that loosens the locking
+// discipline gets caught here under -race.
+func TestPathValidationCache_ConcurrentMarkAbsentAndInvalidateRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrent stress test under -short")
+	}
+	cache := search.NewPathValidationCache()
+
+	const (
+		tenants     = 4
+		refsPerKey  = 3
+		pathsPerOp  = 8
+		iterations  = 200
+		workersPerOp = 4
+	)
+
+	refs := make([]spi.ModelRef, refsPerKey)
+	for i := range refs {
+		refs[i] = spi.ModelRef{EntityName: fmt.Sprintf("e%d", i), ModelVersion: "1"}
+	}
+
+	var wg sync.WaitGroup
+	for w := 0; w < workersPerOp; w++ {
+		// MarkAbsent flooders.
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				tenant := fmt.Sprintf("t%d", (seed+i)%tenants)
+				ref := refs[(seed+i)%refsPerKey]
+				for p := 0; p < pathsPerOp; p++ {
+					cache.MarkAbsent(tenant, ref, fmt.Sprintf("$.field.%d.%d", seed, p))
+				}
+			}
+		}(w)
+
+		// InvalidateRef storms.
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				tenant := fmt.Sprintf("t%d", (seed+i)%tenants)
+				ref := refs[(seed+i)%refsPerKey]
+				cache.InvalidateRef(tenant, ref)
+			}
+		}(w)
+
+		// IsAbsent readers.
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				tenant := fmt.Sprintf("t%d", (seed+i)%tenants)
+				ref := refs[(seed+i)%refsPerKey]
+				_ = cache.IsAbsent(tenant, ref, fmt.Sprintf("$.field.%d.0", seed))
+			}
+		}(w)
+
+		// MarkPresent prunes.
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				tenant := fmt.Sprintf("t%d", (seed+i)%tenants)
+				ref := refs[(seed+i)%refsPerKey]
+				cache.MarkPresent(tenant, ref, fmt.Sprintf("$.field.%d.0", seed))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// Final invariant: after every InvalidateRef+MarkPresent pair the
+	// cache should be in a consistent state for any (tenant, ref).
+	// Specifically a freshly-invalidated bucket reports IsAbsent=false
+	// for any path until the next MarkAbsent.
+	for ti := 0; ti < tenants; ti++ {
+		for _, ref := range refs {
+			tenant := fmt.Sprintf("t%d", ti)
+			cache.InvalidateRef(tenant, ref)
+			if cache.IsAbsent(tenant, ref, "$.never.marked") {
+				t.Errorf("after InvalidateRef, IsAbsent must return false for unwritten path; got true for tenant=%s ref=%v", tenant, ref)
+			}
+		}
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,11 +26,12 @@ set -eu
 REPO="cyoda-platform/cyoda-go"
 INSTALL_DIR="${CYODA_INSTALL_DIR:-$HOME/.local/bin}"
 # Cosign keyless verification expects the signing identity to come from
-# this OIDC issuer (GitHub Actions) and the cert subject to match a
-# workflow path under our org+repo. The release.yml workflow runs with
-# `id-token: write` and is the only ref that can mint a matching cert.
+# this OIDC issuer (GitHub Actions) and the cert subject to match the
+# release.yml workflow path under our org+repo. release.yml is the only
+# workflow with `id-token: write`, so any future workflow added to the
+# repo cannot mint a cert that satisfies this regex.
 COSIGN_OIDC_ISSUER="https://token.actions.githubusercontent.com"
-COSIGN_IDENTITY_REGEX="^https://github.com/cyoda-platform/cyoda-go/"
+COSIGN_IDENTITY_REGEX="^https://github\.com/cyoda-platform/cyoda-go/\.github/workflows/release\.yml@"
 
 err() { printf 'install.sh: error: %s\n' "$*" >&2; }
 warn() { printf 'install.sh: warning: %s\n' "$*" >&2; }
@@ -90,12 +91,26 @@ resolve_version() {
         | head -n1
 }
 
+# cosign_fetch downloads a release asset and prints its HTTP status to
+# stdout (so callers can distinguish 200, 404, and other failures).
+# Unlike curl -fsSL, a 404 here does NOT terminate the script.
+cosign_fetch() {
+    cf_url=$1
+    cf_dest=$2
+    curl -sS -o "$cf_dest" -w "%{http_code}" "$cf_url" 2>/dev/null || printf '000'
+}
+
 # cosign_verify runs keyless Sigstore verification of the archive and
 # SHA256SUMS using sibling .sig + .pem assets published by GoReleaser
 # (issue #47). Default behaviour:
-#   - cosign on PATH AND CYODA_COSIGN_VERIFY != "false" → verify; abort on failure.
-#   - cosign missing AND CYODA_COSIGN_VERIFY = "required" → abort.
-#   - otherwise → skip with a hint about how to enable.
+#   - cosign on PATH AND CYODA_COSIGN_VERIFY != "false" → verify; abort on
+#     verification failure or transient infrastructure errors. A 404 on
+#     the sibling .sig (release predates cosign signing in v0.7.0) is a
+#     soft fall-back to SHA256-only with a warning.
+#   - CYODA_COSIGN_VERIFY = "required" → cosign must be on PATH AND every
+#     sibling artifact must be present. A 404 on the .sig is a hard error.
+#   - cosign missing in auto mode → SHA256-only with a hint about cosign.
+#   - CYODA_COSIGN_VERIFY = "false" → skip entirely.
 cosign_verify() {
     cv_tmp=$1
     cv_archive=$2
@@ -119,14 +134,27 @@ cosign_verify() {
     for cv_target in "$cv_archive" SHA256SUMS; do
         cv_sig_url="https://github.com/$REPO/releases/download/$cv_version/${cv_target}.sig"
         cv_pem_url="https://github.com/$REPO/releases/download/$cv_version/${cv_target}.pem"
-        if ! curl -fsSL -o "$cv_tmp/${cv_target}.sig" "$cv_sig_url"; then
-            err "could not download signature: $cv_sig_url"
+
+        cv_sig_status=$(cosign_fetch "$cv_sig_url" "$cv_tmp/${cv_target}.sig")
+        if [ "$cv_sig_status" = "404" ]; then
+            if [ "$cv_mode" = "required" ]; then
+                err "CYODA_COSIGN_VERIFY=required but ${cv_target}.sig is not on this release ($cv_version). Cosign signing was added in v0.7.0; older releases are unsigned."
+                exit 1
+            fi
+            warn "release $cv_version predates cosign signing (added in v0.7.0); falling back to SHA256-only verification"
+            return 0
+        fi
+        if [ "$cv_sig_status" != "200" ]; then
+            err "could not download signature ($cv_sig_status): $cv_sig_url"
             exit 1
         fi
-        if ! curl -fsSL -o "$cv_tmp/${cv_target}.pem" "$cv_pem_url"; then
-            err "could not download certificate: $cv_pem_url"
+
+        cv_pem_status=$(cosign_fetch "$cv_pem_url" "$cv_tmp/${cv_target}.pem")
+        if [ "$cv_pem_status" != "200" ]; then
+            err "could not download certificate ($cv_pem_status): $cv_pem_url"
             exit 1
         fi
+
         if ! cosign verify-blob \
             --certificate="$cv_tmp/${cv_target}.pem" \
             --signature="$cv_tmp/${cv_target}.sig" \


### PR DESCRIPTION
Addresses the five findings from the code-reviewer pass on the three high-stakes PRs that landed in this release-branch session. Per Gate 6 — resolve, don't defer.

## #210 — cosign + install.sh

**\`scripts/install.sh\`**

- **I-210.1 (Important): Auto-mode 404 handling.** Pre-fix, a user running \`CYODA_VERSION=v0.6.x curl …/releases/latest/download/install.sh | sh\` would hit a 404 on the sibling \`.sig\` (cosign signing was added in v0.7.0) and abort with \"verification FAILED\" — confusing, since older releases simply have no signatures. New \`cosign_fetch\` helper captures the HTTP status; auto mode treats 404-on-sig as \"release predates cosign signing\" and falls back to SHA256-only with a WARN; only \`CYODA_COSIGN_VERIFY=required\` hard-fails on missing siblings. Non-404 errors (5xx, network) still hard-fail in every mode — we do NOT silently degrade security on transient infrastructure errors.
- **Minor: Cert-identity regex tightened** from \`^https://github.com/cyoda-platform/cyoda-go/\` to \`^https://github\\.com/cyoda-platform/cyoda-go/\\.github/workflows/release\\.yml@\`. Only \`release.yml\` has \`id-token: write\` today; the tighter regex prevents any future workflow added to the repo from minting a matching cert.

## #211 — path-validation cache

**\`internal/domain/search/path_validation_cache.go\`**

- **I-211.1 (Important): TOCTOU between \`MarkAbsent\` and \`InvalidateRef\`.** Pre-fix \`bucketFor\` returned a \`*otter.Cache\` pointer under \`c.mu\` and released the lock; the subsequent \`bucket.Set\` ran without \`c.mu\`. A concurrent \`InvalidateRef\` could \`delete(c.buckets, k)\` between those two steps and the \`Set\` would land in an orphaned bucket. End state was correct (next \`MarkAbsent\` re-allocated), but only by accident.

  Now \`MarkAbsent\` / \`IsAbsent\` / \`MarkPresent\` acquire \`c.mu\` for the whole operation, and \`bucketFor\` → \`bucketLocked\` is unexported and documents \"caller MUST hold c.mu\". \`otter.Cache\` is internally thread-safe; the mutex is about preserving the \"operate on the bucket I just resolved from c.buckets\" invariant.

- **New stress test** \`path_validation_concurrent_test.go\` drives concurrent \`MarkAbsent\` + \`InvalidateRef\` + \`IsAbsent\` + \`MarkPresent\` across 16 goroutines and 200 iterations on a small (tenant, ref) set. Asserts no panics, no race-detector hits, and the post-Invalidate invariant (\"freshly-invalidated bucket reports IsAbsent=false\"). \`go test -race\` verified across multiple iterations.

## #213 — AppError refactor

**\`internal/common/errors.go\`**

- **Minor: \`AsRetryable()\` doc warns about receiver mutation.** The fluent style is safe at canonical call sites (\`Operational(...).AsRetryable()\` on a fresh allocation), but a future caller that aliases an \`*AppError\` and calls \`AsRetryable\` on the alias would silently flip the bit on the shared instance. Doc comment now states the constraint.

## Test plan

- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all green (short + E2E)
- [x] \`go test -race ./internal/domain/search/...\` — clean across multiple iterations of the new \`TestPathValidationCache_ConcurrentMarkAbsent...\`
- [x] \`go test -race -short ./...\` — clean
- [x] \`sh -n scripts/install.sh\` — syntactically clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)