### PR TITLE
ci: add SPI pin-sync drift gate; document lockstep-bump rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run shellcheck
-        run: shellcheck scripts/install.sh scripts/dev/run-docker-dev.sh
+        run: shellcheck scripts/install.sh scripts/dev/run-docker-dev.sh scripts/check-spi-pin-sync.sh scripts/check-spi-pin-sync_test.sh
 
   # Continuous security gates (issue #67):
   #   - govulncheck scans the call graph for exploitable stdlib and third-party CVEs,
@@ -133,3 +133,11 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
+
+  pin-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Verify SPI pin sync
+        run: ./scripts/check-spi-pin-sync.sh

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -32,6 +32,7 @@ Coordinated-release procedure documented in [`MAINTAINING.md`](./MAINTAINING.md)
 
 | `cyoda-go` | Root `go.mod` pins | In-tree plugin go.mods pin | SPI surface added in this release |
 |---|---|---|---|
+| **`v0.7.1`** _(planned)_ | `cyoda-go-spi v0.7.1` | `cyoda-go-spi v0.7.1` | — (pin-sync correction; no new SPI surface) |
 | **`v0.7.0`** | `cyoda-go-spi v0.7.0` | `cyoda-go-spi v0.6.1`† | `ProcessorConfig.StartNewTxOnDispatch *bool` |
 | `v0.6.3` | `cyoda-go-spi v0.6.0` | `cyoda-go-spi v0.6.0` | — (binary-only changes) |
 | `v0.6.2` | `cyoda-go-spi v0.6.0` | `cyoda-go-spi v0.6.0` | — |
@@ -44,7 +45,7 @@ Coordinated-release procedure documented in [`MAINTAINING.md`](./MAINTAINING.md)
 
 A plugin pinned to **`cyoda-go-spi v<X.Y.Z>`** is compatible with any **`cyoda-go v<A.B.C>`** whose root `go.mod` pins the same `v<X.Y>.*` series or any *later* `v<X+1.0.0>` series that hasn't broken the interfaces the plugin uses.
 
