### PR TITLE
feat(spi): tx-state sentinel errors — closes #200

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -32,6 +32,7 @@ Coordinated-release procedure documented in [`MAINTAINING.md`](./MAINTAINING.md)
 
 | `cyoda-go` | Root `go.mod` pins | In-tree plugin go.mods pin | SPI surface added in this release |
 |---|---|---|---|
+| **`v0.8.0`** _(planned)_ | `cyoda-go-spi v0.8.0` | `cyoda-go-spi v0.8.0` | Transaction-state sentinel hierarchy: `ErrTxNotFound`, `ErrSavepointNotFound`, `ErrTxTerminated`, `ErrTxRolledBack`, `ErrTxAlreadyCommitted`, `ErrTxCommitInProgress`, `ErrTxTenantMismatch` |
 | **`v0.7.1`** _(planned)_ | `cyoda-go-spi v0.7.1` | `cyoda-go-spi v0.7.1` | — (pin-sync correction; no new SPI surface) |
 | **`v0.7.0`** | `cyoda-go-spi v0.7.0` | `cyoda-go-spi v0.6.1`† | `ProcessorConfig.StartNewTxOnDispatch *bool` |
 | `v0.6.3` | `cyoda-go-spi v0.6.0` | `cyoda-go-spi v0.6.0` | — (binary-only changes) |
@@ -45,7 +46,7 @@ Coordinated-release procedure documented in [`MAINTAINING.md`](./MAINTAINING.md)
 
 A plugin pinned to **`cyoda-go-spi v<X.Y.Z>`** is compatible with any **`cyoda-go v<A.B.C>`** whose root `go.mod` pins the same `v<X.Y>.*` series or any *later* `v<X+1.0.0>` series that hasn't broken the interfaces the plugin uses.
 
-In practice, today: **all SPI versions `v0.5.0` … `v0.7.1` are mutually source-compatible** (additive changes only). Plugins on any of these versions build and run correctly against `cyoda-go v0.7.0` and the planned `v0.7.1`. This will change only when SPI introduces a breaking interface (none planned for v0.x).
+In practice, today: **all SPI versions `v0.5.0` … `v0.8.0` are mutually source-compatible** (additive changes only). Plugins on any of these versions build and run correctly against `cyoda-go v0.7.0` and the planned `v0.7.1` / `v0.8.0`. This will change only when SPI introduces a breaking interface (none planned for v0.x).
 
 ### Migration window
 

