### PR TITLE
fix(release/v0.7.0): security-audit findings on supply-chain + concurrency (closes #218)

### DIFF
--- a/internal/cluster/modelcache/cache.go
+++ b/internal/cluster/modelcache/cache.go
@@ -46,7 +46,11 @@ type CachingModelStore struct {
 	// regardless of whether a cluster broadcaster is wired up. On
 	// single-node deployments this is the only invalidation channel
 	// available; on multi-node it fires alongside the gossip path.
-	localSubMu sync.RWMutex
+	//
+	// Plain Mutex (not RWMutex) — the snapshot taken on the read
+	// path is brief and there's no read-heavy contention pattern
+	// here that benefits from RW semantics.
+	localSubMu sync.Mutex
 	localSubs  []func(tenant string, ref spi.ModelRef)
 }
 
@@ -269,9 +273,9 @@ func (c *CachingModelStore) SubscribeLocal(h func(tenant string, ref spi.ModelRe
 }
 
 func (c *CachingModelStore) notifyLocalSubscribers(tenant string, ref spi.ModelRef) {
-	c.localSubMu.RLock()
+	c.localSubMu.Lock()
 	subs := append([]func(string, spi.ModelRef){}, c.localSubs...)
-	c.localSubMu.RUnlock()
+	c.localSubMu.Unlock()
 	for _, h := range subs {
 		h(tenant, ref)
 	}

--- a/internal/domain/search/export_test.go
+++ b/internal/domain/search/export_test.go
@@ -1,0 +1,21 @@
+package search
+
+// Test-only accessors. The build tag `*_test.go` keeps these out of
+// the production binary while making them visible to external tests
+// in the search_test package.
+
+// PathValidationBucketMapCap returns the configured maximum number of
+// (tenant, ref) buckets the path-validation cache will retain. Issue
+// #218 — used by tests to drive the LRU eviction path.
+func PathValidationBucketMapCap() int {
+	return pathValidationBucketMapCap
+}
+
+// PathValidationCacheBucketCount returns the current number of
+// non-empty buckets in the cache. Test-only introspection used by
+// the LRU stress tests.
+func PathValidationCacheBucketCount(c *PathValidationCache) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.buckets)
+}

--- a/internal/domain/search/path_validation_cache.go
+++ b/internal/domain/search/path_validation_cache.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"container/list"
 	"sync"
 
 	"github.com/maypok86/otter/v2"
@@ -24,6 +25,25 @@ import (
 // thousands. Tune up if observability shows benign workloads hitting
 // the cap.
 const pathValidationBucketCapacity = 100
+
+// pathValidationBucketMapCap bounds the number of distinct
+// (tenant, ref) buckets the cache retains. Issue #218 — pre-cap the
+// map grew without bound; an adversarial tenant with model-creation
+// privilege at scale could accumulate ~unbounded buckets even though
+// each bucket itself was capped at pathValidationBucketCapacity.
+//
+// 10000 matches the pre-#211 single-cache global entry budget so the
+// worst-case memory footprint is roughly equivalent to the old
+// design (10k buckets × 100 entries each = 1M entries — vs. the
+// pre-#211 10k flat entries — at the cost of more buckets, each
+// holding tenant-scoped data). Per-bucket isolation (#175) is
+// preserved.
+//
+// LRU is the eviction policy: the bucket whose last access (read OR
+// write) is oldest gets dropped when MarkAbsent on a fresh key would
+// exceed the cap. InvalidateRef removes a bucket but does NOT touch
+// LRU — invalidate is destructive, not a recency signal.
+const pathValidationBucketMapCap = 10000
 
 // modelRefKey is the (tenant, modelRef) bucket key. One otter cache
 // per bucket; entire-bucket eviction handled by InvalidateRef.
@@ -50,12 +70,28 @@ type modelRefKey struct {
 //
 // Each (tenant, ref) lives in its own bounded otter cache (issue #175
 // — per-bucket capacity isolates cross-tenant eviction). InvalidateRef
-// drops the bucket entirely.
+// drops the bucket entirely. The bucket map itself is also capped
+// with LRU eviction (issue #218) so an adversarial tenant cannot
+// grow the map indefinitely.
 //
 // The zero value is not safe — use NewPathValidationCache.
 type PathValidationCache struct {
 	mu      sync.Mutex
-	buckets map[modelRefKey]*otter.Cache[string, struct{}]
+	buckets map[modelRefKey]*bucketEntry
+	// lruOrder is a doubly-linked list of *bucketEntry ordered by
+	// recency: front = most recently used, back = least recently used.
+	// MarkAbsent and IsAbsent move the touched bucket to the front;
+	// InvalidateRef removes the entry from both the map and the list
+	// without touching recency on anything else.
+	lruOrder *list.List
+}
+
+// bucketEntry pairs the per-bucket otter cache with its LRU-list
+// element so eviction can find the back-of-list key in O(1).
+type bucketEntry struct {
+	key   modelRefKey
+	cache *otter.Cache[string, struct{}]
+	elem  *list.Element // points back to the *bucketEntry in lruOrder
 }
 
 // NewPathValidationCache constructs an empty PathValidationCache.
@@ -63,7 +99,8 @@ type PathValidationCache struct {
 // modelcache.CachingStoreFactory.SubscribeLocal.
 func NewPathValidationCache() *PathValidationCache {
 	return &PathValidationCache{
-		buckets: make(map[modelRefKey]*otter.Cache[string, struct{}]),
+		buckets:  make(map[modelRefKey]*bucketEntry),
+		lruOrder: list.New(),
 	}
 }
 
@@ -141,8 +178,11 @@ func (c *PathValidationCache) MarkPresent(tenant string, ref spi.ModelRef, path 
 }
 
 // InvalidateRef drops every cached negative entry for (tenant, ref).
-// The whole bucket is removed from the map; the next MarkAbsent for
-// that bucket allocates a fresh otter cache.
+// The whole bucket is removed from the map and the LRU list; the next
+// MarkAbsent for that bucket allocates a fresh otter cache.
+//
+// Invalidate is destructive, not a recency signal — it doesn't touch
+// LRU recency on any other bucket (issue #218 design choice).
 //
 // This is the public hook wired up by app.go to
 // modelcache.CachingStoreFactory.SubscribeLocal so the cache reacts
@@ -153,28 +193,51 @@ func (c *PathValidationCache) InvalidateRef(tenant string, ref spi.ModelRef) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.buckets, modelRefKey{
+	k := modelRefKey{
 		tenant:       tenant,
 		entityName:   ref.EntityName,
 		modelVersion: ref.ModelVersion,
-	})
+	}
+	if e, ok := c.buckets[k]; ok {
+		c.lruOrder.Remove(e.elem)
+		delete(c.buckets, k)
+	}
 }
 
 // bucketLocked returns the bucket for k. Caller MUST hold c.mu — the
 // returned otter.Cache pointer is only safe to operate on while c.mu
 // is held, since InvalidateRef may delete the map entry concurrently
 // otherwise (review #211).
+//
+// Side effect: every successful return path (existing OR newly
+// allocated) promotes the bucket to MRU on the LRU list. When
+// createIfMissing=true and the map is at the size cap, the LRU
+// (back-of-list) bucket is evicted before the new one is allocated
+// (issue #218).
 func (c *PathValidationCache) bucketLocked(k modelRefKey, createIfMissing bool) *otter.Cache[string, struct{}] {
-	b, ok := c.buckets[k]
-	if ok {
-		return b
+	if e, ok := c.buckets[k]; ok {
+		c.lruOrder.MoveToFront(e.elem)
+		return e.cache
 	}
 	if !createIfMissing {
 		return nil
 	}
-	b = otter.Must(&otter.Options[string, struct{}]{
+	if len(c.buckets) >= pathValidationBucketMapCap {
+		// Evict the LRU bucket. lruOrder.Back() is the least
+		// recently used entry; the back element's Value is the
+		// *bucketEntry, which carries its own key for map deletion.
+		back := c.lruOrder.Back()
+		if back != nil {
+			victim := back.Value.(*bucketEntry)
+			c.lruOrder.Remove(back)
+			delete(c.buckets, victim.key)
+		}
+	}
+	cache := otter.Must(&otter.Options[string, struct{}]{
 		MaximumSize: pathValidationBucketCapacity,
 	})
-	c.buckets[k] = b
-	return b
+	entry := &bucketEntry{key: k, cache: cache}
+	entry.elem = c.lruOrder.PushFront(entry)
+	c.buckets[k] = entry
+	return cache
 }

--- a/internal/domain/search/path_validation_lru_test.go
+++ b/internal/domain/search/path_validation_lru_test.go
@@ -1,0 +1,130 @@
+package search_test
+
+import (
+	"fmt"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/search"
+)
+
+// TestPathValidationCache_BucketMapEvictsLRU pins issue #218: the
+// per-(tenant, ref) bucket map must enforce a maximum size to bound
+// memory under adversarial workloads (a tenant with model-creation
+// privilege at scale who searches against many distinct models).
+//
+// Pre-fix the map was unbounded; only the per-bucket otter cache
+// was capped. Post-fix the cache evicts least-recently-used buckets
+// when len(buckets) exceeds the configured cap.
+//
+// This test floods the cache with > cap distinct (tenant, ref) keys
+// and asserts:
+//  1. len(buckets) stays at the cap (no unbounded growth);
+//  2. recently-used buckets survive (LRU property);
+//  3. oldest unused buckets are the ones evicted.
+func TestPathValidationCache_BucketMapEvictsLRU(t *testing.T) {
+	cap := search.PathValidationBucketMapCap()
+	if cap <= 1 {
+		t.Fatalf("PathValidationBucketMapCap() = %d, want > 1", cap)
+	}
+
+	cache := search.NewPathValidationCache()
+
+	// Insert cap+50 distinct buckets. The first 50 should be evicted.
+	for i := 0; i < cap+50; i++ {
+		ref := spi.ModelRef{EntityName: fmt.Sprintf("e%d", i), ModelVersion: "1"}
+		cache.MarkAbsent("t", ref, "$.path")
+	}
+
+	if got := search.PathValidationCacheBucketCount(cache); got != cap {
+		t.Fatalf("bucket count after flood: got %d, want %d (cap)", got, cap)
+	}
+
+	// Buckets 0..49 should be evicted (LRU), buckets 50..cap+49 should
+	// survive.
+	for i := 0; i < 50; i++ {
+		ref := spi.ModelRef{EntityName: fmt.Sprintf("e%d", i), ModelVersion: "1"}
+		if cache.IsAbsent("t", ref, "$.path") {
+			t.Errorf("bucket %d should have been evicted (LRU), but IsAbsent still returns true", i)
+		}
+	}
+	for i := 50; i < cap+50; i++ {
+		ref := spi.ModelRef{EntityName: fmt.Sprintf("e%d", i), ModelVersion: "1"}
+		if !cache.IsAbsent("t", ref, "$.path") {
+			t.Errorf("bucket %d should have survived, but IsAbsent returns false", i)
+		}
+	}
+}
+
+// TestPathValidationCache_LRURecencyTouchedByRead pins that IsAbsent
+// promotes the bucket to MRU, so a frequently-read bucket is not
+// evicted just because no new MarkAbsent fires for it.
+func TestPathValidationCache_LRURecencyTouchedByRead(t *testing.T) {
+	cap := search.PathValidationBucketMapCap()
+	cache := search.NewPathValidationCache()
+
+	// Seed bucket 0.
+	ref0 := spi.ModelRef{EntityName: "e0", ModelVersion: "1"}
+	cache.MarkAbsent("t", ref0, "$.path")
+
+	// Fill the rest of the cap.
+	for i := 1; i < cap; i++ {
+		ref := spi.ModelRef{EntityName: fmt.Sprintf("e%d", i), ModelVersion: "1"}
+		cache.MarkAbsent("t", ref, "$.path")
+	}
+
+	// At cap. Now read bucket 0 to promote it to MRU.
+	if !cache.IsAbsent("t", ref0, "$.path") {
+		t.Fatalf("bucket 0 should be present before LRU touch")
+	}
+
+	// Add cap-1 more buckets. Without the IsAbsent touch, bucket 0
+	// would be evicted by the very first new insert (it was the
+	// oldest). With the touch promoting bucket 0 to MRU, bucket 1
+	// becomes the LRU and is evicted by the first insert; bucket 0
+	// survives all cap-1 subsequent inserts because we don't push
+	// it past the back of the list.
+	for i := cap; i < 2*cap-1; i++ {
+		ref := spi.ModelRef{EntityName: fmt.Sprintf("e%d", i), ModelVersion: "1"}
+		cache.MarkAbsent("t", ref, "$.path")
+	}
+
+	if !cache.IsAbsent("t", ref0, "$.path") {
+		t.Errorf("bucket 0 should have survived because IsAbsent touched it (LRU)")
+	}
+	ref1 := spi.ModelRef{EntityName: "e1", ModelVersion: "1"}
+	if cache.IsAbsent("t", ref1, "$.path") {
+		t.Errorf("bucket 1 should have been evicted (oldest after bucket 0 was touched)")
+	}
+}
+
+// TestPathValidationCache_InvalidateRefDoesNotTouchLRU pins that
+// InvalidateRef drops the bucket but does NOT update LRU recency
+// (treating invalidation as orthogonal to access). Otherwise an
+// adversary could spam invalidations to keep their own buckets MRU
+// at the expense of legitimate tenants.
+func TestPathValidationCache_InvalidateRefDoesNotTouchLRU(t *testing.T) {
+	cap := search.PathValidationBucketMapCap()
+	cache := search.NewPathValidationCache()
+
+	// Seed and immediately invalidate bucket 0 — bucket 0 is now
+	// gone from the map entirely (InvalidateRef drops the bucket).
+	ref0 := spi.ModelRef{EntityName: "e0", ModelVersion: "1"}
+	cache.MarkAbsent("t", ref0, "$.path")
+	cache.InvalidateRef("t", ref0)
+
+	// Fill cap buckets fresh.
+	for i := 1; i <= cap; i++ {
+		ref := spi.ModelRef{EntityName: fmt.Sprintf("e%d", i), ModelVersion: "1"}
+		cache.MarkAbsent("t", ref, "$.path")
+	}
+
+	// Add one more — bucket 1 should be evicted (oldest), not e.g.
+	// some bucket that would have been "kept alive" by the earlier
+	// InvalidateRef on bucket 0.
+	cache.MarkAbsent("t", spi.ModelRef{EntityName: "eN", ModelVersion: "1"}, "$.path")
+
+	if cache.IsAbsent("t", spi.ModelRef{EntityName: "e1", ModelVersion: "1"}, "$.path") {
+		t.Errorf("bucket 1 should have been evicted as LRU; InvalidateRef should not promote anything")
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,10 +16,21 @@
 # Cosign verification (issue #47):
 #   - Auto-on when `cosign` is on PATH. Verifies the archive and
 #     SHA256SUMS against keyless Sigstore signatures issued by the
-#     cyoda-platform/cyoda-go release workflow.
+#     cyoda-platform/cyoda-go release.yml workflow on a tag push.
 #   - Disable explicitly: CYODA_COSIGN_VERIFY=false curl ... | sh
 #   - Force-fail-without-cosign: CYODA_COSIGN_VERIFY=required curl ... | sh
 #     (Aborts if cosign is missing rather than falling back to SHA256-only.)
+#
+# Auto-mode trade-off (security note): cosign signing was added in
+# v0.7.0; older releases have no .sig files. To preserve backward
+# compat with the curl-pipe-to-sh UX for users without cosign, auto
+# mode treats a 404 on the .sig as "release predates cosign signing"
+# and falls back to SHA256-only. This means an attacker who controls
+# the GitHub release page on a v0.7.0+ release can bypass cosign by
+# deleting the .sig along with their archive swap — SHA256 against
+# their own SHA256SUMS would still pass. For hardened/production
+# deployments, set CYODA_COSIGN_VERIFY=required: missing .sig is
+# then a hard error, not a fallback.
 
 set -eu
 
@@ -27,11 +38,21 @@ REPO="cyoda-platform/cyoda-go"
 INSTALL_DIR="${CYODA_INSTALL_DIR:-$HOME/.local/bin}"
 # Cosign keyless verification expects the signing identity to come from
 # this OIDC issuer (GitHub Actions) and the cert subject to match the
-# release.yml workflow path under our org+repo. release.yml is the only
-# workflow with `id-token: write`, so any future workflow added to the
-# repo cannot mint a cert that satisfies this regex.
+# release.yml workflow path under our org+repo, fired from a tag push
+# (not workflow_dispatch from an arbitrary branch). release.yml is the
+# only workflow with `id-token: write`, and we additionally pin to the
+# `refs/tags/v*` ref-suffix so a future branch-based dispatch (even
+# from main with proper protection) can't mint a cert that this
+# verifier accepts.
 COSIGN_OIDC_ISSUER="https://token.actions.githubusercontent.com"
-COSIGN_IDENTITY_REGEX="^https://github\.com/cyoda-platform/cyoda-go/\.github/workflows/release\.yml@"
+COSIGN_IDENTITY_REGEX="^https://github\.com/cyoda-platform/cyoda-go/\.github/workflows/release\.yml@refs/tags/v"
+# Bind to push-triggered runs from a tag ref. release.yml's `on:`
+# allows both `push: tags` and `workflow_dispatch`; only the former
+# can produce signed release artifacts that consumers should trust,
+# since workflow_dispatch can be triggered from any branch by anyone
+# with write access.
+COSIGN_GH_WORKFLOW_TRIGGER="push"
+COSIGN_GH_WORKFLOW_REF_REGEX="^refs/tags/v"
 
 err() { printf 'install.sh: error: %s\n' "$*" >&2; }
 warn() { printf 'install.sh: warning: %s\n' "$*" >&2; }
@@ -155,13 +176,18 @@ cosign_verify() {
             exit 1
         fi
 
+        cv_log="$cv_tmp/cosign-${cv_target}.log"
         if ! cosign verify-blob \
             --certificate="$cv_tmp/${cv_target}.pem" \
             --signature="$cv_tmp/${cv_target}.sig" \
             --certificate-identity-regexp="$COSIGN_IDENTITY_REGEX" \
             --certificate-oidc-issuer="$COSIGN_OIDC_ISSUER" \
-            "$cv_tmp/$cv_target" >/dev/null 2>&1; then
+            --certificate-github-workflow-trigger="$COSIGN_GH_WORKFLOW_TRIGGER" \
+            --certificate-github-workflow-ref-regexp="$COSIGN_GH_WORKFLOW_REF_REGEX" \
+            "$cv_tmp/$cv_target" >"$cv_log" 2>&1; then
             err "cosign verification FAILED for $cv_target — refusing to install."
+            err "cosign output (last 5 lines):"
+            tail -n 5 "$cv_log" >&2 || :
             err "Re-run with CYODA_COSIGN_VERIFY=false to skip (not recommended)."
             exit 1
         fi


### PR DESCRIPTION
Addresses **all five** findings from the security audit on PRs #210/#211/#213. Originally S-2 was filed as a separate issue (#218) for v0.8.0, but per Gate 6 ("resolve, don't defer") the design call was straightforward enough to land inline.

## Findings addressed

### S-1 (Important) — install.sh header documents the auto-mode soft-fallback contract

Pre-fix the contract was buried in `cosign_verify`'s docstring; the user-facing "Cosign verification" preamble at the top didn't surface that auto mode silently degrades to SHA256-only on a 404. This is exploitable by an attacker who deletes the `.sig` along with their archive swap on a v0.7.0+ release. Now the header calls out the trade-off and points to `CYODA_COSIGN_VERIFY=required` for hardened deployments.

### S-2 (Important) — PathValidationCache bucket-map LRU + cap (closes #218)

Pre-fix the `(tenant, ref)` bucket map (added in #211) grew without bound; only `InvalidateRef` removed entries. An adversarial tenant with model-creation privilege at scale could accumulate buckets indefinitely. Post-fix:

- LRU via `container/list`. Touched on every `IsAbsent`, `MarkAbsent`, and bucket allocation.
- Cap = 10000 buckets, matching the pre-#211 single-cache global entry budget so worst-case memory footprint is roughly equivalent.
- Eviction at `MarkAbsent` of a fresh key when `len(buckets) >= cap`. No background reaper.
- `InvalidateRef` does NOT touch LRU recency — invalidate is destructive, not an access signal.

Three tests cover the eviction contract, recency promotion, and the no-touch-on-invalidate invariant. **Closes #218.**

### S-3 (Minor) — cosign cert-identity binding tightened

Pre-fix the regex `^https://github.com/cyoda-platform/cyoda-go/.github/workflows/release.yml@` accepted any ref-suffix, including a `workflow_dispatch` from a feature branch. Now we additionally verify `--certificate-github-workflow-trigger=push` and `--certificate-github-workflow-ref-regexp=^refs/tags/v`. Accepted certs are now bound to the push-on-tag flow — the only path that produces release artifacts consumers should trust.

### I-1 — cosign verify-blob error detail surfaced

Pre-fix the verify command was redirected to `/dev/null`. Now output is captured to a log file and the last 5 lines echo on failure — better triage on legitimate failures.

### I-2 — `modelcache.localSubMu`: `RWMutex` → `Mutex`

Both callers hold the lock briefly; no read-heavy contention pattern.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test -short ./...` — green
- [x] `go test ./internal/e2e/...` — green
- [x] `go test -race -short ./...` — clean
- [x] New LRU tests pass
- [x] `sh -n scripts/install.sh` — syntactically clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)