-In practice, today: **all SPI versions `v0.5.0` … `v0.7.0` are mutually source-compatible** (additive changes only). Plugins on any of these versions build and run correctly against `cyoda-go v0.7.0`. This will change only when SPI introduces a breaking interface (none planned for v0.x).
+In practice, today: **all SPI versions `v0.5.0` … `v0.7.1` are mutually source-compatible** (additive changes only). Plugins on any of these versions build and run correctly against `cyoda-go v0.7.0` and the planned `v0.7.1`. This will change only when SPI introduces a breaking interface (none planned for v0.x).
 
 ### Migration window
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,8 @@ Release builds additionally run a Trivy scan against the published GHCR image (`
 
 No external web frameworks. No DI frameworks. No ORM.
 
+- When bumping `cyoda-go-spi` in the root `go.mod`, bump it identically in every `plugins/*/go.mod` in the same PR. The `check-spi-pin-sync` CI gate enforces this. See [`MAINTAINING.md`](MAINTAINING.md#bumping-cyoda-go-spi) for the full procedure.
+
 | Dependency | Purpose |
 |------------|---------|
 | Go standard library `net/http` | HTTP server and routing (Go 1.22+ pattern matching) |

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -293,6 +293,26 @@ Release in topological order:
 Each step waits for the prior tag to land before its `go mod tidy`
 can resolve. In practice: merge, tag, wait for CI, then move on.
 
+### Bumping cyoda-go-spi
+
+`cyoda-go-spi` must be pinned to the same version in every `go.mod` in
+this repo: the root and all `plugins/*/go.mod`. The CI gate
+`make check-spi-pin-sync` (workflow job `pin-sync`) enforces this and
+will fail on PR if any manifest disagrees.
+
+When you bump cyoda-go-spi:
+
+1. Bump in `go.mod` (root).
+2. Bump identically in `plugins/memory/go.mod`, `plugins/postgres/go.mod`, `plugins/sqlite/go.mod`.
+3. Run `go mod tidy` in each module.
+4. Run `make test-all` to verify cross-plugin interactions.
+5. Run `make check-spi-pin-sync` locally to confirm green.
+
+This rule is in addition to the existing **plugin-version lockstep**
+rule (plugin submodule tags use the same version as the umbrella).
+The two rules together ensure that consumers see consistent
+SPI-and-plugin pinning at every umbrella tag.
+
 ### 8. Publish the Helm chart
 
 Frontline binary releases auto-open a PR from

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-up dev-down dev-ps dev-logs dev-run dev-test build test test-all test-short-all clean docker-build docker-push todos
+.PHONY: dev-up dev-down dev-ps dev-logs dev-run dev-test build test test-all test-short-all clean docker-build docker-push todos check-spi-pin-sync
 
 # Plugin submodules: each has its own go.mod, so `go test ./...` from the
 # repo root does not recurse into them. The aggregator targets below close
@@ -85,6 +85,9 @@ todos-p%:              ## List TODOs for a specific plan (e.g. make todos-p6)
 
 clean:                 ## Remove build artifacts
 	rm -rf bin/ coverage.out
+
+check-spi-pin-sync:    ## Verify cyoda-go-spi is pinned to the same version across root and all plugin go.mods
+	@./scripts/check-spi-pin-sync.sh
 
 help:                  ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'

--- a/scripts/check-spi-pin-sync.sh
+++ b/scripts/check-spi-pin-sync.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Verifies every go.mod in this repo (root + plugins/*) pins
+# github.com/cyoda-platform/cyoda-go-spi to the same version.
+#
+# Exits 0 if all pins agree.
+# Exits 1 if any go.mod disagrees, with a readable diff.
+#
+# Used as a CI gate to prevent the v0.6.1-vs-v0.7.0 drift recurring.
+# Compatible with bash 3.2+ (macOS system bash).
+
+set -euo pipefail
+
+# Collect all go.mod files (up to 4 levels deep, skip hidden and vendor dirs).
+# Store as newline-separated in a variable for bash 3.2 compatibility
+# (mapfile / readarray require bash 4+).
+mod_files=$(find . -mindepth 1 -maxdepth 4 -name go.mod -not -path '*/.*' -not -path '*/vendor/*' | sort)
+
+# Extract SPI versions from each go.mod and build a unique-version list.
+# Output format: "<version> <path>" for each file that mentions cyoda-go-spi.
+all_versions=""
+file_version_pairs=""
+
+while IFS= read -r mod; do
+  [[ -z "$mod" ]] && continue
+  ver=$(awk '/[[:space:]]github\.com\/cyoda-platform\/cyoda-go-spi v/ { print $NF; exit }' "$mod" 2>/dev/null || true)
+  if [[ -n "${ver:-}" ]]; then
+    all_versions="${all_versions}${ver}"$'\n'
+    file_version_pairs="${file_version_pairs}${ver} ${mod}"$'\n'
+  fi
+done <<< "$mod_files"
+
+# Count distinct versions seen.
+distinct=$(printf '%s' "$all_versions" | sort -u | grep -c . || true)
+
+if (( distinct == 0 )); then
+  echo "check-spi-pin-sync: no go.mod files reference cyoda-go-spi (nothing to check)"
+  exit 0
+fi
+
+if (( distinct == 1 )); then
+  the_version=$(printf '%s' "$all_versions" | sort -u | head -1)
+  echo "check-spi-pin-sync: OK — all manifests pin cyoda-go-spi $the_version"
+  exit 0
+fi
+
+echo "check-spi-pin-sync: FAIL — cyoda-go-spi pin drift detected"
+echo
+
+# Print each version and the files pinned to it.
+unique_versions=$(printf '%s' "$all_versions" | sort -u)
+while IFS= read -r ver; do
+  [[ -z "$ver" ]] && continue
+  echo "  $ver:"
+  while IFS= read -r pair; do
+    [[ -z "$pair" ]] && continue
+    pair_ver="${pair%% *}"
+    pair_file="${pair#* }"
+    if [[ "$pair_ver" == "$ver" ]]; then
+      echo "    $pair_file"
+    fi
+  done <<< "$file_version_pairs"
+done <<< "$unique_versions"
+
+echo
+echo "Resolution: bump cyoda-go-spi to a single version across root and plugins/*."
+exit 1

--- a/scripts/check-spi-pin-sync_test.sh
+++ b/scripts/check-spi-pin-sync_test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Test harness for scripts/check-spi-pin-sync.sh.
+# Creates a scratch repo with deliberately-drifted go.mods and asserts the
+# gate exits non-zero. Then aligns the manifests and asserts the gate exits zero.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/scripts/check-spi-pin-sync.sh"
+
+[[ -x "$SCRIPT" ]] || { echo "FAIL: $SCRIPT is missing or not executable"; exit 1; }
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+
+# Drift case: root v0.7.1, one plugin v0.6.1 → must fail
+mkdir -p "$scratch/drift/plugins/a" "$scratch/drift/plugins/b"
+cat > "$scratch/drift/go.mod" <<'EOF'
+module example.com/root
+go 1.26
+require github.com/cyoda-platform/cyoda-go-spi v0.7.1
+EOF
+cat > "$scratch/drift/plugins/a/go.mod" <<'EOF'
+module example.com/root/plugins/a
+go 1.26
+require github.com/cyoda-platform/cyoda-go-spi v0.7.1
+EOF
+cat > "$scratch/drift/plugins/b/go.mod" <<'EOF'
+module example.com/root/plugins/b
+go 1.26
+require github.com/cyoda-platform/cyoda-go-spi v0.6.1
+EOF
+
+if (cd "$scratch/drift" && "$SCRIPT") >/dev/null 2>&1; then
+  echo "FAIL: drift case did not fail (expected non-zero)"; exit 1
+fi
+echo "PASS: drift case correctly failed"
+
+# Aligned case: every manifest at v0.7.1 → must pass
+mkdir -p "$scratch/aligned/plugins/a" "$scratch/aligned/plugins/b"
+for f in "$scratch/aligned/go.mod" "$scratch/aligned/plugins/a/go.mod" "$scratch/aligned/plugins/b/go.mod"; do
+  cat > "$f" <<'EOF'
+module example.com
+go 1.26
+require github.com/cyoda-platform/cyoda-go-spi v0.7.1
+EOF
+done
+
+if ! (cd "$scratch/aligned" && "$SCRIPT") >/dev/null 2>&1; then
+  echo "FAIL: aligned case unexpectedly failed"; exit 1
+fi
+echo "PASS: aligned case correctly succeeded"
+
+echo "OK: scripts/check-spi-pin-sync.sh exhibits expected behavior"


### PR DESCRIPTION
## Summary

- Adds `make check-spi-pin-sync` and a CI job `pin-sync` that fails if root and `plugins/*/go.mod` disagree on the `cyoda-go-spi` pin.
- Documents the lockstep-bump rule in `MAINTAINING.md` (new "Bumping cyoda-go-spi" subsection) and `CONTRIBUTING.md` (one-line note).
- Updates `COMPATIBILITY.md` with the v0.7.1 cross-repo row (planned values; to be reconciled to actuals after the binary release).

Companion to PR-C1 (which corrected the actual drift). PR-C2 prevents recurrence.

The gate has been deliberately exercised against a sabotaged manifest to confirm it fires (soft gate from the spec):

```
check-spi-pin-sync: FAIL — cyoda-go-spi pin drift detected

  v0.6.1:
    ./plugins/sqlite/go.mod
  v0.7.1:
    ./go.mod
    ./plugins/memory/go.mod
    ./plugins/postgres/go.mod

Resolution: bump cyoda-go-spi to a single version across root and plugins/*.
exit=1
```

Spec: `docs/superpowers/specs/2026-05-05-spi-release-hygiene-design.md`
Plan: `docs/superpowers/plans/2026-05-05-spi-release-hygiene.md`

## Test plan

- [ ] `make test-short-all` green
- [ ] `go test -race ./...` green (root + memory + sqlite plugins; postgres skipped — no Docker available in sandbox, runs in CI)
- [ ] `./scripts/check-spi-pin-sync_test.sh` passes
- [ ] CI `pin-sync` job runs and is green
- [ ] `shellcheck` CI job covers both new scripts
- [ ] Reviewer mentally confirms the gate's failure mode reads sensibly (temporarily edit a plugin go.mod and run `./scripts/check-spi-pin-sync.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)