### PR TITLE
feat(helm): optional separate migration DSN (migrate.postgres)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -73,7 +73,8 @@ When cyoda-go-cassandra bumps to `cyoda-go v0.7.0`, the four new parity scenario
 
 | Chart `version:` | Chart `appVersion:` | Default binary | Notes |
 |---|---|---|---|
-| `0.6.3` | `0.7.0` | `cyoda-go v0.7.0` | **Current.** Chart manifests unchanged since `cyoda-0.6.3`; `appVersion` advances independently per [PR #232](https://github.com/Cyoda-platform/cyoda-go/pull/232). |
+| `0.7.0` | `0.7.1` | `cyoda-go v0.7.1` | **Current.** Adds optional `migrate.postgres` DSN — a separate migration-Job (owner/DDL) role for the two-role DB model; backward-compatible (falls back to `postgres.existingSecret`). First chart-manifest change since `0.6.3`. |
+| `0.6.3` | `0.7.0` | `cyoda-go v0.7.0` | Chart manifests unchanged since `cyoda-0.6.3`; `appVersion` advances independently per [PR #232](https://github.com/Cyoda-platform/cyoda-go/pull/232). |
 | `0.6.3` | `0.6.3` | `cyoda-go v0.6.3` | Tagged as `cyoda-0.6.3` chart release (April 2026). |
 
 The chart's `version:` bumps only when **rendered manifests** change (templates, values, schema). The chart's `appVersion:` advances each binary release worth advertising via the chart. The two are decoupled by Helm convention.

--- a/deploy/helm/cyoda/Chart.yaml
+++ b/deploy/helm/cyoda/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   Postgres, fronted by Gateway API (default) or a still-maintained Ingress
   controller (transitional).
 type: application
-version: 0.6.3
+version: 0.7.0
 appVersion: "0.7.1" # bump-chart-appversion.yml syncs this to the binary
 kubeVersion: ">=1.31.0"
 keywords:
@@ -21,4 +21,4 @@ maintainers:
     url: https://github.com/cyoda-platform
 annotations:
   artifacthub.io/changes: |
-    - Chart and appVersion synced to the v0.6.x binary series
+    - Optional separate migration DSN (migrate.postgres) for the two-role DB model

--- a/deploy/helm/cyoda/README.md
+++ b/deploy/helm/cyoda/README.md
@@ -4,8 +4,8 @@ Production-ready Helm deployment of cyoda-go backed by an external
 Postgres, fronted by Gateway API (default) or a still-maintained
 Ingress controller (transitional).
 
-Chart version: 0.1.0 — AppVersion: pinned by `bump-chart-appversion.yml`
-on each binary release.
+See `Chart.yaml` for the chart `version:`. `appVersion:` is pinned to the
+binary release by `bump-chart-appversion.yml`.
 
 ## Installation
 
@@ -80,8 +80,10 @@ kubectl -n cyoda create secret generic cyoda-dsn-migrate \
 
 helm upgrade cyoda cyoda/cyoda -n cyoda \
   --set migrate.postgres.existingSecret=cyoda-dsn-migrate
-  # ... your other --set flags
 ```
+
+(combine the `--set migrate.postgres.existingSecret=…` flag with the flags
+from your original `helm install` above.)
 
 When `migrate.postgres.existingSecret` is unset, the migration Job falls back
 to `postgres.existingSecret`, so existing single-DSN installs are unchanged.

--- a/deploy/helm/cyoda/README.md
+++ b/deploy/helm/cyoda/README.md
@@ -65,6 +65,27 @@ helm upgrade cyoda cyoda/cyoda -n cyoda --reuse-values \
 The chart auto-generates the secret (or use
 `bootstrap.clientSecret.existingSecret` for GitOps).
 
+### Separate migration DSN (optional, two-role DB model)
+
+By default the migration Job and the runtime pods share one DSN
+(`postgres.existingSecret`). For least-privilege deployments you can run the
+migration Job (which performs DDL) as a dedicated **owner** role while the
+runtime StatefulSet connects as a non-owner **runtime** role. Set
+`migrate.postgres.existingSecret` (and optionally `existingSecretKey`, default
+`dsn`) to a Secret holding the owner DSN:
+
+```bash
+kubectl -n cyoda create secret generic cyoda-dsn-migrate \
+  --from-literal=dsn='postgres://cyoda_owner:REDACTED@pg.example.com:5432/cyoda?sslmode=require'
+
+helm upgrade cyoda cyoda/cyoda -n cyoda \
+  --set migrate.postgres.existingSecret=cyoda-dsn-migrate
+  # ... your other --set flags
+```
+
+When `migrate.postgres.existingSecret` is unset, the migration Job falls back
+to `postgres.existingSecret`, so existing single-DSN installs are unchanged.
+
 ### NetworkPolicy (default ON)
 
 The chart ships with `networkPolicy.enabled=true`. This restricts port

--- a/deploy/helm/cyoda/templates/_helpers.tpl
+++ b/deploy/helm/cyoda/templates/_helpers.tpl
@@ -95,3 +95,15 @@ Image reference: falls back to .Chart.AppVersion if image.tag is unset.
 {{- $tag := default .Chart.AppVersion .Values.image.tag -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
 {{- end }}
+
+{{/*
+Migration-Job DSN secret. Falls back to the runtime postgres secret when a
+separate migrate secret is not configured (single-DSN, backward-compatible).
+*/}}
+{{- define "cyoda.migrateSecretName" -}}
+{{- .Values.migrate.postgres.existingSecret | default .Values.postgres.existingSecret -}}
+{{- end -}}
+
+{{- define "cyoda.migrateSecretKey" -}}
+{{- .Values.migrate.postgres.existingSecretKey | default .Values.postgres.existingSecretKey -}}
+{{- end -}}

--- a/deploy/helm/cyoda/templates/_helpers.tpl
+++ b/deploy/helm/cyoda/templates/_helpers.tpl
@@ -97,13 +97,24 @@ Image reference: falls back to .Chart.AppVersion if image.tag is unset.
 {{- end }}
 
 {{/*
-Migration-Job DSN secret. Falls back to the runtime postgres secret when a
-separate migrate secret is not configured (single-DSN, backward-compatible).
+Migration-Job DSN secret (name + key). When migrate.postgres.existingSecret is
+set, the Job uses that secret and its key; otherwise BOTH fall back to the
+runtime postgres secret (single-DSN, backward-compatible). Name and key fall
+back together as a unit, so a custom postgres.existingSecretKey is honored by
+the migration Job in single-DSN mode.
 */}}
 {{- define "cyoda.migrateSecretName" -}}
-{{- .Values.migrate.postgres.existingSecret | default .Values.postgres.existingSecret -}}
+{{- if .Values.migrate.postgres.existingSecret -}}
+{{- .Values.migrate.postgres.existingSecret -}}
+{{- else -}}
+{{- .Values.postgres.existingSecret -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "cyoda.migrateSecretKey" -}}
-{{- .Values.migrate.postgres.existingSecretKey | default .Values.postgres.existingSecretKey -}}
+{{- if .Values.migrate.postgres.existingSecret -}}
+{{- .Values.migrate.postgres.existingSecretKey -}}
+{{- else -}}
+{{- .Values.postgres.existingSecretKey -}}
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/cyoda/templates/job-migrate.yaml
+++ b/deploy/helm/cyoda/templates/job-migrate.yaml
@@ -60,7 +60,7 @@ spec:
             defaultMode: 0400
             sources:
               - secret:
-                  name: {{ .Values.postgres.existingSecret }}
+                  name: {{ include "cyoda.migrateSecretName" . }}
                   items:
-                    - key: {{ .Values.postgres.existingSecretKey }}
+                    - key: {{ include "cyoda.migrateSecretKey" . }}
                       path: postgres-dsn

--- a/deploy/helm/cyoda/values.schema.json
+++ b/deploy/helm/cyoda/values.schema.json
@@ -170,7 +170,18 @@
       }
     },
     "networkPolicy": {"type": "object"},
-    "migrate": {"type": "object"},
+    "migrate": {
+      "type": "object",
+      "properties": {
+        "postgres": {
+          "type": "object",
+          "properties": {
+            "existingSecret": {"type": "string"},
+            "existingSecretKey": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    },
     "podDisruptionBudget": {"type": "object"},
     "serviceAccount": {"type": "object"},
     "podAnnotations": {"type": "object"},

--- a/deploy/helm/cyoda/values.yaml
+++ b/deploy/helm/cyoda/values.yaml
@@ -28,7 +28,9 @@ resources:
     cpu: 1000m
     memory: 512Mi
 
-# -- Postgres DSN via operator-managed Secret. REQUIRED.
+# -- Postgres DSN for the RUNTIME pods (StatefulSet) via operator-managed
+# Secret. REQUIRED. In the two-role model this is the non-owner runtime role;
+# the migration Job uses migrate.postgres (falling back to this when unset).
 # The Secret must have a key (default "dsn") whose value is the full
 # connection string: postgres://user:pass@host:5432/db?sslmode=require
 postgres:
@@ -160,6 +162,12 @@ autoscaling:
   behavior: {}
 
 migrate:
+  # -- Optional SEPARATE DSN for the migration Job (the owner/DDL role in the
+  # two-role model). Leave existingSecret empty to fall back to
+  # postgres.existingSecret (single-DSN, backward-compatible default).
+  postgres:
+    existingSecret: ""
+    existingSecretKey: dsn
   activeDeadlineSeconds: 600
   backoffLimit: 2
   resources:


### PR DESCRIPTION
## What

Adds an optional `migrate.postgres.existingSecret` (+ `existingSecretKey`) so the
migration Job can mount a **separate** Postgres DSN from the runtime StatefulSet.
When unset, the Job falls back to `postgres.existingSecret` — so existing
single-DSN installs are unchanged.

- Migrate Job → `migrate.postgres` DSN (intended for an owner/DDL role)
- Runtime StatefulSet → `postgres` DSN (intended for a least-privilege, non-owner role)
- Name **and** key fall back together atomically when `migrate.postgres` is unset.

Chart `0.6.3 → 0.7.0` (additive, backward-compatible); `COMPATIBILITY.md` updated.

## Why

Enables a two-role DB model (migration owner vs. non-owner runtime) — defense-in-depth
and RLS-forward-compatible — without forcing it on anyone (single-DSN remains the default).

## Provenance

Extracted from #246. Per a scoping decision, the multi-cloud **Terraform** that
consumes this capability has been relocated to a dedicated repository
(`Cyoda-platform/cyoda-go-terraform`, private for now), following the common
OSS pattern of keeping cloud-provisioning IaC out of the core repo. This PR is
the **chart-only** slice that belongs in cyoda-go; #246 will be closed.

## Verification

`helm lint` clean; `helm template` renders in both single-DSN and dual-DSN modes;
migrate Job mounts the migrate secret when set and the runtime secret when not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)