### PR TITLE
chore(deps): target Dependabot PRs at release/v0.8.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,20 @@
 version: 2
+
+# target-branch is set per-entry to the active release branch so Dependabot
+# PRs land directly on the release branch during a release cycle (rather
+# than `main`, which would require manual retargeting + rebase — see
+# .claude/memory note "Dependabot PRs during a release cycle").
+#
+# Maintenance: when a release branch merges and is deleted, update every
+# `target-branch:` below to the next active release branch, or remove the
+# field entirely (PRs revert to the default branch). Leaving a stale
+# branch name here makes future Dependabot runs fail silently.
+
 updates:
   # Root Go module
   - package-ecosystem: gomod
     directory: "/"
+    target-branch: "release/v0.8.0"
     schedule:
       interval: weekly
       day: monday
@@ -17,6 +29,7 @@ updates:
   # consumable, so each must be tracked separately.
   - package-ecosystem: gomod
     directory: "/plugins/memory"
+    target-branch: "release/v0.8.0"
     schedule:
       interval: weekly
       day: monday
@@ -29,6 +42,7 @@ updates:
 
   - package-ecosystem: gomod
     directory: "/plugins/sqlite"
+    target-branch: "release/v0.8.0"
     schedule:
       interval: weekly
       day: monday
@@ -41,6 +55,7 @@ updates:
 
   - package-ecosystem: gomod
     directory: "/plugins/postgres"
+    target-branch: "release/v0.8.0"
     schedule:
       interval: weekly
       day: monday
@@ -55,6 +70,7 @@ updates:
   # so distroless/static base updates surface as PRs.
   - package-ecosystem: docker
     directory: "/deploy/docker"
+    target-branch: "release/v0.8.0"
     schedule:
       interval: weekly
       day: monday
@@ -68,6 +84,7 @@ updates:
   # GitHub Actions used by workflows in .github/workflows.
   - package-ecosystem: github-actions
     directory: "/"
+    target-branch: "release/v0.8.0"
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
## Summary

Dependabot is reading `.github/dependabot.yml` from the default branch (`main`) and raising PRs against `main`. But v0.8.0 milestone work flows through `release/v0.8.0`, so every Dependabot PR has to be hand-retargeted + manually rebased (`@dependabot rebase` refuses after `gh pr edit` retargets the base), and several recent bumps were merged directly on the release branch — leaving the open PRs partially or fully superseded.

Add `target-branch: "release/v0.8.0"` to every update entry so weekly Dependabot runs land on the release branch directly.

## Maintenance note

`target-branch` is a per-release-cycle tweak, not permanent config. When `release/v0.8.0` merges and is deleted, the field must be updated to the next active release branch — or removed entirely so PRs revert to `main`. A header comment in the file calls this out.

## Cleanup already done

Closed in advance of this change:
- #270 — busybox 1.37→1.38 (fully superseded by #266)
- #271 — distroless/static digest (fully superseded by #248)
- #273 — dependency-review-action 4→5 (fully superseded by #245)
- #274 — root go_modules group (partially superseded by #267; remaining otel/etc. will be re-proposed)
- #272 — plugins/sqlite group (partially superseded; remaining sqlite3 0.34.3 / wasm 2.5 will be re-proposed)

After this merges, the next Monday Dependabot run will reopen the still-pending portions against `release/v0.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)