--- a/docs/superpowers/plans/2026-06-13-200-spi-tx-state-sentinel-errors.md
+++ b/docs/superpowers/plans/2026-06-13-200-spi-tx-state-sentinel-errors.md
@@ -1,0 +1,1327 @@
+# SPI Sentinel Errors for Transaction State — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace plain-string transaction-state errors across memory/sqlite/postgres plugins with a hierarchy of SPI-level sentinel errors so callers can use `errors.Is` instead of `strings.Contains`.
+
+**Architecture:** Add seven new exported sentinels to `cyoda-go-spi/errors.go` using an unexported `sentinelErr` type with an `Unwrap()` parent. Two-level hierarchy: `ErrTxRolledBack` and `ErrTxAlreadyCommitted` wrap an `ErrTxTerminated` umbrella; `ErrTxNotFound` and `ErrSavepointNotFound` wrap the existing `ErrNotFound`. Conformance tests added to `spitest/transaction.go` exercise each sentinel against every backend via the existing `Harness` pattern; sentinel-graph properties (hierarchy, distinctness) covered as unit tests in `errors_test.go`. Plugin migrations wrap the sentinels at each error site; postgres' `verifyTenant()` helper is a single wrap-site that covers six lifecycle ops. Memory concurrency tests switch from substring matching to `errors.Is`. Tagged as a fresh SPI minor (e.g. `v0.8.0`); cyoda-go bumps the pin in four `go.mod` files.
+
+**Tech Stack:** Go 1.26, `errors` package (stdlib), `errors.Is` / `Unwrap()`, testify (already in SPI repo).
+
+**Spec:** [`docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md`](../specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md)
+
+**Worktree:** `/Users/paul/go-projects/cyoda-light/cyoda-go/.claude/worktrees/feat-200-spi-tx-state-sentinels` on branch `feat/200-spi-tx-state-sentinel-errors`.
+
+---
+
+## Repos involved
+
+This plan touches **two repos**. Both are local clones, sibling directories:
+
+- **SPI repo** — `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/` (Phase A — own branch, own PR, own tag)
+- **cyoda-go worktree** — `/Users/paul/go-projects/cyoda-light/cyoda-go/.claude/worktrees/feat-200-spi-tx-state-sentinels/` (Phase B — this worktree)
+
+Phase A's PR must be merged and tagged BEFORE Phase B's pin bump compiles. During development, use a local `replace` directive in cyoda-go's go.mod files to point at the local SPI checkout — this lets you iterate both phases in parallel without waiting for tags. Remove the replace before opening Phase B's PR.
+
+**Local replace pattern (use during dev, remove before PR):**
+
+```
+// At the bottom of each go.mod (root + plugins/{memory,sqlite,postgres}):
+replace github.com/cyoda-platform/cyoda-go-spi => /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+```
+
+---
+
+## Phase A: cyoda-go-spi PR
+
+All paths in Phase A are relative to `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/`.
+
+### Task A.0: Set up SPI feature branch
+
+**Files:** None (git only).
+
+- [ ] **Step 1: Verify the SPI repo is clean**
+
+Run:
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+git status
+```
+Expected: `working tree clean` on `main` (or whichever the default branch is).
+
+- [ ] **Step 2: Create feature branch off the default branch**
+
+```bash
+git fetch origin
+git checkout -b feat/200-tx-state-sentinels origin/main
+```
+
+- [ ] **Step 3: Confirm the SPI module path**
+
+```bash
+head -1 go.mod
+```
+Expected: `module github.com/cyoda-platform/cyoda-go-spi`
+
+---
+
+### Task A.1: Add sentinel-graph tests (RED)
+
+**Files:**
+- Modify: `errors_test.go`
+
+This is the RED phase for the sentinel definitions. The tests reference sentinel names that don't exist yet — they must FAIL TO COMPILE before Task A.2 makes them pass.
+
+- [ ] **Step 1: Append the new test cases to `errors_test.go`**
+
+Open `errors_test.go` and append these test functions after the existing `TestErrRetryExhausted_DistinctFromErrConflict`:
+
+```go
+// TestTxSentinelHierarchy verifies the parent/child relationships defined
+// by the sentinelErr.Unwrap() chain. Every child must match its parent
+// via errors.Is.
+func TestTxSentinelHierarchy(t *testing.T) {
+	positive := []struct {
+		name   string
+		child  error
+		parent error
+	}{
+		{"ErrTxNotFound→ErrNotFound", ErrTxNotFound, ErrNotFound},
+		{"ErrSavepointNotFound→ErrNotFound", ErrSavepointNotFound, ErrNotFound},
+		{"ErrTxRolledBack→ErrTxTerminated", ErrTxRolledBack, ErrTxTerminated},
+		{"ErrTxAlreadyCommitted→ErrTxTerminated", ErrTxAlreadyCommitted, ErrTxTerminated},
+	}
+	for _, tc := range positive {
+		t.Run(tc.name, func(t *testing.T) {
+			if !errors.Is(tc.child, tc.parent) {
+				t.Errorf("expected errors.Is(%v, %v) == true", tc.child, tc.parent)
+			}
+		})
+	}
+}
+
+// TestTxSentinelsAreDistinct verifies that siblings under a shared parent
+// and unrelated sentinels do not match each other via errors.Is. These
+// negative pairs are load-bearing for callers that distinguish conditions.
+func TestTxSentinelsAreDistinct(t *testing.T) {
+	negative := []struct {
+		name string
+		a    error
+		b    error
+	}{
+		// Siblings under ErrNotFound — tx-not-found vs savepoint-not-found
+		// must stay distinguishable.
+		{"ErrTxNotFound!~ErrSavepointNotFound", ErrTxNotFound, ErrSavepointNotFound},
+		{"ErrSavepointNotFound!~ErrTxNotFound", ErrSavepointNotFound, ErrTxNotFound},
+
+		// Siblings under ErrTxTerminated — rolled-back vs already-committed
+		// must stay distinguishable for diagnostic purposes.
+		{"ErrTxRolledBack!~ErrTxAlreadyCommitted", ErrTxRolledBack, ErrTxAlreadyCommitted},
+		{"ErrTxAlreadyCommitted!~ErrTxRolledBack", ErrTxAlreadyCommitted, ErrTxRolledBack},
+
+		// CommitInProgress is a transient race, NOT a terminal state.
+		// It must not match the ErrTxTerminated umbrella.
+		{"ErrTxCommitInProgress!~ErrTxTerminated", ErrTxCommitInProgress, ErrTxTerminated},
+		{"ErrTxTerminated!~ErrTxCommitInProgress", ErrTxTerminated, ErrTxCommitInProgress},
+
+		// Cross-tree pairs.
+		{"ErrTxRolledBack!~ErrNotFound", ErrTxRolledBack, ErrNotFound},
+		{"ErrTxNotFound!~ErrTxTerminated", ErrTxNotFound, ErrTxTerminated},
+		{"ErrTxTenantMismatch!~ErrTxTerminated", ErrTxTenantMismatch, ErrTxTerminated},
+		{"ErrTxTenantMismatch!~ErrNotFound", ErrTxTenantMismatch, ErrNotFound},
+		{"ErrTxCommitInProgress!~ErrTxNotFound", ErrTxCommitInProgress, ErrTxNotFound},
+
+		// Existing sentinels stay clean.
+		{"ErrConflict!~ErrTxTerminated", ErrConflict, ErrTxTerminated},
+		{"ErrConflict!~ErrTxRolledBack", ErrConflict, ErrTxRolledBack},
+	}
+	for _, tc := range negative {
+		t.Run(tc.name, func(t *testing.T) {
+			if errors.Is(tc.a, tc.b) {
+				t.Errorf("expected errors.Is(%v, %v) == false", tc.a, tc.b)
+			}
+		})
+	}
+}
+
+// TestTxSentinelWrapChain verifies that fmt.Errorf("...: %w", sentinel)
+// composes correctly with the sentinelErr.Unwrap() chain — errors.Is
+// must walk both layers and match against the sentinel AND its parent.
+func TestTxSentinelWrapChain(t *testing.T) {
+	wrapped := fmt.Errorf("plugin context: %w", ErrTxNotFound)
+	if !errors.Is(wrapped, ErrTxNotFound) {
+		t.Error("wrapped ErrTxNotFound should match ErrTxNotFound")
+	}
+	if !errors.Is(wrapped, ErrNotFound) {
+		t.Error("wrapped ErrTxNotFound should match ErrNotFound via Unwrap chain")
+	}
+	if errors.Is(wrapped, ErrTxRolledBack) {
+		t.Error("wrapped ErrTxNotFound must not match unrelated ErrTxRolledBack")
+	}
+
+	deeplyWrapped := fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", ErrTxRolledBack))
+	if !errors.Is(deeplyWrapped, ErrTxRolledBack) {
+		t.Error("doubly-wrapped ErrTxRolledBack should match ErrTxRolledBack")
+	}
+	if !errors.Is(deeplyWrapped, ErrTxTerminated) {
+		t.Error("doubly-wrapped ErrTxRolledBack should match ErrTxTerminated via Unwrap chain")
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail to compile**
+
+```bash
+go test ./...
+```
+Expected: compile failures — `undefined: ErrTxNotFound`, `undefined: ErrSavepointNotFound`, etc. This is the RED.
+
+---
+
+### Task A.2: Define the sentinels (GREEN)
+
+**Files:**
+- Modify: `errors.go`
+
+- [ ] **Step 1: Append the new sentinels and `sentinelErr` type**
+
+Open `errors.go` and append after the existing `ErrRetryExhausted` declaration:
+
+```go
+// sentinelErr is the unexported error type used to declare sentinels that
+// belong in a hierarchy. The Unwrap method makes errors.Is walk to the
+// parent sentinel as well as match the leaf, so callers can match either
+// the specific condition or its umbrella.
+type sentinelErr struct {
+	msg    string
+	parent error
+}
+
+func (e *sentinelErr) Error() string { return e.msg }
+func (e *sentinelErr) Unwrap() error { return e.parent }
+
+// ErrTxNotFound indicates that a transaction handle does not refer to a
+// known transaction — either the txID never existed, or its state has
+// been fully purged. Wraps ErrNotFound so existing
+//
+//	errors.Is(err, spi.ErrNotFound)
+//
+// checks on tx-lifecycle paths continue to match.
+var ErrTxNotFound = &sentinelErr{msg: "transaction not found", parent: ErrNotFound}
+
+// ErrSavepointNotFound indicates that a savepoint identifier does not
+// refer to a known savepoint on the given transaction. Wraps ErrNotFound.
+var ErrSavepointNotFound = &sentinelErr{msg: "savepoint not found", parent: ErrNotFound}
+
+// ErrTxTerminated is the umbrella sentinel for any operation on a
+// transaction that has reached a terminal state (committed or rolled
+// back). Callers that do not need to distinguish rollback from commit
+// can match this directly.
+//
+// NOTE: Backends that own transaction state in a remote engine
+// (postgres) may surface mid-op rollback as ErrConflict (e.g. via
+// SQLSTATE 25P02) instead of ErrTxRolledBack, where the engine's
+// abort code is already semantically meaningful. The ErrTxTerminated
+// sentinel is required only where the plugin owns its own in-process
+// tx-state buffer (memory, sqlite, cassandra). Consumers writing
+// backend-agnostic code should match both ErrTxTerminated and
+// ErrConflict on data-op paths.
+var ErrTxTerminated = errors.New("transaction in terminal state")
+
+// ErrTxRolledBack indicates that an in-flight operation observed the
+// transaction marked rolled-back (memory/sqlite race) or attempted an op
+// on a transaction whose terminal state is Rollback. Wraps ErrTxTerminated.
+// See ErrTxTerminated godoc for the postgres-engine caveat.
+var ErrTxRolledBack = &sentinelErr{msg: "transaction rolled back", parent: ErrTxTerminated}
+
+// ErrTxAlreadyCommitted indicates an attempt to Join, Commit, or
+// otherwise operate on a transaction whose terminal state is Commit.
+// Wraps ErrTxTerminated.
+var ErrTxAlreadyCommitted = &sentinelErr{msg: "transaction already committed", parent: ErrTxTerminated}
+
+// ErrTxCommitInProgress indicates that Commit was called on a
+// transaction another goroutine is already committing. Distinct from
+// ErrTxTerminated because the transaction is not yet terminal — the
+// loser of the race may still observe the committed result.
+var ErrTxCommitInProgress = errors.New("transaction commit in progress")
+
+// ErrTxTenantMismatch indicates a transaction-lifecycle operation
+// (Join, Commit, Rollback, Savepoint, etc.) was attempted with a
+// UserContext whose tenant does not match the transaction's tenant.
+// Tenant-isolation invariant — distinct from data-op tenant checks.
+var ErrTxTenantMismatch = errors.New("transaction tenant mismatch")
+```
+
+- [ ] **Step 2: Run the tests to confirm they pass**
+
+```bash
+go test ./...
+```
+Expected: all tests pass, including the three new ones (`TestTxSentinelHierarchy`, `TestTxSentinelsAreDistinct`, `TestTxSentinelWrapChain`).
+
+- [ ] **Step 3: Vet**
+
+```bash
+go vet ./...
+```
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add errors.go errors_test.go
+git commit -m "feat(errors): add transaction-state sentinel hierarchy
+
+Introduce seven sentinel errors for transaction-lifecycle conditions:
+
+- ErrTxNotFound, ErrSavepointNotFound (wrap ErrNotFound)
+- ErrTxTerminated umbrella with ErrTxRolledBack, ErrTxAlreadyCommitted
+- ErrTxCommitInProgress, ErrTxTenantMismatch
+
+Hierarchy via an unexported sentinelErr type with Unwrap(). Callers can
+match the specific cause or the umbrella; existing errors.Is(err,
+ErrNotFound) checks on tx-lifecycle paths continue to match through
+the new ErrTxNotFound / ErrSavepointNotFound wrap.
+
+ErrTxTerminated godoc documents the postgres-engine caveat: remote-
+engine backends may surface mid-op rollback as ErrConflict (SQLSTATE
+25P02) instead of ErrTxRolledBack.
+
+Tests cover every transitive parent match (positive), every off-
+diagonal sibling/cross-tree pair (negative), and the fmt.Errorf wrap-
+chain composition.
+
+Refs Cyoda-platform/cyoda-go#200"
+```
+
+---
+
+### Task A.3: Add per-backend conformance subtests
+
+**Files:**
+- Modify: `spitest/transaction.go`
+
+The subtests reference the sentinels from Task A.2 and exercise behaviour the spec calls out. In the SPI repo they're library code — there's no backend to run them against here. The RED→GREEN cycle happens in Phase B against memory/sqlite/postgres. In this task we just verify they compile and the suite registration is syntactically right.
+
+- [ ] **Step 1: Add the seven subtests to `runTransactionSuite`**
+
+Open `spitest/transaction.go`. Find the existing `runTransactionSuite` function (currently registers `CommitVisibility`, `RollbackDiscards`, `Join`, `SubmitTime`, `Savepoint/ReleaseMergesWork`, `Savepoint/RollbackToDiscards`, `BeginAfterCommit`). Insert the new `runSubtest` calls AFTER `BeginAfterCommit` and BEFORE the closing brace:
+
+```go
+	runSubtest(t, h, tracker, "TxStateErrors/JoinAfterCommit", testTxStateJoinAfterCommit)
+	runSubtest(t, h, tracker, "TxStateErrors/CommitAfterCommit", testTxStateCommitAfterCommit)
+	runSubtest(t, h, tracker, "TxStateErrors/CommitAfterRollback", testTxStateCommitAfterRollback)
+	runSubtest(t, h, tracker, "TxStateErrors/OpAfterRollback", testTxStateOpAfterRollback)
+	runSubtest(t, h, tracker, "TxStateErrors/TenantMismatchOnJoin", testTxStateTenantMismatchOnJoin)
+	runSubtest(t, h, tracker, "TxStateErrors/TenantMismatchOnCommit", testTxStateTenantMismatchOnCommit)
+	runSubtest(t, h, tracker, "TxStateErrors/SavepointNotFound", testTxStateSavepointNotFound)
+```
+
+- [ ] **Step 2: Append the subtest implementations to the end of `spitest/transaction.go`**
+
+Append (after the existing subtests, inside the same package):
+
+```go
+// testTxStateJoinAfterCommit verifies that joining a transaction whose
+// terminal state is Commit produces ErrTxAlreadyCommitted (which also
+// matches ErrTxTerminated via Unwrap).
+func testTxStateJoinAfterCommit(t *testing.T, h Harness) {
+	ctx := tenantContext(h.NewTenant())
+	tm, err := h.Factory.TransactionManager(ctx)
+	require.NoError(t, err)
+
+	txID, txCtx, err := tm.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tm.Commit(txCtx, txID))
+
+	_, err = tm.Join(ctx, txID)
+	require.Error(t, err, "Join after Commit must fail")
+	require.True(t,
+		errors.Is(err, spi.ErrTxAlreadyCommitted) || errors.Is(err, spi.ErrTxNotFound),
+		"Join after Commit must wrap ErrTxAlreadyCommitted or ErrTxNotFound (backends that purge committed-tx state collapse these); got: %v", err)
+	require.True(t, errors.Is(err, spi.ErrTxTerminated) || errors.Is(err, spi.ErrTxNotFound),
+		"Join after Commit must wrap ErrTxTerminated or ErrTxNotFound; got: %v", err)
+}
+
+// testTxStateCommitAfterCommit verifies that double-Commit produces
+// ErrTxAlreadyCommitted or ErrTxNotFound (backends that purge state
+// after the first Commit collapse to NotFound).
+func testTxStateCommitAfterCommit(t *testing.T, h Harness) {
+	ctx := tenantContext(h.NewTenant())
+	tm, err := h.Factory.TransactionManager(ctx)
+	require.NoError(t, err)
+
+	txID, txCtx, err := tm.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tm.Commit(txCtx, txID))
+
+	err = tm.Commit(txCtx, txID)
+	require.Error(t, err, "second Commit must fail")
+	require.True(t,
+		errors.Is(err, spi.ErrTxAlreadyCommitted) || errors.Is(err, spi.ErrTxNotFound),
+		"second Commit must wrap ErrTxAlreadyCommitted or ErrTxNotFound; got: %v", err)
+}
+
+// testTxStateCommitAfterRollback verifies that Commit on a rolled-back tx
+// produces ErrTxRolledBack or ErrTxNotFound (backends that purge state
+// after Rollback collapse to NotFound).
+func testTxStateCommitAfterRollback(t *testing.T, h Harness) {
+	ctx := tenantContext(h.NewTenant())
+	tm, err := h.Factory.TransactionManager(ctx)
+	require.NoError(t, err)
+
+	txID, txCtx, err := tm.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, tm.Rollback(txCtx, txID))
+
+	err = tm.Commit(txCtx, txID)
+	require.Error(t, err, "Commit after Rollback must fail")
+	require.True(t,
+		errors.Is(err, spi.ErrTxRolledBack) || errors.Is(err, spi.ErrTxNotFound),
+		"Commit after Rollback must wrap ErrTxRolledBack or ErrTxNotFound; got: %v", err)
+}
+
+// testTxStateOpAfterRollback verifies that a data op against a rolled-back
+// transaction produces ErrTxTerminated. Backends with remote tx state
+// (postgres) may skip this via Harness.Skip — see the ErrTxTerminated
+// godoc caveat.
+func testTxStateOpAfterRollback(t *testing.T, h Harness) {
+	ctx := tenantContext(h.NewTenant())
+	tm, err := h.Factory.TransactionManager(ctx)
+	require.NoError(t, err)
+
+	txID, txCtx, err := tm.Begin(ctx)
+	require.NoError(t, err)
+
+	es, err := h.Factory.EntityStore(txCtx)
+	require.NoError(t, err)
+
+	id := newID()
+	_, err = es.Save(txCtx, newEntity(t, "m-op-after-rb", id, map[string]any{"k": "v"}))
+	require.NoError(t, err)
+
+	require.NoError(t, tm.Rollback(txCtx, txID))
+
+	_, err = es.Get(txCtx, id)
+	require.Error(t, err, "Get after Rollback must fail")
+	require.True(t, errors.Is(err, spi.ErrTxTerminated),
+		"op after Rollback must wrap ErrTxTerminated; got: %v", err)
+}
+
+// testTxStateTenantMismatchOnJoin verifies that tenant B cannot Join a
+// transaction begun by tenant A; the error wraps ErrTxTenantMismatch.
+func testTxStateTenantMismatchOnJoin(t *testing.T, h Harness) {
+	ctxA := tenantContext(h.NewTenant())
+	ctxB := tenantContext(h.NewTenant())
+
+	tmA, err := h.Factory.TransactionManager(ctxA)
+	require.NoError(t, err)
+	txID, _, err := tmA.Begin(ctxA)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tmA.Rollback(ctxA, txID) })
+
+	tmB, err := h.Factory.TransactionManager(ctxB)
+	require.NoError(t, err)
+	_, err = tmB.Join(ctxB, txID)
+	require.Error(t, err, "tenant B Join of tenant A tx must fail")
+	require.True(t, errors.Is(err, spi.ErrTxTenantMismatch),
+		"cross-tenant Join must wrap ErrTxTenantMismatch; got: %v", err)
+}
+
+// testTxStateTenantMismatchOnCommit verifies that tenant B cannot Commit a
+// transaction begun by tenant A; the error wraps ErrTxTenantMismatch.
+func testTxStateTenantMismatchOnCommit(t *testing.T, h Harness) {
+	ctxA := tenantContext(h.NewTenant())
+	ctxB := tenantContext(h.NewTenant())
+
+	tmA, err := h.Factory.TransactionManager(ctxA)
+	require.NoError(t, err)
+	txID, txCtxA, err := tmA.Begin(ctxA)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tmA.Rollback(txCtxA, txID) })
+
+	tmB, err := h.Factory.TransactionManager(ctxB)
+	require.NoError(t, err)
+	err = tmB.Commit(ctxB, txID)
+	require.Error(t, err, "tenant B Commit of tenant A tx must fail")
+	require.True(t, errors.Is(err, spi.ErrTxTenantMismatch),
+		"cross-tenant Commit must wrap ErrTxTenantMismatch; got: %v", err)
+}
+
+// testTxStateSavepointNotFound verifies that RollbackToSavepoint with an
+// unknown savepoint id produces ErrSavepointNotFound (which also matches
+// ErrNotFound via Unwrap).
+func testTxStateSavepointNotFound(t *testing.T, h Harness) {
+	ctx := tenantContext(h.NewTenant())
+	tm, err := h.Factory.TransactionManager(ctx)
+	require.NoError(t, err)
+
+	txID, txCtx, err := tm.Begin(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tm.Rollback(txCtx, txID) })
+
+	err = tm.RollbackToSavepoint(txCtx, txID, "no-such-savepoint")
+	require.Error(t, err, "RollbackToSavepoint with unknown id must fail")
+	require.True(t, errors.Is(err, spi.ErrSavepointNotFound),
+		"unknown savepoint must wrap ErrSavepointNotFound; got: %v", err)
+	require.True(t, errors.Is(err, spi.ErrNotFound),
+		"ErrSavepointNotFound must also match ErrNotFound via Unwrap; got: %v", err)
+}
+```
+
+- [ ] **Step 3: Run the SPI tests to confirm everything compiles**
+
+```bash
+go test ./...
+```
+Expected: all tests pass. (The new subtests are not invoked here — no backend — but they must compile cleanly.)
+
+- [ ] **Step 4: Vet**
+
+```bash
+go vet ./...
+```
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add spitest/transaction.go
+git commit -m "feat(spitest): add transaction-state sentinel conformance subtests
+
+Seven new subtests under runTransactionSuite cover the conditions
+defined by the sentinel hierarchy added in the previous commit:
+
+- TxStateErrors/JoinAfterCommit
+- TxStateErrors/CommitAfterCommit
+- TxStateErrors/CommitAfterRollback
+- TxStateErrors/OpAfterRollback (backends with remote tx state may
+  skip via Harness.Skip)
+- TxStateErrors/TenantMismatchOnJoin
+- TxStateErrors/TenantMismatchOnCommit
+- TxStateErrors/SavepointNotFound
+
+Assertions tolerate the spec's documented contract slack — backends
+that purge tx state after termination may collapse 'AlreadyCommitted'
+or 'RolledBack' into NotFound; the assertion accepts either.
+
+Refs Cyoda-platform/cyoda-go#200"
+```
+
+---
+
+### Task A.4: Update SPI CHANGELOG and prepare for tagging
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Inspect the CHANGELOG shape**
+
+```bash
+head -40 CHANGELOG.md
+```
+
+Note the format the SPI repo uses (Keep-a-Changelog style or otherwise).
+
+- [ ] **Step 2: Add a release entry**
+
+At the top of the version list (under any "Unreleased" section if present), add:
+
+```markdown
+## [v0.8.0] - 2026-06-13
+
+### Added
+
+- Transaction-state sentinel hierarchy (`ErrTxNotFound`, `ErrSavepointNotFound`, `ErrTxTerminated`, `ErrTxRolledBack`, `ErrTxAlreadyCommitted`, `ErrTxCommitInProgress`, `ErrTxTenantMismatch`). Backwards-compatible: `ErrTxNotFound` and `ErrSavepointNotFound` wrap `ErrNotFound`; existing `errors.Is(err, ErrNotFound)` callers continue to match.
+- Seven new `spitest/transaction.go` subtests asserting backend conformance to the sentinel contract.
+
+### Notes for consumers
+
+- Plugins should wrap the sentinels at every tx-state error site. The memory + sqlite + postgres plugins in `cyoda-go` are migrated as part of the corresponding `cyoda-go v0.8.0` release.
+- The `OpAfterRollback` subtest may be skipped on backends that own tx state in a remote engine (e.g. postgres' pgx.Tx surfaces mid-op rollback as `ErrConflict` via SQLSTATE 25P02). See `ErrTxTerminated` godoc for details.
+```
+
+(Adjust the version number if `v0.8.0` is already taken; pick the next free minor — never force-move.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): record v0.8.0 transaction-state sentinels"
+```
+
+- [ ] **Step 4: Push and open the SPI PR**
+
+```bash
+git push -u origin feat/200-tx-state-sentinels
+gh pr create --title "feat: transaction-state sentinel hierarchy (#200)" \
+             --body "$(cat <<'EOF'
+Adds the SPI surface for cyoda-go issue #200: seven new sentinel errors covering transaction-lifecycle conditions, plus per-backend conformance subtests under `spitest/transaction.go`.
+
+Design spec lives in cyoda-go: `docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md`.
+
+Backwards-compatible: `ErrTxNotFound` and `ErrSavepointNotFound` wrap the existing `ErrNotFound`, so callers using `errors.Is(err, ErrNotFound)` on tx-lifecycle paths continue to match.
+
+The cyoda-go side (memory/sqlite/postgres plugin migrations, concurrency-test cleanup, `Harness.Skip` wiring) lands in a follow-up PR after this is tagged.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Wait for review and merge**
+
+This is a manual handoff. Once the PR is merged to `main`, tag it:
+
+```bash
+git checkout main
+git pull
+git tag v0.8.0
+git push origin v0.8.0
+```
+
+(Tag name should match the CHANGELOG entry from Step 2.)
+
+---
+
+## Phase B: cyoda-go PR
+
+All paths in Phase B are relative to the worktree: `/Users/paul/go-projects/cyoda-light/cyoda-go/.claude/worktrees/feat-200-spi-tx-state-sentinels/`.
+
+### Task B.1: Bump SPI pin in all four go.mods
+
+**Files:**
+- Modify: `go.mod`
+- Modify: `plugins/memory/go.mod`
+- Modify: `plugins/sqlite/go.mod`
+- Modify: `plugins/postgres/go.mod`
+
+Phase A must be tagged before this task. Until the tag exists, use the temporary `replace` directive described at the top of this plan.
+
+- [ ] **Step 1: Confirm the new SPI version exists**
+
+```bash
+go list -m -versions github.com/cyoda-platform/cyoda-go-spi | tr ' ' '\n' | tail -5
+```
+Expected: includes `v0.8.0` (or whatever fresh tag Phase A produced).
+
+- [ ] **Step 2: Update root `go.mod`**
+
+In `go.mod`, change the line:
+```
+github.com/cyoda-platform/cyoda-go-spi v0.7.1
+```
+to:
+```
+github.com/cyoda-platform/cyoda-go-spi v0.8.0
+```
+
+- [ ] **Step 3: Repeat for each plugin go.mod**
+
+```bash
+# plugins/memory/go.mod, plugins/sqlite/go.mod, plugins/postgres/go.mod
+# Replace the v0.7.1 line with v0.8.0 in each.
+```
+
+- [ ] **Step 4: Tidy each module**
+
+```bash
+go mod tidy
+(cd plugins/memory && go mod tidy)
+(cd plugins/sqlite && go mod tidy)
+(cd plugins/postgres && go mod tidy)
+```
+Expected: `go.sum` files updated; no errors.
+
+- [ ] **Step 5: Confirm the RED — new subtests fail against unmigrated plugins**
+
+```bash
+go test ./plugins/memory/... -run TestConformance -v 2>&1 | grep -A1 'TxStateErrors'
+```
+Expected: failures on subtests like `TxStateErrors/JoinAfterCommit`, `TxStateErrors/OpAfterRollback`, `TxStateErrors/TenantMismatchOnJoin`, etc. — the assertions cannot find the sentinels in the error chain because the plugin doesn't wrap them yet.
+
+This is the RED for Phase B. Do not commit yet — the subsequent tasks turn this GREEN per-plugin.
+
+---
+
+### Task B.2: Memory plugin — migrate `txmanager.go`
+
+**Files:**
+- Modify: `plugins/memory/txmanager.go`
+
+- [ ] **Step 1: Verify imports**
+
+Open `plugins/memory/txmanager.go` and confirm `spi` is imported as:
+```go
+spi "github.com/cyoda-platform/cyoda-go-spi"
+```
+(It already is — verify only.)
+
+- [ ] **Step 2: Migrate the lookup / closed / tenant / commit-race sites**
+
+Apply these substitutions (line numbers reflect the current file; the exact text may have drifted slightly — match on the format string content):
+
+| Line | Replace | With |
+|---|---|---|
+| 122 | `fmt.Errorf("transaction not found: %s", txID)` | `fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 131 | `fmt.Errorf("transaction already closed: %s", txID)` | `fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxAlreadyCommitted, txID)` |
+| 140 | `fmt.Errorf("tenant mismatch on transaction join")` | `fmt.Errorf("Join: %w", spi.ErrTxTenantMismatch)` |
+| 156 | `fmt.Errorf("transaction not found or already completed: %w", spi.ErrNotFound)` | `fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 160 | `fmt.Errorf("transaction tenant mismatch")` | `fmt.Errorf("Commit: %w", spi.ErrTxTenantMismatch)` |
+| 164 | `fmt.Errorf("transaction already being committed")` | `fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxCommitInProgress, txID)` |
+| 308 | `fmt.Errorf("transaction not found or already completed: %w", spi.ErrNotFound)` | `fmt.Errorf("Rollback: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 312 | `fmt.Errorf("transaction tenant mismatch")` | `fmt.Errorf("Rollback: %w", spi.ErrTxTenantMismatch)` |
+| 346 | `fmt.Errorf("transaction not found: %s", txID)` (in `GetSubmitTime`) | `fmt.Errorf("GetSubmitTime: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+
+Leave line 339 (`"transaction not yet committed"` in `GetSubmitTime`) **untouched** — per spec, this stays plain (one-site operational signal).
+
+- [ ] **Step 3: Migrate the savepoint sites**
+
+| Line | Replace | With |
+|---|---|---|
+| 379 | `fmt.Errorf("Savepoint: transaction %s not found", txID)` | `fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 382 | `fmt.Errorf("Savepoint: tenant mismatch on transaction %s", txID)` | `fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)` |
+| 392 | `fmt.Errorf("Savepoint: transaction %s already closed", txID)` | `fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxAlreadyCommitted, txID)` |
+| 449 | `fmt.Errorf("RollbackToSavepoint: transaction %s not found", txID)` | `fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 452 | `fmt.Errorf("RollbackToSavepoint: tenant mismatch on transaction %s", txID)` | `fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)` |
+| 459 | `fmt.Errorf("RollbackToSavepoint: transaction %s already closed", txID)` | `fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxAlreadyCommitted, txID)` |
+| 467 | `fmt.Errorf("RollbackToSavepoint: savepoint %s not found", savepointID)` | `fmt.Errorf("RollbackToSavepoint: %w (savepointID=%s)", spi.ErrSavepointNotFound, savepointID)` |
+| 471 | `fmt.Errorf("RollbackToSavepoint: savepoint %s not found", savepointID)` | `fmt.Errorf("RollbackToSavepoint: %w (savepointID=%s)", spi.ErrSavepointNotFound, savepointID)` |
+| 500 | `fmt.Errorf("ReleaseSavepoint: transaction %s not found", txID)` | `fmt.Errorf("ReleaseSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 503 | `fmt.Errorf("ReleaseSavepoint: tenant mismatch on transaction %s", txID)` | `fmt.Errorf("ReleaseSavepoint: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)` |
+| 508 | `fmt.Errorf("ReleaseSavepoint: savepoint %s not found", savepointID)` | `fmt.Errorf("ReleaseSavepoint: %w (savepointID=%s)", spi.ErrSavepointNotFound, savepointID)` |
+| 511 | `fmt.Errorf("ReleaseSavepoint: savepoint %s not found", savepointID)` | `fmt.Errorf("ReleaseSavepoint: %w (savepointID=%s)", spi.ErrSavepointNotFound, savepointID)` |
+
+(If the file also has a "tx already closed" check in `ReleaseSavepoint` analogous to lines 392/459, wrap with `spi.ErrTxAlreadyCommitted` the same way.)
+
+Leave lines 79, 82 (no user context / no tenant) and the `store_factory.go:159` "TransactionManager not initialized" **untouched** — per spec, SDK-misuse errors stay plain.
+
+- [ ] **Step 4: Build**
+
+```bash
+(cd plugins/memory && go build ./...)
+```
+Expected: clean build. If there's a compilation error, the most likely cause is a variable name in the wrap that doesn't match the function's local variable (e.g. `txID` vs `id`) — adjust to match.
+
+---
+
+### Task B.3: Memory plugin — migrate `entity_store.go`
+
+**Files:**
+- Modify: `plugins/memory/entity_store.go`
+
+All eight sites have the same shape: `fmt.Errorf("transaction has been rolled back")` with the tx-state check `if txState.RolledBack { ... }`. The migration adds the sentinel and (where the txID is in scope) the tx ID for debuggability.
+
+- [ ] **Step 1: Migrate each "transaction has been rolled back" site**
+
+For each of the 8 sites (currently at lines 106, 131, 253, 296, 348, 450, 513, 588), apply the same substitution:
+
+Old:
+```go
+return fmt.Errorf("transaction has been rolled back")
+```
+or
+```go
+return ..., fmt.Errorf("transaction has been rolled back")
+```
+
+New (preserve the return shape — adjust the function-name prefix to match the enclosing method, e.g. `Save:`, `Get:`, `Delete:`, etc.):
+```go
+return fmt.Errorf("<MethodName>: %w", spi.ErrTxRolledBack)
+```
+or
+```go
+return ..., fmt.Errorf("<MethodName>: %w", spi.ErrTxRolledBack)
+```
+
+If `txID` is in scope at the site (check the enclosing function — it usually is via `txState.TxID` or a parameter), include it:
+```go
+return fmt.Errorf("<MethodName>: %w (txID=%s)", spi.ErrTxRolledBack, txID)
+```
+
+Concrete per-site method names (cross-check against the function the line lives in):
+
+| Line | Enclosing method | Prefix to use |
+|---|---|---|
+| 106 | `Save` | `"Save: %w (txID=%s)"` |
+| 131 | `CompareAndSave` | `"CompareAndSave: %w (txID=%s)"` |
+| 253 | `Get` | `"Get: %w (txID=%s)"` |
+| 296 | `GetAll` | `"GetAll: %w (txID=%s)"` |
+| 348 | `Delete` | `"Delete: %w (txID=%s)"` |
+| 450 | `Exists` | `"Exists: %w (txID=%s)"` |
+| 513 | `Count` | `"Count: %w (txID=%s)"` |
+| 588 | `DeleteAll` | `"DeleteAll: %w (txID=%s)"` |
+
+- [ ] **Step 2: Run the conformance suite — observe GREEN**
+
+```bash
+(cd plugins/memory && go test ./... -run TestConformance -v 2>&1 | grep -E 'PASS|FAIL.*TxStateErrors|^---')
+```
+Expected: every `TxStateErrors/*` subtest reports PASS.
+
+If a subtest still FAILs, the most likely cause is that a wrap was missed (the test follows a different code path) or a variable name mismatch. Use `go test -run 'TestConformance/Transaction/TxStateErrors/JoinAfterCommit' -v` to focus and inspect.
+
+- [ ] **Step 3: Run the full memory plugin test suite — ensure no regression**
+
+```bash
+(cd plugins/memory && go test ./...)
+```
+Expected: ALL tests pass, including the existing concurrency tests (which still use `strings.Contains` — they'll be cleaned up in the next task but the substring matches still match the new wrapped messages because we preserved the prefix words like "rolled back", "not found", etc. in the sentinel's `.Error()` strings).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/memory/txmanager.go plugins/memory/entity_store.go go.mod go.sum plugins/memory/go.mod plugins/memory/go.sum plugins/sqlite/go.mod plugins/sqlite/go.sum plugins/postgres/go.mod plugins/postgres/go.sum
+git commit -m "feat(memory): wrap tx-state sentinel errors
+
+Migrates plugins/memory error sites to wrap the new SPI sentinels:
+
+- ErrTxNotFound, ErrSavepointNotFound (wrap ErrNotFound)
+- ErrTxTerminated, ErrTxRolledBack, ErrTxAlreadyCommitted
+- ErrTxCommitInProgress, ErrTxTenantMismatch
+
+txmanager.go covers lookup/closed/tenant/commit-race/savepoint paths.
+entity_store.go covers the 8 'transaction has been rolled back' sites
+across Save, CompareAndSave, Get, GetAll, Delete, Exists, Count,
+DeleteAll, adding the txID to the wrapped message for debuggability.
+
+GetSubmitTime's 'not yet committed' path (txmanager.go:339) stays plain
+per spec (one-site operational signal).
+
+SDK-misuse errors (no user context, no tenant, TransactionManager not
+initialized) stay plain per spec.
+
+Also bumps cyoda-go-spi pin to v0.8.0 in root go.mod and all three
+plugin go.mods.
+
+Refs #200"
+```
+
+---
+
+### Task B.4: Memory plugin — concurrency test cleanup
+
+**Files:**
+- Modify: `plugins/memory/concurrency_inreadops_test.go`
+- Modify: `plugins/memory/concurrency_cas_test.go`
+- Modify: `plugins/memory/concurrency_savepoint_test.go`
+
+The three test files currently use `strings.Contains(msg, ...)` to tolerate race-induced tx-state errors. Replace with `errors.Is`.
+
+- [ ] **Step 1: Verify imports**
+
+In each of the three files, ensure these imports are present:
+```go
+import (
+	"errors"
+	...
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	...
+)
+```
+If `errors` or `spi` is missing in a file you're editing, add it. The `strings` import becomes unused after this task — Go's compiler will refuse the build if it's left dangling, so the cleanup is forced.
+
+- [ ] **Step 2: Replace the substring blocks in `concurrency_inreadops_test.go`**
+
+Find each block of the shape (current lines around 87-90, 280-283):
+
+```go
+msg := err.Error()
+if strings.Contains(msg, "rolled back") ||
+    strings.Contains(msg, "already completed") ||
+    strings.Contains(msg, "not found") ||
+    strings.Contains(msg, "already being committed") {
+    // tolerated tx-state race
+    return
+}
+```
+
+Replace with:
+
+```go
+if errors.Is(err, spi.ErrTxTerminated) ||
+    errors.Is(err, spi.ErrTxNotFound) ||
+    errors.Is(err, spi.ErrTxCommitInProgress) {
+    // tolerated tx-state race
+    return
+}
+```
+
+(The three-way disjunction is required — `ErrTxCommitInProgress` is intentionally NOT under the `ErrTxTerminated` umbrella because the tx is not yet terminal. Spec section "Concurrency Test Update" line 257.)
+
+- [ ] **Step 3: Replace the substring blocks in `concurrency_cas_test.go`**
+
+Same pattern at current lines ~97-100, ~173-175. Apply the same `errors.Is`-based replacement. Note this file tolerates "rolled back" / "already completed" / "not found" but does NOT currently match "already being committed" — for those sites, the two-way disjunction is sufficient:
+
+```go
+if errors.Is(err, spi.ErrTxTerminated) ||
+    errors.Is(err, spi.ErrTxNotFound) {
+    return
+}
+```
+
+Confirm by grepping the file for `"already being committed"` before deciding two-way vs three-way per site:
+
+```bash
+grep -n "already being committed" plugins/memory/concurrency_cas_test.go
+```
+
+- [ ] **Step 4: Replace the substring blocks in `concurrency_savepoint_test.go`**
+
+Includes the TODO marker at lines 49-52. Remove the TODO comment block entirely:
+
+```go
+// TODO(#200): replace substring matches on tolerated errors ("not found",
+// "rolled back", "already closed", "already completed", "already being
+// committed") with errors.Is against sentinel error types once they land.
+// Until then a closed-mid-op tx is a legitimate outcome, not a defect.
+```
+
+Delete those four lines.
+
+Then migrate the substring blocks at lines 123-127, 143-144, 295-296 (and any others — verify with `grep -n "strings.Contains" plugins/memory/concurrency_savepoint_test.go`). The sites that currently match "already being committed" use the three-way disjunction; sites that don't use the two-way.
+
+- [ ] **Step 5: Confirm `strings` import is no longer needed**
+
+```bash
+grep -n '"strings"' plugins/memory/concurrency_*.go
+```
+If `strings` is unused in any of the three files, remove the import line.
+
+- [ ] **Step 6: Run the memory plugin tests**
+
+```bash
+(cd plugins/memory && go test ./... -v 2>&1 | tail -30)
+```
+Expected: all tests pass.
+
+Confirm specifically that the concurrency tests still pass (they're race-conditional so multiple runs may be wise):
+
+```bash
+(cd plugins/memory && go test ./... -run 'Concurrency' -count=5)
+```
+Expected: 5 successful runs.
+
+- [ ] **Step 7: Vet**
+
+```bash
+(cd plugins/memory && go vet ./...)
+```
+Expected: no output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add plugins/memory/concurrency_inreadops_test.go plugins/memory/concurrency_cas_test.go plugins/memory/concurrency_savepoint_test.go
+git commit -m "test(memory): replace strings.Contains with errors.Is on tx-state errors
+
+The three concurrency_*_test.go helpers (runOpVsRollback, runOpVsCommit)
+that tolerate tx-state-race errors now use errors.Is against the SPI
+sentinels added in cyoda-go-spi v0.8.0 instead of substring matching.
+
+Race-loser tolerance now matches via:
+  errors.Is(err, spi.ErrTxTerminated) ||  // rolled-back or already-committed
+  errors.Is(err, spi.ErrTxNotFound) ||    // tx purged
+  errors.Is(err, spi.ErrTxCommitInProgress)  // mid-Commit race (not terminal)
+
+The third disjunct is required only at sites that currently tolerate
+'already being committed' — concurrency_inreadops_test.go:283,
+concurrency_savepoint_test.go:143,295.
+
+Drops the TODO(#200) marker block at concurrency_savepoint_test.go:49-52.
+
+Refs #200"
+```
+
+---
+
+### Task B.5: SQLite plugin — migrate `txmanager.go` and `entity_store.go`
+
+**Files:**
+- Modify: `plugins/sqlite/txmanager.go`
+- Modify: `plugins/sqlite/entity_store.go`
+
+SQLite mirrors memory almost line-for-line. The same substitutions apply.
+
+- [ ] **Step 1: Apply the txmanager substitutions**
+
+For sqlite `plugins/sqlite/txmanager.go`, the lines are slightly offset from memory but the error strings are identical. Apply the same table from Task B.2 Steps 2 and 3, matching on the error message text rather than line numbers (the editor's find-and-replace by string is fastest). Sites to migrate (use `grep -n "fmt.Errorf" plugins/sqlite/txmanager.go` to enumerate):
+
+- `"transaction not found: %s"` → `ErrTxNotFound`
+- `"transaction already closed: %s"` → `ErrTxAlreadyCommitted`
+- `"tenant mismatch on transaction join"` → `ErrTxTenantMismatch`
+- `"transaction not found or already completed: %w"` → `ErrTxNotFound`
+- `"transaction tenant mismatch"` → `ErrTxTenantMismatch`
+- `"transaction already being committed"` → `ErrTxCommitInProgress`
+- `"GetSubmitTime: transaction not found: %s"` (around L474) → `ErrTxNotFound`
+- All `"Savepoint: ..."`, `"RollbackToSavepoint: ..."`, `"ReleaseSavepoint: ..."` not-found / tenant / already-closed / savepoint-not-found sites → corresponding sentinels per the memory mapping.
+
+Use the same wrap pattern (`fmt.Errorf("MethodName: %w (txID=%s)", spi.ErrXxx, txID)`).
+
+Leave the "no user context" / "no tenant" sites plain.
+
+- [ ] **Step 2: Apply the entity_store substitutions**
+
+For sqlite `plugins/sqlite/entity_store.go`, the eight "transaction has been rolled back" sites mirror memory. Use the same per-method-name table from Task B.3 Step 1.
+
+- [ ] **Step 3: Run sqlite tests — observe GREEN**
+
+```bash
+(cd plugins/sqlite && go test ./... -v 2>&1 | grep -E 'PASS|FAIL.*TxStateErrors|^---')
+```
+Expected: every `TxStateErrors/*` subtest reports PASS.
+
+- [ ] **Step 4: Run sqlite full suite**
+
+```bash
+(cd plugins/sqlite && go test ./...)
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Vet**
+
+```bash
+(cd plugins/sqlite && go vet ./...)
+```
+Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/sqlite/txmanager.go plugins/sqlite/entity_store.go
+git commit -m "feat(sqlite): wrap tx-state sentinel errors
+
+Mirrors plugins/memory migration: every tx-lifecycle and entity-store
+'rolled back' error site now wraps the corresponding SPI sentinel.
+
+Conformance subtests TxStateErrors/* under spitest/transaction.go now
+pass on the sqlite backend.
+
+Refs #200"
+```
+
+---
+
+### Task B.6: Postgres plugin — migrate `transaction_manager.go`
+
+**Files:**
+- Modify: `plugins/postgres/transaction_manager.go`
+
+Postgres has subset coverage: no in-process `RolledBack` state, no commit-in-progress, but full savepoint paths and a `verifyTenant()` helper that all six lifecycle ops route through.
+
+- [ ] **Step 1: Migrate the lookup not-found sites**
+
+| Line | Replace | With |
+|---|---|---|
+| 118 | `fmt.Errorf("Commit: transaction %s not found", txID)` | `fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 122 | `fmt.Errorf("Commit: tx state for %s not found", txID)` | `fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 215 | `fmt.Errorf("Rollback: transaction %s not found", txID)` | `fmt.Errorf("Rollback: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 220 | `fmt.Errorf("Rollback: transaction %s not found", txID)` | `fmt.Errorf("Rollback: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 244 | `fmt.Errorf("Join: transaction %s not found", txID)` | `fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 249 | `fmt.Errorf("Join: transaction %s not found", txID)` | `fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 318 | `fmt.Errorf("Savepoint: transaction %s not found", txID)` | `fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 322 | `fmt.Errorf("Savepoint: tx state for %s not found", txID)` | `fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 344 | `fmt.Errorf("RollbackToSavepoint: transaction %s not found", txID)` | `fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 348 | `fmt.Errorf("RollbackToSavepoint: tx state for %s not found", txID)` | `fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 370 | `fmt.Errorf("ReleaseSavepoint: transaction %s not found", txID)` | `fmt.Errorf("ReleaseSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+| 374 | `fmt.Errorf("ReleaseSavepoint: tx state for %s not found", txID)` | `fmt.Errorf("ReleaseSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)` |
+
+- [ ] **Step 2: Migrate the `verifyTenant()` helper (single wrap covers six call sites)**
+
+At line 414:
+
+Old:
+```go
+return fmt.Errorf("%s: tenant mismatch on transaction %s", op, txID)
+```
+
+New:
+```go
+return fmt.Errorf("%s: %w (txID=%s)", op, spi.ErrTxTenantMismatch, txID)
+```
+
+This is the entire postgres tenant-mismatch surface — all of Commit/Rollback/Join/Savepoint/RollbackToSavepoint/ReleaseSavepoint route through here.
+
+- [ ] **Step 3: Leave L270 (`GetSubmitTime`) plain**
+
+Per spec, postgres `GetSubmitTime` at L270 deliberately conflates "not yet committed" with "unknown txID" — stays plain on data-structure grounds. Do not modify.
+
+---
+
+### Task B.7: Postgres plugin — migrate `txstate.go`
+
+**Files:**
+- Modify: `plugins/postgres/txstate.go`
+
+- [ ] **Step 1: Migrate the savepoint-not-found sites**
+
+| Line | Replace | With |
+|---|---|---|
+| 166 | `fmt.Errorf("unknown savepoint %q", id)` | `fmt.Errorf("%w (savepointID=%q)", spi.ErrSavepointNotFound, id)` |
+| 223 | `fmt.Errorf("unknown savepoint %q", id)` | `fmt.Errorf("%w (savepointID=%q)", spi.ErrSavepointNotFound, id)` |
+
+- [ ] **Step 2: Add the `spi` import if not present**
+
+If `txstate.go` doesn't already import `spi`, add:
+```go
+spi "github.com/cyoda-platform/cyoda-go-spi"
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+(cd plugins/postgres && go build ./...)
+```
+Expected: clean build.
+
+---
+
+### Task B.8: Postgres plugin — wire `Harness.Skip` and run conformance
+
+**Files:**
+- Modify: `plugins/postgres/conformance_test.go`
+
+- [ ] **Step 1: Locate the harness construction**
+
+Open `plugins/postgres/conformance_test.go` and find the `spitest.StoreFactoryConformance(t, spitest.Harness{...})` call (around line 153 per earlier survey).
+
+- [ ] **Step 2: Add the `Skip` map**
+
+Inside the `spitest.Harness{}` literal, add:
+
+```go
+Skip: map[string]string{
+    "Transaction/TxStateErrors/OpAfterRollback": "postgres: pgx.Tx aborts surface as ErrConflict via SQLSTATE 25P02, not as ErrTxRolledBack",
+},
+```
+
+(If `Skip` is already present in the literal, add the new entry to the existing map rather than declaring a second one.)
+
+- [ ] **Step 3: Run the postgres conformance suite (requires Docker)**
+
+```bash
+(cd plugins/postgres && go test ./... -run TestConformance -v 2>&1 | grep -E 'PASS|FAIL.*TxStateErrors|SKIP.*TxStateErrors|^---')
+```
+Expected: every `TxStateErrors/*` subtest reports PASS, except `TxStateErrors/OpAfterRollback` which reports SKIP with the documented reason.
+
+If `TxStateErrors/SavepointNotFound` FAILs, postgres' savepoint paths are not wrapping `ErrSavepointNotFound` — re-check Task B.7. Do NOT add it to the Skip map; the spec calls for it to pass on postgres.
+
+- [ ] **Step 4: Run the full postgres test suite**
+
+```bash
+(cd plugins/postgres && go test ./...)
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Vet**
+
+```bash
+(cd plugins/postgres && go vet ./...)
+```
+Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/postgres/transaction_manager.go plugins/postgres/txstate.go plugins/postgres/conformance_test.go
+git commit -m "feat(postgres): wrap tx-state sentinel errors
+
+Migrates plugins/postgres to wrap the new SPI sentinels:
+
+- ErrTxNotFound — every 'transaction/tx state not found' site across
+  Commit, Rollback, Join, and the three savepoint methods (12 sites
+  in transaction_manager.go).
+- ErrTxTenantMismatch — wrapped once in verifyTenant() at L414; this
+  single site covers all six lifecycle ops that call it (Commit,
+  Rollback, Join, Savepoint, RollbackToSavepoint, ReleaseSavepoint).
+- ErrSavepointNotFound — both 'unknown savepoint' sites in txstate.go.
+
+GetSubmitTime at L270 stays plain per spec — the message deliberately
+conflates 'not yet committed' with 'unknown txID' because the
+submitTimes map cannot distinguish them without extra bookkeeping.
+
+conformance_test.go declares a single Harness.Skip entry for
+TxStateErrors/OpAfterRollback because pgx.Tx surfaces mid-op
+rollback as ErrConflict (SQLSTATE 25P02), not as ErrTxRolledBack —
+documented behaviour per the ErrTxTerminated SPI godoc.
+
+Refs #200"
+```
+
+---
+
+### Task B.9: Update `COMPATIBILITY.md`
+
+**Files:**
+- Modify: `COMPATIBILITY.md`
+
+- [ ] **Step 1: Locate the matrix**
+
+Open `COMPATIBILITY.md` and find the `## Compatibility matrix — cyoda-go × cyoda-go-spi` section. The matrix table has columns `cyoda-go` / Root pin / Plugin pin / SPI surface added.
+
+- [ ] **Step 2: Add the v0.8.0 row at the top of the matrix**
+
+Insert above the existing `v0.7.1 (planned)` row (or above whatever is the top row):
+
+```markdown
+| **`v0.8.0`** _(planned)_ | `cyoda-go-spi v0.8.0` | `cyoda-go-spi v0.8.0` | Tx-state sentinel hierarchy: `ErrTxNotFound`, `ErrSavepointNotFound`, `ErrTxTerminated`, `ErrTxRolledBack`, `ErrTxAlreadyCommitted`, `ErrTxCommitInProgress`, `ErrTxTenantMismatch` |
+```
+
+If `v0.7.1` is no longer marked `_(planned)_` (it has been released), drop the `_(planned)_` qualifier from that row.
+
+- [ ] **Step 3: Check the "Plugin tag history" section**
+
+The plugin tag history table at the bottom needs no change for this PR — the in-tree plugin module tags are bumped as part of the v0.8.0 release coordination by the maintainer, not by this PR.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add COMPATIBILITY.md
+git commit -m "docs(compatibility): record v0.8.0 SPI surface (#200 sentinels)
+
+Adds the cyoda-go v0.8.0 row to the cyoda-go × cyoda-go-spi
+compatibility matrix, listing the seven new transaction-state
+sentinels added in cyoda-go-spi v0.8.0.
+
+Refs #200"
+```
+
+---
+
+### Task B.10: Full verification
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Run `make test-all`**
+
+```bash
+make test-all
+```
+Expected: all green (root + memory + sqlite + postgres). Postgres requires Docker; if it's not running, start it first.
+
+- [ ] **Step 2: Run each plugin's full suite explicitly**
+
+```bash
+(cd plugins/memory && go test ./...)
+(cd plugins/sqlite && go test ./...)
+(cd plugins/postgres && go test ./...)
+```
+Expected: each module green. (`make test-all` should have covered this, but the explicit run confirms.)
+
+- [ ] **Step 3: Vet each module**
+
+```bash
+go vet ./...
+(cd plugins/memory && go vet ./...)
+(cd plugins/sqlite && go vet ./...)
+(cd plugins/postgres && go vet ./...)
+```
+Expected: no output anywhere.
+
+- [ ] **Step 4: One-shot race detector**
+
+```bash
+go test -race ./...
+(cd plugins/memory && go test -race ./...)
+(cd plugins/sqlite && go test -race ./...)
+(cd plugins/postgres && go test -race ./...)
+```
+Expected: all green; no race reports. Per project convention this is a one-shot sanity check before PR, not a per-step gate.
+
+- [ ] **Step 5: Confirm no orphaned `strings.Contains` on tx-state errors**
+
+```bash
+grep -rn 'strings.Contains.*rolled back\|strings.Contains.*already completed\|strings.Contains.*already being committed\|strings.Contains.*tenant mismatch' --include='*.go' .
+```
+Expected: no matches. (If matches remain in `plugins/sqlite/` or other locations, they were missed in this migration — go back and fix.)
+
+- [ ] **Step 6: Confirm the TODO marker is gone**
+
+```bash
+grep -rn 'TODO(#200)' --include='*.go' .
+```
+Expected: no matches.
+
+- [ ] **Step 7: Confirm no local `replace` directives remain**
+
+```bash
+grep -n 'replace.*cyoda-go-spi' go.mod plugins/*/go.mod
+```
+Expected: no matches. (If any remain from the dev-time iteration described at the top of this plan, remove them and re-run `go mod tidy`.)
+
+---
+
+### Task B.11: Open the PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/200-spi-tx-state-sentinel-errors
+```
+
+- [ ] **Step 2: Open the PR against `release/v0.8.0`**
+
+```bash
+gh pr create --base release/v0.8.0 \
+             --title "feat(spi): tx-state sentinel errors — closes #200" \
+             --body "$(cat <<'EOF'
+Replaces plain-string transaction-state errors across the memory, sqlite, and postgres storage plugins with the SPI sentinel hierarchy added in `cyoda-go-spi v0.8.0`.
+
+Spec: [`docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md`](../blob/feat/200-spi-tx-state-sentinel-errors/docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md)
+
+Plan: [`docs/superpowers/plans/2026-06-13-200-spi-tx-state-sentinel-errors.md`](../blob/feat/200-spi-tx-state-sentinel-errors/docs/superpowers/plans/2026-06-13-200-spi-tx-state-sentinel-errors.md)
+
+**What changes**
+
+- Root `go.mod` + all three plugin `go.mod`s bump `cyoda-go-spi` pin from `v0.7.1` to `v0.8.0`.
+- `plugins/memory/{txmanager.go,entity_store.go}` — every tx-state error site now wraps the relevant SPI sentinel; the eight "transaction has been rolled back" sites in `entity_store.go` gain a `txID=` debuggability field.
+- `plugins/memory/concurrency_{inreadops,cas,savepoint}_test.go` — replaces `strings.Contains` tolerance blocks with `errors.Is`. Three-way disjunction (`ErrTxTerminated || ErrTxNotFound || ErrTxCommitInProgress`) at the three sites that tolerate "already being committed"; two-way elsewhere. Drops the `TODO(#200)` marker.
+- `plugins/sqlite/{txmanager.go,entity_store.go}` — mirrors memory.
+- `plugins/postgres/{transaction_manager.go,txstate.go,conformance_test.go}` — wraps the lookup/tenant/savepoint sites; `verifyTenant()` at L414 is a single wrap that carries the entire postgres tenant-mismatch contract. `OpAfterRollback` conformance subtest is skipped on postgres with a documented reason (pgx.Tx surfaces mid-op rollback as `ErrConflict` via SQLSTATE 25P02).
+- `COMPATIBILITY.md` matrix gains the v0.8.0 row listing the seven new sentinels.
+
+**Not in this PR (deliberately)**
+
+- HTTP/gRPC status mapping based on the new sentinels — separate follow-up per `#200` body.
+- Cassandra plugin migration — separate repo, picks up on its next SPI bump.
+- SDK-misuse error promotion (`no user context`, `no tenant`, `TransactionManager not initialized`) — these stay plain per spec.
+
+Closes #200
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)" \
+             --milestone v0.8.0
+```
+
+(Verify the milestone name matches the repo's actual milestone. Per project convention, milestone-targeted PRs are mandatory on `release/vX.Y.Z` branches.)
+
+- [ ] **Step 3: Hand off for review**
+
+The PR is now ready for code-review and security-review per the project workflow. Per `CLAUDE.md`:
+- `code-review` skill review
+- `antigravity-bundle-security-developer:cc-skill-security-review` security audit
+- Address feedback via `superpowers:receiving-code-review`
+- Merge when both reviewers approve
+
+---
+
+## Self-review
+
+After writing this plan, checking it against the spec:
+
+- ✅ Sentinel set (7 sentinels with hierarchy) — Task A.2 defines all seven exactly.
+- ✅ Backward compat for `ErrNotFound` wrap — `sentinelErr.Unwrap()` chain in Task A.2; verified by `TestTxSentinelHierarchy` and `TestTxSentinelWrapChain` in Task A.1.
+- ✅ Postgres godoc caveat for `ErrTxTerminated` — included in Task A.2 godoc.
+- ✅ Pure sentinel-graph tests in `errors_test.go` — Task A.1.
+- ✅ Per-backend conformance in `spitest/transaction.go` — Task A.3.
+- ✅ Memory plugin migration — Tasks B.2, B.3 (txmanager + entity_store).
+- ✅ Memory concurrency-test cleanup — Task B.4 (three-way for "already being committed" sites, two-way elsewhere; TODO marker removed).
+- ✅ SQLite migration — Task B.5.
+- ✅ Postgres migration — Tasks B.6, B.7, B.8 including verifyTenant single-wrap, txstate.go, and Harness.Skip.
+- ✅ COMPATIBILITY.md update — Task B.9.
+- ✅ Verification (per-plugin tests, vet, race) — Task B.10.
+- ✅ PR open targeting `release/v0.8.0` with milestone — Task B.11.
+- ✅ Out-of-scope items (HTTP mapping, Cassandra, SDK-misuse promotion) explicitly excluded — referenced in B.11 PR body.
+
+No placeholders. Every step has concrete code or commands. Types and method names are consistent between Task A.1 (tests) and Task A.2 (definitions); between Task A.3 (subtests) and Tasks B.2–B.8 (migrations). The plan is decomposable into bite-sized red/green slices; each commit is self-contained and reviewable.

--- a/docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md
+++ b/docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md
@@ -144,9 +144,9 @@ Rationale: these signal misuse of the API rather than an operational tx-state co
 | 449, 452, 459, 467, 471 | RollbackToSavepoint variants | corresponding sentinels |
 | 500, 503, 508, 511 | ReleaseSavepoint variants | corresponding sentinels |
 
-`plugins/memory/entity_store.go` — 8 sites (Save 106, CompareAndSave 131, Get 253, GetAll 296, Delete 348, Exists 450, Count 513, DeleteAll 588):
+`plugins/memory/entity_store.go` — 8 sites (Save, CompareAndSave, Get, GetAsAt, GetAll, Delete, DeleteAll, Exists). `Count` (around L615) delegates to `GetAll` for the in-tx case so it inherits the `ErrTxRolledBack` wrap via the call chain — no separate site.
 
-- `"transaction has been rolled back"` → `fmt.Errorf("tx %s: %w", txID, spi.ErrTxRolledBack)` (adds tx ID for debuggability)
+- `"transaction has been rolled back"` → `fmt.Errorf("<Method>: %w (txID=%s)", spi.ErrTxRolledBack, txID)` (adds tx ID for debuggability)
 
 ### SQLite plugin
 
@@ -262,7 +262,7 @@ Only `OpAfterRollback` is skipped on postgres. `SavepointNotFound` is NOT skippe
 
 `plugins/memory/concurrency_inreadops_test.go`, `concurrency_cas_test.go`, `concurrency_savepoint_test.go`:
 
-- Replace each `runOpVsRollback` / `runOpVsCommit` helper's `strings.Contains(msg, "rolled back") || strings.Contains(msg, "already completed") || ...` block with a three-way `errors.Is(err, spi.ErrTxTerminated) || errors.Is(err, spi.ErrTxNotFound) || errors.Is(err, spi.ErrTxCommitInProgress)`. The third disjunct is required for any helper that currently tolerates `"already being committed"` (`concurrency_inreadops_test.go:283`, `concurrency_savepoint_test.go:143,295`) — `ErrTxCommitInProgress` is deliberately not under the `ErrTxTerminated` umbrella because the tx is not yet terminal. Helpers that don't tolerate that substring today can stay two-way.
+- Replace each `runOpVsRollback` / `runOpVsCommit` helper's `strings.Contains(msg, "rolled back") || strings.Contains(msg, "already completed") || ...` block with a sentinel-based check via a shared `isToleratedClosedTxErr` helper. The helper matches the three-way disjunction `errors.Is(err, spi.ErrTxTerminated) || errors.Is(err, spi.ErrTxNotFound) || errors.Is(err, spi.ErrTxCommitInProgress)`, PLUS bare `errors.Is(err, spi.ErrNotFound)` to preserve the existing tolerance of entity-level not-found from in-read ops (Get/GetAll/Exists/Delete legitimately surface entity-not-found when a concurrent Rollback/Commit changes visibility mid-op). The `ErrTxCommitInProgress` disjunct is required for any helper that currently tolerates `"already being committed"` (`concurrency_inreadops_test.go:283`, `concurrency_savepoint_test.go:143,295`) — `ErrTxCommitInProgress` is deliberately not under the `ErrTxTerminated` umbrella because the tx is not yet terminal.
 - Drop the `TODO(#200)` comment block at `concurrency_savepoint_test.go:49-52`.
 
 ## Migration Sequencing

--- a/docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md
+++ b/docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md
@@ -17,7 +17,7 @@ The memory plugin (and, by mirroring, the sqlite plugin) returns transaction-lif
 
 This forces callers — including the memory plugin's own race-conditional tests in `plugins/memory/concurrency_*_test.go` — to do `strings.Contains` substring matching alongside `errors.Is(spi.ErrNotFound)`. The substring fallback is brittle, typo-sensitive, and can silently swallow unrelated errors that happen to contain the same substring.
 
-`plugins/memory/concurrency_savepoint_test.go:49-51` already carries a `TODO(#200)` flagging this. This spec discharges that TODO.
+`plugins/memory/concurrency_savepoint_test.go:49-52` already carries a `TODO(#200)` flagging this. This spec discharges that TODO.
 
 ## Why this is SPI-level
 
@@ -162,12 +162,12 @@ Rationale: these signal misuse of the API rather than an operational tx-state co
 | 122 | `"Commit: tx state for %s not found"` | `ErrTxNotFound` |
 | 215, 220 | `"Rollback: transaction %s not found"` | `ErrTxNotFound` |
 | 244, 249 | `"Join: transaction %s not found"` (both lookup paths) | `ErrTxNotFound` |
-| 318 | `"Savepoint: transaction %s not found"` | `ErrTxNotFound` |
-| 344 | `"RollbackToSavepoint: transaction %s not found"` | `ErrTxNotFound` |
-| 370 | `"ReleaseSavepoint: transaction %s not found"` | `ErrTxNotFound` |
+| 318, 322 | `"Savepoint: transaction %s not found"` / `"Savepoint: tx state for %s not found"` (registry + txState lookups) | `ErrTxNotFound` (both) |
+| 344, 348 | `"RollbackToSavepoint: transaction %s not found"` / `"RollbackToSavepoint: tx state for %s not found"` | `ErrTxNotFound` (both) |
+| 370, 374 | `"ReleaseSavepoint: transaction %s not found"` / `"ReleaseSavepoint: tx state for %s not found"` | `ErrTxNotFound` (both) |
 | **414** | **`verifyTenant()` helper — `"%s: tenant mismatch on transaction %s"`** | **`ErrTxTenantMismatch` — single wrap site, called from Commit (L124), Rollback (L222), Join (L251), Savepoint (L324), RollbackToSavepoint (L350), ReleaseSavepoint (L376)** |
 
-L270 (`GetSubmitTime: ... has no submit time (not yet committed or unknown)`) deliberately conflates "not yet committed" with "unknown txID" into one operational message — stays plain per the SDK-misuse / one-site policy applied to memory `txmanager.go:339`.
+L270 (`GetSubmitTime: ... has no submit time (not yet committed or unknown)`) deliberately conflates "not yet committed" with "unknown txID" into one operational message. Note this is **not** the same situation as memory L339 (where the code distinguishes active-vs-unknown but the spec policy keeps it plain due to one-site, no-consumer-match): postgres' `submitTimes` map is only populated on terminal entry, so active-but-uncommitted and never-existed are **observationally identical** at this site without extra bookkeeping. Stays plain on data-structure grounds. Splitting would require adding a probe into `tm.tenants[txID]` (which IS populated for active txs) — out of scope here.
 
 `plugins/postgres/txstate.go`:
 
@@ -176,7 +176,7 @@ L270 (`GetSubmitTime: ... has no submit time (not yet committed or unknown)`) de
 | 166, 223 | `"unknown savepoint %q"` | `ErrSavepointNotFound` |
 
 Postgres does **not** have:
-- In-process `tx.RolledBack` race (server-side tx; mid-op rollback surfaces as `pgconn.PgError` SQLSTATE 25P02, already mapped to `ErrConflict` via `classifyError` at `transaction_manager.go:171-174` — not changed; this is the postgres-engine caveat documented in the SPI godoc on `ErrTxTerminated`)
+- In-process `tx.RolledBack` race (server-side tx; mid-op rollback surfaces as `pgconn.PgError` SQLSTATE 25P02, already mapped to `ErrConflict` via the inline `InFailedSQLTransaction` branch at `transaction_manager.go:170-174`, with the broader serialization/deadlock mapping in `classifyError` at L432-441 — not changed; this is the postgres-engine caveat documented in the SPI godoc on `ErrTxTerminated`)
 - `transaction already being committed` (no in-process commit registry)
 - `transaction already closed` distinct from `transaction not found` (server-side tx; once committed/rolled back, lookups return "not found")
 
@@ -186,7 +186,11 @@ Postgres `GetSubmitTime` "not yet committed" path (if present and distinct from 
 
 ### Cassandra plugin (not modified in this PR)
 
-Cassandra picks up the new sentinels when it next bumps its `cyoda-go-spi` pin. Until then its own string-coded error system (`TX_NOT_FOUND`, `TX_NOT_ACTIVE`, `ErrCodeTxNoState`, etc. at `cyoda-go-cassandra/internal/tx/tx_manager.go`) continues unchanged. On the bump, expect approximately six conformance subtest failures: `JoinAfterCommit`, `CommitAfterCommit`, `CommitAfterRollback`, `TenantMismatchOnJoin`, `TenantMismatchOnCommit`, and `SavepointNotFound` — a predictable, scoped conformance prompt. **No courtesy PR; no tracking issue in the Cassandra repo** (per project convention — Cassandra repo is private and out of scope here).
+Cassandra picks up the new sentinels when it next bumps its `cyoda-go-spi` pin. Until then its own string-coded error system (`TX_NOT_FOUND`, `TX_NOT_ACTIVE`, `ErrCodeTxNoState`, etc. at `cyoda-go-cassandra/internal/tx/tx_manager.go`) continues unchanged. On the bump, expect approximately six conformance subtest failures: `JoinAfterCommit`, `CommitAfterCommit`, `CommitAfterRollback`, `TenantMismatchOnJoin`, `TenantMismatchOnCommit`, and `SavepointNotFound` — a predictable, scoped conformance prompt.
+
+Note for the future Cassandra-side change: tenant-mismatch is **not just a sentinel rename** there. Cassandra's tx lookups are tenant-partitioned, so a tenant-B caller looking up a tenant-A tx falls through to `TX_NOT_FOUND` instead of "tenant mismatch". Conforming to `ErrTxTenantMismatch` requires an explicit pre-lookup tenant check, not just wrapping the existing error code. This is a substantive Cassandra-side change, not a sed-rewrite — documented here so the future Cassandra PR author isn't surprised.
+
+**No courtesy PR; no tracking issue in the Cassandra repo** (per project convention — Cassandra repo is private and out of scope here).
 
 ## Parity Test Additions
 
@@ -205,6 +209,9 @@ Hierarchy and distinctness are properties of the SPI itself, not per-backend beh
   - `errors.Is(ErrTxNotFound, ErrTxRolledBack) == false`
   - `errors.Is(ErrTxRolledBack, ErrNotFound) == false`
   - `errors.Is(ErrTxTenantMismatch, ErrTxTerminated) == false`
+  - `errors.Is(ErrSavepointNotFound, ErrTxNotFound) == false` — siblings under `ErrNotFound`; callers distinguishing "tx missing" vs "savepoint missing" rely on this distinction.
+  - `errors.Is(ErrTxNotFound, ErrSavepointNotFound) == false` — mirror of the above.
+  - `errors.Is(ErrTxCommitInProgress, ErrTxTerminated) == false` — CommitInProgress is a transient race, not a terminal state.
   - … etc., covering every off-diagonal pair.
 - **Wrap chain** — `fmt.Errorf("ctx: %w", ErrTxNotFound)` is `errors.Is`-detectable as both `ErrTxNotFound` AND `ErrNotFound` (verifying the `sentinelErr.Unwrap` chain composes correctly with `fmt.Errorf`'s wrap).
 
@@ -255,8 +262,8 @@ Only `OpAfterRollback` is skipped on postgres. `SavepointNotFound` is NOT skippe
 
 `plugins/memory/concurrency_inreadops_test.go`, `concurrency_cas_test.go`, `concurrency_savepoint_test.go`:
 
-- Replace each `runOpVsRollback` / `runOpVsCommit` helper's `strings.Contains(msg, "rolled back") || strings.Contains(msg, "already completed") || ...` block with a single `errors.Is(err, spi.ErrTxTerminated) || errors.Is(err, spi.ErrTxNotFound)`.
-- Drop the `TODO(#200)` comment block at `concurrency_savepoint_test.go:49-51`.
+- Replace each `runOpVsRollback` / `runOpVsCommit` helper's `strings.Contains(msg, "rolled back") || strings.Contains(msg, "already completed") || ...` block with a three-way `errors.Is(err, spi.ErrTxTerminated) || errors.Is(err, spi.ErrTxNotFound) || errors.Is(err, spi.ErrTxCommitInProgress)`. The third disjunct is required for any helper that currently tolerates `"already being committed"` (`concurrency_inreadops_test.go:283`, `concurrency_savepoint_test.go:143,295`) — `ErrTxCommitInProgress` is deliberately not under the `ErrTxTerminated` umbrella because the tx is not yet terminal. Helpers that don't tolerate that substring today can stay two-way.
+- Drop the `TODO(#200)` comment block at `concurrency_savepoint_test.go:49-52`.
 
 ## Migration Sequencing
 
@@ -267,7 +274,7 @@ Only `OpAfterRollback` is skipped on postgres. `SavepointNotFound` is NOT skippe
    - `plugins/sqlite/go.mod`
    - `plugins/postgres/go.mod`
 
-   Migrate memory/sqlite/postgres error sites; update memory concurrency tests; configure `Harness.Skip` for postgres-irrelevant subtests; update `COMPATIBILITY.md` matrix (new SPI tag row, listing the seven added sentinels in the "SPI surface" column); run `make test-all` AND each `plugins/{memory,sqlite,postgres}` independently `go test ./...` (root `./...` does not cross plugin submodule boundaries — see `CLAUDE.md` "Plugin submodules need explicit test runs"); run `go vet ./...` per the per-module-hygiene CI job; one-shot `go test -race ./...` before PR.
+   Migrate memory/sqlite/postgres error sites; update memory concurrency tests; configure `Harness.Skip` for postgres-irrelevant subtests; update `COMPATIBILITY.md` matrix by listing the seven added sentinels in the `cyoda-go` v0.8.0 row's "SPI surface" column (the matrix is indexed by cyoda-go version, not by SPI tag, so the sentinels are bundled into the v0.8.0 entry rather than getting their own row); run `make test-all` AND each `plugins/{memory,sqlite,postgres}` independently `go test ./...` (root `./...` does not cross plugin submodule boundaries — see `CLAUDE.md` "Plugin submodules need explicit test runs"); run `go vet ./...` per the per-module-hygiene CI job; one-shot `go test -race ./...` before PR.
 
 3. **`cyoda-go-cassandra` (out of scope, separate repo)** — conforms on next SPI bump. Pinning protects existing CI.
 
@@ -288,7 +295,7 @@ Only `OpAfterRollback` is skipped on postgres. `SavepointNotFound` is NOT skippe
 - [ ] Postgres plugin wraps the sentinels at every applicable site, including `verifyTenant()` (L414) which carries the entire postgres tenant-mismatch contract via one wrap, savepoint paths in `transaction_manager.go` (L315/341/367) and `txstate.go` (L166, 223). `Harness.Skip` documents the single non-applicable subtest (`OpAfterRollback`) with reason.
 - [ ] `plugins/memory/concurrency_*_test.go` uses `errors.Is` against `ErrTxTerminated` / `ErrTxNotFound`; no `strings.Contains` on tx-state error messages; `TODO(#200)` comment removed.
 - [ ] New `spitest/transaction.go` subtests pass on memory, sqlite, AND postgres (with only `OpAfterRollback` skipped on postgres).
-- [ ] `COMPATIBILITY.md` matrix updated with the new `cyoda-go-spi` tag row.
+- [ ] `COMPATIBILITY.md` matrix's v0.8.0 row lists the seven added sentinels in the "SPI surface" column.
 - [ ] `make test-all` green AND each `plugins/{memory,sqlite,postgres}` module independently `go test ./...` green.
 - [ ] `go test -race ./...` clean per project convention (one-shot before PR; not per-step).
 - [ ] `go vet ./...` clean across root + each plugin submodule.
@@ -297,7 +304,7 @@ Only `OpAfterRollback` is skipped on postgres. `SavepointNotFound` is NOT skippe
 ## References
 
 - Issue #200
-- `plugins/memory/concurrency_savepoint_test.go:49-51` — original `TODO(#200)` marker
+- `plugins/memory/concurrency_savepoint_test.go:49-52` — original `TODO(#200)` marker
 - `plugins/memory/txmanager.go`, `plugins/memory/entity_store.go` — primary migration targets
 - `plugins/sqlite/txmanager.go`, `plugins/sqlite/entity_store.go` — mirror migration
 - `plugins/postgres/transaction_manager.go`, `plugins/postgres/txstate.go` — migration including full savepoint paths and `verifyTenant()` single-wrap

--- a/docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md
+++ b/docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md
@@ -61,24 +61,34 @@ var (
     // refer to a known savepoint on the given transaction. Wraps ErrNotFound.
     ErrSavepointNotFound = &sentinelErr{msg: "savepoint not found", parent: ErrNotFound}
 
-    // ErrTxClosed is the umbrella sentinel for any operation on a
+    // ErrTxTerminated is the umbrella sentinel for any operation on a
     // transaction that has reached a terminal state. Callers that do not
     // need to distinguish rollback from commit can match this directly.
-    ErrTxClosed = errors.New("transaction in terminal state")
+    //
+    // NOTE: Backends that own transaction state in a remote engine
+    // (postgres) may surface mid-op rollback as ErrConflict (e.g. via
+    // SQLSTATE 25P02) instead of ErrTxRolledBack, where the engine's
+    // abort code is already semantically meaningful. The ErrTxTerminated
+    // sentinel is required only where the plugin owns its own in-process
+    // tx-state buffer (memory, sqlite, cassandra). Consumers writing
+    // backend-agnostic code should match both ErrTxTerminated and
+    // ErrConflict on data-op paths.
+    ErrTxTerminated = errors.New("transaction in terminal state")
 
     // ErrTxRolledBack indicates that an in-flight operation observed the
     // transaction marked rolled-back (memory/sqlite race) or attempted an op
-    // on a transaction whose terminal state is Rollback. Wraps ErrTxClosed.
-    ErrTxRolledBack = &sentinelErr{msg: "transaction rolled back", parent: ErrTxClosed}
+    // on a transaction whose terminal state is Rollback. Wraps ErrTxTerminated.
+    // See ErrTxTerminated godoc for postgres-engine caveat.
+    ErrTxRolledBack = &sentinelErr{msg: "transaction rolled back", parent: ErrTxTerminated}
 
     // ErrTxAlreadyCommitted indicates an attempt to Join, Commit, or
     // otherwise operate on a transaction whose terminal state is Commit.
-    // Wraps ErrTxClosed.
-    ErrTxAlreadyCommitted = &sentinelErr{msg: "transaction already committed", parent: ErrTxClosed}
+    // Wraps ErrTxTerminated.
+    ErrTxAlreadyCommitted = &sentinelErr{msg: "transaction already committed", parent: ErrTxTerminated}
 
     // ErrTxCommitInProgress indicates that Commit was called on a
     // transaction another goroutine is already committing. Distinct from
-    // ErrTxClosed because the transaction is not yet terminal — the loser
+    // ErrTxTerminated because the transaction is not yet terminal — the loser
     // of the race may still observe the committed result.
     ErrTxCommitInProgress = errors.New("transaction commit in progress")
 
@@ -96,9 +106,9 @@ var (
 |---|---|
 | `ErrTxNotFound` | `ErrNotFound` |
 | `ErrSavepointNotFound` | `ErrNotFound` |
-| `ErrTxRolledBack` | `ErrTxClosed` |
-| `ErrTxAlreadyCommitted` | `ErrTxClosed` |
-| `ErrTxClosed` | — |
+| `ErrTxRolledBack` | `ErrTxTerminated` |
+| `ErrTxAlreadyCommitted` | `ErrTxTerminated` |
+| `ErrTxTerminated` | — |
 | `ErrTxCommitInProgress` | — |
 | `ErrTxTenantMismatch` | — |
 
@@ -129,6 +139,7 @@ Rationale: these signal misuse of the API rather than an operational tx-state co
 | 164 | `"transaction already being committed"` | `ErrTxCommitInProgress` |
 | 308 | `"transaction not found or already completed: %w"` (Rollback) | `ErrTxNotFound` |
 | 312 | `"transaction tenant mismatch"` (Rollback) | `ErrTxTenantMismatch` |
+| 346 | `"transaction not found: %s"` (`GetSubmitTime` not-found path — line 339 "not yet committed" stays plain) | `ErrTxNotFound` |
 | 379, 382, 392 | Savepoint not found / tenant mismatch / already closed | `ErrSavepointNotFound` / `ErrTxTenantMismatch` / `ErrTxAlreadyCommitted` |
 | 449, 452, 459, 467, 471 | RollbackToSavepoint variants | corresponding sentinels |
 | 500, 503, 508, 511 | ReleaseSavepoint variants | corresponding sentinels |
@@ -139,7 +150,7 @@ Rationale: these signal misuse of the API rather than an operational tx-state co
 
 ### SQLite plugin
 
-`plugins/sqlite/txmanager.go` + `plugins/sqlite/entity_store.go` — same line-by-line mapping as memory; the error strings are identical. See the survey table in the brainstorm transcript for full file:line list.
+`plugins/sqlite/txmanager.go` + `plugins/sqlite/entity_store.go` — same line-by-line mapping as memory; the error strings are identical. Includes the `GetSubmitTime` "not found" site at `plugins/sqlite/txmanager.go:474` → `ErrTxNotFound` for parity with memory line 346. See the survey table in the brainstorm transcript for the full file:line list.
 
 ### Postgres plugin
 
@@ -150,28 +161,60 @@ Rationale: these signal misuse of the API rather than an operational tx-state co
 | 118 | `"Commit: transaction %s not found"` | `ErrTxNotFound` |
 | 122 | `"Commit: tx state for %s not found"` | `ErrTxNotFound` |
 | 215, 220 | `"Rollback: transaction %s not found"` | `ErrTxNotFound` |
-| 244 | `"Join: transaction %s not found"` | `ErrTxNotFound` |
+| 244, 249 | `"Join: transaction %s not found"` (both lookup paths) | `ErrTxNotFound` |
+| 318 | `"Savepoint: transaction %s not found"` | `ErrTxNotFound` |
+| 344 | `"RollbackToSavepoint: transaction %s not found"` | `ErrTxNotFound` |
+| 370 | `"ReleaseSavepoint: transaction %s not found"` | `ErrTxNotFound` |
+| **414** | **`verifyTenant()` helper — `"%s: tenant mismatch on transaction %s"`** | **`ErrTxTenantMismatch` — single wrap site, called from Commit (L124), Rollback (L222), Join (L251), Savepoint (L324), RollbackToSavepoint (L350), ReleaseSavepoint (L376)** |
+
+L270 (`GetSubmitTime: ... has no submit time (not yet committed or unknown)`) deliberately conflates "not yet committed" with "unknown txID" into one operational message — stays plain per the SDK-misuse / one-site policy applied to memory `txmanager.go:339`.
+
+`plugins/postgres/txstate.go`:
+
+| Line(s) | Current | Wrap |
+|---|---|---|
+| 166, 223 | `"unknown savepoint %q"` | `ErrSavepointNotFound` |
 
 Postgres does **not** have:
-- In-process `tx.RolledBack` race (server-side tx; mid-op rollback surfaces as `pgconn.PgError` SQLSTATE 25P02, already mapped to `ErrConflict` via `classifyError` — not changed)
+- In-process `tx.RolledBack` race (server-side tx; mid-op rollback surfaces as `pgconn.PgError` SQLSTATE 25P02, already mapped to `ErrConflict` via `classifyError` at `transaction_manager.go:171-174` — not changed; this is the postgres-engine caveat documented in the SPI godoc on `ErrTxTerminated`)
 - `transaction already being committed` (no in-process commit registry)
 - `transaction already closed` distinct from `transaction not found` (server-side tx; once committed/rolled back, lookups return "not found")
-- Savepoint paths in `transaction_manager.go` (savepoint support lives elsewhere if at all)
 
-Tenant verification in postgres goes via `verifyTenant()` helper — that helper's error path also gets wrapped with `ErrTxTenantMismatch`.
+`verifyTenant()` at `transaction_manager.go:411-417` is the single point that all tx-lifecycle ops route through for tenant-mismatch checking. Wrapping `ErrTxTenantMismatch` there is the only site needed for postgres tenant-mismatch contract conformance.
+
+Postgres `GetSubmitTime` "not yet committed" path (if present and distinct from "not found") follows the memory/sqlite policy: stays plain (one-site operational signal, no consumer match).
 
 ### Cassandra plugin (not modified in this PR)
 
-Cassandra picks up the new sentinels when it next bumps its `cyoda-go-spi` pin. Until then its own error-code system continues unchanged. The `spitest/` subtests added in this spec will fail in Cassandra's CI on the bump — that failure is the prompt to conform. **No courtesy PR; no tracking issue in the Cassandra repo** (per project convention — Cassandra repo is private and out of scope here).
+Cassandra picks up the new sentinels when it next bumps its `cyoda-go-spi` pin. Until then its own string-coded error system (`TX_NOT_FOUND`, `TX_NOT_ACTIVE`, `ErrCodeTxNoState`, etc. at `cyoda-go-cassandra/internal/tx/tx_manager.go`) continues unchanged. On the bump, expect approximately six conformance subtest failures: `JoinAfterCommit`, `CommitAfterCommit`, `CommitAfterRollback`, `TenantMismatchOnJoin`, `TenantMismatchOnCommit`, and `SavepointNotFound` — a predictable, scoped conformance prompt. **No courtesy PR; no tracking issue in the Cassandra repo** (per project convention — Cassandra repo is private and out of scope here).
 
 ## Parity Test Additions
 
-In `cyoda-go-spi/spitest/transaction.go`, extend `runTransactionSuite` with a new subtest group:
+The contract under test is the SPI's own sentinel surface, so the conformance tests live in `cyoda-go-spi/spitest/` rather than `cyoda-go/e2e/parity/registry.go`. Issue #200's body suggests the latter, but `e2e/parity` is HTTP-only and the issue defers HTTP mapping anyway — the natural assertion surface is the Go-level SPI boundary. `spitest/` is already where every backend (memory, sqlite, postgres, cassandra) imports a shared conformance suite.
+
+### Pure sentinel-graph tests — `cyoda-go-spi/errors_test.go`
+
+Hierarchy and distinctness are properties of the SPI itself, not per-backend behaviour. They go alongside the existing `TestSentinelsAreDistinct` (`errors_test.go:9-18`), running once per CI rather than N times for N backends:
+
+- **Positive pairs** — every `(child, parent)` transitive pair in the hierarchy table:
+  - `errors.Is(ErrTxNotFound, ErrNotFound) == true`
+  - `errors.Is(ErrSavepointNotFound, ErrNotFound) == true`
+  - `errors.Is(ErrTxRolledBack, ErrTxTerminated) == true`
+  - `errors.Is(ErrTxAlreadyCommitted, ErrTxTerminated) == true`
+- **Negative pairs** — siblings and cross-tree:
+  - `errors.Is(ErrTxNotFound, ErrTxRolledBack) == false`
+  - `errors.Is(ErrTxRolledBack, ErrNotFound) == false`
+  - `errors.Is(ErrTxTenantMismatch, ErrTxTerminated) == false`
+  - … etc., covering every off-diagonal pair.
+- **Wrap chain** — `fmt.Errorf("ctx: %w", ErrTxNotFound)` is `errors.Is`-detectable as both `ErrTxNotFound` AND `ErrNotFound` (verifying the `sentinelErr.Unwrap` chain composes correctly with `fmt.Errorf`'s wrap).
+
+### Per-backend conformance — `cyoda-go-spi/spitest/transaction.go`
+
+Extend `runTransactionSuite` with subtests that exercise each backend's TransactionManager + EntityStore behaviour:
 
 ```go
 func runTransactionSuite(t *testing.T, h Harness, tracker *skipTracker) {
     // ... existing subtests ...
-    runSubtest(t, h, tracker, "TxStateErrors/HierarchyContract", testTxStateHierarchyContract)
     runSubtest(t, h, tracker, "TxStateErrors/JoinAfterCommit", testTxStateJoinAfterCommit)
     runSubtest(t, h, tracker, "TxStateErrors/CommitAfterCommit", testTxStateCommitAfterCommit)
     runSubtest(t, h, tracker, "TxStateErrors/CommitAfterRollback", testTxStateCommitAfterRollback)
@@ -184,37 +227,35 @@ func runTransactionSuite(t *testing.T, h Harness, tracker *skipTracker) {
 
 ### Subtest contract sketches
 
-- **HierarchyContract** (no harness fixture call — pure sentinel-graph check): `errors.Is(ErrTxRolledBack, ErrTxClosed)`, `errors.Is(ErrTxAlreadyCommitted, ErrTxClosed)`, `errors.Is(ErrTxNotFound, ErrNotFound)`, `errors.Is(ErrSavepointNotFound, ErrNotFound)`. Belt-and-braces on the SPI itself.
-- **JoinAfterCommit**: Begin → Commit → second goroutine `Join(txID)` → assert `errors.Is(err, ErrTxAlreadyCommitted)` AND `errors.Is(err, ErrTxClosed)`.
+- **JoinAfterCommit**: Begin → Commit → second goroutine `Join(txID)` → assert `errors.Is(err, ErrTxAlreadyCommitted)` AND `errors.Is(err, ErrTxTerminated)`.
 - **CommitAfterCommit**: Begin → Commit → Commit again → assert `errors.Is(err, ErrTxNotFound)` OR `ErrTxAlreadyCommitted` (Postgres collapses these; either is acceptable contract).
 - **CommitAfterRollback**: Begin → Rollback → Commit → assert `errors.Is(err, ErrTxNotFound)` OR `ErrTxRolledBack` (Postgres collapses).
-- **OpAfterRollback**: Begin → Save → Rollback (foreground) → Get on rolled-back txCtx → assert `errors.Is(err, ErrTxClosed)`. Subtest skipped on postgres via `Harness.Skip` because postgres' pgx.Tx does not expose mid-op state — the error surfaces as `ErrConflict`.
+- **OpAfterRollback**: Begin → Save → Rollback (foreground) → Get on rolled-back txCtx → assert `errors.Is(err, ErrTxTerminated)`. Subtest skipped on postgres via `Harness.Skip` because pgx.Tx does not expose mid-op state — the error surfaces as `ErrConflict`. This skip is documented in SPI godoc on `ErrTxTerminated` so consumers don't assume universal coverage.
 - **TenantMismatchOnJoin**: Tenant A begins tx → Tenant B attempts Join → assert `errors.Is(err, ErrTxTenantMismatch)`.
-- **TenantMismatchOnCommit**: Tenant A begins tx → Tenant B attempts Commit → assert `errors.Is(err, ErrTxTenantMismatch)`. (Postgres: tx commit goes via the same TransactionManager not via pgx directly; the application-layer guard still applies.)
-- **SavepointNotFound**: Begin → RollbackToSavepoint with unknown id → assert `errors.Is(err, ErrSavepointNotFound)` AND `errors.Is(err, ErrNotFound)`. Subtest skipped on postgres via `Harness.Skip` if savepoint support is not present.
+- **TenantMismatchOnCommit**: Tenant A begins tx → Tenant B attempts Commit → assert `errors.Is(err, ErrTxTenantMismatch)`. Postgres' `verifyTenant()` helper carries this contract.
+- **SavepointNotFound**: Begin → RollbackToSavepoint with unknown id → assert `errors.Is(err, ErrSavepointNotFound)` AND `errors.Is(err, ErrNotFound)`. Passes on all three plugins including postgres (savepoint paths verified at `plugins/postgres/transaction_manager.go:315,341,367` and `plugins/postgres/txstate.go:166,223`).
 
 ### Postgres skips
 
-Configured in `plugins/postgres/spi_conformance_test.go` (or wherever the harness is wired):
+Configured in `plugins/postgres/conformance_test.go` (the existing wiring point):
 
 ```go
 h := spitest.Harness{
     Factory: ...,
     NewTenant: ...,
     Skip: map[string]string{
-        "Transaction/TxStateErrors/OpAfterRollback":   "postgres: pgx.Tx aborts surface as ErrConflict via SQLSTATE 25P02, not as ErrTxRolledBack",
-        "Transaction/TxStateErrors/SavepointNotFound": "postgres: savepoint API not exposed via TransactionManager",
+        "Transaction/TxStateErrors/OpAfterRollback": "postgres: pgx.Tx aborts surface as ErrConflict via SQLSTATE 25P02, not as ErrTxRolledBack",
     },
 }
 ```
 
-The `Skip` map's typo-detection (unused keys flagged at end of run) ensures these stay accurate.
+Only `OpAfterRollback` is skipped on postgres. `SavepointNotFound` is NOT skipped — postgres has full savepoint support. The `Skip` map's typo-detection (unused keys flagged at end of run via `skipTracker.unusedKeys` at `spitest/spitest.go:75-85`) ensures the skip stays honest.
 
 ## Concurrency Test Update (memory plugin)
 
 `plugins/memory/concurrency_inreadops_test.go`, `concurrency_cas_test.go`, `concurrency_savepoint_test.go`:
 
-- Replace each `runOpVsRollback` / `runOpVsCommit` helper's `strings.Contains(msg, "rolled back") || strings.Contains(msg, "already completed") || ...` block with a single `errors.Is(err, spi.ErrTxClosed) || errors.Is(err, spi.ErrTxNotFound)`.
+- Replace each `runOpVsRollback` / `runOpVsCommit` helper's `strings.Contains(msg, "rolled back") || strings.Contains(msg, "already completed") || ...` block with a single `errors.Is(err, spi.ErrTxTerminated) || errors.Is(err, spi.ErrTxNotFound)`.
 - Drop the `TODO(#200)` comment block at `concurrency_savepoint_test.go:49-51`.
 
 ## Migration Sequencing
@@ -226,7 +267,7 @@ The `Skip` map's typo-detection (unused keys flagged at end of run) ensures thes
    - `plugins/sqlite/go.mod`
    - `plugins/postgres/go.mod`
 
-   Migrate memory/sqlite/postgres error sites; update memory concurrency tests; configure `Harness.Skip` for postgres-irrelevant subtests; run `make test-all` (covers root + all three plugin submodules); run `go vet ./...` per the per-module-hygiene CI job; one-shot `go test -race ./...` before PR.
+   Migrate memory/sqlite/postgres error sites; update memory concurrency tests; configure `Harness.Skip` for postgres-irrelevant subtests; update `COMPATIBILITY.md` matrix (new SPI tag row, listing the seven added sentinels in the "SPI surface" column); run `make test-all` AND each `plugins/{memory,sqlite,postgres}` independently `go test ./...` (root `./...` does not cross plugin submodule boundaries — see `CLAUDE.md` "Plugin submodules need explicit test runs"); run `go vet ./...` per the per-module-hygiene CI job; one-shot `go test -race ./...` before PR.
 
 3. **`cyoda-go-cassandra` (out of scope, separate repo)** — conforms on next SPI bump. Pinning protects existing CI.
 
@@ -240,13 +281,15 @@ The `Skip` map's typo-detection (unused keys flagged at end of run) ensures thes
 
 ## Acceptance
 
-- [ ] Sentinel constants defined in `cyoda-go-spi/errors.go` with godoc; `errors_test.go` extended to assert hierarchy and distinctness.
-- [ ] Memory plugin wraps the sentinels at every site listed in the migration table.
-- [ ] SQLite plugin wraps the sentinels at every mirrored site.
-- [ ] Postgres plugin wraps the sentinels at every applicable site; `Harness.Skip` documents non-applicable subtests with reason strings.
-- [ ] `plugins/memory/concurrency_*_test.go` uses `errors.Is` against `ErrTxClosed` / `ErrTxNotFound`; no `strings.Contains` on tx-state error messages; `TODO(#200)` comment removed.
-- [ ] New `spitest/transaction.go` subtests pass on memory and sqlite; documented-skipped on postgres.
-- [ ] `make test-all` green.
+- [ ] Sentinel constants defined in `cyoda-go-spi/errors.go` with godoc, including the postgres-engine caveat on `ErrTxTerminated`/`ErrTxRolledBack`.
+- [ ] `cyoda-go-spi/errors_test.go` covers every transitive `(child, parent)` pair (positive matches) and every off-diagonal pair (negative — distinct sentinels), plus the `fmt.Errorf` wrap-chain composition.
+- [ ] Memory plugin wraps the sentinels at every site listed in the migration table (including the `GetSubmitTime` not-found at L346).
+- [ ] SQLite plugin wraps the sentinels at every mirrored site (including the `GetSubmitTime` not-found at L474).
+- [ ] Postgres plugin wraps the sentinels at every applicable site, including `verifyTenant()` (L414) which carries the entire postgres tenant-mismatch contract via one wrap, savepoint paths in `transaction_manager.go` (L315/341/367) and `txstate.go` (L166, 223). `Harness.Skip` documents the single non-applicable subtest (`OpAfterRollback`) with reason.
+- [ ] `plugins/memory/concurrency_*_test.go` uses `errors.Is` against `ErrTxTerminated` / `ErrTxNotFound`; no `strings.Contains` on tx-state error messages; `TODO(#200)` comment removed.
+- [ ] New `spitest/transaction.go` subtests pass on memory, sqlite, AND postgres (with only `OpAfterRollback` skipped on postgres).
+- [ ] `COMPATIBILITY.md` matrix updated with the new `cyoda-go-spi` tag row.
+- [ ] `make test-all` green AND each `plugins/{memory,sqlite,postgres}` module independently `go test ./...` green.
 - [ ] `go test -race ./...` clean per project convention (one-shot before PR; not per-step).
 - [ ] `go vet ./...` clean across root + each plugin submodule.
 - [ ] SPI godoc documents which conditions each sentinel signals, including which conditions are intentionally left plain (SDK-misuse).
@@ -257,7 +300,8 @@ The `Skip` map's typo-detection (unused keys flagged at end of run) ensures thes
 - `plugins/memory/concurrency_savepoint_test.go:49-51` — original `TODO(#200)` marker
 - `plugins/memory/txmanager.go`, `plugins/memory/entity_store.go` — primary migration targets
 - `plugins/sqlite/txmanager.go`, `plugins/sqlite/entity_store.go` — mirror migration
-- `plugins/postgres/transaction_manager.go` — partial migration
+- `plugins/postgres/transaction_manager.go`, `plugins/postgres/txstate.go` — migration including full savepoint paths and `verifyTenant()` single-wrap
+- `plugins/postgres/conformance_test.go` — wiring point for `Harness.Skip`
 - `cyoda-go-spi/spitest/transaction.go` — extension point for parity subtests
 - `cyoda-go-spi/errors.go` — sentinel definitions
 - `internal/domain/workflow/engine_processors.go` — codebase precedent for `errors.Join` / multi-error chains (not used directly here but cited for design fit)

--- a/docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md
+++ b/docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md
@@ -1,0 +1,263 @@
+# SPI Sentinel Errors for Transaction State — Design
+
+**Issue:** #200
+**Milestone:** v0.8.0
+**Status:** Spec
+**Author:** Paul Schleger / Claude
+
+## Problem
+
+The memory plugin (and, by mirroring, the sqlite plugin) returns transaction-lifecycle errors as plain strings:
+
+- `fmt.Errorf("transaction has been rolled back")` — when a data op runs against a tx that was concurrently rolled back. **8 sites in memory `entity_store.go`, 8 sites in sqlite `entity_store.go`.**
+- `fmt.Errorf("transaction already being committed")` — when `Commit` fires on a tx mid-`Commit`.
+- `fmt.Errorf("transaction already closed: %s", txID)` — `Join` after `Commit`.
+- `fmt.Errorf("transaction not found or already completed: %w", spi.ErrNotFound)` — half-typed; only Commit/Rollback paths in memory + sqlite already wrap a sentinel.
+- `fmt.Errorf("tenant mismatch on transaction join")` and four variants. **6 sites in memory, 6 in sqlite — not a niche case.**
+
+This forces callers — including the memory plugin's own race-conditional tests in `plugins/memory/concurrency_*_test.go` — to do `strings.Contains` substring matching alongside `errors.Is(spi.ErrNotFound)`. The substring fallback is brittle, typo-sensitive, and can silently swallow unrelated errors that happen to contain the same substring.
+
+`plugins/memory/concurrency_savepoint_test.go:49-51` already carries a `TODO(#200)` flagging this. This spec discharges that TODO.
+
+## Why this is SPI-level
+
+The error semantics are part of the contract every backend must honour:
+
+- Memory plugin (this repo, `plugins/memory/`)
+- SQLite plugin (this repo, `plugins/sqlite/`) — mirrors memory's error strings almost verbatim
+- Postgres plugin (this repo, `plugins/postgres/`) — server-side tx; subset of conditions apply
+- Cassandra plugin (separate private repo, `../cyoda-go-cassandra`) — uses its own error-code system today; will conform on its next SPI bump
+
+A consistent sentinel set in `cyoda-go-spi` lets:
+
+- Callers do `errors.Is(err, spi.ErrTxRolledBack)` instead of fragile substring matches.
+- Cross-plugin parity be enforceable via the existing `spitest/` harness pattern.
+- Future API-layer error mapping (HTTP/gRPC) become structural (deferred to a follow-up; out of scope here).
+
+## Sentinel Set
+
+In `cyoda-go-spi/errors.go`, add seven new exported sentinels organized in a small two-level hierarchy. Existing sentinels (`ErrNotFound`, `ErrConflict`, `ErrEpochMismatch`, `ErrRetryExhausted`) are untouched.
+
+```go
+// sentinelErr lets a sentinel carry an Unwrap parent so errors.Is matches
+// both the specific sentinel and its umbrella/parent. Unexported.
+type sentinelErr struct {
+    msg    string
+    parent error
+}
+
+func (e *sentinelErr) Error() string { return e.msg }
+func (e *sentinelErr) Unwrap() error { return e.parent }
+
+var (
+    // ErrTxNotFound indicates that a transaction handle does not refer to a
+    // known transaction — either the txID never existed, or its state has
+    // been fully purged. Wraps ErrNotFound so existing
+    //   errors.Is(err, spi.ErrNotFound)
+    // checks on tx-lifecycle paths continue to match.
+    ErrTxNotFound = &sentinelErr{msg: "transaction not found", parent: ErrNotFound}
+
+    // ErrSavepointNotFound indicates that a savepoint identifier does not
+    // refer to a known savepoint on the given transaction. Wraps ErrNotFound.
+    ErrSavepointNotFound = &sentinelErr{msg: "savepoint not found", parent: ErrNotFound}
+
+    // ErrTxClosed is the umbrella sentinel for any operation on a
+    // transaction that has reached a terminal state. Callers that do not
+    // need to distinguish rollback from commit can match this directly.
+    ErrTxClosed = errors.New("transaction in terminal state")
+
+    // ErrTxRolledBack indicates that an in-flight operation observed the
+    // transaction marked rolled-back (memory/sqlite race) or attempted an op
+    // on a transaction whose terminal state is Rollback. Wraps ErrTxClosed.
+    ErrTxRolledBack = &sentinelErr{msg: "transaction rolled back", parent: ErrTxClosed}
+
+    // ErrTxAlreadyCommitted indicates an attempt to Join, Commit, or
+    // otherwise operate on a transaction whose terminal state is Commit.
+    // Wraps ErrTxClosed.
+    ErrTxAlreadyCommitted = &sentinelErr{msg: "transaction already committed", parent: ErrTxClosed}
+
+    // ErrTxCommitInProgress indicates that Commit was called on a
+    // transaction another goroutine is already committing. Distinct from
+    // ErrTxClosed because the transaction is not yet terminal — the loser
+    // of the race may still observe the committed result.
+    ErrTxCommitInProgress = errors.New("transaction commit in progress")
+
+    // ErrTxTenantMismatch indicates a transaction-lifecycle operation
+    // (Join, Commit, Rollback, Savepoint, etc.) was attempted with a
+    // UserContext whose tenant does not match the transaction's tenant.
+    // Tenant isolation invariant — distinct from data-op tenant checks.
+    ErrTxTenantMismatch = errors.New("transaction tenant mismatch")
+)
+```
+
+### Hierarchy contract
+
+| Sentinel | `errors.Is` parents (transitive) |
+|---|---|
+| `ErrTxNotFound` | `ErrNotFound` |
+| `ErrSavepointNotFound` | `ErrNotFound` |
+| `ErrTxRolledBack` | `ErrTxClosed` |
+| `ErrTxAlreadyCommitted` | `ErrTxClosed` |
+| `ErrTxClosed` | — |
+| `ErrTxCommitInProgress` | — |
+| `ErrTxTenantMismatch` | — |
+
+### What is **not** a sentinel
+
+These remain plain `fmt.Errorf` strings and are documented in SPI godoc as **not part of the sentinel contract**:
+
+- `"no user context — cannot begin transaction"` — SDK misuse / programming error.
+- `"user context has no tenant — cannot begin transaction"` — SDK misuse.
+- `"memory: TransactionManager not initialized (call NewTransactionManager first)"` — factory misuse.
+- `"transaction not yet committed"` (memory `GetSubmitTime` on still-active tx) — operational signal callers don't currently match on; one site; leaving plain to avoid pollution.
+
+Rationale: these signal misuse of the API rather than an operational tx-state condition. Promoting them to sentinels would broaden the contract surface for no consumer benefit.
+
+## Plugin Migration
+
+### Memory plugin
+
+`plugins/memory/txmanager.go`:
+
+| Line(s) | Current | Wrap |
+|---|---|---|
+| 122 | `"transaction not found: %s"` | `ErrTxNotFound` |
+| 131 | `"transaction already closed: %s"` | `ErrTxAlreadyCommitted` |
+| 140 | `"tenant mismatch on transaction join"` | `ErrTxTenantMismatch` |
+| 156 | `"transaction not found or already completed: %w"` (wraps `ErrNotFound`) | `ErrTxNotFound` (which wraps `ErrNotFound`) |
+| 160 | `"transaction tenant mismatch"` | `ErrTxTenantMismatch` |
+| 164 | `"transaction already being committed"` | `ErrTxCommitInProgress` |
+| 308 | `"transaction not found or already completed: %w"` (Rollback) | `ErrTxNotFound` |
+| 312 | `"transaction tenant mismatch"` (Rollback) | `ErrTxTenantMismatch` |
+| 379, 382, 392 | Savepoint not found / tenant mismatch / already closed | `ErrSavepointNotFound` / `ErrTxTenantMismatch` / `ErrTxAlreadyCommitted` |
+| 449, 452, 459, 467, 471 | RollbackToSavepoint variants | corresponding sentinels |
+| 500, 503, 508, 511 | ReleaseSavepoint variants | corresponding sentinels |
+
+`plugins/memory/entity_store.go` — 8 sites (Save 106, CompareAndSave 131, Get 253, GetAll 296, Delete 348, Exists 450, Count 513, DeleteAll 588):
+
+- `"transaction has been rolled back"` → `fmt.Errorf("tx %s: %w", txID, spi.ErrTxRolledBack)` (adds tx ID for debuggability)
+
+### SQLite plugin
+
+`plugins/sqlite/txmanager.go` + `plugins/sqlite/entity_store.go` — same line-by-line mapping as memory; the error strings are identical. See the survey table in the brainstorm transcript for full file:line list.
+
+### Postgres plugin
+
+`plugins/postgres/transaction_manager.go`:
+
+| Line(s) | Current | Wrap |
+|---|---|---|
+| 118 | `"Commit: transaction %s not found"` | `ErrTxNotFound` |
+| 122 | `"Commit: tx state for %s not found"` | `ErrTxNotFound` |
+| 215, 220 | `"Rollback: transaction %s not found"` | `ErrTxNotFound` |
+| 244 | `"Join: transaction %s not found"` | `ErrTxNotFound` |
+
+Postgres does **not** have:
+- In-process `tx.RolledBack` race (server-side tx; mid-op rollback surfaces as `pgconn.PgError` SQLSTATE 25P02, already mapped to `ErrConflict` via `classifyError` — not changed)
+- `transaction already being committed` (no in-process commit registry)
+- `transaction already closed` distinct from `transaction not found` (server-side tx; once committed/rolled back, lookups return "not found")
+- Savepoint paths in `transaction_manager.go` (savepoint support lives elsewhere if at all)
+
+Tenant verification in postgres goes via `verifyTenant()` helper — that helper's error path also gets wrapped with `ErrTxTenantMismatch`.
+
+### Cassandra plugin (not modified in this PR)
+
+Cassandra picks up the new sentinels when it next bumps its `cyoda-go-spi` pin. Until then its own error-code system continues unchanged. The `spitest/` subtests added in this spec will fail in Cassandra's CI on the bump — that failure is the prompt to conform. **No courtesy PR; no tracking issue in the Cassandra repo** (per project convention — Cassandra repo is private and out of scope here).
+
+## Parity Test Additions
+
+In `cyoda-go-spi/spitest/transaction.go`, extend `runTransactionSuite` with a new subtest group:
+
+```go
+func runTransactionSuite(t *testing.T, h Harness, tracker *skipTracker) {
+    // ... existing subtests ...
+    runSubtest(t, h, tracker, "TxStateErrors/HierarchyContract", testTxStateHierarchyContract)
+    runSubtest(t, h, tracker, "TxStateErrors/JoinAfterCommit", testTxStateJoinAfterCommit)
+    runSubtest(t, h, tracker, "TxStateErrors/CommitAfterCommit", testTxStateCommitAfterCommit)
+    runSubtest(t, h, tracker, "TxStateErrors/CommitAfterRollback", testTxStateCommitAfterRollback)
+    runSubtest(t, h, tracker, "TxStateErrors/OpAfterRollback", testTxStateOpAfterRollback)
+    runSubtest(t, h, tracker, "TxStateErrors/TenantMismatchOnJoin", testTxStateTenantMismatchOnJoin)
+    runSubtest(t, h, tracker, "TxStateErrors/TenantMismatchOnCommit", testTxStateTenantMismatchOnCommit)
+    runSubtest(t, h, tracker, "TxStateErrors/SavepointNotFound", testTxStateSavepointNotFound)
+}
+```
+
+### Subtest contract sketches
+
+- **HierarchyContract** (no harness fixture call — pure sentinel-graph check): `errors.Is(ErrTxRolledBack, ErrTxClosed)`, `errors.Is(ErrTxAlreadyCommitted, ErrTxClosed)`, `errors.Is(ErrTxNotFound, ErrNotFound)`, `errors.Is(ErrSavepointNotFound, ErrNotFound)`. Belt-and-braces on the SPI itself.
+- **JoinAfterCommit**: Begin → Commit → second goroutine `Join(txID)` → assert `errors.Is(err, ErrTxAlreadyCommitted)` AND `errors.Is(err, ErrTxClosed)`.
+- **CommitAfterCommit**: Begin → Commit → Commit again → assert `errors.Is(err, ErrTxNotFound)` OR `ErrTxAlreadyCommitted` (Postgres collapses these; either is acceptable contract).
+- **CommitAfterRollback**: Begin → Rollback → Commit → assert `errors.Is(err, ErrTxNotFound)` OR `ErrTxRolledBack` (Postgres collapses).
+- **OpAfterRollback**: Begin → Save → Rollback (foreground) → Get on rolled-back txCtx → assert `errors.Is(err, ErrTxClosed)`. Subtest skipped on postgres via `Harness.Skip` because postgres' pgx.Tx does not expose mid-op state — the error surfaces as `ErrConflict`.
+- **TenantMismatchOnJoin**: Tenant A begins tx → Tenant B attempts Join → assert `errors.Is(err, ErrTxTenantMismatch)`.
+- **TenantMismatchOnCommit**: Tenant A begins tx → Tenant B attempts Commit → assert `errors.Is(err, ErrTxTenantMismatch)`. (Postgres: tx commit goes via the same TransactionManager not via pgx directly; the application-layer guard still applies.)
+- **SavepointNotFound**: Begin → RollbackToSavepoint with unknown id → assert `errors.Is(err, ErrSavepointNotFound)` AND `errors.Is(err, ErrNotFound)`. Subtest skipped on postgres via `Harness.Skip` if savepoint support is not present.
+
+### Postgres skips
+
+Configured in `plugins/postgres/spi_conformance_test.go` (or wherever the harness is wired):
+
+```go
+h := spitest.Harness{
+    Factory: ...,
+    NewTenant: ...,
+    Skip: map[string]string{
+        "Transaction/TxStateErrors/OpAfterRollback":   "postgres: pgx.Tx aborts surface as ErrConflict via SQLSTATE 25P02, not as ErrTxRolledBack",
+        "Transaction/TxStateErrors/SavepointNotFound": "postgres: savepoint API not exposed via TransactionManager",
+    },
+}
+```
+
+The `Skip` map's typo-detection (unused keys flagged at end of run) ensures these stay accurate.
+
+## Concurrency Test Update (memory plugin)
+
+`plugins/memory/concurrency_inreadops_test.go`, `concurrency_cas_test.go`, `concurrency_savepoint_test.go`:
+
+- Replace each `runOpVsRollback` / `runOpVsCommit` helper's `strings.Contains(msg, "rolled back") || strings.Contains(msg, "already completed") || ...` block with a single `errors.Is(err, spi.ErrTxClosed) || errors.Is(err, spi.ErrTxNotFound)`.
+- Drop the `TODO(#200)` comment block at `concurrency_savepoint_test.go:49-51`.
+
+## Migration Sequencing
+
+1. **`cyoda-go-spi` PR** — add sentinels + spitest subtests + godoc. Tag a fresh minor (e.g., `v0.X.Y+1`) — never force-move (per project convention).
+2. **`cyoda-go` PR (this issue)** — bump `cyoda-go-spi` pin in:
+   - root `go.mod`
+   - `plugins/memory/go.mod`
+   - `plugins/sqlite/go.mod`
+   - `plugins/postgres/go.mod`
+
+   Migrate memory/sqlite/postgres error sites; update memory concurrency tests; configure `Harness.Skip` for postgres-irrelevant subtests; run `make test-all` (covers root + all three plugin submodules); run `go vet ./...` per the per-module-hygiene CI job; one-shot `go test -race ./...` before PR.
+
+3. **`cyoda-go-cassandra` (out of scope, separate repo)** — conforms on next SPI bump. Pinning protects existing CI.
+
+## Out of Scope
+
+- HTTP/gRPC status mapping based on the new sentinels (separate follow-up; the issue body explicitly defers this).
+- Internationalisation of error messages.
+- Restructuring error wrapping conventions broadly.
+- Cassandra plugin migration (separate repo, separate cadence).
+- Promoting SDK-misuse errors (`no user context`, `no tenant`, `TransactionManager not initialized`) to sentinels.
+
+## Acceptance
+
+- [ ] Sentinel constants defined in `cyoda-go-spi/errors.go` with godoc; `errors_test.go` extended to assert hierarchy and distinctness.
+- [ ] Memory plugin wraps the sentinels at every site listed in the migration table.
+- [ ] SQLite plugin wraps the sentinels at every mirrored site.
+- [ ] Postgres plugin wraps the sentinels at every applicable site; `Harness.Skip` documents non-applicable subtests with reason strings.
+- [ ] `plugins/memory/concurrency_*_test.go` uses `errors.Is` against `ErrTxClosed` / `ErrTxNotFound`; no `strings.Contains` on tx-state error messages; `TODO(#200)` comment removed.
+- [ ] New `spitest/transaction.go` subtests pass on memory and sqlite; documented-skipped on postgres.
+- [ ] `make test-all` green.
+- [ ] `go test -race ./...` clean per project convention (one-shot before PR; not per-step).
+- [ ] `go vet ./...` clean across root + each plugin submodule.
+- [ ] SPI godoc documents which conditions each sentinel signals, including which conditions are intentionally left plain (SDK-misuse).
+
+## References
+
+- Issue #200
+- `plugins/memory/concurrency_savepoint_test.go:49-51` — original `TODO(#200)` marker
+- `plugins/memory/txmanager.go`, `plugins/memory/entity_store.go` — primary migration targets
+- `plugins/sqlite/txmanager.go`, `plugins/sqlite/entity_store.go` — mirror migration
+- `plugins/postgres/transaction_manager.go` — partial migration
+- `cyoda-go-spi/spitest/transaction.go` — extension point for parity subtests
+- `cyoda-go-spi/errors.go` — sentinel definitions
+- `internal/domain/workflow/engine_processors.go` — codebase precedent for `errors.Join` / multi-error chains (not used directly here but cited for design fit)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/charmbracelet/glamour v1.0.0
-	github.com/cyoda-platform/cyoda-go-spi v0.7.1
+	github.com/cyoda-platform/cyoda-go-spi v0.8.0
 	github.com/getkin/kin-openapi v0.139.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/google/uuid v1.6.0
@@ -177,3 +177,5 @@ require (
 )
 
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
+
+replace github.com/cyoda-platform/cyoda-go-spi => /Users/paul/go-projects/cyoda-light/cyoda-go-spi

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/charmbracelet/glamour v1.0.0
-	github.com/cyoda-platform/cyoda-go-spi v0.7.1
+	github.com/cyoda-platform/cyoda-go-spi v0.8.0
 	github.com/getkin/kin-openapi v0.139.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/charmbracelet/glamour v1.0.0
-	github.com/cyoda-platform/cyoda-go-spi v0.8.0
+	github.com/cyoda-platform/cyoda-go-spi v0.7.1
 	github.com/getkin/kin-openapi v0.139.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/google/uuid v1.6.0
@@ -177,5 +177,3 @@ require (
 )
 
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
-
-replace github.com/cyoda-platform/cyoda-go-spi => /Users/paul/go-projects/cyoda-light/cyoda-go-spi

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GK
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.8.0 h1:h22W8g3ggreLw+EaawAVC5yeUnNgKereANq5TTwt4ok=
+github.com/cyoda-platform/cyoda-go-spi v0.8.0/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.1 h1:V0YfAg8XzlSqDtAidYa4B/H+LU9dnxce9hEsl4wahOw=
 github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.1/go.mod h1:4VA39DOyLB8iU212SFPuFxsqjdl1unc9vhgV7fjlLwc=
 github.com/cyoda-platform/cyoda-go/plugins/postgres v0.7.1 h1:Rpa0Um1InbrfNJ38l2ktEqTjaGvjFxgJQqgQzaToRUc=

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,6 @@ github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GK
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.1 h1:V0YfAg8XzlSqDtAidYa4B/H+LU9dnxce9hEsl4wahOw=
 github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.1/go.mod h1:4VA39DOyLB8iU212SFPuFxsqjdl1unc9vhgV7fjlLwc=
 github.com/cyoda-platform/cyoda-go/plugins/postgres v0.7.1 h1:Rpa0Um1InbrfNJ38l2ktEqTjaGvjFxgJQqgQzaToRUc=

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GK
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
+github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.1 h1:V0YfAg8XzlSqDtAidYa4B/H+LU9dnxce9hEsl4wahOw=
 github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.1/go.mod h1:4VA39DOyLB8iU212SFPuFxsqjdl1unc9vhgV7fjlLwc=
 github.com/cyoda-platform/cyoda-go/plugins/postgres v0.7.1 h1:Rpa0Um1InbrfNJ38l2ktEqTjaGvjFxgJQqgQzaToRUc=

--- a/plugins/memory/concurrency_cas_test.go
+++ b/plugins/memory/concurrency_cas_test.go
@@ -3,7 +3,6 @@ package memory_test
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"testing"
 
@@ -91,13 +90,7 @@ func TestCompareAndSave_TxBufferWriteVsCommit_NoRace(t *testing.T) {
 					Data: []byte(fmt.Sprintf(`{"iter":%d}`, iter)),
 				}
 				_, cerr := store.CompareAndSave(txCtx, e, "tx-seed")
-				if cerr == nil || errors.Is(cerr, spi.ErrConflict) {
-					return
-				}
-				msg := cerr.Error()
-				if strings.Contains(msg, "rolled back") ||
-					strings.Contains(msg, "already completed") ||
-					strings.Contains(msg, "not found") {
+				if cerr == nil || errors.Is(cerr, spi.ErrConflict) || isToleratedClosedTxErr(cerr) {
 					return
 				}
 				t.Errorf("CompareAndSave failed: %v", cerr)
@@ -166,13 +159,7 @@ func TestSave_TxBufferWriteVsRollback_NoRace(t *testing.T) {
 					Data: []byte(fmt.Sprintf(`{"iter":%d}`, iter)),
 				}
 				_, serr := store.Save(txCtx, e)
-				if serr == nil {
-					return
-				}
-				msg := serr.Error()
-				if strings.Contains(msg, "rolled back") ||
-					strings.Contains(msg, "already completed") ||
-					strings.Contains(msg, "not found") {
+				if serr == nil || isToleratedClosedTxErr(serr) {
 					return
 				}
 				t.Errorf("Save failed: %v", serr)

--- a/plugins/memory/concurrency_helpers_test.go
+++ b/plugins/memory/concurrency_helpers_test.go
@@ -1,0 +1,25 @@
+package memory_test
+
+import (
+	"errors"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// isToleratedClosedTxErr reports whether err is a benign "tx already
+// closed/rolled back/committed/not found" outcome — the kind that is
+// expected when a concurrent op races against Commit/Rollback/Savepoint/
+// RollbackToSavepoint/Join. Anything else is a defect and should fail the
+// test.
+//
+// Matches the three-way disjunction of transaction-state sentinels defined
+// in cyoda-go-spi, plus bare ErrNotFound because in-read ops
+// (Get/GetAll/Exists/Delete) can legitimately surface entity-level not-found
+// when a concurrent Rollback or Commit changes visibility mid-op — that is
+// a tolerated race outcome, not a defect.
+func isToleratedClosedTxErr(err error) bool {
+	return errors.Is(err, spi.ErrTxNotFound) ||
+		errors.Is(err, spi.ErrTxTerminated) ||
+		errors.Is(err, spi.ErrTxCommitInProgress) ||
+		errors.Is(err, spi.ErrNotFound)
+}

--- a/plugins/memory/concurrency_inreadops_test.go
+++ b/plugins/memory/concurrency_inreadops_test.go
@@ -3,7 +3,6 @@ package memory_test
 import (
 	"context"
 	"errors"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -26,10 +25,13 @@ import (
 //
 // Each test runs many iterations to give the scheduler chances to
 // interleave the in-flight op with Rollback. Tolerated errors are the
-// legitimate outcomes of a tx that closed mid-op:
-//   - "rolled back"
-//   - "already completed"
-//   - "not found"
+// legitimate outcomes of a tx that closed mid-op, recognised via
+// errors.Is against the SPI tx-state sentinels (issue #200):
+//   - spi.ErrTxTerminated      ("already completed" / "rolled back")
+//   - spi.ErrTxNotFound        ("not found")
+//   - spi.ErrTxCommitInProgress ("already being committed")
+//
+// See isToleratedClosedTxErr in concurrency_helpers_test.go.
 //
 // These tests are intended to be run with `go test -race`. Without
 // `-race`, they will not exercise the data-race detector but still
@@ -81,13 +83,7 @@ func runOpVsRollback(
 				defer wg.Done()
 				<-start
 				if oerr := op(txCtx, store); oerr != nil {
-					if errors.Is(oerr, spi.ErrConflict) || errors.Is(oerr, spi.ErrNotFound) {
-						return
-					}
-					msg := oerr.Error()
-					if strings.Contains(msg, "rolled back") ||
-						strings.Contains(msg, "already completed") ||
-						strings.Contains(msg, "not found") {
+					if errors.Is(oerr, spi.ErrConflict) || isToleratedClosedTxErr(oerr) {
 						return
 					}
 					t.Errorf("%s: op failed: %v", name, oerr)
@@ -273,14 +269,7 @@ func runOpVsCommit(
 				defer wg.Done()
 				<-start
 				if oerr := op(txCtx, store); oerr != nil {
-					if errors.Is(oerr, spi.ErrConflict) || errors.Is(oerr, spi.ErrNotFound) {
-						return
-					}
-					msg := oerr.Error()
-					if strings.Contains(msg, "rolled back") ||
-						strings.Contains(msg, "already completed") ||
-						strings.Contains(msg, "not found") ||
-						strings.Contains(msg, "already being committed") {
+					if errors.Is(oerr, spi.ErrConflict) || isToleratedClosedTxErr(oerr) {
 						return
 					}
 					t.Errorf("%s: op failed: %v", name, oerr)

--- a/plugins/memory/concurrency_savepoint_test.go
+++ b/plugins/memory/concurrency_savepoint_test.go
@@ -9,24 +9,6 @@ import (
 	"github.com/cyoda-platform/cyoda-go/plugins/memory"
 )
 
-// isToleratedClosedTxErr reports whether err is a benign "tx already
-// closed/rolled back/committed/not found" outcome — the kind that is
-// expected when a concurrent op wins the race against Savepoint/Join/Save/
-// RollbackToSavepoint. Anything else is a defect and should fail the test.
-func isToleratedClosedTxErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	switch {
-	case errors.Is(err, spi.ErrTxNotFound),
-		errors.Is(err, spi.ErrTxTerminated),
-		errors.Is(err, spi.ErrTxCommitInProgress),
-		errors.Is(err, spi.ErrNotFound):
-		return true
-	}
-	return false
-}
-
 // Locking-discipline race tests for Savepoint, RollbackToSavepoint, and
 // Join in plugins/memory/txmanager.go. Issue #199 surfaces that Savepoint
 // and RollbackToSavepoint mutate tx-state under m.mu only, never tx.OpMu —

--- a/plugins/memory/concurrency_savepoint_test.go
+++ b/plugins/memory/concurrency_savepoint_test.go
@@ -2,13 +2,30 @@ package memory_test
 
 import (
 	"errors"
-	"strings"
 	"sync"
 	"testing"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/plugins/memory"
 )
+
+// isToleratedClosedTxErr reports whether err is a benign "tx already
+// closed/rolled back/committed/not found" outcome — the kind that is
+// expected when a concurrent op wins the race against Savepoint/Join/Save/
+// RollbackToSavepoint. Anything else is a defect and should fail the test.
+func isToleratedClosedTxErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch {
+	case errors.Is(err, spi.ErrTxNotFound),
+		errors.Is(err, spi.ErrTxTerminated),
+		errors.Is(err, spi.ErrTxCommitInProgress),
+		errors.Is(err, spi.ErrNotFound):
+		return true
+	}
+	return false
+}
 
 // Locking-discipline race tests for Savepoint, RollbackToSavepoint, and
 // Join in plugins/memory/txmanager.go. Issue #199 surfaces that Savepoint
@@ -46,10 +63,10 @@ import (
 //     (in an IIFE) — Commit and Rollback both write tx.Closed in their defer
 //     under tx.OpMu.Lock only, never under m.mu.
 //
-// TODO(#200): replace substring matches on tolerated errors ("not found",
-// "rolled back", "already closed", "already completed", "already being
-// committed") with errors.Is against sentinel error types once they land.
-// Until then a closed-mid-op tx is a legitimate outcome, not a defect.
+// Tolerated errors are recognised via errors.Is against the SPI tx-state
+// sentinel hierarchy (ErrTxNotFound, ErrTxTerminated, ErrTxCommitInProgress,
+// ErrNotFound) — see isToleratedClosedTxErr below. A closed-mid-op tx is a
+// legitimate outcome, not a defect.
 //
 // These tests are intended to be run with `go test -race`. Without `-race`
 // they still verify the tolerated-error contract.
@@ -120,11 +137,7 @@ func TestSavepoint_VsCommit_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if _, sperr := txMgr.Savepoint(ctx, txID); sperr != nil {
-					msg := sperr.Error()
-					if strings.Contains(msg, "not found") ||
-						strings.Contains(msg, "already completed") ||
-						strings.Contains(msg, "rolled back") ||
-						strings.Contains(msg, "already closed") {
+					if isToleratedClosedTxErr(sperr) {
 						return
 					}
 					t.Errorf("Savepoint failed: %v", sperr)
@@ -136,12 +149,7 @@ func TestSavepoint_VsCommit_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if cerr := txMgr.Commit(ctx, txID); cerr != nil {
-					if errors.Is(cerr, spi.ErrConflict) || errors.Is(cerr, spi.ErrNotFound) {
-						return
-					}
-					msg := cerr.Error()
-					if strings.Contains(msg, "already being committed") ||
-						strings.Contains(msg, "not found") {
+					if errors.Is(cerr, spi.ErrConflict) || isToleratedClosedTxErr(cerr) {
 						return
 					}
 					t.Errorf("Commit failed: %v", cerr)
@@ -192,11 +200,7 @@ func TestSavepoint_VsRollback_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if _, sperr := txMgr.Savepoint(ctx, txID); sperr != nil {
-					msg := sperr.Error()
-					if strings.Contains(msg, "not found") ||
-						strings.Contains(msg, "already completed") ||
-						strings.Contains(msg, "rolled back") ||
-						strings.Contains(msg, "already closed") {
+					if isToleratedClosedTxErr(sperr) {
 						return
 					}
 					t.Errorf("Savepoint failed: %v", sperr)
@@ -272,11 +276,7 @@ func TestRollbackToSavepoint_VsCommit_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if rerr := txMgr.RollbackToSavepoint(ctx, txID, spID); rerr != nil {
-					msg := rerr.Error()
-					if strings.Contains(msg, "not found") ||
-						strings.Contains(msg, "already completed") ||
-						strings.Contains(msg, "rolled back") ||
-						strings.Contains(msg, "already closed") {
+					if isToleratedClosedTxErr(rerr) {
 						return
 					}
 					t.Errorf("RollbackToSavepoint failed: %v", rerr)
@@ -288,12 +288,7 @@ func TestRollbackToSavepoint_VsCommit_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if cerr := txMgr.Commit(ctx, txID); cerr != nil {
-					if errors.Is(cerr, spi.ErrConflict) || errors.Is(cerr, spi.ErrNotFound) {
-						return
-					}
-					msg := cerr.Error()
-					if strings.Contains(msg, "already being committed") ||
-						strings.Contains(msg, "not found") {
+					if errors.Is(cerr, spi.ErrConflict) || isToleratedClosedTxErr(cerr) {
 						return
 					}
 					t.Errorf("Commit failed: %v", cerr)
@@ -361,10 +356,7 @@ func TestRollbackToSavepoint_VsSave_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if _, serr := store.Save(txCtx, e); serr != nil {
-					msg := serr.Error()
-					if strings.Contains(msg, "rolled back") ||
-						strings.Contains(msg, "already completed") ||
-						strings.Contains(msg, "not found") {
+					if isToleratedClosedTxErr(serr) {
 						return
 					}
 					t.Errorf("Save failed: %v", serr)
@@ -376,11 +368,7 @@ func TestRollbackToSavepoint_VsSave_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if rerr := txMgr.RollbackToSavepoint(ctx, txID, spID); rerr != nil {
-					msg := rerr.Error()
-					if strings.Contains(msg, "not found") ||
-						strings.Contains(msg, "already completed") ||
-						strings.Contains(msg, "rolled back") ||
-						strings.Contains(msg, "already closed") {
+					if isToleratedClosedTxErr(rerr) {
 						return
 					}
 					t.Errorf("RollbackToSavepoint failed: %v", rerr)
@@ -433,10 +421,7 @@ func TestJoin_VsRollback_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if _, jerr := txMgr.Join(ctx, txID); jerr != nil {
-					msg := jerr.Error()
-					if strings.Contains(msg, "not found") ||
-						strings.Contains(msg, "already closed") ||
-						strings.Contains(msg, "rolled back") {
+					if isToleratedClosedTxErr(jerr) {
 						return
 					}
 					t.Errorf("Join failed: %v", jerr)

--- a/plugins/memory/entity_store.go
+++ b/plugins/memory/entity_store.go
@@ -103,7 +103,7 @@ func (s *EntityStore) Save(ctx context.Context, entity *spi.Entity) (int64, erro
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return 0, fmt.Errorf("transaction has been rolled back")
+			return 0, fmt.Errorf("Save: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Transaction mode: write to buffer, not main store.
 		cp := copyEntity(entity)
@@ -128,7 +128,7 @@ func (s *EntityStore) CompareAndSave(ctx context.Context, entity *spi.Entity, ex
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return 0, fmt.Errorf("transaction has been rolled back")
+			return 0, fmt.Errorf("CompareAndSave: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Check CAS against main store (committed data), not buffer.
 		// Hold entityMu.RLock through both version check AND buffer write
@@ -250,7 +250,7 @@ func (s *EntityStore) Get(ctx context.Context, entityID string) (*spi.Entity, er
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return nil, fmt.Errorf("transaction has been rolled back")
+			return nil, fmt.Errorf("Get: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Check if deleted in this transaction.
 		if tx.Deletes[entityID] {
@@ -293,7 +293,7 @@ func (s *EntityStore) GetAsAt(ctx context.Context, entityID string, asAt time.Ti
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return nil, fmt.Errorf("transaction has been rolled back")
+			return nil, fmt.Errorf("GetAsAt: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		tx.ReadSet[entityID] = true
 	}
@@ -345,7 +345,7 @@ func (s *EntityStore) GetAll(ctx context.Context, modelRef spi.ModelRef) ([]*spi
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return nil, fmt.Errorf("transaction has been rolled back")
+			return nil, fmt.Errorf("GetAll: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Combine: snapshot of main store + buffer - deletes. Wrap the
 		// entityMu hold in an IIFE so the unlock runs via defer (per
@@ -447,7 +447,7 @@ func (s *EntityStore) Delete(ctx context.Context, entityID string) error {
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return fmt.Errorf("transaction has been rolled back")
+			return fmt.Errorf("Delete: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Check existence: buffer first, then committed store. Wrap the
 		// entityMu hold in an IIFE so the unlock runs via defer.
@@ -510,7 +510,7 @@ func (s *EntityStore) DeleteAll(ctx context.Context, modelRef spi.ModelRef) erro
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return fmt.Errorf("transaction has been rolled back")
+			return fmt.Errorf("DeleteAll: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Get all entities for the model (snapshot), mark each as deleted
 		// in tx. Wrap the entityMu hold in an IIFE so the unlock runs via
@@ -585,7 +585,7 @@ func (s *EntityStore) Exists(ctx context.Context, entityID string) (bool, error)
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return false, fmt.Errorf("transaction has been rolled back")
+			return false, fmt.Errorf("Exists: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Check deletes first.
 		if tx.Deletes[entityID] {

--- a/plugins/memory/go.mod
+++ b/plugins/memory/go.mod
@@ -3,9 +3,11 @@ module github.com/cyoda-platform/cyoda-go/plugins/memory
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.7.1
+	github.com/cyoda-platform/cyoda-go-spi v0.8.0
 	github.com/google/uuid v1.6.0
 )
+
+replace github.com/cyoda-platform/cyoda-go-spi => /Users/paul/go-projects/cyoda-light/cyoda-go-spi
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/plugins/memory/go.mod
+++ b/plugins/memory/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/memory
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.7.1
+	github.com/cyoda-platform/cyoda-go-spi v0.8.0
 	github.com/google/uuid v1.6.0
 )
 

--- a/plugins/memory/go.mod
+++ b/plugins/memory/go.mod
@@ -3,11 +3,9 @@ module github.com/cyoda-platform/cyoda-go/plugins/memory
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.8.0
+	github.com/cyoda-platform/cyoda-go-spi v0.7.1
 	github.com/google/uuid v1.6.0
 )
-
-replace github.com/cyoda-platform/cyoda-go-spi => /Users/paul/go-projects/cyoda-light/cyoda-go-spi
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/plugins/memory/go.sum
+++ b/plugins/memory/go.sum
@@ -1,6 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.8.0 h1:h22W8g3ggreLw+EaawAVC5yeUnNgKereANq5TTwt4ok=
+github.com/cyoda-platform/cyoda-go-spi v0.8.0/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/plugins/memory/go.sum
+++ b/plugins/memory/go.sum
@@ -1,4 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
+github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/plugins/memory/go.sum
+++ b/plugins/memory/go.sum
@@ -1,6 +1,4 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/plugins/memory/txmanager.go
+++ b/plugins/memory/txmanager.go
@@ -119,16 +119,19 @@ func (m *TransactionManager) Join(ctx context.Context, txID string) (context.Con
 	m.mu.Unlock()
 
 	if !ok {
-		return nil, fmt.Errorf("transaction not found: %s", txID)
+		return nil, fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 
-	closed := func() bool {
+	rolledBack, closed := func() (bool, bool) {
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
-		return tx.RolledBack || tx.Closed
+		return tx.RolledBack, tx.Closed
 	}()
+	if rolledBack {
+		return nil, fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxRolledBack, txID)
+	}
 	if closed {
-		return nil, fmt.Errorf("transaction already closed: %s", txID)
+		return nil, fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxAlreadyCommitted, txID)
 	}
 
 	// Verify tenant matches. Strict — rejects nil UserContext to match
@@ -137,7 +140,7 @@ func (m *TransactionManager) Join(ctx context.Context, txID string) (context.Con
 	// Join an arbitrary active tx.
 	uc := spi.GetUserContext(ctx)
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
-		return nil, fmt.Errorf("tenant mismatch on transaction join")
+		return nil, fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 
 	return spi.WithTransaction(ctx, tx), nil
@@ -153,15 +156,15 @@ func (m *TransactionManager) Commit(ctx context.Context, txID string) error {
 	tx, ok := m.active[txID]
 	if !ok {
 		m.mu.Unlock()
-		return fmt.Errorf("transaction not found or already completed: %w", spi.ErrNotFound)
+		return fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
 		m.mu.Unlock()
-		return fmt.Errorf("transaction tenant mismatch")
+		return fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 	if m.committing[txID] {
 		m.mu.Unlock()
-		return fmt.Errorf("transaction already being committed")
+		return fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxCommitInProgress, txID)
 	}
 	m.committing[txID] = true
 	m.mu.Unlock()
@@ -305,11 +308,11 @@ func (m *TransactionManager) Rollback(ctx context.Context, txID string) error {
 	tx, ok := m.active[txID]
 	if !ok {
 		m.mu.Unlock()
-		return fmt.Errorf("transaction not found or already completed: %w", spi.ErrNotFound)
+		return fmt.Errorf("Rollback: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
 		m.mu.Unlock()
-		return fmt.Errorf("transaction tenant mismatch")
+		return fmt.Errorf("Rollback: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 	m.mu.Unlock()
 
@@ -343,7 +346,7 @@ func (m *TransactionManager) GetSubmitTime(_ context.Context, txID string) (time
 		return t, nil
 	}
 
-	return time.Time{}, fmt.Errorf("transaction not found: %s", txID)
+	return time.Time{}, fmt.Errorf("GetSubmitTime: %w (txID=%s)", spi.ErrTxNotFound, txID)
 }
 
 // CommittedLogLen returns the current length of the committed log.
@@ -376,10 +379,10 @@ func (m *TransactionManager) Savepoint(ctx context.Context, txID string) (string
 	tx, ok := m.active[txID]
 	m.mu.Unlock()
 	if !ok {
-		return "", fmt.Errorf("Savepoint: transaction %s not found", txID)
+		return "", fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
-		return "", fmt.Errorf("Savepoint: tenant mismatch on transaction %s", txID)
+		return "", fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 
 	tx.OpMu.RLock()
@@ -388,8 +391,11 @@ func (m *TransactionManager) Savepoint(ctx context.Context, txID string) (string
 	// Commit and Rollback set tx.Closed/RolledBack inside their tx.OpMu.Lock
 	// region; once we hold tx.OpMu.RLock those flags are stable and reading
 	// them tells us whether the tx was closed during our OpMu acquisition.
-	if tx.RolledBack || tx.Closed {
-		return "", fmt.Errorf("Savepoint: transaction %s already closed", txID)
+	if tx.RolledBack {
+		return "", fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxRolledBack, txID)
+	}
+	if tx.Closed {
+		return "", fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxAlreadyCommitted, txID)
 	}
 
 	spID := uuid.UUID(m.uuids.NewTimeUUID()).String()
@@ -446,17 +452,20 @@ func (m *TransactionManager) RollbackToSavepoint(ctx context.Context, txID strin
 	tx, ok := m.active[txID]
 	m.mu.Unlock()
 	if !ok {
-		return fmt.Errorf("RollbackToSavepoint: transaction %s not found", txID)
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
-		return fmt.Errorf("RollbackToSavepoint: tenant mismatch on transaction %s", txID)
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 
 	tx.OpMu.Lock()
 	defer tx.OpMu.Unlock()
 
-	if tx.RolledBack || tx.Closed {
-		return fmt.Errorf("RollbackToSavepoint: transaction %s already closed", txID)
+	if tx.RolledBack {
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxRolledBack, txID)
+	}
+	if tx.Closed {
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxAlreadyCommitted, txID)
 	}
 
 	m.mu.Lock()
@@ -464,11 +473,11 @@ func (m *TransactionManager) RollbackToSavepoint(ctx context.Context, txID strin
 
 	txSavepoints, ok := m.savepoints[txID]
 	if !ok {
-		return fmt.Errorf("RollbackToSavepoint: savepoint %s not found", savepointID)
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s, savepointID=%s)", spi.ErrSavepointNotFound, txID, savepointID)
 	}
 	snap, ok := txSavepoints[savepointID]
 	if !ok {
-		return fmt.Errorf("RollbackToSavepoint: savepoint %s not found", savepointID)
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s, savepointID=%s)", spi.ErrSavepointNotFound, txID, savepointID)
 	}
 
 	tx.Buffer = snap.buffer
@@ -497,18 +506,18 @@ func (m *TransactionManager) ReleaseSavepoint(ctx context.Context, txID string, 
 
 	tx, ok := m.active[txID]
 	if !ok {
-		return fmt.Errorf("ReleaseSavepoint: transaction %s not found", txID)
+		return fmt.Errorf("ReleaseSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
-		return fmt.Errorf("ReleaseSavepoint: tenant mismatch on transaction %s", txID)
+		return fmt.Errorf("ReleaseSavepoint: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 
 	txSavepoints, ok := m.savepoints[txID]
 	if !ok {
-		return fmt.Errorf("ReleaseSavepoint: savepoint %s not found", savepointID)
+		return fmt.Errorf("ReleaseSavepoint: %w (txID=%s, savepointID=%s)", spi.ErrSavepointNotFound, txID, savepointID)
 	}
 	if _, ok := txSavepoints[savepointID]; !ok {
-		return fmt.Errorf("ReleaseSavepoint: savepoint %s not found", savepointID)
+		return fmt.Errorf("ReleaseSavepoint: %w (txID=%s, savepointID=%s)", spi.ErrSavepointNotFound, txID, savepointID)
 	}
 
 	delete(txSavepoints, savepointID)

--- a/plugins/memory/txmanager_join_test.go
+++ b/plugins/memory/txmanager_join_test.go
@@ -1,6 +1,7 @@
 package memory_test
 
 import (
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -123,8 +124,8 @@ func TestJoinTenantMismatch(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error on tenant mismatch join")
 	}
-	if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("unexpected error message: %v", err)
+	if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	// Clean up.
@@ -226,8 +227,8 @@ func TestJoinRejectsNilUserContext(t *testing.T) {
 	// Pass a context with NO UserContext — Join must reject.
 	if _, err := tm.Join(spi.WithTransaction(t.Context(), nil), txID); err == nil {
 		t.Fatal("expected error when joining without UserContext")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctx, txID)

--- a/plugins/memory/txmanager_join_test.go
+++ b/plugins/memory/txmanager_join_test.go
@@ -2,7 +2,6 @@ package memory_test
 
 import (
 	"errors"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -61,8 +60,8 @@ func TestJoinNonExistentTransaction(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error joining non-existent transaction")
 	}
-	if !strings.Contains(err.Error(), "transaction not found") {
-		t.Fatalf("unexpected error message: %v", err)
+	if !errors.Is(err, spi.ErrTxNotFound) {
+		t.Fatalf("expected ErrTxNotFound, got: %v", err)
 	}
 }
 
@@ -83,8 +82,15 @@ func TestJoinRolledBackTransaction(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error joining rolled-back transaction")
 	}
-	if !strings.Contains(err.Error(), "closed") && !strings.Contains(err.Error(), "not found") {
-		t.Fatalf("unexpected error message: %v", err)
+	// Memory's Rollback removes the tx from m.active before this Join runs,
+	// so the lookup hits ErrTxNotFound rather than the more specific
+	// ErrTxRolledBack — the latter would surface only if a caller observed
+	// tx.RolledBack via an already-held tx reference. Both sentinels are
+	// valid terminal-state signals; either satisfies the contract. This
+	// matches the contract-slack disjunction used in spitest's
+	// TxStateErrors/JoinAfterCommit subtest.
+	if !errors.Is(err, spi.ErrTxTerminated) && !errors.Is(err, spi.ErrTxNotFound) {
+		t.Fatalf("expected ErrTxTerminated or ErrTxNotFound, got: %v", err)
 	}
 }
 
@@ -105,8 +111,12 @@ func TestJoinCommittedTransaction(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error joining committed transaction")
 	}
-	if !strings.Contains(err.Error(), "closed") && !strings.Contains(err.Error(), "not found") {
-		t.Fatalf("unexpected error message: %v", err)
+	// Memory's Commit removes the tx from m.active before this Join runs,
+	// so the lookup hits ErrTxNotFound rather than ErrTxAlreadyCommitted.
+	// Both satisfy the terminal-state contract; the disjunction matches
+	// spitest's TxStateErrors/JoinAfterCommit.
+	if !errors.Is(err, spi.ErrTxTerminated) && !errors.Is(err, spi.ErrTxNotFound) {
+		t.Fatalf("expected ErrTxTerminated or ErrTxNotFound, got: %v", err)
 	}
 }
 

--- a/plugins/memory/txmanager_submittime_test.go
+++ b/plugins/memory/txmanager_submittime_test.go
@@ -1,10 +1,12 @@
 package memory_test
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/plugins/memory"
 )
 
@@ -66,7 +68,7 @@ func TestGetSubmitTime_NotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nonexistent transaction")
 	}
-	if !strings.Contains(err.Error(), "not found") {
-		t.Fatalf("expected 'not found' error, got: %v", err)
+	if !errors.Is(err, spi.ErrTxNotFound) {
+		t.Fatalf("expected ErrTxNotFound, got: %v", err)
 	}
 }

--- a/plugins/memory/txmanager_test.go
+++ b/plugins/memory/txmanager_test.go
@@ -2,7 +2,6 @@ package memory_test
 
 import (
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -559,8 +558,8 @@ func TestSavepoint_RejectsCrossTenant(t *testing.T) {
 
 	if _, err := tm.Savepoint(ctxB, txAID); err == nil {
 		t.Fatal("expected error when tenant B takes savepoint on tenant A's tx")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)
@@ -586,8 +585,8 @@ func TestRollbackToSavepoint_RejectsCrossTenant(t *testing.T) {
 
 	if err := tm.RollbackToSavepoint(ctxB, txAID, spID); err == nil {
 		t.Fatal("expected error when tenant B rolls back tenant A's savepoint")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)
@@ -613,8 +612,8 @@ func TestReleaseSavepoint_RejectsCrossTenant(t *testing.T) {
 
 	if err := tm.ReleaseSavepoint(ctxB, txAID, spID); err == nil {
 		t.Fatal("expected error when tenant B releases tenant A's savepoint")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)

--- a/plugins/postgres/conformance_test.go
+++ b/plugins/postgres/conformance_test.go
@@ -161,5 +161,14 @@ func TestConformance(t *testing.T) {
 			}
 			time.Sleep(d)
 		},
+		Skip: map[string]string{
+			// pgx.Tx aborts surface as ErrConflict via SQLSTATE 25P02
+			// (in_failed_sql_transaction), not as ErrTxRolledBack. This is
+			// the documented postgres-engine behaviour per the ErrTxTerminated
+			// SPI godoc — backends that don't own their own in-process
+			// tx-state buffer surface mid-op rollback through the engine's
+			// failure code.
+			"Transaction/TxStateErrors/OpAfterRollback": "postgres: pgx.Tx aborts surface as ErrConflict via SQLSTATE 25P02, not as ErrTxRolledBack",
+		},
 	})
 }

--- a/plugins/postgres/go.mod
+++ b/plugins/postgres/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/postgres
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.7.1
+	github.com/cyoda-platform/cyoda-go-spi v0.8.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa

--- a/plugins/postgres/go.mod
+++ b/plugins/postgres/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/postgres
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.8.0
+	github.com/cyoda-platform/cyoda-go-spi v0.7.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
@@ -30,5 +30,3 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/cyoda-platform/cyoda-go-spi => /Users/paul/go-projects/cyoda-light/cyoda-go-spi

--- a/plugins/postgres/go.mod
+++ b/plugins/postgres/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/postgres
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.7.1
+	github.com/cyoda-platform/cyoda-go-spi v0.8.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
@@ -30,3 +30,5 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/cyoda-platform/cyoda-go-spi => /Users/paul/go-projects/cyoda-light/cyoda-go-spi

--- a/plugins/postgres/go.sum
+++ b/plugins/postgres/go.sum
@@ -9,8 +9,6 @@ github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/plugins/postgres/go.sum
+++ b/plugins/postgres/go.sum
@@ -9,6 +9,8 @@ github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
+github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/plugins/postgres/go.sum
+++ b/plugins/postgres/go.sum
@@ -9,8 +9,8 @@ github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.8.0 h1:h22W8g3ggreLw+EaawAVC5yeUnNgKereANq5TTwt4ok=
+github.com/cyoda-platform/cyoda-go-spi v0.8.0/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/plugins/postgres/transaction_manager.go
+++ b/plugins/postgres/transaction_manager.go
@@ -115,11 +115,11 @@ func (tm *TransactionManager) Begin(ctx context.Context) (string, context.Contex
 func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
-		return fmt.Errorf("Commit: transaction %s not found", txID)
+		return fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	state, ok := tm.lookupTxState(txID)
 	if !ok {
-		return fmt.Errorf("Commit: tx state for %s not found", txID)
+		return fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if err := verifyTenant(ctx, state.tenantID, "Commit", txID); err != nil {
 		return err
@@ -212,12 +212,12 @@ func (tm *TransactionManager) Commit(ctx context.Context, txID string) error {
 func (tm *TransactionManager) Rollback(ctx context.Context, txID string) error {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
-		return fmt.Errorf("Rollback: transaction %s not found", txID)
+		return fmt.Errorf("Rollback: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 
 	tenantID, ok := tm.lookupTenant(txID)
 	if !ok {
-		return fmt.Errorf("Rollback: transaction %s not found", txID)
+		return fmt.Errorf("Rollback: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if err := verifyTenant(ctx, tenantID, "Rollback", txID); err != nil {
 		return err
@@ -241,12 +241,12 @@ func (tm *TransactionManager) Rollback(ctx context.Context, txID string) error {
 func (tm *TransactionManager) Join(ctx context.Context, txID string) (context.Context, error) {
 	_, ok := tm.registry.Lookup(txID)
 	if !ok {
-		return nil, fmt.Errorf("Join: transaction %s not found", txID)
+		return nil, fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 
 	tenantID, ok := tm.lookupTenant(txID)
 	if !ok {
-		return nil, fmt.Errorf("Join: transaction %s not found", txID)
+		return nil, fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if err := verifyTenant(ctx, tenantID, "Join", txID); err != nil {
 		return nil, err
@@ -315,11 +315,11 @@ func (tm *TransactionManager) lookupTxState(txID string) (*txState, bool) {
 func (tm *TransactionManager) Savepoint(ctx context.Context, txID string) (string, error) {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
-		return "", fmt.Errorf("Savepoint: transaction %s not found", txID)
+		return "", fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	state, ok := tm.lookupTxState(txID)
 	if !ok {
-		return "", fmt.Errorf("Savepoint: tx state for %s not found", txID)
+		return "", fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if err := verifyTenant(ctx, state.tenantID, "Savepoint", txID); err != nil {
 		return "", err
@@ -341,14 +341,23 @@ func (tm *TransactionManager) Savepoint(ctx context.Context, txID string) (strin
 func (tm *TransactionManager) RollbackToSavepoint(ctx context.Context, txID string, savepointID string) error {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
-		return fmt.Errorf("RollbackToSavepoint: transaction %s not found", txID)
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	state, ok := tm.lookupTxState(txID)
 	if !ok {
-		return fmt.Errorf("RollbackToSavepoint: tx state for %s not found", txID)
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if err := verifyTenant(ctx, state.tenantID, "RollbackToSavepoint", txID); err != nil {
 		return err
+	}
+	// Validate the savepoint exists in the in-memory snapshot stack BEFORE
+	// issuing the SQL command. PostgreSQL would surface a missing savepoint as
+	// SQLSTATE 3B001, which is opaque to errors.Is(err, spi.ErrSavepointNotFound).
+	// Checking first guarantees the SPI sentinel is wrapped consistently
+	// regardless of whether the txState snapshot stack and the DB savepoint
+	// stack ever diverge (they shouldn't, but the contract is the sentinel).
+	if !state.HasSavepoint(savepointID) {
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s, savepointID=%s)", spi.ErrSavepointNotFound, txID, savepointID)
 	}
 	spName := "sp_" + savepointID
 	if _, err := pgxTx.Exec(ctx, "ROLLBACK TO SAVEPOINT "+pgx.Identifier{spName}.Sanitize()); err != nil {
@@ -367,14 +376,19 @@ func (tm *TransactionManager) RollbackToSavepoint(ctx context.Context, txID stri
 func (tm *TransactionManager) ReleaseSavepoint(ctx context.Context, txID string, savepointID string) error {
 	pgxTx, ok := tm.registry.Lookup(txID)
 	if !ok {
-		return fmt.Errorf("ReleaseSavepoint: transaction %s not found", txID)
+		return fmt.Errorf("ReleaseSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	state, ok := tm.lookupTxState(txID)
 	if !ok {
-		return fmt.Errorf("ReleaseSavepoint: tx state for %s not found", txID)
+		return fmt.Errorf("ReleaseSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if err := verifyTenant(ctx, state.tenantID, "ReleaseSavepoint", txID); err != nil {
 		return err
+	}
+	// Validate the savepoint exists before issuing the SQL command — see
+	// RollbackToSavepoint for rationale.
+	if !state.HasSavepoint(savepointID) {
+		return fmt.Errorf("ReleaseSavepoint: %w (txID=%s, savepointID=%s)", spi.ErrSavepointNotFound, txID, savepointID)
 	}
 	spName := "sp_" + savepointID
 	if _, err := pgxTx.Exec(ctx, "RELEASE SAVEPOINT "+pgx.Identifier{spName}.Sanitize()); err != nil {
@@ -411,7 +425,7 @@ func (tm *TransactionManager) lookupTenant(txID string) (spi.TenantID, bool) {
 func verifyTenant(ctx context.Context, txTenantID spi.TenantID, op string, txID string) error {
 	uc := spi.GetUserContext(ctx)
 	if uc == nil || uc.Tenant.ID != txTenantID {
-		return fmt.Errorf("%s: tenant mismatch on transaction %s", op, txID)
+		return fmt.Errorf("%s: %w (txID=%s)", op, spi.ErrTxTenantMismatch, txID)
 	}
 	return nil
 }

--- a/plugins/postgres/transaction_manager_tenant_test.go
+++ b/plugins/postgres/transaction_manager_tenant_test.go
@@ -1,8 +1,10 @@
 package postgres_test
 
 import (
-	"strings"
+	"errors"
 	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
 )
 
 // Tenant-isolation regression tests for the postgres plugin's TM lifecycle
@@ -39,8 +41,8 @@ func TestPostgresCommit_RejectsCrossTenant(t *testing.T) {
 
 	if err := tm.Commit(ctxB, txAID); err == nil {
 		t.Fatal("expected error when tenant B commits tenant A's tx")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)
@@ -58,8 +60,8 @@ func TestPostgresRollback_RejectsCrossTenant(t *testing.T) {
 
 	if err := tm.Rollback(ctxB, txAID); err == nil {
 		t.Fatal("expected error when tenant B rolls back tenant A's tx")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)
@@ -77,8 +79,8 @@ func TestPostgresJoin_RejectsCrossTenant(t *testing.T) {
 
 	if _, err := tm.Join(ctxB, txAID); err == nil {
 		t.Fatal("expected error when tenant B joins tenant A's tx")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)
@@ -96,8 +98,8 @@ func TestPostgresSavepoint_RejectsCrossTenant(t *testing.T) {
 
 	if _, err := tm.Savepoint(ctxB, txAID); err == nil {
 		t.Fatal("expected error when tenant B takes savepoint on tenant A's tx")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)
@@ -119,8 +121,8 @@ func TestPostgresRollbackToSavepoint_RejectsCrossTenant(t *testing.T) {
 
 	if err := tm.RollbackToSavepoint(ctxB, txAID, spID); err == nil {
 		t.Fatal("expected error when tenant B rolls back tenant A's savepoint")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)
@@ -142,8 +144,8 @@ func TestPostgresReleaseSavepoint_RejectsCrossTenant(t *testing.T) {
 
 	if err := tm.ReleaseSavepoint(ctxB, txAID, spID); err == nil {
 		t.Fatal("expected error when tenant B releases tenant A's savepoint")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)

--- a/plugins/postgres/txstate.go
+++ b/plugins/postgres/txstate.go
@@ -149,6 +149,22 @@ func (s *txState) PushSavepoint(id string) {
 	s.savepoints = append(s.savepoints, snap)
 }
 
+// HasSavepoint reports whether a savepoint with the given id is currently
+// on the snapshot stack. Used by the TM lifecycle methods to pre-validate
+// the savepoint exists before issuing the SQL command, so missing
+// savepoints surface as spi.ErrSavepointNotFound rather than an opaque
+// PostgreSQL SQLSTATE 3B001 error.
+func (s *txState) HasSavepoint(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, sp := range s.savepoints {
+		if sp.id == id {
+			return true
+		}
+	}
+	return false
+}
+
 // RestoreSavepoint restores readSet/writeSet to the snapshot captured at
 // PushSavepoint(id) and trims any savepoints pushed after id. The named
 // savepoint itself remains (mirroring postgres ROLLBACK TO SAVEPOINT).
@@ -163,7 +179,7 @@ func (s *txState) RestoreSavepoint(id string) error {
 		}
 	}
 	if idx < 0 {
-		return fmt.Errorf("unknown savepoint %q", id)
+		return fmt.Errorf("%w (savepointID=%q)", spi.ErrSavepointNotFound, id)
 	}
 	snap := s.savepoints[idx]
 	s.readSet = make(map[string]int64, len(snap.readSet))
@@ -220,7 +236,7 @@ func (s *txState) ReleaseSavepoint(id string) error {
 		}
 	}
 	if idx < 0 {
-		return fmt.Errorf("unknown savepoint %q", id)
+		return fmt.Errorf("%w (savepointID=%q)", spi.ErrSavepointNotFound, id)
 	}
 	s.savepoints = append(s.savepoints[:idx], s.savepoints[idx+1:]...)
 	return nil

--- a/plugins/postgres/txstate_test.go
+++ b/plugins/postgres/txstate_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -269,21 +270,27 @@ func TestReleaseSavepoint_DropsEntryKeepsWork(t *testing.T) {
 }
 
 // TestRestoreSavepoint_Unknown verifies that restoring an unknown savepoint
-// returns an error.
+// returns spi.ErrSavepointNotFound.
 func TestRestoreSavepoint_Unknown(t *testing.T) {
 	s := newTxState("t1")
 	err := s.RestoreSavepoint("nonexistent")
 	if err == nil {
 		t.Fatal("expected error for unknown savepoint, got nil")
 	}
+	if !errors.Is(err, spi.ErrSavepointNotFound) {
+		t.Fatalf("expected ErrSavepointNotFound, got: %v", err)
+	}
 }
 
 // TestReleaseSavepoint_Unknown verifies that releasing an unknown savepoint
-// returns an error.
+// returns spi.ErrSavepointNotFound.
 func TestReleaseSavepoint_Unknown(t *testing.T) {
 	s := newTxState("t1")
 	err := s.ReleaseSavepoint("bogus")
 	if err == nil {
 		t.Fatal("expected error for unknown savepoint, got nil")
+	}
+	if !errors.Is(err, spi.ErrSavepointNotFound) {
+		t.Fatalf("expected ErrSavepointNotFound, got: %v", err)
 	}
 }

--- a/plugins/sqlite/concurrency_savepoint_test.go
+++ b/plugins/sqlite/concurrency_savepoint_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 
@@ -46,8 +45,10 @@ import (
 //   - Join reads tx.RolledBack / tx.Closed. Required posture: tx.OpMu.RLock
 //     in an IIFE.
 //
-// TODO(#200): replace substring matches on tolerated errors with
-// errors.Is against sentinel error types once they land.
+// Tolerated-error matching uses errors.Is against the SPI sentinel
+// hierarchy (ErrTxNotFound, ErrTxTerminated, ErrTxCommitInProgress,
+// ErrNotFound) — see isToleratedTxClosedErr below. A closed-mid-op tx
+// is a tolerated race outcome, not a defect.
 
 const sqliteSavepointRaceIterations = 50
 
@@ -117,8 +118,7 @@ func TestSavepoint_VsCommit_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if _, sperr := tm.Savepoint(ctx, txID); sperr != nil {
-					msg := sperr.Error()
-					if isToleratedTxClosedErr(msg) {
+					if isToleratedTxClosedErr(sperr) {
 						return
 					}
 					t.Errorf("Savepoint failed: %v", sperr)
@@ -130,10 +130,7 @@ func TestSavepoint_VsCommit_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if cerr := tm.Commit(ctx, txID); cerr != nil {
-					if errors.Is(cerr, spi.ErrConflict) || errors.Is(cerr, spi.ErrNotFound) {
-						return
-					}
-					if isToleratedTxClosedErr(cerr.Error()) {
+					if errors.Is(cerr, spi.ErrConflict) || isToleratedTxClosedErr(cerr) {
 						return
 					}
 					t.Errorf("Commit failed: %v", cerr)
@@ -174,8 +171,7 @@ func TestSavepoint_VsRollback_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if _, sperr := tm.Savepoint(ctx, txID); sperr != nil {
-					msg := sperr.Error()
-					if isToleratedTxClosedErr(msg) {
+					if isToleratedTxClosedErr(sperr) {
 						return
 					}
 					t.Errorf("Savepoint failed: %v", sperr)
@@ -248,8 +244,7 @@ func TestRollbackToSavepoint_VsCommit_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if rerr := tm.RollbackToSavepoint(ctx, txID, spID); rerr != nil {
-					msg := rerr.Error()
-					if isToleratedTxClosedErr(msg) {
+					if isToleratedTxClosedErr(rerr) {
 						return
 					}
 					t.Errorf("RollbackToSavepoint failed: %v", rerr)
@@ -261,10 +256,7 @@ func TestRollbackToSavepoint_VsCommit_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if cerr := tm.Commit(ctx, txID); cerr != nil {
-					if errors.Is(cerr, spi.ErrConflict) || errors.Is(cerr, spi.ErrNotFound) {
-						return
-					}
-					if isToleratedTxClosedErr(cerr.Error()) {
+					if errors.Is(cerr, spi.ErrConflict) || isToleratedTxClosedErr(cerr) {
 						return
 					}
 					t.Errorf("Commit failed: %v", cerr)
@@ -323,7 +315,7 @@ func TestRollbackToSavepoint_VsSave_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if _, serr := store.Save(txCtx, e); serr != nil {
-					if isToleratedTxClosedErr(serr.Error()) {
+					if isToleratedTxClosedErr(serr) {
 						return
 					}
 					t.Errorf("Save failed: %v", serr)
@@ -335,7 +327,7 @@ func TestRollbackToSavepoint_VsSave_NoRace(t *testing.T) {
 				defer wg.Done()
 				<-start
 				if rerr := tm.RollbackToSavepoint(ctx, txID, spID); rerr != nil {
-					if isToleratedTxClosedErr(rerr.Error()) {
+					if isToleratedTxClosedErr(rerr) {
 						return
 					}
 					t.Errorf("RollbackToSavepoint failed: %v", rerr)
@@ -359,10 +351,20 @@ func TestRollbackToSavepoint_VsSave_NoRace(t *testing.T) {
 // memory plugin is documented in
 // docs/audits/2026-05-sqlite-plugin-tx-locking.md.
 
-func isToleratedTxClosedErr(msg string) bool {
-	return strings.Contains(msg, "not found") ||
-		strings.Contains(msg, "already completed") ||
-		strings.Contains(msg, "rolled back") ||
-		strings.Contains(msg, "already closed") ||
-		strings.Contains(msg, "already being committed")
+// isToleratedTxClosedErr reports whether err is a benign "tx already
+// closed/rolled back/committed/not found" outcome — the kind that is
+// expected when a concurrent op races against Commit/Rollback/Savepoint/
+// RollbackToSavepoint/Join. Anything else is a defect and should fail the
+// test.
+//
+// Matches the three-way disjunction of transaction-state sentinels defined
+// in cyoda-go-spi, plus bare ErrNotFound because in-read ops
+// (Get/GetAll/Exists/Delete) can legitimately surface entity-level not-found
+// when a concurrent Rollback or Commit changes visibility mid-op — that is
+// a tolerated race outcome, not a defect.
+func isToleratedTxClosedErr(err error) bool {
+	return errors.Is(err, spi.ErrTxNotFound) ||
+		errors.Is(err, spi.ErrTxTerminated) ||
+		errors.Is(err, spi.ErrTxCommitInProgress) ||
+		errors.Is(err, spi.ErrNotFound)
 }

--- a/plugins/sqlite/entity_store.go
+++ b/plugins/sqlite/entity_store.go
@@ -198,7 +198,7 @@ func (s *entityStore) Save(ctx context.Context, entity *spi.Entity) (int64, erro
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return 0, fmt.Errorf("transaction has been rolled back")
+			return 0, fmt.Errorf("Save: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Transaction mode: write to buffer, not main store.
 		cp := copyEntity(entity)
@@ -292,7 +292,7 @@ func (s *entityStore) CompareAndSave(ctx context.Context, entity *spi.Entity, ex
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return 0, fmt.Errorf("transaction has been rolled back")
+			return 0, fmt.Errorf("CompareAndSave: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Check CAS against committed store (not buffer).
 		var currentTxID sql.NullString
@@ -335,7 +335,7 @@ func (s *entityStore) Get(ctx context.Context, entityID string) (*spi.Entity, er
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return nil, fmt.Errorf("transaction has been rolled back")
+			return nil, fmt.Errorf("Get: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Check if deleted in this transaction.
 		if tx.Deletes[entityID] {
@@ -418,7 +418,7 @@ func (s *entityStore) GetAsAt(ctx context.Context, entityID string, asAt time.Ti
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return nil, fmt.Errorf("transaction has been rolled back")
+			return nil, fmt.Errorf("GetAsAt: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		tx.ReadSet[entityID] = true
 	}
@@ -459,7 +459,7 @@ func (s *entityStore) GetAll(ctx context.Context, modelRef spi.ModelRef) ([]*spi
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return nil, fmt.Errorf("transaction has been rolled back")
+			return nil, fmt.Errorf("GetAll: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		return s.getAllTx(ctx, tx, modelRef)
 	}
@@ -587,7 +587,7 @@ func (s *entityStore) Delete(ctx context.Context, entityID string) error {
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return fmt.Errorf("transaction has been rolled back")
+			return fmt.Errorf("Delete: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Check existence: buffer first, then committed store.
 		if _, inBuffer := tx.Buffer[entityID]; !inBuffer {
@@ -664,7 +664,7 @@ func (s *entityStore) DeleteAll(ctx context.Context, modelRef spi.ModelRef) erro
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return fmt.Errorf("transaction has been rolled back")
+			return fmt.Errorf("DeleteAll: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Get all entities for the model (snapshot), mark each as deleted.
 		snapshotMicro := timeToMicro(tx.SnapshotTime)
@@ -750,7 +750,7 @@ func (s *entityStore) Exists(ctx context.Context, entityID string) (bool, error)
 		tx.OpMu.RLock()
 		defer tx.OpMu.RUnlock()
 		if tx.RolledBack {
-			return false, fmt.Errorf("transaction has been rolled back")
+			return false, fmt.Errorf("Exists: %w (txID=%s)", spi.ErrTxRolledBack, tx.ID)
 		}
 		// Check deletes first.
 		if tx.Deletes[entityID] {

--- a/plugins/sqlite/go.mod
+++ b/plugins/sqlite/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/sqlite
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.7.1
+	github.com/cyoda-platform/cyoda-go-spi v0.8.0
 	github.com/gofrs/flock v0.13.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
@@ -41,3 +41,5 @@ require (
 	modernc.org/strutil v1.1.3 // indirect
 	modernc.org/token v1.0.0 // indirect
 )
+
+replace github.com/cyoda-platform/cyoda-go-spi => /Users/paul/go-projects/cyoda-light/cyoda-go-spi

--- a/plugins/sqlite/go.mod
+++ b/plugins/sqlite/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/sqlite
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.8.0
+	github.com/cyoda-platform/cyoda-go-spi v0.7.1
 	github.com/gofrs/flock v0.13.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
@@ -41,5 +41,3 @@ require (
 	modernc.org/strutil v1.1.3 // indirect
 	modernc.org/token v1.0.0 // indirect
 )
-
-replace github.com/cyoda-platform/cyoda-go-spi => /Users/paul/go-projects/cyoda-light/cyoda-go-spi

--- a/plugins/sqlite/go.mod
+++ b/plugins/sqlite/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/sqlite
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.7.1
+	github.com/cyoda-platform/cyoda-go-spi v0.8.0
 	github.com/gofrs/flock v0.13.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0

--- a/plugins/sqlite/go.sum
+++ b/plugins/sqlite/go.sum
@@ -1,6 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.8.0 h1:h22W8g3ggreLw+EaawAVC5yeUnNgKereANq5TTwt4ok=
+github.com/cyoda-platform/cyoda-go-spi v0.8.0/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/plugins/sqlite/go.sum
+++ b/plugins/sqlite/go.sum
@@ -1,6 +1,4 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
-github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/plugins/sqlite/go.sum
+++ b/plugins/sqlite/go.sum
@@ -1,4 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cyoda-platform/cyoda-go-spi v0.7.1 h1:kfj5AJ6VbNpdBIV3MmhElFJiRx5rYxFPW2+TROOJass=
+github.com/cyoda-platform/cyoda-go-spi v0.7.1/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/plugins/sqlite/savepoint_tenant_test.go
+++ b/plugins/sqlite/savepoint_tenant_test.go
@@ -2,10 +2,11 @@ package sqlite_test
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
-	"strings"
 	"testing"
 
+	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/plugins/sqlite"
 )
 
@@ -43,8 +44,8 @@ func TestSqliteSavepoint_RejectsCrossTenant(t *testing.T) {
 
 	if _, err := tm.Savepoint(ctxB, txAID); err == nil {
 		t.Fatal("expected error when tenant B takes savepoint on tenant A's tx")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)
@@ -69,8 +70,8 @@ func TestSqliteRollbackToSavepoint_RejectsCrossTenant(t *testing.T) {
 
 	if err := tm.RollbackToSavepoint(ctxB, txAID, spID); err == nil {
 		t.Fatal("expected error when tenant B rolls back tenant A's savepoint")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)
@@ -95,8 +96,8 @@ func TestSqliteReleaseSavepoint_RejectsCrossTenant(t *testing.T) {
 
 	if err := tm.ReleaseSavepoint(ctxB, txAID, spID); err == nil {
 		t.Fatal("expected error when tenant B releases tenant A's savepoint")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)
@@ -121,8 +122,8 @@ func TestSqliteJoin_RejectsNilUserContext(t *testing.T) {
 
 	if _, err := tm.Join(context.Background(), txAID); err == nil {
 		t.Fatal("expected error when joining without UserContext")
-	} else if !strings.Contains(err.Error(), "tenant mismatch") {
-		t.Fatalf("expected tenant-mismatch error, got: %v", err)
+	} else if !errors.Is(err, spi.ErrTxTenantMismatch) {
+		t.Fatalf("expected ErrTxTenantMismatch, got: %v", err)
 	}
 
 	_ = tm.Rollback(ctxA, txAID)

--- a/plugins/sqlite/txmanager.go
+++ b/plugins/sqlite/txmanager.go
@@ -124,10 +124,13 @@ func (m *transactionManager) Join(ctx context.Context, txID string) (context.Con
 
 	tx, ok := m.active[txID]
 	if !ok {
-		return nil, fmt.Errorf("transaction not found: %s", txID)
+		return nil, fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
-	if tx.RolledBack || tx.Closed {
-		return nil, fmt.Errorf("transaction already closed: %s", txID)
+	if tx.RolledBack {
+		return nil, fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxRolledBack, txID)
+	}
+	if tx.Closed {
+		return nil, fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxAlreadyCommitted, txID)
 	}
 
 	// Verify tenant matches. Strict — rejects nil UserContext to match
@@ -136,7 +139,7 @@ func (m *transactionManager) Join(ctx context.Context, txID string) (context.Con
 	// Join an arbitrary active tx.
 	uc := spi.GetUserContext(ctx)
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
-		return nil, fmt.Errorf("tenant mismatch on transaction join")
+		return nil, fmt.Errorf("Join: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 
 	return spi.WithTransaction(ctx, tx), nil
@@ -156,15 +159,15 @@ func (m *transactionManager) Commit(ctx context.Context, txID string) error {
 	tx, ok := m.active[txID]
 	if !ok {
 		m.mu.Unlock()
-		return fmt.Errorf("transaction not found or already completed: %w", spi.ErrNotFound)
+		return fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
 		m.mu.Unlock()
-		return fmt.Errorf("transaction tenant mismatch")
+		return fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 	if m.committing[txID] {
 		m.mu.Unlock()
-		return fmt.Errorf("transaction already being committed")
+		return fmt.Errorf("Commit: %w (txID=%s)", spi.ErrTxCommitInProgress, txID)
 	}
 	m.committing[txID] = true
 	m.mu.Unlock()
@@ -426,11 +429,11 @@ func (m *transactionManager) Rollback(ctx context.Context, txID string) error {
 	tx, ok := m.active[txID]
 	if !ok {
 		m.mu.Unlock()
-		return fmt.Errorf("transaction not found or already completed: %w", spi.ErrNotFound)
+		return fmt.Errorf("Rollback: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
 		m.mu.Unlock()
-		return fmt.Errorf("transaction tenant mismatch")
+		return fmt.Errorf("Rollback: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 	m.mu.Unlock()
 
@@ -471,7 +474,7 @@ func (m *transactionManager) GetSubmitTime(_ context.Context, txID string) (time
 	err := m.factory.db.QueryRow(
 		"SELECT submit_time FROM submit_times WHERE tx_id = ?", txID).Scan(&micro)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("transaction not found: %s", txID)
+		return time.Time{}, fmt.Errorf("GetSubmitTime: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	return time.UnixMicro(micro), nil
 }
@@ -503,17 +506,20 @@ func (m *transactionManager) Savepoint(ctx context.Context, txID string) (string
 	tx, ok := m.active[txID]
 	m.mu.Unlock()
 	if !ok {
-		return "", fmt.Errorf("Savepoint: transaction %s not found", txID)
+		return "", fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
-		return "", fmt.Errorf("Savepoint: tenant mismatch on transaction %s", txID)
+		return "", fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 
 	tx.OpMu.RLock()
 	defer tx.OpMu.RUnlock()
 
-	if tx.RolledBack || tx.Closed {
-		return "", fmt.Errorf("Savepoint: transaction %s already closed", txID)
+	if tx.RolledBack {
+		return "", fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxRolledBack, txID)
+	}
+	if tx.Closed {
+		return "", fmt.Errorf("Savepoint: %w (txID=%s)", spi.ErrTxAlreadyCommitted, txID)
 	}
 
 	spID := uuid.UUID(m.uuids.NewTimeUUID()).String()
@@ -566,17 +572,20 @@ func (m *transactionManager) RollbackToSavepoint(ctx context.Context, txID strin
 	tx, ok := m.active[txID]
 	m.mu.Unlock()
 	if !ok {
-		return fmt.Errorf("RollbackToSavepoint: transaction %s not found", txID)
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
-		return fmt.Errorf("RollbackToSavepoint: tenant mismatch on transaction %s", txID)
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 
 	tx.OpMu.Lock()
 	defer tx.OpMu.Unlock()
 
-	if tx.RolledBack || tx.Closed {
-		return fmt.Errorf("RollbackToSavepoint: transaction %s already closed", txID)
+	if tx.RolledBack {
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxRolledBack, txID)
+	}
+	if tx.Closed {
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s)", spi.ErrTxAlreadyCommitted, txID)
 	}
 
 	m.mu.Lock()
@@ -584,11 +593,11 @@ func (m *transactionManager) RollbackToSavepoint(ctx context.Context, txID strin
 
 	txSavepoints, ok := m.savepoints[txID]
 	if !ok {
-		return fmt.Errorf("RollbackToSavepoint: savepoint %s not found", savepointID)
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s, savepointID=%s)", spi.ErrSavepointNotFound, txID, savepointID)
 	}
 	snap, ok := txSavepoints[savepointID]
 	if !ok {
-		return fmt.Errorf("RollbackToSavepoint: savepoint %s not found", savepointID)
+		return fmt.Errorf("RollbackToSavepoint: %w (txID=%s, savepointID=%s)", spi.ErrSavepointNotFound, txID, savepointID)
 	}
 
 	tx.Buffer = snap.buffer
@@ -616,18 +625,18 @@ func (m *transactionManager) ReleaseSavepoint(ctx context.Context, txID string, 
 
 	tx, ok := m.active[txID]
 	if !ok {
-		return fmt.Errorf("ReleaseSavepoint: transaction %s not found", txID)
+		return fmt.Errorf("ReleaseSavepoint: %w (txID=%s)", spi.ErrTxNotFound, txID)
 	}
 	if uc == nil || uc.Tenant.ID != tx.TenantID {
-		return fmt.Errorf("ReleaseSavepoint: tenant mismatch on transaction %s", txID)
+		return fmt.Errorf("ReleaseSavepoint: %w (txID=%s)", spi.ErrTxTenantMismatch, txID)
 	}
 
 	txSavepoints, ok := m.savepoints[txID]
 	if !ok {
-		return fmt.Errorf("ReleaseSavepoint: savepoint %s not found", savepointID)
+		return fmt.Errorf("ReleaseSavepoint: %w (txID=%s, savepointID=%s)", spi.ErrSavepointNotFound, txID, savepointID)
 	}
 	if _, ok := txSavepoints[savepointID]; !ok {
-		return fmt.Errorf("ReleaseSavepoint: savepoint %s not found", savepointID)
+		return fmt.Errorf("ReleaseSavepoint: %w (txID=%s, savepointID=%s)", spi.ErrSavepointNotFound, txID, savepointID)
 	}
 
 	delete(txSavepoints, savepointID)


### PR DESCRIPTION
Replaces plain-string transaction-state errors across the memory, sqlite, and postgres storage plugins with the SPI sentinel hierarchy added in [`cyoda-go-spi v0.8.0`](https://github.com/Cyoda-platform/cyoda-go-spi/releases/tag/v0.8.0).

## Spec & plan

- **Spec:** [`docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md`](../tree/feat/200-spi-tx-state-sentinel-errors/docs/superpowers/specs/2026-06-13-200-spi-tx-state-sentinel-errors-design.md)
- **Plan:** [`docs/superpowers/plans/2026-06-13-200-spi-tx-state-sentinel-errors.md`](../tree/feat/200-spi-tx-state-sentinel-errors/docs/superpowers/plans/2026-06-13-200-spi-tx-state-sentinel-errors.md)

## What changes

- **`go.mod` (root) + 3 plugin `go.mod`s** — `cyoda-go-spi` pin bumped from `v0.7.1` to `v0.8.0`. `make check-spi-pin-sync` passes.
- **`plugins/memory/{txmanager.go,entity_store.go}`** — every tx-state error site now wraps the relevant SPI sentinel. The eight "transaction has been rolled back" sites in `entity_store.go` gain a `txID=` debuggability field. `Join` / `Savepoint` / `RollbackToSavepoint` split `RolledBack || Closed` into two branches so a specifically-rolled-back tx surfaces `ErrTxRolledBack` (not collapsed into `ErrTxAlreadyCommitted`). Savepoint-not-found wraps include both `txID` and `savepointID`.
- **`plugins/memory/concurrency_{inreadops,cas,savepoint}_test.go`** — `strings.Contains` tolerance blocks replaced with `errors.Is` against the SPI sentinels. Three-way disjunction (`ErrTxTerminated || ErrTxNotFound || ErrTxCommitInProgress`) at the sites that tolerate "already being committed"; two-way elsewhere. Shared helper `isToleratedClosedTxErr` lives in a new `concurrency_helpers_test.go`. Drops the `TODO(#200)` marker.
- **`plugins/sqlite/{txmanager.go,entity_store.go}`** — mirrors memory. Includes a sqlite-local `isToleratedTxClosedErr` helper migration in `concurrency_savepoint_test.go` (the only sqlite concurrency test file; sqlite has no `concurrency_{inreadops,cas}_test.go` analogues).
- **`plugins/postgres/{transaction_manager.go,txstate.go,conformance_test.go}`** — wraps the 12 lookup not-found sites in `transaction_manager.go`; `verifyTenant()` at L427 is a single wrap that carries the entire postgres tenant-mismatch contract (covers Commit/Rollback/Join/Savepoint/RollbackToSavepoint/ReleaseSavepoint). `txstate.go` "unknown savepoint" sites wrap `ErrSavepointNotFound`. A new `HasSavepoint` pre-check fires before `tx.Exec("ROLLBACK TO SAVEPOINT ...")` so the SPI sentinel is wrapped before pgx returns SQLSTATE 3B001 — and keeps the transaction usable after a missing-savepoint error (parity with memory/sqlite; a failed SQL ROLLBACK TO SAVEPOINT would otherwise put `pgx.Tx` in SQLSTATE 25P02). `Harness.Skip` declares ONE entry: `Transaction/TxStateErrors/OpAfterRollback` with the documented reason (pgx surfaces mid-op rollback as `ErrConflict` via SQLSTATE 25P02, not `ErrTxRolledBack`).
- **Test tightening across all three plugins** — tenant-mismatch substring assertions replaced with `errors.Is(err, spi.ErrTxTenantMismatch)`; postgres `txstate_test.go` savepoint assertions tightened to `errors.Is(err, spi.ErrSavepointNotFound)`. Six test files total.
- **`COMPATIBILITY.md`** — new v0.8.0 row in the cyoda-go × cyoda-go-spi matrix, listing all seven new sentinels in the "SPI surface" column. The "Out-of-tree plugin authors" prose extended to cover v0.8.0.

## Conformance

All 7 `TxStateErrors/*` subtests added in cyoda-go-spi v0.8.0 PASS on memory and sqlite. Postgres reports 6 PASS + 1 SKIP (`OpAfterRollback`, documented).

## Verification

- `make test-all` green
- Per-plugin `go test -count=1 ./...` green (memory, sqlite, postgres)
- `go vet ./...` clean across root + 3 plugins
- `go test -race ./...` one-shot pre-PR — green; 0 races, 0 fails (root `internal/e2e` 442s; plugins 1–14s)
- `make check-spi-pin-sync` — OK, all manifests pin `cyoda-go-spi v0.8.0`
- No `strings.Contains` on tx-state errors anywhere
- No `TODO(#200)` markers anywhere

## Not in this PR (deliberately, per spec)

- HTTP/gRPC status mapping based on the new sentinels — separate follow-up per #200 body.
- Cassandra plugin migration — separate repo, picks up on its next SPI bump. Note: Cassandra's tenant-mismatch surface will need an explicit pre-lookup tenant check, not just an error-code rename, because its lookups are tenant-partitioned.
- SDK-misuse error promotion (`no user context`, `no tenant`, `TransactionManager not initialized`) — these stay plain per spec.

## History note

Commits `ef1c80d` (revert) + `c22ff24` (bump) net out a procedural mistake mid-development: the original implementation commits prematurely bumped pins to v0.8.0 + added committed `replace` directives. Per MAINTAINING.md "Coordinated release across sibling repos", SPI is tagged FIRST, then cyoda-go bumps pins in ONE follow-up commit, with local composition via `go.work` overlay (not `replace`). The revert restored the pre-bump state; the SPI was then tagged; `c22ff24` is the legitimate v0.8.0 bump. Will collapse to a single squash-merge commit.

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)