### PR TITLE
feat(grpc): wire ProcessorConfig.Context pass-through for Cloud parity (closes #253)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -7989,7 +7989,14 @@ components:
           description: Retry policy for the function
         context:
           type: string
-          description: Additional context for the function
+          description: |
+            Pass-through string forwarded verbatim as the `parameters` JSON
+            node of the outgoing `EntityCriteriaCalculationRequest`. The value
+            is encoded as a JSON string (pass-as-string); the receiver gets a
+            JSON-quoted string in `parameters`. Empty value causes the
+            `parameters` field to be omitted entirely. Use to distinguish
+            multiple workflow roles served by a single externalized criterion
+            implementation without registering a separate name per role.
     ExternalizedFunctionDto:
       type: object
       properties:
@@ -8647,7 +8654,14 @@ components:
           description: Retry policy for the function
         context:
           type: string
-          description: Additional context for the function
+          description: |
+            Pass-through string forwarded verbatim as the `parameters` JSON
+            node of the outgoing `EntityProcessorCalculationRequest`. The
+            value is encoded as a JSON string (pass-as-string); the receiver
+            gets a JSON-quoted string in `parameters`. Empty value causes the
+            `parameters` field to be omitted entirely. Use to distinguish
+            multiple workflow roles served by a single externalized processor
+            implementation without registering a separate name per role.
         asyncResult:
           type: boolean
           description: |

--- a/cmd/compute-test-client/catalog.go
+++ b/cmd/compute-test-client/catalog.go
@@ -76,6 +76,31 @@ func newCatalog() *catalog {
 				}
 				return entity, nil
 			},
