### PR TITLE
ci: run full CI battery on release/** branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [develop, main]
+    branches: [develop, main, 'release/**']
   pull_request:
-    branches: [develop, main]
+    branches: [develop, main, 'release/**']
   workflow_dispatch:
 
 # Default to read-only token for all jobs. Individual jobs may opt-in to


### PR DESCRIPTION
Adds `release/**` to ci.yml's `push` and `pull_request` branch filters so the full battery (test+race, plugin tests, govulncheck, per-module-hygiene, CodeQL, **and the enforce-mode OpenAPI conformance gate**) runs against release-branch commits and PRs.

## Why

`ci.yml` previously gated on `[develop, main]` only, so PRs targeting `release/vX.Y.Z` ran only the `smoke` workflow. Latent regressions sat hidden until the release→main merge — defeating the release-branch RC model.

## How it surfaced

While reviewing #265 (processor type split), the rebase + local full-suite run uncovered a 23-operation conformance failure (operationIds rewritten camelCase→PascalCase by oapi-codegen's native embedded-spec after the swagger-encode workaround was deleted). #265's own CI ran only smoke — the enforce-mode conformance gate that would have failed has never run on a release-branch PR. Fixed in #265 via `go:embed openapi.yaml` (the architecturally correct verbatim embed); this PR ensures the gate runs in CI from now on, not just at release→main.

## Trade-off

Every release-branch PR (including Dependabot) now runs the full battery — heavier CI, but that's the point: the RC bundle gets the same gate strength as main.

## Diff

```yaml
-    branches: [develop, main]
+    branches: [develop, main, 'release/**']
```
(same change for both `push` and `pull_request`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)