+			// echo-context-to-field — records the pass-through Context
+			// (delivered in EntityProcessorCalculationRequest.parameters as a
+			// JSON string per the cyoda-go contract) into entity data at
+			// `_context` so callers can observe it through the entity HTTP
+			// API. Absence of a context surfaces as no field write —
+			// distinguishable from the "context was empty string" case via
+			// field presence.
+			"echo-context-to-field": func(ctx context.Context, entity *Entity, config json.RawMessage) (*Entity, error) {
+				var data map[string]any
+				if err := json.Unmarshal(entity.Data, &data); err != nil {
+					return nil, err
+				}
+				if len(config) > 0 {
+					var ctxStr string
+					if err := json.Unmarshal(config, &ctxStr); err != nil {
+						return nil, fmt.Errorf("echo-context-to-field: expected JSON-string parameters, got %s: %w", config, err)
+					}
+					data["_context"] = ctxStr
+				}
+				out, err := json.Marshal(data)
+				if err != nil {
+					return nil, err
+				}
+				return &Entity{ID: entity.ID, State: entity.State, Data: out}, nil
+			},
 			"set-field": func(ctx context.Context, entity *Entity, config json.RawMessage) (*Entity, error) {
 				var cfg struct {
 					Field string `json:"field"`
@@ -122,6 +147,22 @@ func newCatalog() *catalog {
 			},
 			"select-standard": func(ctx context.Context, entity *Entity, config json.RawMessage) (bool, error) {
 				return true, nil
+			},
+			// context-equals — matches when the pass-through Context
+			// (delivered in EntityCriteriaCalculationRequest.parameters as a
+			// JSON string) equals the literal "match". Anything else
+			// (including a missing Context) returns false. Used by the
+			// workflow_externalization parity test to assert the criterion
+			// path forwards Context faithfully.
+			"context-equals": func(ctx context.Context, entity *Entity, config json.RawMessage) (bool, error) {
+				if len(config) == 0 {
+					return false, nil
+				}
+				var ctxStr string
+				if err := json.Unmarshal(config, &ctxStr); err != nil {
+					return false, fmt.Errorf("context-equals: expected JSON-string parameters, got %s: %w", config, err)
+				}
+				return ctxStr == "match", nil
 			},
 			"field-equals": func(ctx context.Context, entity *Entity, config json.RawMessage) (bool, error) {
 				var cfg struct {

--- a/cmd/compute-test-client/main_test.go
+++ b/cmd/compute-test-client/main_test.go
@@ -209,3 +209,79 @@ func TestCatalog_FieldEquals(t *testing.T) {
 		t.Error("field-equals: got true for non-matching value, want false")
 	}
 }
+
+// TestCatalog_EchoContextToField verifies the pass-through Context (delivered
+// as a JSON-string in parameters) is recorded into _context.
+func TestCatalog_EchoContextToField(t *testing.T) {
+	cat := newCatalog()
+	proc, ok := cat.processor("echo-context-to-field")
+	if !ok {
+		t.Fatal("echo-context-to-field processor not registered")
+	}
+
+	// Context present: a JSON-string config like `"premium"` ends up in _context.
+	out, err := proc(context.Background(), &Entity{ID: "e-1", Data: json.RawMessage(`{"k":1}`)}, json.RawMessage(`"premium"`))
+	if err != nil {
+		t.Fatalf("echo-context-to-field: %v", err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(out.Data, &data); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if data["_context"] != "premium" {
+		t.Errorf("expected _context=premium, got %v", data["_context"])
+	}
+
+	// Context absent: no _context field written.
+	out2, err := proc(context.Background(), &Entity{ID: "e-2", Data: json.RawMessage(`{"k":1}`)}, nil)
+	if err != nil {
+		t.Fatalf("echo-context-to-field (empty config): %v", err)
+	}
+	var data2 map[string]any
+	if err := json.Unmarshal(out2.Data, &data2); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if _, ok := data2["_context"]; ok {
+		t.Error("expected no _context field when config is empty")
+	}
+
+	// Malformed (non-string JSON) surfaces as an error.
+	if _, err := proc(context.Background(), &Entity{ID: "e-3", Data: json.RawMessage(`{"k":1}`)}, json.RawMessage(`{"role":"premium"}`)); err == nil {
+		t.Error("expected error for non-string JSON config")
+	}
+}
+
+// TestCatalog_ContextEquals verifies the context-equals criterion matches only
+// when the pass-through Context equals the literal "match".
+func TestCatalog_ContextEquals(t *testing.T) {
+	cat := newCatalog()
+	crit, ok := cat.criterion("context-equals")
+	if !ok {
+		t.Fatal("context-equals criterion not registered")
+	}
+
+	got, err := crit(context.Background(), &Entity{ID: "e-1"}, json.RawMessage(`"match"`))
+	if err != nil {
+		t.Fatalf("context-equals match: %v", err)
+	}
+	if !got {
+		t.Error("context-equals: expected true for context=\"match\"")
+	}
+
+	got, err = crit(context.Background(), &Entity{ID: "e-2"}, json.RawMessage(`"nope"`))
+	if err != nil {
+		t.Fatalf("context-equals nope: %v", err)
+	}
+	if got {
+		t.Error("context-equals: expected false for context=\"nope\"")
+	}
+
+	// No context: false.
+	got, err = crit(context.Background(), &Entity{ID: "e-3"}, nil)
+	if err != nil {
+		t.Fatalf("context-equals nil: %v", err)
+	}
+	if got {
+		t.Error("context-equals: expected false when context absent")
+	}
+}

--- a/cmd/cyoda/help/content/workflows.md
+++ b/cmd/cyoda/help/content/workflows.md
@@ -172,7 +172,7 @@ An invalid `executionMode` value is treated as `SYNC` / `ASYNC_SAME_TX` (the eng
 - `calculationNodesTags` — string — comma-separated tags for routing to registered calculation nodes; the engine selects a node that declares all required tags; returns `errors.NO_COMPUTE_MEMBER_FOR_TAG` if no node matches
 - `responseTimeoutMs` — int64 — timeout in milliseconds for `SYNC` processor response; `0` means use node default
 - `retryPolicy` — string — retry policy name (plugin/platform-defined); empty means no retry
-- `context` — string — arbitrary string forwarded to the processor as context metadata
+- `context` — string — pass-through string forwarded **verbatim** as the `parameters` JSON node of the outgoing `EntityProcessorCalculationRequest` (and `EntityCriteriaCalculationRequest` when used on a `function`-typed criterion's `config`). Marshalling shape is **pass-as-string**: the value is encoded as a JSON string, not parsed as JSON. The receiver gets a JSON-quoted string in `parameters`. Empty `context` causes `parameters` to be omitted entirely. Use to distinguish multiple workflow roles served by a single externalized processor or criterion implementation without registering a separate name per role.
 
 ## CRITERIA
 

--- a/docs/WORKFLOW_IMPORT_EXPORT_AUDIT.md
+++ b/docs/WORKFLOW_IMPORT_EXPORT_AUDIT.md
@@ -325,7 +325,7 @@ Verified via repository-wide grep of non-test code:
 | Field | OpenAPI / SPI | Consumed? |
 |---|---|---|
 | `ProcessorConfig.RetryPolicy` | `api/openapi.yaml:8619–8621`, `cyoda-go-spi@v0.7.1/types.go:152` | **No.** Only references are the generated DTO and the SPI struct. |
-| `ProcessorConfig.Context` | `api/openapi.yaml:8622–8624`, `types.go:153` | **No.** Same. |
+| `ProcessorConfig.Context` | `api/openapi.yaml:8622–8624`, `types.go:153` | **Resolved in v0.8.0.** Wired as a pass-through string into the dispatch `parameters` JSON node at `internal/grpc/dispatch.go:71, 221`. Historical analysis below retained for context. |
 | `ProcessorDefinition.Type` | `api/openapi.yaml:8674–8679`, `types.go:141` | **No.** Discriminator carried for parity, no engine branch uses it. |
 
 The other ProcessorConfig fields **are** consumed by the gRPC dispatcher
@@ -723,7 +723,7 @@ and the OpenAPI-generated DTO reference the field.
 | `ProcessorConfig.CalculationNodesTags` | USED (dispatcher) | `internal/grpc/dispatch.go:47, 187`; `internal/cluster/dispatch/cluster_dispatcher.go:65` |
 | `ProcessorConfig.ResponseTimeoutMs` | USED (dispatcher) | `internal/grpc/dispatch.go:104, 248` (defaults to 30 s) |
 | `ProcessorConfig.RetryPolicy` | DEAD | no consumer |
-| `ProcessorConfig.Context` | DEAD | no consumer |
+| `ProcessorConfig.Context` | USED (dispatcher) | `internal/grpc/dispatch.go:71, 221` — pass-through string forwarded as `parameters` JSON node; resolved in v0.8.0 |
 | `ProcessorConfig.StartNewTxOnDispatch` | USED | `engine_processors.go:205` (only when COMMIT_BEFORE_DISPATCH; validated by `validate.go:51`) |
 
 The dispatcher consumption matters: every claim about a "dead" config field

--- a/e2e/parity/externalapi/workflow_externalization.go
+++ b/e2e/parity/externalapi/workflow_externalization.go
@@ -62,6 +62,7 @@ func init() {
 		parity.NamedTest{Name: "ExternalAPI_09_12_ExternalizedCriterionSkipsCall", Fn: RunExternalAPI_09_12_ExternalizedCriterionSkipsCall},
 		parity.NamedTest{Name: "ExternalAPI_09_13_ProcessorContextPassesThrough", Fn: RunExternalAPI_09_13_ProcessorContextPassesThrough},
 		parity.NamedTest{Name: "ExternalAPI_09_14_CriterionContextPassesThrough", Fn: RunExternalAPI_09_14_CriterionContextPassesThrough},
+		parity.NamedTest{Name: "ExternalAPI_09_15_CriterionContextNegative", Fn: RunExternalAPI_09_15_CriterionContextNegative},
 	)
 }
 
@@ -358,8 +359,9 @@ func RunExternalAPI_09_12_ExternalizedCriterionSkipsCall(t *testing.T, fixture p
 
 // externalProcessorWorkflowWithContext returns a workflow whose
 // CREATED→PROCESSED transition carries a single externalized processor with
-// the given pass-through context string. Used by the issue-253 parity test
-// to observe ProcessorConfig.context surfacing at the calculation member.
+// the given pass-through context string. Used by the context pass-through
+// parity test to observe ProcessorConfig.context surfacing at the
+// calculation member.
 func externalProcessorWorkflowWithContext(workflowName, procName, contextValue string) string {
 	return `{
 		"importMode": "REPLACE",
@@ -412,15 +414,34 @@ func RunExternalAPI_09_13_ProcessorContextPassesThrough(t *testing.T, fixture pa
 	}
 }
 
+// criterionContextWorkflow returns a workflow whose CREATED→PROCESSED
+// auto-transition is guarded by a context-equals criterion configured with
+// the supplied context string. The criterion matches only when the engine
+// forwards the context value verbatim as the request's `parameters` node
+// AND the value equals the literal "match".
+func criterionContextWorkflow(workflowName, contextValue string) string {
+	return `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1", "name": "` + workflowName + `", "initialState": "CREATED", "active": true,
+			"states": {
+				"CREATED": {"transitions": [{"name": "process", "next": "PROCESSED", "manual": false,
+					"criterion": {"type": "function", "function": {"name": "context-equals",
+						"config": {"calculationNodesTags": "", "context": "` + contextValue + `"}}}
+				}]},
+				"PROCESSED": {}
+			}
+		}]
+	}`
+}
+
 // RunExternalAPI_09_14_CriterionContextPassesThrough
 //
 // FunctionCondition.config.context follows the same pass-through-string rule
 // as the processor path. The context-equals criterion returns true only when
-// the parameters string equals "match". Two workflows on the same model are
-// not supported by the current external-criterion plumbing, so we exercise the
-// positive case (context="match" → transition fires → entity at PROCESSED)
-// here; the negative case is covered indirectly by 09/12 and the unit test
-// TestDispatchCriteria_EmptyContextOmitsParameters.
+// the dispatched parameters string equals "match". With context="match" the
+// transition fires and the entity reaches PROCESSED — the negative case is
+// covered by 09/15 below.
 func RunExternalAPI_09_14_CriterionContextPassesThrough(t *testing.T, fixture parity.BackendFixture) {
 	t.Helper()
 	tenant := fixture.ComputeTenant(t)
@@ -428,20 +449,7 @@ func RunExternalAPI_09_14_CriterionContextPassesThrough(t *testing.T, fixture pa
 
 	const modelName = "extCtxCrit"
 	const modelVersion = 1
-	wf := `{
-		"importMode": "REPLACE",
-		"workflows": [{
-			"version": "1", "name": "ext-ctx-crit-wf", "initialState": "CREATED", "active": true,
-			"states": {
-				"CREATED": {"transitions": [{"name": "process", "next": "PROCESSED", "manual": false,
-					"criterion": {"type": "function", "function": {"name": "context-equals",
-						"config": {"calculationNodesTags": "", "context": "match"}}}
-				}]},
-				"PROCESSED": {}
-			}
-		}]
-	}`
-	setupExternalModel(t, c, modelName, modelVersion, `{"k":1}`, wf)
+	setupExternalModel(t, c, modelName, modelVersion, `{"k":1}`, criterionContextWorkflow("ext-ctx-crit-wf", "match"))
 
 	id, err := c.CreateEntity(t, modelName, modelVersion, `{"k":1}`)
 	if err != nil {
@@ -453,6 +461,36 @@ func RunExternalAPI_09_14_CriterionContextPassesThrough(t *testing.T, fixture pa
 	}
 	if got.Meta.State != "PROCESSED" {
 		t.Errorf("expected state PROCESSED (criterion context=\"match\" → transition fires); got %s — Context not passed through to criterion", got.Meta.State)
+	}
+}
+
+// RunExternalAPI_09_15_CriterionContextNegative
+//
+// Mirror of 09_14 with a non-matching context. context-equals returns false,
+// the auto-transition does not fire, and the entity stays at CREATED. This
+// proves end-to-end that the engine actually forwards the configured context
+// value — not that context-equals coincidentally returns true (which is what
+// the positive case alone could be explained by if the dispatcher passed an
+// arbitrary or hard-coded payload).
+func RunExternalAPI_09_15_CriterionContextNegative(t *testing.T, fixture parity.BackendFixture) {
+	t.Helper()
+	tenant := fixture.ComputeTenant(t)
+	c := parityclient.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "extCtxCritNeg"
+	const modelVersion = 1
+	setupExternalModel(t, c, modelName, modelVersion, `{"k":1}`, criterionContextWorkflow("ext-ctx-crit-neg-wf", "no-match"))
+
+	id, err := c.CreateEntity(t, modelName, modelVersion, `{"k":1}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	if got.Meta.State != "CREATED" {
+		t.Errorf("expected state CREATED (criterion context=\"no-match\" → transition does not fire); got %s — engine may be forwarding a wrong/empty context value or context-equals received unexpected input", got.Meta.State)
 	}
 }
 

--- a/e2e/parity/externalapi/workflow_externalization.go
+++ b/e2e/parity/externalapi/workflow_externalization.go
@@ -378,13 +378,12 @@ func externalProcessorWorkflowWithContext(workflowName, procName, contextValue s
 	}`
 }
 
-// RunExternalAPI_09_13_ProcessorContextPassesThrough
-//
-// ProcessorConfig.context is a pass-through string forwarded verbatim as the
-// `parameters` JSON node of EntityProcessorCalculationRequest. The
-// echo-context-to-field processor records the received parameters string at
-// entity.data._context. We assert the value round-trips through the engine
-// dispatcher to the calculation member faithfully.
+// RunExternalAPI_09_13_ProcessorContextPassesThrough — ProcessorConfig.context
+// is a pass-through string forwarded verbatim as the `parameters` JSON node of
+// EntityProcessorCalculationRequest. The echo-context-to-field processor
+// records the received parameters string at entity.data._context. We assert
+// the value round-trips through the engine dispatcher to the calculation
+// member faithfully.
 func RunExternalAPI_09_13_ProcessorContextPassesThrough(t *testing.T, fixture parity.BackendFixture) {
 	t.Helper()
 	tenant := fixture.ComputeTenant(t)
@@ -435,13 +434,11 @@ func criterionContextWorkflow(workflowName, contextValue string) string {
 	}`
 }
 
-// RunExternalAPI_09_14_CriterionContextPassesThrough
-//
-// FunctionCondition.config.context follows the same pass-through-string rule
-// as the processor path. The context-equals criterion returns true only when
-// the dispatched parameters string equals "match". With context="match" the
-// transition fires and the entity reaches PROCESSED — the negative case is
-// covered by 09/15 below.
+// RunExternalAPI_09_14_CriterionContextPassesThrough — FunctionCondition.config.context
+// follows the same pass-through-string rule as the processor path. The
+// context-equals criterion returns true only when the dispatched parameters
+// string equals "match". With context="match" the transition fires and the
+// entity reaches PROCESSED — the negative case is covered by 09/15 below.
 func RunExternalAPI_09_14_CriterionContextPassesThrough(t *testing.T, fixture parity.BackendFixture) {
 	t.Helper()
 	tenant := fixture.ComputeTenant(t)
@@ -464,14 +461,13 @@ func RunExternalAPI_09_14_CriterionContextPassesThrough(t *testing.T, fixture pa
 	}
 }
 
-// RunExternalAPI_09_15_CriterionContextNegative
-//
-// Mirror of 09_14 with a non-matching context. context-equals returns false,
-// the auto-transition does not fire, and the entity stays at CREATED. This
-// proves end-to-end that the engine actually forwards the configured context
-// value — not that context-equals coincidentally returns true (which is what
-// the positive case alone could be explained by if the dispatcher passed an
-// arbitrary or hard-coded payload).
+// RunExternalAPI_09_15_CriterionContextNegative — mirror of 09_14 with a
+// non-matching context. context-equals returns false, the auto-transition
+// does not fire, and the entity stays at CREATED. This proves end-to-end
+// that the engine actually forwards the configured context value — not that
+// context-equals coincidentally returns true (which is what the positive
+// case alone could be explained by if the dispatcher passed an arbitrary or
+// hard-coded payload).
 func RunExternalAPI_09_15_CriterionContextNegative(t *testing.T, fixture parity.BackendFixture) {
 	t.Helper()
 	tenant := fixture.ComputeTenant(t)

--- a/e2e/parity/externalapi/workflow_externalization.go
+++ b/e2e/parity/externalapi/workflow_externalization.go
@@ -28,9 +28,9 @@ package externalapi
 //
 // Compute-test-client catalog (cmd/compute-test-client/catalog.go):
 //   processors: noop, tag-with-foo, bump-amount, inject-error,
-//               slow-configurable, set-field
+//               slow-configurable, set-field, echo-context-to-field
 //   criteria:   always-true, always-false, amount-gt-100, select-premium,
-//               select-standard, field-equals
+//               select-standard, field-equals, context-equals
 //
 // The catalog has no warning/error-flag processor — adding one would
 // require extending processorFunc to expose the gRPC ProcessorResponse
@@ -60,6 +60,8 @@ func init() {
 		parity.NamedTest{Name: "ExternalAPI_09_10_ExternalTimeoutFailover", Fn: RunExternalAPI_09_10_ExternalTimeoutFailover},
 		parity.NamedTest{Name: "ExternalAPI_09_11_ProcessingNodeDisconnectsMidRequest", Fn: RunExternalAPI_09_11_ProcessingNodeDisconnectsMidRequest},
 		parity.NamedTest{Name: "ExternalAPI_09_12_ExternalizedCriterionSkipsCall", Fn: RunExternalAPI_09_12_ExternalizedCriterionSkipsCall},
+		parity.NamedTest{Name: "ExternalAPI_09_13_ProcessorContextPassesThrough", Fn: RunExternalAPI_09_13_ProcessorContextPassesThrough},
+		parity.NamedTest{Name: "ExternalAPI_09_14_CriterionContextPassesThrough", Fn: RunExternalAPI_09_14_CriterionContextPassesThrough},
 	)
 }
 
@@ -351,6 +353,106 @@ func RunExternalAPI_09_12_ExternalizedCriterionSkipsCall(t *testing.T, fixture p
 	}
 	if got.Meta.State != "CREATED" {
 		t.Errorf("09/12: expected entity at CREATED (criterion=always-false → transition not taken), got %s", got.Meta.State)
+	}
+}
+
+// externalProcessorWorkflowWithContext returns a workflow whose
+// CREATED→PROCESSED transition carries a single externalized processor with
+// the given pass-through context string. Used by the issue-253 parity test
+// to observe ProcessorConfig.context surfacing at the calculation member.
+func externalProcessorWorkflowWithContext(workflowName, procName, contextValue string) string {
+	return `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1", "name": "` + workflowName + `", "initialState": "CREATED", "active": true,
+			"states": {
+				"CREATED": {"transitions": [{"name": "process", "next": "PROCESSED", "manual": false,
+					"processors": [{"type": "calculator", "name": "` + procName + `", "executionMode": "SYNC",
+						"config": {"attachEntity": true, "calculationNodesTags": "", "context": "` + contextValue + `"}}]
+				}]},
+				"PROCESSED": {}
+			}
+		}]
+	}`
+}
+
+// RunExternalAPI_09_13_ProcessorContextPassesThrough
+//
+// ProcessorConfig.context is a pass-through string forwarded verbatim as the
+// `parameters` JSON node of EntityProcessorCalculationRequest. The
+// echo-context-to-field processor records the received parameters string at
+// entity.data._context. We assert the value round-trips through the engine
+// dispatcher to the calculation member faithfully.
+func RunExternalAPI_09_13_ProcessorContextPassesThrough(t *testing.T, fixture parity.BackendFixture) {
+	t.Helper()
+	tenant := fixture.ComputeTenant(t)
+	c := parityclient.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "extCtxProc"
+	const modelVersion = 1
+	const contextValue = "premium-role"
+	wf := externalProcessorWorkflowWithContext("ext-ctx-proc-wf", "echo-context-to-field", contextValue)
+	setupExternalModel(t, c, modelName, modelVersion, `{"k":1}`, wf)
+
+	id, err := c.CreateEntity(t, modelName, modelVersion, `{"k":1}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	if got.Meta.State != "PROCESSED" {
+		t.Fatalf("expected state PROCESSED, got %s", got.Meta.State)
+	}
+	if v, ok := got.Data["_context"]; !ok {
+		t.Errorf("expected entity.data._context to be populated by echo-context-to-field (data=%+v)", got.Data)
+	} else if v != contextValue {
+		t.Errorf("expected entity.data._context=%q, got %q (processor saw mismatched parameters — Context not passed through)", contextValue, v)
+	}
+}
+
+// RunExternalAPI_09_14_CriterionContextPassesThrough
+//
+// FunctionCondition.config.context follows the same pass-through-string rule
+// as the processor path. The context-equals criterion returns true only when
+// the parameters string equals "match". Two workflows on the same model are
+// not supported by the current external-criterion plumbing, so we exercise the
+// positive case (context="match" → transition fires → entity at PROCESSED)
+// here; the negative case is covered indirectly by 09/12 and the unit test
+// TestDispatchCriteria_EmptyContextOmitsParameters.
+func RunExternalAPI_09_14_CriterionContextPassesThrough(t *testing.T, fixture parity.BackendFixture) {
+	t.Helper()
+	tenant := fixture.ComputeTenant(t)
+	c := parityclient.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "extCtxCrit"
+	const modelVersion = 1
+	wf := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1", "name": "ext-ctx-crit-wf", "initialState": "CREATED", "active": true,
+			"states": {
+				"CREATED": {"transitions": [{"name": "process", "next": "PROCESSED", "manual": false,
+					"criterion": {"type": "function", "function": {"name": "context-equals",
+						"config": {"calculationNodesTags": "", "context": "match"}}}
+				}]},
+				"PROCESSED": {}
+			}
+		}]
+	}`
+	setupExternalModel(t, c, modelName, modelVersion, `{"k":1}`, wf)
+
+	id, err := c.CreateEntity(t, modelName, modelVersion, `{"k":1}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	if got.Meta.State != "PROCESSED" {
+		t.Errorf("expected state PROCESSED (criterion context=\"match\" → transition fires); got %s — Context not passed through to criterion", got.Meta.State)
 	}
 }
 

--- a/internal/grpc/dispatch.go
+++ b/internal/grpc/dispatch.go
@@ -65,6 +65,12 @@ func (d *ProcessorDispatcher) DispatchProcessor(ctx context.Context, entity *spi
 		TransactionID: &txID,
 		Success:       true,
 	}
+	// ProcessorConfig.Context is a pass-through string surfaced verbatim in
+	// the request's parameters node. One processor implementation can serve
+	// multiple workflow roles distinguished by Context.
+	if processor.Config.Context != "" {
+		req.Parameters = processor.Config.Context
+	}
 	if processor.Config.AttachEntity {
 		versionInt := 0
 		fmt.Sscanf(entity.Meta.ModelRef.ModelVersion, "%d", &versionInt)
@@ -171,6 +177,9 @@ func (d *ProcessorDispatcher) DispatchCriteria(ctx context.Context, entity *spi.
 				CalculationNodesTags string `json:"calculationNodesTags"`
 				AttachEntity         *bool  `json:"attachEntity"` // nil = default true
 				ResponseTimeoutMs    int64  `json:"responseTimeoutMs"`
+				// Context — pass-through string surfaced verbatim in the
+				// request's parameters node.
+				Context string `json:"context"`
 			} `json:"config"`
 		} `json:"function"`
 	}
@@ -208,6 +217,9 @@ func (d *ProcessorDispatcher) DispatchCriteria(ctx context.Context, entity *spi.
 	}
 	if processorName != "" {
 		req.Processor = &events.ProcessorInfoJson{Name: processorName}
+	}
+	if parsed.Function.Config.Context != "" {
+		req.Parameters = parsed.Function.Config.Context
 	}
 	if attachEntity {
 		versionInt := 0

--- a/internal/grpc/dispatch_test.go
+++ b/internal/grpc/dispatch_test.go
@@ -342,3 +342,221 @@ func TestDispatchCriteria_MatchesFalse(t *testing.T) {
 		t.Error("expected matches=false")
 	}
 }
+
+// extractParameters returns the "parameters" field of the request payload as a
+// raw JSON value (or nil if absent). Cloud's contract for ProcessorConfig.context
+// is pass-as-string into the request's parameters node — see
+// docs/WORKFLOW_IMPORT_EXPORT_AUDIT.md §M1 and api/grpc/events/types.go:822, 2403.
+func extractParameters(ce *cepb.CloudEvent) (json.RawMessage, bool, error) {
+	_, payload, err := ParseCloudEvent(ce)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to parse cloud event: %w", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &m); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal payload: %w", err)
+	}
+	raw, ok := m["parameters"]
+	if !ok {
+		return nil, false, nil
+	}
+	return raw, true, nil
+}
+
+// TestDispatchProcessor_ContextSurfacesAsParametersString
+// processor.Config.Context is a pass-through string. When non-empty, the
+// dispatcher must place it verbatim into the request's `parameters` JSON node
+// so a single external processor implementation can serve multiple workflow
+// roles distinguished by the context value.
+func TestDispatchProcessor_ContextSurfacesAsParametersString(t *testing.T) {
+	dispatcher, registry, memberID, sentCh := setupTestDispatcher(t)
+	ctx := testContext()
+	entity := testEntity()
+
+	const ctxValue = `{"role":"premium-approver"}`
+	processor := spi.ProcessorDefinition{
+		Name: "my-proc",
+		Config: spi.ProcessorConfig{
+			AttachEntity:         false,
+			CalculationNodesTags: "python",
+			ResponseTimeoutMs:    5000,
+			Context:              ctxValue,
+		},
+	}
+
+	go func() {
+		ce := <-sentCh
+		reqID, err := extractRequestID(ce)
+		if err != nil {
+			t.Errorf("extractRequestID: %v", err)
+			return
+		}
+
+		raw, present, err := extractParameters(ce)
+		if err != nil {
+			t.Errorf("extractParameters: %v", err)
+			return
+		}
+		if !present {
+			t.Error("expected parameters field to be present when Context is set")
+		} else {
+			var got string
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Errorf("expected parameters to be a JSON string, got %s: %v", raw, err)
+			} else if got != ctxValue {
+				t.Errorf("expected parameters=%q, got %q", ctxValue, got)
+			}
+		}
+
+		// Also assert via the generated typed schema decodes cleanly with the
+		// string-shaped parameters (Parameters is interface{}).
+		_, payload, _ := ParseCloudEvent(ce)
+		var typed events.EntityProcessorCalculationRequestJson
+		if err := json.Unmarshal(payload, &typed); err != nil {
+			t.Errorf("sent processor request does not match schema: %v", err)
+		} else if s, ok := typed.Parameters.(string); !ok || s != ctxValue {
+			t.Errorf("expected typed.Parameters as string %q, got %T %v", ctxValue, typed.Parameters, typed.Parameters)
+		}
+
+		member := registry.Get(memberID)
+		member.CompleteRequest(reqID, &ProcessingResponse{Success: true})
+	}()
+
+	if _, err := dispatcher.DispatchProcessor(ctx, entity, processor, "wf1", "t1", "tx-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestDispatchProcessor_EmptyContextOmitsParameters
+// When Context is the zero value, dispatcher must omit parameters entirely
+// (no `"parameters":null` and no empty string) so existing requests on the
+// wire are unchanged. The `parameters` field carries `omitempty` for that reason.
+func TestDispatchProcessor_EmptyContextOmitsParameters(t *testing.T) {
+	dispatcher, registry, memberID, sentCh := setupTestDispatcher(t)
+	ctx := testContext()
+	entity := testEntity()
+
+	processor := spi.ProcessorDefinition{
+		Name: "my-proc",
+		Config: spi.ProcessorConfig{
+			CalculationNodesTags: "python",
+			ResponseTimeoutMs:    5000,
+			// Context deliberately empty.
+		},
+	}
+
+	go func() {
+		ce := <-sentCh
+		reqID, err := extractRequestID(ce)
+		if err != nil {
+			t.Errorf("extractRequestID: %v", err)
+			return
+		}
+		if _, present, err := extractParameters(ce); err != nil {
+			t.Errorf("extractParameters: %v", err)
+		} else if present {
+			t.Error("expected parameters field to be omitted when Context is empty")
+		}
+		member := registry.Get(memberID)
+		member.CompleteRequest(reqID, &ProcessingResponse{Success: true})
+	}()
+
+	if _, err := dispatcher.DispatchProcessor(ctx, entity, processor, "wf1", "t1", "tx-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestDispatchCriteria_ContextSurfacesAsParametersString
+// FunctionCondition.config.context follows the same pass-through-string rule
+// as the processor path. The criterion JSON shape carries the function wrapper
+// emitted by the engine's evaluateCriterion routing.
+func TestDispatchCriteria_ContextSurfacesAsParametersString(t *testing.T) {
+	dispatcher, registry, memberID, sentCh := setupTestDispatcher(t)
+	ctx := testContext()
+	entity := testEntity()
+
+	const ctxValue = `gold-tier`
+	criterion := json.RawMessage(`{
+		"type": "function",
+		"function": {
+			"name": "my-criteria",
+			"config": {
+				"calculationNodesTags": "python",
+				"responseTimeoutMs": 5000,
+				"context": "` + ctxValue + `"
+			}
+		}
+	}`)
+
+	go func() {
+		ce := <-sentCh
+		reqID, err := extractRequestID(ce)
+		if err != nil {
+			t.Errorf("extractRequestID: %v", err)
+			return
+		}
+
+		raw, present, err := extractParameters(ce)
+		if err != nil {
+			t.Errorf("extractParameters: %v", err)
+			return
+		}
+		if !present {
+			t.Error("expected parameters field to be present when criterion context is set")
+		} else {
+			var got string
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Errorf("expected parameters to be a JSON string, got %s: %v", raw, err)
+			} else if got != ctxValue {
+				t.Errorf("expected parameters=%q, got %q", ctxValue, got)
+			}
+		}
+
+		matchesTrue := true
+		member := registry.Get(memberID)
+		member.CompleteRequest(reqID, &ProcessingResponse{Success: true, Matches: &matchesTrue})
+	}()
+
+	if _, err := dispatcher.DispatchCriteria(ctx, entity, criterion, "transition", "wf1", "t1", "proc1", "tx-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestDispatchCriteria_EmptyContextOmitsParameters
+func TestDispatchCriteria_EmptyContextOmitsParameters(t *testing.T) {
+	dispatcher, registry, memberID, sentCh := setupTestDispatcher(t)
+	ctx := testContext()
+	entity := testEntity()
+
+	criterion := json.RawMessage(`{
+		"type": "function",
+		"function": {
+			"name": "my-criteria",
+			"config": {
+				"calculationNodesTags": "python",
+				"responseTimeoutMs": 5000
+			}
+		}
+	}`)
+
+	go func() {
+		ce := <-sentCh
+		reqID, err := extractRequestID(ce)
+		if err != nil {
+			t.Errorf("extractRequestID: %v", err)
+			return
+		}
+		if _, present, err := extractParameters(ce); err != nil {
+			t.Errorf("extractParameters: %v", err)
+		} else if present {
+			t.Error("expected parameters field to be omitted when criterion context is empty")
+		}
+		matchesTrue := true
+		member := registry.Get(memberID)
+		member.CompleteRequest(reqID, &ProcessingResponse{Success: true, Matches: &matchesTrue})
+	}()
+
+	if _, err := dispatcher.DispatchCriteria(ctx, entity, criterion, "transition", "wf1", "t1", "proc1", "tx-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/grpc/dispatch_test.go
+++ b/internal/grpc/dispatch_test.go
@@ -363,11 +363,11 @@ func extractParameters(ce *cepb.CloudEvent) (json.RawMessage, bool, error) {
 	return raw, true, nil
 }
 
-// TestDispatchProcessor_ContextSurfacesAsParametersString
-// processor.Config.Context is a pass-through string. When non-empty, the
-// dispatcher must place it verbatim into the request's `parameters` JSON node
-// so a single external processor implementation can serve multiple workflow
-// roles distinguished by the context value.
+// TestDispatchProcessor_ContextSurfacesAsParametersString verifies that
+// processor.Config.Context, when non-empty, is placed verbatim into the
+// request's `parameters` JSON node so a single external processor
+// implementation can serve multiple workflow roles distinguished by the
+// context value.
 func TestDispatchProcessor_ContextSurfacesAsParametersString(t *testing.T) {
 	dispatcher, registry, memberID, sentCh := setupTestDispatcher(t)
 	ctx := testContext()
@@ -427,10 +427,10 @@ func TestDispatchProcessor_ContextSurfacesAsParametersString(t *testing.T) {
 	}
 }
 
-// TestDispatchProcessor_EmptyContextOmitsParameters
-// When Context is the zero value, dispatcher must omit parameters entirely
-// (no `"parameters":null` and no empty string) so existing requests on the
-// wire are unchanged. The `parameters` field carries `omitempty` for that reason.
+// TestDispatchProcessor_EmptyContextOmitsParameters verifies that when
+// Context is the zero value the dispatcher omits parameters entirely (no
+// `"parameters":null` and no empty string) so existing requests on the wire
+// are unchanged. The `parameters` field carries `omitempty` for that reason.
 func TestDispatchProcessor_EmptyContextOmitsParameters(t *testing.T) {
 	dispatcher, registry, memberID, sentCh := setupTestDispatcher(t)
 	ctx := testContext()
@@ -466,10 +466,10 @@ func TestDispatchProcessor_EmptyContextOmitsParameters(t *testing.T) {
 	}
 }
 
-// TestDispatchCriteria_ContextSurfacesAsParametersString
+// TestDispatchCriteria_ContextSurfacesAsParametersString verifies that
 // FunctionCondition.config.context follows the same pass-through-string rule
-// as the processor path. The criterion JSON shape carries the function wrapper
-// emitted by the engine's evaluateCriterion routing.
+// as the processor path. The criterion JSON shape carries the function
+// wrapper emitted by the engine's evaluateCriterion routing.
 func TestDispatchCriteria_ContextSurfacesAsParametersString(t *testing.T) {
 	dispatcher, registry, memberID, sentCh := setupTestDispatcher(t)
 	ctx := testContext()
@@ -522,7 +522,9 @@ func TestDispatchCriteria_ContextSurfacesAsParametersString(t *testing.T) {
 	}
 }
 
-// TestDispatchCriteria_EmptyContextOmitsParameters
+// TestDispatchCriteria_EmptyContextOmitsParameters verifies that an absent
+// or empty criterion context omits the request's parameters field — mirror
+// of TestDispatchProcessor_EmptyContextOmitsParameters for the criteria path.
 func TestDispatchCriteria_EmptyContextOmitsParameters(t *testing.T) {
 	dispatcher, registry, memberID, sentCh := setupTestDispatcher(t)
 	ctx := testContext()


### PR DESCRIPTION
Closes #253.

## What changed

`ProcessorConfig.Context` (and `FunctionCondition.config.context` on externalized criteria) was a documented OpenAPI/SPI field with **zero consumers** in the codebase — surfaced by the workflow import/export audit at `docs/WORKFLOW_IMPORT_EXPORT_AUDIT.md` §M1 special case 1.

This PR wires it. When non-empty, `Context` is forwarded **verbatim** as the JSON-string `parameters` node of the outgoing `EntityProcessorCalculationRequest` / `EntityCriteriaCalculationRequest`. Empty context omits `parameters` entirely.

## Why pass-as-string

Per the issue's recommended default:

- Matches the SPI type (`string`)
- No JSON-validation surprises at dispatch time
- The receiving side already has `Parameters interface{}`, so the wire shape is `"parameters": "<context-string>"` — the consumer unmarshals the JSON-quoted string and uses it as a role discriminator.

Documented on both `ExternalizedProcessorConfigDto.context` and `ExternalizedFunctionConfigDto.context` in `api/openapi.yaml`, and in the workflows help topic.

## Scope

- `internal/grpc/dispatch.go` — assign `Context` to `req.Parameters` in `DispatchProcessor` and `DispatchCriteria`; extend the criterion parser to read `function.config.context`.
- `internal/grpc/dispatch_test.go` — 4 RED→GREEN unit tests covering present/empty on each path, with a typed-schema decode check that asserts string-shaped `Parameters` round-trips through the generated DTO.
- `cmd/compute-test-client/{catalog.go,main_test.go}` — add `echo-context-to-field` processor and `context-equals` criterion so the parity tier can observe the pass-through value at the calculation-member side.
- `e2e/parity/externalapi/workflow_externalization.go` — two new parity scenarios:
  - `ExternalAPI_09_13_ProcessorContextPassesThrough` — processor path
  - `ExternalAPI_09_14_CriterionContextPassesThrough` — criterion path
- `api/openapi.yaml` + `cmd/cyoda/help/content/workflows.md` — document pass-as-string contract.

## Execution-mode coverage

Per the acceptance criteria, the Context wire is set at request construction independent of `ExecutionMode` — SYNC, ASYNC_SAME_TX, ASYNC_NEW_TX, and COMMIT_BEFORE_DISPATCH all reach the same dispatch path. The unit tests cover the wire-construction; the parity test exercises SYNC end-to-end through the engine.

## Verification

- ✅ `go vet ./...` clean
- ✅ `go test -short ./...` clean
- ✅ `make test-short-all` clean across all plugin submodules
- ✅ `go test ./internal/e2e/...` clean (52s, full HTTP stack)
- ✅ Parity backends green: memory (13s), sqlite (12s), postgres (22s)
- ✅ `go test -race` on `internal/grpc/`, `cmd/compute-test-client/`, and `e2e/parity/memory/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)