### PR TITLE
feat(workflow): scheduled-transition configuration shape + SPI

### DIFF
--- a/api/generated.go
+++ b/api/generated.go
@@ -2866,9 +2866,13 @@ type TransitionDefinitionDto struct {
 	// Processors List of processors to execute for this transition
 	Processors *[]TransitionDefinitionDto_Processors_Item `json:"processors,omitempty"`
 
-	// Schedule Optional scheduling configuration. Presence marks the transition as
-	// scheduled; mutually exclusive with manual=true. Runtime not yet
-	// implemented — see TransitionScheduleDto for engine behaviour.
+	// Schedule Optional scheduling configuration. Presence marks the transition
+	// as scheduled — it fires automatically `delayMs` milliseconds
+	// after the entity enters the source state. Mutually exclusive
+	// with `manual=true`. The runtime scheduler is not yet
+	// implemented; until it ships, the engine silently skips
+	// scheduled transitions during automated cascade selection, and
+	// explicit fires by name return HTTP 400 `TRANSITION_NOT_FOUND`.
 	Schedule *TransitionScheduleDto `json:"schedule,omitempty"`
 }
 

--- a/api/generated.go
+++ b/api/generated.go
@@ -22,6 +22,33 @@ const (
 	BearerAuthScopes bearerAuthContextKey = "bearerAuth.Scopes"
 )
 
+// Defines values for AggregateOp.
+const (
+	Avg   AggregateOp = "avg"
+	Max   AggregateOp = "max"
+	Min   AggregateOp = "min"
+	Stdev AggregateOp = "stdev"
+	Sum   AggregateOp = "sum"
+)
+
+// Valid indicates whether the value is a known member of the AggregateOp enum.
+func (e AggregateOp) Valid() bool {
+	switch e {
+	case Avg:
+		return true
+	case Max:
+		return true
+	case Min:
+		return true
+	case Stdev:
+		return true
+	case Sum:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ArrayConditionDtoOperatorType.
 const (
 	ArrayConditionDtoOperatorTypeAND                 ArrayConditionDtoOperatorType = "AND"
@@ -1650,6 +1677,21 @@ type AbstractConditionDto struct {
 	Type string `json:"type"`
 }
 
+// AggregateOp Aggregation operator. `sum`, `avg`, `min`, `max`, and `stdev` apply to scalar numeric fields; non-numeric or missing values are skipped per spec §3 (D4 semantics — see grouped-stats design doc).
+type AggregateOp string
+
+// AggregationExpr One requested aggregation. `field` is a JSONPath into the entity payload. `as` is an optional alias for the result key in the bucket's `aggregations` map; when omitted, the alias defaults to `op(field)` (e.g. `sum($.amount)`).
+type AggregationExpr struct {
+	// As Optional result alias.
+	As *string `json:"as,omitempty"`
+
+	// Field JSONPath of the field to aggregate (e.g. `$.amount`).
+	Field string `json:"field"`
+
+	// Op Aggregation operator. `sum`, `avg`, `min`, `max`, and `stdev` apply to scalar numeric fields; non-numeric or missing values are skipped per spec §3 (D4 semantics — see grouped-stats design doc).
+	Op AggregateOp `json:"op"`
+}
+
 // ArrayConditionDto defines model for ArrayConditionDto.
 type ArrayConditionDto struct {
 	JsonPath     *string                        `json:"jsonPath,omitempty"`
@@ -2057,7 +2099,13 @@ type ExternalizedFunctionConfigDto struct {
 	// CalculationNodesTags Comma-separated list of calculation node tags
 	CalculationNodesTags *string `json:"calculationNodesTags,omitempty"`
 
-	// Context Additional context for the function
+	// Context Pass-through string forwarded verbatim as the `parameters` JSON
+	// node of the outgoing `EntityCriteriaCalculationRequest`. The value
+	// is encoded as a JSON string (pass-as-string); the receiver gets a
+	// JSON-quoted string in `parameters`. Empty value causes the
+	// `parameters` field to be omitted entirely. Use to distinguish
+	// multiple workflow roles served by a single externalized criterion
+	// implementation without registering a separate name per role.
 	Context *string `json:"context,omitempty"`
 
 	// ResponseTimeoutMs Response timeout in milliseconds
@@ -2092,7 +2140,13 @@ type ExternalizedProcessorConfigDto struct {
 	// CalculationNodesTags Comma-separated list of calculation node tags
 	CalculationNodesTags *string `json:"calculationNodesTags,omitempty"`
 
-	// Context Additional context for the function
+	// Context Pass-through string forwarded verbatim as the `parameters` JSON
+	// node of the outgoing `EntityProcessorCalculationRequest`. The
+	// value is encoded as a JSON string (pass-as-string); the receiver
+	// gets a JSON-quoted string in `parameters`. Empty value causes the
+	// `parameters` field to be omitted entirely. Use to distinguish
+	// multiple workflow roles served by a single externalized processor
+	// implementation without registering a separate name per role.
 	Context *string `json:"context,omitempty"`
 
 	// CrossoverToAsyncMs Crossover delay to switch to asynchronous processing (ms),
@@ -2180,6 +2234,50 @@ type GroupConditionDto_Conditions_Item struct {
 
 // GroupConditionDtoOperator defines model for GroupConditionDto.Operator.
 type GroupConditionDtoOperator string
+
+// GroupKeyEntry One (path, value) pair in a bucket's ordered group key. `path` echoes the corresponding `groupBy` dimension; `value` is the observed value (any JSON scalar) or `null` when the field is absent or non-scalar (D4 semantics).
+type GroupKeyEntry struct {
+	// Path Group-by dimension (echoes the request entry).
+	Path string `json:"path"`
+
+	// Value Observed value for this dimension, or null.
+	Value interface{} `json:"value"`
+}
+
+// GroupedStatsBucket One row of the grouped-stats result. `groupKey` is ordered to match the request's `groupBy` list. `aggregations` is omitted when the request specified no aggregations; otherwise each requested aggregation appears keyed by its alias (or `op(field)` default), with `null` for empty groups.
+type GroupedStatsBucket struct {
+	// Aggregations Per-alias aggregation results. Values are numeric or `null` (when the aggregation has no eligible inputs). Absent when the request specified no aggregations.
+	Aggregations *map[string]*float32 `json:"aggregations,omitempty"`
+
+	// Count Number of entities in this group.
+	Count int64 `json:"count"`
+
+	// GroupKey Ordered group-key entries matching the request's `groupBy`.
+	GroupKey []GroupKeyEntry `json:"groupKey"`
+}
+
+// GroupedStatsRequest Request body for the grouped-stats query endpoint. `groupBy` dimensions may be either the literal string `state` (the workflow state) or a JSONPath expression starting with `$.` over the entity payload.
+type GroupedStatsRequest struct {
+	// Aggregations Optional per-group aggregations.
+	Aggregations *[]AggregationExpr `json:"aggregations,omitempty"`
+
+	// Condition Optional Condition DSL predicate restricting the population. Uses the same union shape as the async-search endpoint.
+	Condition *GroupedStatsRequest_Condition `json:"condition,omitempty"`
+
+	// GroupBy Ordered list of group-by dimensions. Each entry is either the literal `state` or a JSONPath expression. At least one entry is required.
+	GroupBy []string `json:"groupBy"`
+
+	// Limit Optional cap on the number of buckets returned. Must be positive and less than or equal to the server-configured `CYODA_STATS_GROUP_MAX` (default 10000); requests exceeding the cap are rejected with 400 `MALFORMED_REQUEST`.
+	Limit *int32 `json:"limit,omitempty"`
+
+	// PointInTime Optional point-in-time for the query in ISO 8601 / RFC 3339 format. Defaults to the current consistency time.
+	PointInTime *time.Time `json:"pointInTime,omitempty"`
+}
+
+// GroupedStatsRequest_Condition Optional Condition DSL predicate restricting the population. Uses the same union shape as the async-search endpoint.
+type GroupedStatsRequest_Condition struct {
+	union json.RawMessage
+}
 
 // InvalidateKeyRequestDto defines model for InvalidateKeyRequestDto.
 type InvalidateKeyRequestDto struct {
@@ -2767,6 +2865,11 @@ type TransitionDefinitionDto struct {
 
 	// Processors List of processors to execute for this transition
 	Processors *[]TransitionDefinitionDto_Processors_Item `json:"processors,omitempty"`
+
+	// Schedule Optional scheduling configuration. Presence marks the transition as
+	// scheduled; mutually exclusive with manual=true. Runtime not yet
+	// implemented — see TransitionScheduleDto for engine behaviour.
+	Schedule *TransitionScheduleDto `json:"schedule,omitempty"`
 }
 
 // TransitionDefinitionDto_Criterion defines model for TransitionDefinitionDto.Criterion.
@@ -2781,6 +2884,39 @@ type TransitionDefinitionDto_Processors_Item struct {
 
 // TransitionNameList An ordered list of workflow transition names available from the entity's current state. Each entry is the name of a configured transition (e.g. "APPROVE", "REJECT") or a virtual loopback transition name. An empty array means no transitions are available from the current state.
 type TransitionNameList = []string
+
+// TransitionScheduleDto Scheduling configuration for an automatic future state transition.
+// Presence of this object marks the parent transition as scheduled.
+// The transition is scheduled to fire at `stateEntryTime + delayMs`
+// (the "scheduledTime"). When the scheduler picks the task up for
+// execution at `executionTime`, it computes `lateness = executionTime
+// - scheduledTime`; if `lateness > timeoutMs` the task is dropped
+// and the transition is NOT attempted. `timeoutMs` gives operators
+// control over how the system should handle backlog or intermittent-
+// offline conditions: short timeoutMs values prefer freshness over
+// eventual execution; absent timeoutMs always eventually fires.
+//
+// Mutually exclusive with parent transition's manual=true.
+//
+// The runtime that arms and fires the timer is not yet implemented.
+// Until it ships, the engine silently skips scheduled transitions
+// during automated cascade selection, and explicit fires by name are
+// rejected with HTTP 400 TRANSITION_NOT_FOUND.
+type TransitionScheduleDto struct {
+	// DelayMs Delay between source-state entry and the scheduled execution
+	// time, in milliseconds. Must be a positive integer (zero or
+	// negative would make this a regular automated transition).
+	DelayMs int64 `json:"delayMs"`
+
+	// TimeoutMs Late-tolerance window past the scheduled execution time, in
+	// milliseconds. When the scheduler picks the task up, if
+	// `(executionTime - scheduledTime) > timeoutMs` the task is
+	// dropped. Absent (omitted) means no timeout — the task fires
+	// whenever the scheduler eventually picks it up. Explicit zero
+	// is the strictest setting — drop on any lateness. Independent
+	// of `delayMs`; the two measure different quantities.
+	TimeoutMs *int64 `json:"timeoutMs,omitempty"`
+}
 
 // TrustedKeyResponseDto defines model for TrustedKeyResponseDto.
 type TrustedKeyResponseDto struct {
@@ -2889,7 +3025,20 @@ type ValueMapsYearMonthsMonth string
 // WorkflowConfigurationDto defines model for WorkflowConfigurationDto.
 type WorkflowConfigurationDto struct {
 	// Active Flag indicating if the workflow is active
-	Active    *bool                               `json:"active,omitempty"`
+	Active *bool `json:"active,omitempty"`
+
+	// Criterion Optional selection criterion evaluated against the entity to
+	// decide which of several workflows applies. When a model has
+	// multiple workflow definitions, the engine iterates them in
+	// declaration order and picks the first one whose `active` flag
+	// is true AND whose `criterion` matches the entity. A `null`
+	// (absent) criterion matches unconditionally. If no active
+	// workflow matches — and `active=false` workflows are skipped
+	// entirely during selection — the engine falls back to the
+	// embedded default workflow and emits both a body warning and
+	// an operator-visible `slog.Warn` line. Workflow-level criteria
+	// use the same Condition DSL as search and transition-level
+	// criteria.
 	Criterion *WorkflowConfigurationDto_Criterion `json:"criterion,omitempty"`
 
 	// Desc Description of the workflow
@@ -2908,7 +3057,18 @@ type WorkflowConfigurationDto struct {
 	Version string `json:"version"`
 }
 
-// WorkflowConfigurationDto_Criterion defines model for WorkflowConfigurationDto.Criterion.
+// WorkflowConfigurationDto_Criterion Optional selection criterion evaluated against the entity to
+// decide which of several workflows applies. When a model has
+// multiple workflow definitions, the engine iterates them in
+// declaration order and picks the first one whose `active` flag
+// is true AND whose `criterion` matches the entity. A `null`
+// (absent) criterion matches unconditionally. If no active
+// workflow matches — and `active=false` workflows are skipped
+// entirely during selection — the engine falls back to the
+// embedded default workflow and emits both a body warning and
+// an operator-visible `slog.Warn` line. Workflow-level criteria
+// use the same Condition DSL as search and transition-level
+// criteria.
 type WorkflowConfigurationDto_Criterion struct {
 	union json.RawMessage
 }
@@ -2927,14 +3087,32 @@ type WorkflowExportResponseDto struct {
 
 // WorkflowImportRequestDto Workflow configurations to import
 type WorkflowImportRequestDto struct {
-	// ImportMode Import mode for handling existing workflows
+	// AllowCycles When true, bypasses the import-time check that rejects workflows
+	// containing unguarded automated cycles (transitions with manual=false
+	// and no criterion that form a closed loop). The runtime cascade
+	// safety net — per-state visit cap and total cascade depth limit —
+	// remains in effect and catches actual runaway at fire time. Use
+	// when the cyclicity is intentional, e.g. polling patterns built on
+	// scheduled transitions. Default false preserves the pre-existing
+	// rejection behaviour exactly.
+	AllowCycles *bool `json:"allowCycles,omitempty"`
+
+	// ImportMode Import mode for handling existing workflows. Defaults to MERGE
+	// when the field is omitted or empty. Parsing is case-insensitive:
+	// "merge", "Merge", and "MERGE" are all accepted. Any value outside
+	// the documented enum (after case-folding) is rejected with
+	// 400 BAD_REQUEST.
 	ImportMode *WorkflowImportRequestDtoImportMode `json:"importMode,omitempty"`
 
 	// Workflows Array of workflow configurations to import
 	Workflows []WorkflowConfigurationDto `json:"workflows"`
 }
 
-// WorkflowImportRequestDtoImportMode Import mode for handling existing workflows
+// WorkflowImportRequestDtoImportMode Import mode for handling existing workflows. Defaults to MERGE
+// when the field is omitted or empty. Parsing is case-insensitive:
+// "merge", "Merge", and "MERGE" are all accepted. Any value outside
+// the documented enum (after case-folding) is rejected with
+// 400 BAD_REQUEST.
 type WorkflowImportRequestDtoImportMode string
 
 // WorkflowImportSuccessDto Confirmation returned when a workflow import completes successfully.
@@ -3394,6 +3572,9 @@ type SearchEntitiesParams struct {
 	TimeoutMillis *string `form:"timeoutMillis,omitempty" json:"timeoutMillis,omitempty"`
 }
 
+// QueryGroupedEntityStatisticsForModelJSONRequestBody defines body for QueryGroupedEntityStatisticsForModel for application/json ContentType.
+type QueryGroupedEntityStatisticsForModelJSONRequestBody = GroupedStatsRequest
+
 // DeleteEntitiesJSONRequestBody defines body for DeleteEntities for application/json ContentType.
 type DeleteEntitiesJSONRequestBody = AbstractConditionDto
 
@@ -3692,6 +3873,146 @@ func (t GroupConditionDto_Conditions_Item) MarshalJSON() ([]byte, error) {
 }
 
 func (t *GroupConditionDto_Conditions_Item) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsArrayConditionDto returns the union data inside the GroupedStatsRequest_Condition as a ArrayConditionDto
+func (t GroupedStatsRequest_Condition) AsArrayConditionDto() (ArrayConditionDto, error) {
+	var body ArrayConditionDto
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromArrayConditionDto overwrites any union data inside the GroupedStatsRequest_Condition as the provided ArrayConditionDto
+func (t *GroupedStatsRequest_Condition) FromArrayConditionDto(v ArrayConditionDto) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeArrayConditionDto performs a merge with any union data inside the GroupedStatsRequest_Condition, using the provided ArrayConditionDto
+func (t *GroupedStatsRequest_Condition) MergeArrayConditionDto(v ArrayConditionDto) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsFunctionConditionDto returns the union data inside the GroupedStatsRequest_Condition as a FunctionConditionDto
+func (t GroupedStatsRequest_Condition) AsFunctionConditionDto() (FunctionConditionDto, error) {
+	var body FunctionConditionDto
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromFunctionConditionDto overwrites any union data inside the GroupedStatsRequest_Condition as the provided FunctionConditionDto
+func (t *GroupedStatsRequest_Condition) FromFunctionConditionDto(v FunctionConditionDto) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeFunctionConditionDto performs a merge with any union data inside the GroupedStatsRequest_Condition, using the provided FunctionConditionDto
+func (t *GroupedStatsRequest_Condition) MergeFunctionConditionDto(v FunctionConditionDto) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsGroupConditionDto returns the union data inside the GroupedStatsRequest_Condition as a GroupConditionDto
+func (t GroupedStatsRequest_Condition) AsGroupConditionDto() (GroupConditionDto, error) {
+	var body GroupConditionDto
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromGroupConditionDto overwrites any union data inside the GroupedStatsRequest_Condition as the provided GroupConditionDto
+func (t *GroupedStatsRequest_Condition) FromGroupConditionDto(v GroupConditionDto) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeGroupConditionDto performs a merge with any union data inside the GroupedStatsRequest_Condition, using the provided GroupConditionDto
+func (t *GroupedStatsRequest_Condition) MergeGroupConditionDto(v GroupConditionDto) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsLifecycleConditionDto returns the union data inside the GroupedStatsRequest_Condition as a LifecycleConditionDto
+func (t GroupedStatsRequest_Condition) AsLifecycleConditionDto() (LifecycleConditionDto, error) {
+	var body LifecycleConditionDto
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromLifecycleConditionDto overwrites any union data inside the GroupedStatsRequest_Condition as the provided LifecycleConditionDto
+func (t *GroupedStatsRequest_Condition) FromLifecycleConditionDto(v LifecycleConditionDto) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeLifecycleConditionDto performs a merge with any union data inside the GroupedStatsRequest_Condition, using the provided LifecycleConditionDto
+func (t *GroupedStatsRequest_Condition) MergeLifecycleConditionDto(v LifecycleConditionDto) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsSimpleConditionDto returns the union data inside the GroupedStatsRequest_Condition as a SimpleConditionDto
+func (t GroupedStatsRequest_Condition) AsSimpleConditionDto() (SimpleConditionDto, error) {
+	var body SimpleConditionDto
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromSimpleConditionDto overwrites any union data inside the GroupedStatsRequest_Condition as the provided SimpleConditionDto
+func (t *GroupedStatsRequest_Condition) FromSimpleConditionDto(v SimpleConditionDto) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeSimpleConditionDto performs a merge with any union data inside the GroupedStatsRequest_Condition, using the provided SimpleConditionDto
+func (t *GroupedStatsRequest_Condition) MergeSimpleConditionDto(v SimpleConditionDto) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t GroupedStatsRequest_Condition) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *GroupedStatsRequest_Condition) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -4330,6 +4651,9 @@ type ServerInterface interface {
 	// Retrieve entity statistics for a specific model
 	// (GET /entity/stats/{entityName}/{modelVersion})
 	GetEntityStatisticsForModel(w http.ResponseWriter, r *http.Request, entityName string, modelVersion int32, params GetEntityStatisticsForModelParams)
+	// Query grouped entity statistics for a specific model
+	// (POST /entity/stats/{entityName}/{modelVersion}/query)
+	QueryGroupedEntityStatisticsForModel(w http.ResponseWriter, r *http.Request, entityName string, modelVersion int32)
 	// Delete a single entity
 	// (DELETE /entity/{entityId})
 	DeleteSingleEntity(w http.ResponseWriter, r *http.Request, entityId openapi_types.UUID)
@@ -5027,6 +5351,47 @@ func (siw *ServerInterfaceWrapper) GetEntityStatisticsForModel(w http.ResponseWr
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetEntityStatisticsForModel(w, r, entityName, modelVersion, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// QueryGroupedEntityStatisticsForModel operation middleware
+func (siw *ServerInterfaceWrapper) QueryGroupedEntityStatisticsForModel(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "entityName" -------------
+	var entityName string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "entityName", r.PathValue("entityName"), &entityName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "entityName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "modelVersion" -------------
+	var modelVersion int32
+
+	err = runtime.BindStyledParameterWithOptions("simple", "modelVersion", r.PathValue("modelVersion"), &modelVersion, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int32"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "modelVersion", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.QueryGroupedEntityStatisticsForModel(w, r, entityName, modelVersion)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -7580,6 +7945,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/entity/stats/states", wrapper.GetEntityStatisticsByState)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/entity/stats/states/{entityName}/{modelVersion}", wrapper.GetEntityStatisticsByStateForModel)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/entity/stats/{entityName}/{modelVersion}", wrapper.GetEntityStatisticsForModel)
+	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/entity/stats/{entityName}/{modelVersion}/query", wrapper.QueryGroupedEntityStatisticsForModel)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/entity/{entityId}", wrapper.DeleteSingleEntity)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/entity/{entityId}", wrapper.GetOneEntity)
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/entity/{entityId}/changes", wrapper.GetEntityChangesMetadata)

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8903,6 +8903,12 @@ components:
           items:
             oneOf:
               - $ref: "#/components/schemas/ExternalizedProcessorDefinitionDto"
+        schedule:
+          $ref: "#/components/schemas/TransitionScheduleDto"
+          description: |
+            Optional scheduling configuration. Presence marks the transition as
+            scheduled; mutually exclusive with manual=true. Runtime not yet
+            implemented — see TransitionScheduleDto for engine behaviour.
         criterion:
           oneOf:
             - $ref: "#/components/schemas/ArrayConditionDto"
@@ -8914,6 +8920,49 @@ components:
         - manual
         - name
         - next
+    TransitionScheduleDto:
+      type: object
+      description: |
+        Scheduling configuration for an automatic future state transition.
+        Presence of this object marks the parent transition as scheduled.
+        The transition is scheduled to fire at `stateEntryTime + delayMs`
+        (the "scheduledTime"). When the scheduler picks the task up for
+        execution at `executionTime`, it computes `lateness = executionTime
+        - scheduledTime`; if `lateness > timeoutMs` the task is dropped
+        and the transition is NOT attempted. `timeoutMs` gives operators
+        control over how the system should handle backlog or intermittent-
+        offline conditions: short timeoutMs values prefer freshness over
+        eventual execution; absent timeoutMs always eventually fires.
+
+        Mutually exclusive with parent transition's manual=true.
+
+        The runtime that arms and fires the timer is not yet implemented.
+        Until it ships, the engine silently skips scheduled transitions
+        during automated cascade selection, and explicit fires by name are
+        rejected with HTTP 400 TRANSITION_NOT_FOUND.
+      properties:
+        delayMs:
+          type: integer
+          format: int64
+          minimum: 1
+          description: |
+            Delay between source-state entry and the scheduled execution
+            time, in milliseconds. Must be a positive integer (zero or
+            negative would make this a regular automated transition).
+        timeoutMs:
+          type: integer
+          format: int64
+          minimum: 0
+          description: |
+            Late-tolerance window past the scheduled execution time, in
+            milliseconds. When the scheduler picks the task up, if
+            `(executionTime - scheduledTime) > timeoutMs` the task is
+            dropped. Absent (omitted) means no timeout — the task fires
+            whenever the scheduler eventually picks it up. Explicit zero
+            is the strictest setting — drop on any lateness. Independent
+            of `delayMs`; the two measure different quantities.
+      required:
+        - delayMs
     WorkflowConfigurationDto:
       type: object
       properties:
@@ -8991,6 +9040,18 @@ components:
             - REPLACE
             - ACTIVATE
             - MERGE
+        allowCycles:
+          type: boolean
+          default: false
+          description: |
+            When true, bypasses the import-time check that rejects workflows
+            containing unguarded automated cycles (transitions with manual=false
+            and no criterion that form a closed loop). The runtime cascade
+            safety net — per-state visit cap and total cascade depth limit —
+            remains in effect and catches actual runaway at fire time. Use
+            when the cyclicity is intentional, e.g. polling patterns built on
+            scheduled transitions. Default false preserves the pre-existing
+            rejection behaviour exactly.
       required:
         - workflows
     UpdateOidcProviderRequestDto:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -8906,9 +8906,13 @@ components:
         schedule:
           $ref: "#/components/schemas/TransitionScheduleDto"
           description: |
-            Optional scheduling configuration. Presence marks the transition as
-            scheduled; mutually exclusive with manual=true. Runtime not yet
-            implemented — see TransitionScheduleDto for engine behaviour.
+            Optional scheduling configuration. Presence marks the transition
+            as scheduled — it fires automatically `delayMs` milliseconds
+            after the entity enters the source state. Mutually exclusive
+            with `manual=true`. The runtime scheduler is not yet
+            implemented; until it ships, the engine silently skips
+            scheduled transitions during automated cascade selection, and
+            explicit fires by name return HTTP 400 `TRANSITION_NOT_FOUND`.
         criterion:
           oneOf:
             - $ref: "#/components/schemas/ArrayConditionDto"

--- a/cmd/cyoda/help/content/workflows.md
+++ b/cmd/cyoda/help/content/workflows.md
@@ -174,6 +174,83 @@ Import-time validation rejects any `executionMode` value not in the list above (
 - `retryPolicy` — string — retry policy name (plugin/platform-defined); empty means no retry
 - `context` — string — pass-through string forwarded **verbatim** as the `parameters` JSON node of the outgoing `EntityProcessorCalculationRequest` (and `EntityCriteriaCalculationRequest` when used on a `function`-typed criterion's `config`). Marshalling shape is **pass-as-string**: the value is encoded as a JSON string, not parsed as JSON. The receiver gets a JSON-quoted string in `parameters`. Empty `context` causes `parameters` to be omitted entirely. Use to distinguish multiple workflow roles served by a single externalized processor or criterion implementation without registering a separate name per role.
 
+## SCHEDULED TRANSITIONS
+
+A transition may carry an optional `schedule` object marking it as
+scheduled. Presence of `schedule` declares that the transition fires
+automatically at `scheduledTime = stateEntryTime + delayMs`. The
+`schedule` shape is:
+
+```json
+{
+  "name": "AutoClose",
+  "next": "Closed",
+  "manual": false,
+  "schedule": {
+    "delayMs": 86400000,
+    "timeoutMs": 600000
+  }
+}
+```
+
+**Fields:**
+
+- `delayMs` (integer, required) — delay between source-state entry
+  and the scheduled execution time, in milliseconds. Must be `> 0`.
+- `timeoutMs` (integer, optional) — late-tolerance window past the
+  scheduled execution time, in milliseconds. When the scheduler
+  picks the task up, if `(executionTime - scheduledTime) > timeoutMs`
+  the task is dropped and the transition is NOT attempted. Absent
+  (omitted) means no timeout — fire whenever the scheduler
+  eventually picks it up. Explicit `0` is the strictest setting —
+  drop on any lateness. Independent of `delayMs`; the two measure
+  different quantities.
+
+**Import-time validation rules:**
+
+- `manual: true` and `schedule` present are mutually exclusive
+  (`VALIDATION_FAILED`).
+- `schedule.delayMs <= 0` is rejected (`VALIDATION_FAILED`).
+- No further rule on `timeoutMs` beyond `>= 0` (enforced at the DTO
+  boundary).
+
+**Engine behaviour (runtime not yet implemented).** The scheduler
+that arms and fires scheduled transitions is not yet implemented.
+Two guards govern behaviour until it ships:
+
+- During automated cascade evaluation, scheduled transitions are
+  silently skipped — they are never selected for immediate firing.
+  Other automated/manual transitions out of the same state fire
+  normally. An entity whose only exit is scheduled rests in its
+  current state.
+- Explicitly firing a scheduled transition by name returns HTTP 400
+  `TRANSITION_NOT_FOUND` with the message `transition "X" in state
+  "Y" is scheduled; scheduled transitions are not yet implemented`.
+  Same code returned when a transition is `disabled: true` — same
+  semantic: "the transition exists but is not currently dispatchable
+  from the caller's POV." The entity remains in the source state.
+
+**Importing cyclic scheduled workflows.** A canonical scheduled-
+transition use case is a polling pattern such as `S1 →scheduled→ S2
+→scheduled→ S1`. The import-time cycle detector rejects unguarded
+automated cycles by default — including this one, because a delayed
+cycle is still a cycle. To import such a workflow, set the request-
+level field `allowCycles: true` on the import body:
+
+```json
+{
+  "importMode": "REPLACE",
+  "allowCycles": true,
+  "workflows": [ /* ... */ ]
+}
+```
+
+`allowCycles: true` bypasses only the cycle-detection check. Schedule
+shape rules (manual+schedule, delayMs) and all other validators
+remain unconditional. The runtime cascade-depth and per-state visit
+caps still catch actual runaway at fire time. Use only for workflows
+whose cyclicity is intentional.
+
 ## CRITERIA
 
 Criteria on workflows and transitions use the same `Condition` DSL as search. All four condition types are supported: `simple`, `lifecycle`, `group`, `array`. Criteria are evaluated in-memory against the entity's JSON payload and lifecycle metadata.

--- a/docs/superpowers/plans/2026-06-15-issue-259-scheduled-transition-shape.md
+++ b/docs/superpowers/plans/2026-06-15-issue-259-scheduled-transition-shape.md
@@ -1,0 +1,2472 @@
+# Issue #259 — Scheduled-transition configuration shape + SPI — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the scheduled-transition configuration shape (SPI type, OpenAPI surface, validator rules, engine guards) plus a request-level `allowCycles` escape hatch — all per the rev 3 spec at `docs/superpowers/specs/2026-06-15-issue-259-scheduled-transition-shape-design.md`. Timer runtime stays deferred to #251.
+
+**Architecture:** Two coordinated PRs.
+1. **cyoda-go-spi PR** (sibling repo at `/Users/paul/go-projects/cyoda-light/cyoda-go-spi`) — additive SPI types: new `TransitionSchedule` struct, new `Schedule *TransitionSchedule` field on `TransitionDefinition`, plus a docstring update on `ProcessorDefinition.Type` deferred from #250.
+2. **cyoda-go PR** (this worktree) — pseudo-version pin bump to SPI main HEAD, OpenAPI surface update, validator rules, engine cascade-skip + explicit-fire-reject guards, `allowCycles` request envelope, help-topic, parity scenarios, E2E.
+
+**Tech Stack:** Go 1.26, `log/slog`, `encoding/json`, `errors.Is`/wrap, `oapi-codegen` (for `api/generated.go`), testcontainers-go (for E2E), `httptest` (for in-process E2E HTTP server).
+
+---
+
+## Spec cross-reference
+
+This plan executes the spec sections in this order:
+
+| Plan phase | Spec section | What |
+|---|---|---|
+| Phase 1 (Tasks 1–4) | §5.3 | cyoda-go-spi PR |
+| Phase 2 (Task 5) | §10 step 2a | SPI pin bump |
+| Phase 3 (Tasks 6–7) | §5.1, §5.2 | OpenAPI + regen |
+| Phase 4 (Tasks 8–10) | §5.4 (Schedule rules) | Validator |
+| Phase 5 (Tasks 11–12) | §5.4 (`allowCycles`) | Import envelope |
+| Phase 6 (Task 13) | §5.5(a) | Cascade-skip |
+| Phase 7 (Task 14) | §5.5(b) | Explicit-fire reject |
+| Phase 8 (Task 15) | §6.1 test 8 | Round-trip |
+| Phase 9 (Task 16) | §6.1 test 9 | E2E |
+| Phase 10 (Task 17) | §5.7 | Parity scenarios |
+| Phase 11 (Task 18) | §5.6 | Help-topic |
+| Phase 12 (Task 19) | Appendix B | Verification + open PR |
+
+---
+
+## File map
+
+### cyoda-go-spi (sibling repo)
+
+- Modify: `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types.go` — add `TransitionSchedule` type (after `ProcessorConfig`), add `Schedule` field on `TransitionDefinition` (line 130-137), add docstring on `ProcessorDefinition.Type` (line 140).
+- Modify: `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types_test.go` — round-trip tests for `TransitionSchedule` and `TransitionDefinition.Schedule`.
+- Modify: `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/CHANGELOG.md` — `[Unreleased]` Added + Changed entries.
+
+### cyoda-go (this worktree at `/Users/paul/go-projects/cyoda-light/cyoda-go/.claude/worktrees/259-scheduled-transition-config-shape/`)
+
+- Modify: `go.mod` + `plugins/memory/go.mod` + `plugins/sqlite/go.mod` + `plugins/postgres/go.mod` — bump cyoda-go-spi pseudo-version.
+- Modify: `api/openapi.yaml` — add `TransitionScheduleDto` schema, add `schedule` property to `TransitionDefinitionDto`, add `allowCycles` to the workflow-import request body schema.
+- Modify: `api/generated.go` — regenerated.
+- Modify: `internal/domain/workflow/handler.go` — `AllowCycles bool` on `importRequest` (lines 60-64); thread to `validateWorkflows`; `slog.Warn` when true.
+- Modify: `internal/domain/workflow/validate.go` — two Schedule-coherence checks in `validateWorkflowStructure` per-transition loop (between Next-state check at lines 193-196 and processor loop at 198); `validateWorkflows` signature gets `allowCycles bool` parameter and short-circuits `validateWorkflowLoops` when true.
+- Modify: `internal/domain/workflow/scenarios_test.go` — update 8 `validateWorkflows` call sites for the new signature.
+- Modify: `internal/domain/workflow/engine.go` — cascade-skip filter at line 528 (one-line addition); explicit-fire reject branch in `attemptTransition` immediately after the `Disabled` check at lines 449-453.
+- Create or modify: `internal/domain/workflow/validate_test.go` or sibling — Schedule-rule unit tests, `allowCycles` tests.
+- Create or modify: `internal/domain/workflow/engine_test.go` or sibling — cascade-skip + explicit-fire-reject + round-trip tests.
+- Modify: `internal/e2e/` (pick the existing workflow-import E2E file or add a new one named after the issue) — E2E test for explicit-fire of scheduled transition.
+- Modify: `e2e/externalapi/scenarios/08-workflow-import-export.yaml` — append `wf-import/07-scheduled-transition-roundtrip`, `wf-import/08-scheduled-transition-rejects`, `wf-import/09-allowcycles-bypass`.
+- Modify: `cmd/cyoda/help/content/workflows.md` — add `## SCHEDULED TRANSITIONS` section (level 2) after the `## PROCESSORS` section, before `## CRITERIA`.
+
+---
+
+# Phase 1 — cyoda-go-spi PR
+
+> **Working directory for this phase:** `/Users/paul/go-projects/cyoda-light/cyoda-go-spi`.
+> Create a feature branch off `origin/main`; the SPI PR will target SPI `main`.
+
+## Task 1: Create SPI feature branch and add `TransitionSchedule` type
+
+**Files:**
+- Modify: `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types.go`
+- Modify: `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types_test.go`
+
+- [ ] **Step 1: Create the feature branch**
+
+Run from `/Users/paul/go-projects/cyoda-light/cyoda-go-spi`:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+git fetch origin
+git checkout -b feat/scheduled-transition-shape origin/main
+```
+
+Expected: `Switched to a new branch 'feat/scheduled-transition-shape'`.
+
+- [ ] **Step 2: Write failing round-trip test for `TransitionSchedule`**
+
+Append to `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types_test.go`:
+
+```go
+func TestTransitionSchedule_RoundTrips(t *testing.T) {
+	// Non-nil positive TimeoutMs round-trips byte-equivalent.
+	tm := int64(5000)
+	sched := TransitionSchedule{DelayMs: 1000, TimeoutMs: &tm}
+	bs, err := json.Marshal(sched)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(bs), `"delayMs":1000`) {
+		t.Errorf("missing delayMs: %s", bs)
+	}
+	if !strings.Contains(string(bs), `"timeoutMs":5000`) {
+		t.Errorf("missing timeoutMs: %s", bs)
+	}
+
+	var back TransitionSchedule
+	if err := json.Unmarshal(bs, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.DelayMs != 1000 {
+		t.Errorf("DelayMs round-trip lost value: got %d", back.DelayMs)
+	}
+	if back.TimeoutMs == nil || *back.TimeoutMs != 5000 {
+		t.Errorf("TimeoutMs round-trip lost value: got %v", back.TimeoutMs)
+	}
+
+	// Non-nil zero TimeoutMs (strictest semantic) survives omitempty.
+	zero := int64(0)
+	schedZero := TransitionSchedule{DelayMs: 1000, TimeoutMs: &zero}
+	bs2, _ := json.Marshal(schedZero)
+	if !strings.Contains(string(bs2), `"timeoutMs":0`) {
+		t.Errorf("non-nil zero TimeoutMs should marshal as timeoutMs:0, got %s", bs2)
+	}
+	var back2 TransitionSchedule
+	_ = json.Unmarshal(bs2, &back2)
+	if back2.TimeoutMs == nil || *back2.TimeoutMs != 0 {
+		t.Errorf("non-nil zero TimeoutMs round-trip dropped distinction: %v", back2.TimeoutMs)
+	}
+
+	// Nil TimeoutMs (no-timeout semantic) does not marshal.
+	schedNil := TransitionSchedule{DelayMs: 1000}
+	bs3, _ := json.Marshal(schedNil)
+	if strings.Contains(string(bs3), "timeoutMs") {
+		t.Errorf("nil TimeoutMs should be omitted, got %s", bs3)
+	}
+	var back3 TransitionSchedule
+	_ = json.Unmarshal(bs3, &back3)
+	if back3.TimeoutMs != nil {
+		t.Errorf("nil TimeoutMs round-trip surfaced a non-nil pointer: %v", back3.TimeoutMs)
+	}
+}
+```
+
+- [ ] **Step 3: Run the test to confirm it fails**
+
+Run:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+go test -run TestTransitionSchedule_RoundTrips -v .
+```
+
+Expected: FAIL with `undefined: TransitionSchedule`.
+
+- [ ] **Step 4: Add the `TransitionSchedule` type**
+
+Edit `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types.go` — insert immediately after the `ProcessorConfig` struct (after line 161, before any `SMEvent*` constants):
+
+```go
+// TransitionSchedule configures automatic firing of a future state
+// transition. Presence of this struct on a TransitionDefinition marks
+// the transition as scheduled.
+//
+// Semantics. The scheduled execution time of the transition is
+// scheduledTime = stateEntryTime + DelayMs. When the scheduler picks
+// the task up at executionTime, it computes
+// lateness = executionTime - scheduledTime.
+//   - If TimeoutMs is nil, the task is always attempted (no timeout).
+//   - If TimeoutMs is non-nil and lateness > *TimeoutMs, the task is
+//     dropped and the transition is NOT attempted.
+//   - If TimeoutMs is non-nil and lateness <= *TimeoutMs (including
+//     *TimeoutMs == 0 when lateness is 0), the transition fires.
+//
+// TimeoutMs gives operators control over how the system handles
+// backlog and intermittent-offline conditions. Short positive values
+// prefer freshness — stale tasks are discarded rather than fired
+// against a possibly-changed entity. Nil prefers eventual execution.
+//
+// Scheduled transitions are mutually exclusive with Manual=true.
+//
+// Scheduled transitions are a special case of a generic ScheduledTask
+// abstraction. The lateness-tolerance concept (TimeoutMs) applies
+// uniformly across all ScheduledTask variants. The generic
+// abstraction and the runtime that implements it ship in a later
+// release; until then, the cyoda-go engine silently skips scheduled
+// transitions during automated cascade selection, and rejects explicit
+// fires by name with HTTP 400 TRANSITION_NOT_FOUND.
+type TransitionSchedule struct {
+	// DelayMs is the delay between source-state entry and the
+	// scheduled execution time, in milliseconds. Must be > 0.
+	DelayMs int64 `json:"delayMs"`
+
+	// TimeoutMs is the late-tolerance window past the scheduled
+	// execution time, in milliseconds. Nil means no timeout — the
+	// task fires whenever the scheduler eventually picks it up.
+	// Non-nil zero is the strictest setting — drop on any lateness.
+	// Non-nil positive N drops the task if it picks up more than N
+	// milliseconds after scheduledTime. Independent of DelayMs; the
+	// two measure different quantities.
+	TimeoutMs *int64 `json:"timeoutMs,omitempty"`
+}
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+Run:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+go test -run TestTransitionSchedule_RoundTrips -v .
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full SPI test suite to confirm no regressions**
+
+Run:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+go test ./... -v
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+git add types.go types_test.go
+git commit -m "feat(types): add TransitionSchedule struct for scheduled-transition shape
+
+New SPI type for the scheduled-transition configuration shape carve-out
+(cyoda-go #259). DelayMs (required, >0) is the delay from state-entry
+to scheduled execution time. TimeoutMs (*int64, optional) is the
+late-tolerance window past scheduled time — nil means no timeout, &0
+is the strictest setting, &N drops if late > N ms.
+
+Runtime not yet wired — see cyoda-go #251 for full feature tracking.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add `Schedule` field to `TransitionDefinition`
+
+**Files:**
+- Modify: `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types.go` — `TransitionDefinition` struct at lines 130-137.
+- Modify: `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types_test.go` — round-trip test for the new field.
+
+- [ ] **Step 1: Write failing round-trip test for `TransitionDefinition.Schedule`**
+
+Append to `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types_test.go`:
+
+```go
+func TestTransitionDefinition_Schedule_RoundTrips(t *testing.T) {
+	tm := int64(5000)
+	tr := TransitionDefinition{
+		Name:     "AutoClose",
+		Next:     "Closed",
+		Manual:   false,
+		Schedule: &TransitionSchedule{DelayMs: 86400000, TimeoutMs: &tm},
+	}
+	bs, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(bs), `"schedule":{"delayMs":86400000,"timeoutMs":5000}`) {
+		t.Errorf("schedule field missing or wrong shape: %s", bs)
+	}
+
+	var back TransitionDefinition
+	if err := json.Unmarshal(bs, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.Schedule == nil {
+		t.Fatalf("Schedule round-trip dropped the field: %+v", back)
+	}
+	if back.Schedule.DelayMs != 86400000 {
+		t.Errorf("Schedule.DelayMs lost value: got %d", back.Schedule.DelayMs)
+	}
+	if back.Schedule.TimeoutMs == nil || *back.Schedule.TimeoutMs != 5000 {
+		t.Errorf("Schedule.TimeoutMs lost value: got %v", back.Schedule.TimeoutMs)
+	}
+
+	// Schedule omitted is preserved as nil through round-trip.
+	trNoSched := TransitionDefinition{Name: "Foo", Next: "Bar"}
+	bs2, _ := json.Marshal(trNoSched)
+	if strings.Contains(string(bs2), "schedule") {
+		t.Errorf("nil Schedule should be omitted, got %s", bs2)
+	}
+	var back2 TransitionDefinition
+	_ = json.Unmarshal(bs2, &back2)
+	if back2.Schedule != nil {
+		t.Errorf("Schedule round-trip surfaced a non-nil pointer for absent field: %v", back2.Schedule)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+go test -run TestTransitionDefinition_Schedule_RoundTrips -v .
+```
+
+Expected: FAIL with `unknown field Schedule in struct literal of type TransitionDefinition`.
+
+- [ ] **Step 3: Add the `Schedule` field**
+
+Edit `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types.go` — change `TransitionDefinition` to add `Schedule` as the last field:
+
+```go
+// TransitionDefinition represents a single transition from a state.
+type TransitionDefinition struct {
+	Name       string                `json:"name"`
+	Next       string                `json:"next"`
+	Manual     bool                  `json:"manual"`
+	Disabled   bool                  `json:"disabled,omitempty"`
+	Criterion  json.RawMessage       `json:"criterion,omitempty"`
+	Processors []ProcessorDefinition `json:"processors,omitempty"`
+	Schedule   *TransitionSchedule   `json:"schedule,omitempty"`
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+go test -run TestTransitionDefinition_Schedule_RoundTrips -v .
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full SPI test suite**
+
+Run:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+go test ./... -v
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+git add types.go types_test.go
+git commit -m "feat(types): add TransitionDefinition.Schedule field
+
+Optional *TransitionSchedule pointer on TransitionDefinition. Presence
+marks the transition as scheduled. Pointer (not value) so absent
+vs. zero is distinguishable on the wire — supports the round-trip
+fidelity contract per cyoda-go #259 spec §5.3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add deferred docstring on `ProcessorDefinition.Type`
+
+**Files:**
+- Modify: `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types.go` — `ProcessorDefinition` struct at lines 140-145.
+
+This change was deferred from cyoda-go #250 spec §5.3, intentionally held back for the first substantive SPI carve-out — that's #259. **First check whether `origin/main` already carries the docstring** (per spec §8 O1 risk-bullet): if #260's SPI PR landed first, this docstring is already on `main` and this task is a no-op.
+
+- [ ] **Step 1: Check whether `origin/main` already has the docstring**
+
+Run:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+git fetch origin
+git show origin/main:types.go | grep -A 3 "type ProcessorDefinition struct"
+```
+
+If the output shows a docstring above the `Type` field starting with `// Type is the execution-location axis`, the docstring is already on main — **skip the rest of this task entirely**, jump to Task 4. Otherwise proceed.
+
+- [ ] **Step 2: Add the docstring**
+
+Edit `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/types.go` — replace the `ProcessorDefinition` struct (lines 139-145) with:
+
+```go
+// ProcessorDefinition represents a processor attached to a transition.
+type ProcessorDefinition struct {
+	// Type is the execution-location axis. Recognised values are defined
+	// by the cyoda-go engine package; canonical values are "externalized"
+	// (dispatched via gRPC to a calculation node selected by
+	// Config.CalculationNodesTags) and "internalized" (reserved for an
+	// in-process execution location, currently rejected at engine
+	// dispatch as not yet implemented). Empty is treated as "externalized".
+	// Any value other than "internalized" falls through to the
+	// ExecutionMode dispatch path; import-time validation does not
+	// constrain this field.
+	Type          string          `json:"type"`
+	Name          string          `json:"name"`
+	ExecutionMode string          `json:"executionMode,omitempty"`
+	Config        ProcessorConfig `json:"config,omitempty"`
+}
+```
+
+- [ ] **Step 3: Verify the SPI test suite still passes**
+
+Run:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+go test ./... -v
+```
+
+Expected: all green (docstring-only change should not affect any test).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+git add types.go
+git commit -m "docs(types): document ProcessorDefinition.Type as execution-location axis
+
+Deferred from cyoda-go #250 spec §5.3 — intentionally held back for the
+first substantive SPI carve-out. Documents Type as the
+execution-location axis with values 'externalized' / 'internalized',
+matches the engine's tolerance behaviour exactly (only 'internalized'
+is rejected; unknown values fall through to ExecutionMode dispatch).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: CHANGELOG entries, push, open SPI PR
+
+**Files:**
+- Modify: `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/CHANGELOG.md` — `[Unreleased]` section.
+
+- [ ] **Step 1: Update CHANGELOG**
+
+Edit `/Users/paul/go-projects/cyoda-light/cyoda-go-spi/CHANGELOG.md` — under the `[Unreleased]` section's existing `### Added` block, append:
+
+```markdown
+- `TransitionSchedule` type + `TransitionDefinition.Schedule` field for
+  the scheduled-transition shape carve-out (cyoda-go #259). The new
+  type carries `DelayMs` (required, >0) and `TimeoutMs *int64`
+  (optional; nil = no timeout, &0 = strictest, &N = drop if late > N
+  ms). Runtime not yet wired — see cyoda-go #251 for full feature
+  tracking.
+```
+
+If Task 3 was NOT skipped (i.e. you added the docstring), also add a new `### Changed` subsection under `[Unreleased]` (after the Added block, before any existing Notes block):
+
+```markdown
+### Changed
+
+- Document `ProcessorDefinition.Type` field as the execution-location
+  axis (deferred from cyoda-go #250 per its spec §5.3, intentionally
+  bundled with the first substantive SPI carve-out — that is cyoda-go
+  #259).
+```
+
+If Task 3 was skipped (docstring already on main), do NOT add the Changed block — it would create a duplicate entry.
+
+- [ ] **Step 2: Commit the CHANGELOG**
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+git add CHANGELOG.md
+git commit -m "chore(changelog): record TransitionSchedule additions for cyoda-go #259
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+git push -u origin feat/scheduled-transition-shape
+```
+
+- [ ] **Step 4: Open the SPI PR**
+
+Run:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+gh pr create --base main --head feat/scheduled-transition-shape \
+  --title "feat(types): scheduled-transition shape" \
+  --body "$(cat <<'EOF'
+Additive SPI change for the cyoda-go v0.8.0 scheduled-transition shape
+carve-out.
+
+## What this adds
+
+- New \`TransitionSchedule\` type carrying \`DelayMs int64\` (required, >0)
+  and \`TimeoutMs *int64\` (optional pointer). Semantics:
+    - \`TimeoutMs == nil\` → no timeout, task fires whenever the scheduler
+      eventually picks it up.
+    - \`TimeoutMs == &0\` → strictest, drop on any lateness past scheduled
+      time.
+    - \`TimeoutMs == &N\` (N > 0) → drop if \`lateness > N ms\` where
+      \`lateness = executionTime - (stateEntryTime + DelayMs)\`.
+- New \`TransitionDefinition.Schedule *TransitionSchedule\` field
+  (optional). Presence marks the transition as scheduled.
+- Docstring on \`ProcessorDefinition.Type\` (deferred from cyoda-go #250
+  spec §5.3). Skip if it landed via a sibling carve-out first.
+
+## What this does NOT do
+
+- No runtime — the timer that arms and fires scheduled transitions is
+  cyoda-go #251 (deferred beyond v0.8.0).
+- No new \`SMEventScheduledTransition*\` events — those ship with #251.
+- No tag — bundled into v0.8.0's end-of-milestone tag per MAINTAINING.md
+  coordinated-release procedure.
+
+## Cross-repo
+
+- Consumer: cyoda-go #259 (this carve-out).
+- Parent feature (deferred): cyoda-go #251.
+
+## Reference
+
+cyoda-go spec: \`docs/superpowers/specs/2026-06-15-issue-259-scheduled-transition-shape-design.md\` rev 3.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 5: Pause for human review of the SPI PR**
+
+> **CHECKPOINT.** Do NOT continue to Phase 2 until the SPI PR is merged to `cyoda-go-spi` `main`. The cyoda-go pseudo-version pin (Phase 2) requires the merge commit SHA. Manual operator step.
+
+---
+
+# Phase 2 — cyoda-go pseudo-version pin refresh
+
+> **Working directory from here on:** the cyoda-go worktree at
+> `/Users/paul/go-projects/cyoda-light/cyoda-go/.claude/worktrees/259-scheduled-transition-config-shape/`.
+
+## Task 5: Bump cyoda-go-spi pin across all four `go.mod` files
+
+**Files:**
+- Modify: `go.mod`
+- Modify: `plugins/memory/go.mod`
+- Modify: `plugins/sqlite/go.mod`
+- Modify: `plugins/postgres/go.mod`
+
+- [ ] **Step 1: Confirm the SPI PR was merged and capture the new HEAD SHA**
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go-spi
+git fetch origin
+git rev-parse --short origin/main
+```
+
+Expected: short SHA of the new SPI `main` HEAD (the SPI PR's merge commit). Record it — call it `$SPISHA`.
+
+- [ ] **Step 2: Update root `go.mod` with `go get`**
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go/.claude/worktrees/259-scheduled-transition-config-shape
+GOPRIVATE=github.com/Cyoda-platform/* go get github.com/cyoda-platform/cyoda-go-spi@main
+go mod tidy
+```
+
+Expected: `go.mod` and `go.sum` updated with a fresh pseudo-version (the SHA prefix should match `$SPISHA`).
+
+- [ ] **Step 3: Update each plugin submodule**
+
+For each of `plugins/memory`, `plugins/sqlite`, `plugins/postgres`:
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go/.claude/worktrees/259-scheduled-transition-config-shape/plugins/memory
+GOPRIVATE=github.com/Cyoda-platform/* go get github.com/cyoda-platform/cyoda-go-spi@main
+go mod tidy
+
+cd ../sqlite
+GOPRIVATE=github.com/Cyoda-platform/* go get github.com/cyoda-platform/cyoda-go-spi@main
+go mod tidy
+
+cd ../postgres
+GOPRIVATE=github.com/Cyoda-platform/* go get github.com/cyoda-platform/cyoda-go-spi@main
+go mod tidy
+```
+
+- [ ] **Step 4: Verify all four `go.mod` files pin the same pseudo-version**
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go/.claude/worktrees/259-scheduled-transition-config-shape
+grep "cyoda-go-spi v" go.mod plugins/*/go.mod
+```
+
+Expected: identical pseudo-version string across all four files, containing the `$SPISHA` SHA fragment.
+
+- [ ] **Step 5: Build everything to confirm the new SPI compiles**
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go/.claude/worktrees/259-scheduled-transition-config-shape
+go build ./...
+```
+
+Expected: clean build.
+
+- [ ] **Step 6: Run short tests to confirm no regression from the pin bump**
+
+```bash
+go test -short ./...
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add go.mod go.sum plugins/*/go.mod plugins/*/go.sum
+git commit -m "chore(deps): bump cyoda-go-spi pin for #259 SPI types
+
+Picks up the bundled TransitionSchedule type + TransitionDefinition.Schedule
+field for the scheduled-transition shape carve-out (closes #259 in this
+repo), plus the deferred #250 ProcessorDefinition.Type docstring.
+
+Per cyoda-go-spi MAINTAINING.md coordinated-release procedure: no SPI
+tag was cut — bundled into v0.8.0's end-of-milestone tag. All four
+go.mod files (root + plugins/memory|sqlite|postgres) bump to the same
+pseudo-version pinned to SPI main HEAD.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 3 — OpenAPI surface
+
+## Task 6: Add `TransitionScheduleDto` schema + `schedule` on `TransitionDefinitionDto` + `allowCycles` on import body
+
+**Files:**
+- Modify: `api/openapi.yaml`
+
+- [ ] **Step 1: Add `TransitionScheduleDto` schema**
+
+In `api/openapi.yaml`, add a new schema definition near the existing `TransitionDefinitionDto` (insert in alphabetical order under `components.schemas`). The exact insertion point is just before `TransitionDefinitionDto`:
+
+```yaml
+    TransitionScheduleDto:
+      type: object
+      description: |
+        Scheduling configuration for an automatic future state transition.
+        Presence of this object marks the parent transition as scheduled.
+        The transition is scheduled to fire at `stateEntryTime + delayMs`
+        (the "scheduledTime"). When the scheduler picks the task up for
+        execution at `executionTime`, it computes `lateness = executionTime
+        - scheduledTime`; if `lateness > timeoutMs` the task is dropped
+        and the transition is NOT attempted. `timeoutMs` gives operators
+        control over how the system should handle backlog or intermittent-
+        offline conditions: short timeoutMs values prefer freshness over
+        eventual execution; absent timeoutMs always eventually fires.
+
+        Mutually exclusive with parent transition's manual=true.
+
+        The runtime that arms and fires the timer is not yet implemented.
+        Until it ships, the engine silently skips scheduled transitions
+        during automated cascade selection, and explicit fires by name are
+        rejected with HTTP 400 TRANSITION_NOT_FOUND.
+      properties:
+        delayMs:
+          type: integer
+          format: int64
+          minimum: 1
+          description: |
+            Delay between source-state entry and the scheduled execution
+            time, in milliseconds. Must be a positive integer (zero or
+            negative would make this a regular automated transition).
+        timeoutMs:
+          type: integer
+          format: int64
+          minimum: 0
+          description: |
+            Late-tolerance window past the scheduled execution time, in
+            milliseconds. When the scheduler picks the task up, if
+            `(executionTime - scheduledTime) > timeoutMs` the task is
+            dropped. Absent (omitted) means no timeout — the task fires
+            whenever the scheduler eventually picks it up. Explicit zero
+            is the strictest setting — drop on any lateness. Independent
+            of `delayMs`; the two measure different quantities.
+      required:
+        - delayMs
+```
+
+- [ ] **Step 2: Add `schedule` to `TransitionDefinitionDto.properties`**
+
+Locate `TransitionDefinitionDto` in `api/openapi.yaml`. Add to its `properties` block, after the existing `processors` property:
+
+```yaml
+        schedule:
+          $ref: "#/components/schemas/TransitionScheduleDto"
+          description: |
+            Optional scheduling configuration. Presence marks the transition as
+            scheduled; mutually exclusive with manual=true. Runtime not yet
+            implemented — see TransitionScheduleDto for engine behaviour.
+```
+
+Do NOT add `schedule` to `required`.
+
+- [ ] **Step 3: Add `allowCycles` to the workflow-import request body schema**
+
+Find the request body schema for `POST /model/{entityName}/{modelVersion}/workflow/import`. Confirm the schema name (likely `WorkflowImportRequestDto` or similar — search for it):
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go/.claude/worktrees/259-scheduled-transition-config-shape
+grep -n -B 1 -A 3 "workflow/import" api/openapi.yaml | head -30
+```
+
+Then add to the request body schema's `properties` (after the existing `importMode` / `workflows` properties):
+
+```yaml
+        allowCycles:
+          type: boolean
+          default: false
+          description: |
+            When true, bypasses the import-time check that rejects workflows
+            containing unguarded automated cycles (transitions with manual=false
+            and no criterion that form a closed loop). The runtime cascade
+            safety net — per-state visit cap and total cascade depth limit —
+            remains in effect and catches actual runaway at fire time. Use
+            when the cyclicity is intentional, e.g. polling patterns built on
+            scheduled transitions. Default false preserves the pre-#259
+            rejection behaviour exactly.
+```
+
+Do NOT add to `required`.
+
+- [ ] **Step 4: Commit the OpenAPI changes**
+
+```bash
+git add api/openapi.yaml
+git commit -m "feat(openapi): add TransitionScheduleDto + schedule + allowCycles
+
+Schema work for #259:
+- New TransitionScheduleDto with delayMs (required, >0) and timeoutMs
+  (optional, >=0). Description captures the late-tolerance-past-
+  scheduled-time semantic agreed with the project lead.
+- Optional schedule property on TransitionDefinitionDto, presence
+  marks the transition as scheduled (mutually exclusive with
+  manual=true).
+- Optional allowCycles boolean on the workflow-import request body,
+  default false, request-level escape hatch for unguarded automated
+  cycles.
+
+Runtime in-place engine guards land in subsequent commits; the
+generated DTOs come from the next make generate run.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Regenerate `api/generated.go`
+
+**Files:**
+- Modify: `api/generated.go`
+
+- [ ] **Step 1: Run the codegen target**
+
+```bash
+cd /Users/paul/go-projects/cyoda-light/cyoda-go/.claude/worktrees/259-scheduled-transition-config-shape
+make generate
+```
+
+Expected: succeeds with `api/generated.go` updated. If the target name differs, run:
+
+```bash
+grep -n "generate:" Makefile
+```
+
+…and use whatever target invokes `oapi-codegen`.
+
+- [ ] **Step 2: Verify the new DTOs are present**
+
+```bash
+grep -n "TransitionScheduleDto\|AllowCycles\|Schedule " api/generated.go | head -20
+```
+
+Expected output should contain:
+- `type TransitionScheduleDto struct {` (or similar).
+- `Schedule *TransitionScheduleDto` on `TransitionDefinitionDto`.
+- `AllowCycles` field on the import request body type.
+
+- [ ] **Step 3: Verify the build is clean**
+
+```bash
+go build ./...
+```
+
+Expected: clean build.
+
+- [ ] **Step 4: Verify short tests still pass**
+
+```bash
+go test -short ./...
+```
+
+Expected: all green (the codegen alone changes no behaviour).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/generated.go
+git commit -m "chore(api): regenerate DTOs for #259 schema additions
+
+Regenerated from the updated api/openapi.yaml. Adds:
+- TransitionScheduleDto struct with DelayMs int64 + TimeoutMs *int64.
+- Schedule *TransitionScheduleDto field on TransitionDefinitionDto.
+- AllowCycles bool on the workflow-import request body type.
+
+No behavioural change — just generator output.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 4 — Validator (TDD)
+
+## Task 8: Validator rule — `Manual && Schedule != nil` rejection
+
+**Files:**
+- Modify: `internal/domain/workflow/validate.go` — `validateWorkflowStructure` per-transition loop between lines 193 and 198.
+- Create or modify: `internal/domain/workflow/validate_test.go` (or whichever existing file holds validator tests — check with `grep -ln 'validateImportRequest\|validateWorkflowStructure' internal/domain/workflow/*_test.go`).
+
+- [ ] **Step 1: Write failing test for manual+schedule rejection**
+
+Add to the validator test file:
+
+```go
+func TestValidator_ManualAndSchedule_Rejected(t *testing.T) {
+	tm := int64(1000)
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "test",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {
+				Transitions: []spi.TransitionDefinition{
+					{
+						Name:     "T1",
+						Next:     "S1",
+						Manual:   true,
+						Schedule: &spi.TransitionSchedule{DelayMs: 1000, TimeoutMs: &tm},
+					},
+				},
+			},
+		},
+	}
+	err := validateImportRequest([]spi.WorkflowDefinition{wf})
+	if err == nil {
+		t.Fatal("expected validation error for manual=true + schedule, got nil")
+	}
+	if !strings.Contains(err.Error(), "manual and scheduled are mutually exclusive") {
+		t.Errorf("error message missing expected substring; got: %v", err)
+	}
+}
+```
+
+If the test file does not exist, create `internal/domain/workflow/validate_test.go` with:
+
+```go
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go-spi"
+)
+```
+
+…and the test function above.
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+go test -run TestValidator_ManualAndSchedule_Rejected -v ./internal/domain/workflow/
+```
+
+Expected: FAIL with `expected validation error for manual=true + schedule, got nil` (the validator currently accepts the shape).
+
+- [ ] **Step 3: Add the rule in `validateWorkflowStructure`**
+
+Edit `internal/domain/workflow/validate.go`. Find the per-transition loop (around lines 178-212). Between the Next-state existence check (lines 193-196) and the processor loop (line 198), insert:
+
+```go
+			if tr.Manual && tr.Schedule != nil {
+				return fmt.Errorf(
+					"workflow %q state %q transition %q: manual and scheduled are mutually exclusive",
+					wf.Name, stateName, tr.Name)
+			}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+go test -run TestValidator_ManualAndSchedule_Rejected -v ./internal/domain/workflow/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full package tests to confirm no regression**
+
+```bash
+go test -short ./internal/domain/workflow/...
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/domain/workflow/validate.go internal/domain/workflow/validate_test.go
+git commit -m "feat(workflow): reject manual+schedule transitions at import (#259)
+
+A scheduled transition fires automatically on a timer; declaring it
+manual at the same time is a config contradiction. validateWorkflowStructure
+rejects the combination with VALIDATION_FAILED 400.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Validator rule — `Schedule != nil && DelayMs <= 0` rejection
+
+**Files:**
+- Modify: `internal/domain/workflow/validate.go`
+- Modify: validator test file from Task 8.
+
+- [ ] **Step 1: Write failing tests for `DelayMs <= 0`**
+
+Append to the validator test file:
+
+```go
+func TestValidator_DelayMsZero_Rejected(t *testing.T) {
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "test",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {
+				Transitions: []spi.TransitionDefinition{
+					{
+						Name:     "T1",
+						Next:     "S1",
+						Manual:   false,
+						Schedule: &spi.TransitionSchedule{DelayMs: 0},
+					},
+				},
+			},
+		},
+	}
+	err := validateImportRequest([]spi.WorkflowDefinition{wf})
+	if err == nil || !strings.Contains(err.Error(), "delayMs must be > 0") {
+		t.Errorf("expected delayMs error, got: %v", err)
+	}
+}
+
+func TestValidator_DelayMsNegative_Rejected(t *testing.T) {
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "test",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {
+				Transitions: []spi.TransitionDefinition{
+					{
+						Name:     "T1",
+						Next:     "S1",
+						Manual:   false,
+						Schedule: &spi.TransitionSchedule{DelayMs: -100},
+					},
+				},
+			},
+		},
+	}
+	err := validateImportRequest([]spi.WorkflowDefinition{wf})
+	if err == nil || !strings.Contains(err.Error(), "delayMs must be > 0") {
+		t.Errorf("expected delayMs error, got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```bash
+go test -run 'TestValidator_DelayMs(Zero|Negative)_Rejected' -v ./internal/domain/workflow/
+```
+
+Expected: FAIL with `expected delayMs error, got: <nil>` for both.
+
+- [ ] **Step 3: Add the rule**
+
+Edit `internal/domain/workflow/validate.go`. Below the manual+schedule check added in Task 8, add:
+
+```go
+			if tr.Schedule != nil && tr.Schedule.DelayMs <= 0 {
+				return fmt.Errorf(
+					"workflow %q state %q transition %q: schedule.delayMs must be > 0 (got %d)",
+					wf.Name, stateName, tr.Name, tr.Schedule.DelayMs)
+			}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+go test -run 'TestValidator_DelayMs(Zero|Negative)_Rejected' -v ./internal/domain/workflow/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run package tests**
+
+```bash
+go test -short ./internal/domain/workflow/...
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/domain/workflow/validate.go internal/domain/workflow/validate_test.go
+git commit -m "feat(workflow): reject schedule.delayMs <= 0 at import (#259)
+
+A scheduled transition with delayMs <= 0 is effectively a regular
+automated transition (firing in zero or negative time has no
+schedule semantic). Reject at import with VALIDATION_FAILED 400.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Validator happy-path regression tests
+
+**Files:**
+- Modify: validator test file from Task 8.
+
+- [ ] **Step 1: Add happy-path tests**
+
+Append to the validator test file:
+
+```go
+func TestValidator_ScheduleHappyPaths(t *testing.T) {
+	tmZero := int64(0)
+	tmPositive := int64(5000)
+
+	cases := []struct {
+		name string
+		sch  *spi.TransitionSchedule
+	}{
+		{"timeoutMs_absent_nil", &spi.TransitionSchedule{DelayMs: 1000}},
+		{"timeoutMs_explicit_zero", &spi.TransitionSchedule{DelayMs: 1000, TimeoutMs: &tmZero}},
+		{"timeoutMs_less_than_delayMs", &spi.TransitionSchedule{DelayMs: 1000, TimeoutMs: &([]int64{500}[0])}},
+		{"timeoutMs_greater_than_delayMs", &spi.TransitionSchedule{DelayMs: 1000, TimeoutMs: &tmPositive}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wf := spi.WorkflowDefinition{
+				Version:      "1",
+				Name:         "test",
+				InitialState: "S1",
+				Active:       true,
+				States: map[string]spi.StateDefinition{
+					"S1": {
+						Transitions: []spi.TransitionDefinition{
+							{Name: "T1", Next: "S1", Manual: false, Schedule: tc.sch},
+						},
+					},
+				},
+			}
+			if err := validateImportRequest([]spi.WorkflowDefinition{wf}); err != nil {
+				t.Errorf("expected acceptance for shape %q; got: %v", tc.name, err)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+go test -run TestValidator_ScheduleHappyPaths -v ./internal/domain/workflow/
+```
+
+Expected: all four sub-tests PASS. The third case (`timeoutMs_less_than_delayMs`) is the critical assertion that proves the rev 1 / rev 2 bogus rule was removed — under the late-tolerance semantic, this is a valid shape.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/domain/workflow/validate_test.go
+git commit -m "test(workflow): pin Schedule-shape happy paths (#259)
+
+Four shapes that MUST validate:
+- timeoutMs absent (nil) - no-timeout semantic
+- timeoutMs explicit zero (&0) - strictest semantic
+- timeoutMs < delayMs (e.g. delay 1000ms, timeout 500ms) - valid
+  under late-tolerance semantic (NOT max-age-of-armed-timer)
+- timeoutMs > delayMs - valid
+
+The third case is the regression guard for rev 1 / rev 2's bogus
+TimeoutMs >= DelayMs rule.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 5 — `allowCycles` request envelope
+
+## Task 11: Add `AllowCycles` to `importRequest` + signature change on `validateWorkflows` + slog.Warn
+
+**Files:**
+- Modify: `internal/domain/workflow/handler.go` (lines 60-64 for `importRequest`; line 183 for the `validateWorkflows` call).
+- Modify: `internal/domain/workflow/validate.go` — `validateWorkflows` signature.
+- Modify: `internal/domain/workflow/scenarios_test.go` — 8 call sites at lines 267, 287, 313, 334, 587, 619, 641, 652 (check current line numbers — they may have shifted from Phase 4 additions).
+
+- [ ] **Step 1: Change `validateWorkflows` signature**
+
+Edit `internal/domain/workflow/validate.go`. Find `validateWorkflows`. Change its signature from:
+
+```go
+func validateWorkflows(workflows []spi.WorkflowDefinition) error {
+```
+
+…to:
+
+```go
+func validateWorkflows(workflows []spi.WorkflowDefinition, allowCycles bool) error {
+```
+
+…and update the body to short-circuit `validateWorkflowLoops` when `allowCycles` is true:
+
+```go
+func validateWorkflows(workflows []spi.WorkflowDefinition, allowCycles bool) error {
+	for _, wf := range workflows {
+		if !allowCycles {
+			if err := validateWorkflowLoops(wf); err != nil {
+				return err
+			}
+		}
+		if err := validateProcessorFlags(wf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+```
+
+(If the existing body iterates differently, adapt the short-circuit logic accordingly. The principle: skip only `validateWorkflowLoops`; keep `validateProcessorFlags` unconditional.)
+
+- [ ] **Step 2: Update the handler call site**
+
+Edit `internal/domain/workflow/handler.go` lines 60-64. Replace the `importRequest` struct:
+
+```go
+// importRequest is the JSON body shape for workflow import.
+type importRequest struct {
+	ImportMode  string              `json:"importMode"`
+	AllowCycles bool                `json:"allowCycles,omitempty"`
+	Workflows   []workflowImportDef `json:"workflows"`
+}
+```
+
+Then locate the `validateWorkflows(result)` call at line 183. Replace with:
+
+```go
+	if err := validateWorkflows(result, req.AllowCycles); err != nil {
+		common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeValidationFailed, err.Error()))
+		return
+	}
+
+	if req.AllowCycles {
+		workflowNames := make([]string, len(result))
+		for i, wf := range result {
+			workflowNames[i] = wf.Name
+		}
+		slog.WarnContext(r.Context(), "workflow import: cycle validation bypassed",
+			"pkg", "workflow",
+			"entityName", entityName,
+			"modelVersion", modelVersion,
+			"importMode", mode,
+			"workflows", workflowNames)
+	}
+```
+
+If `slog` is not already imported in `handler.go`, add `"log/slog"` to the import block.
+
+- [ ] **Step 3: Update all `validateWorkflows` call sites in `scenarios_test.go`**
+
+```bash
+grep -n "validateWorkflows" internal/domain/workflow/scenarios_test.go
+```
+
+Each call site has the form `validateWorkflows([]spi.WorkflowDefinition{wf})` or similar. Add `false` as the second argument at every site:
+
+```bash
+sed -i.bak 's|validateWorkflows(\([^)]*\))|validateWorkflows(\1, false)|g' internal/domain/workflow/scenarios_test.go
+rm internal/domain/workflow/scenarios_test.go.bak
+```
+
+Verify with grep:
+
+```bash
+grep -n "validateWorkflows" internal/domain/workflow/scenarios_test.go
+```
+
+All entries should now have `, false)` at the end.
+
+- [ ] **Step 4: Run the package tests to confirm compile + green**
+
+```bash
+go test -short ./internal/domain/workflow/...
+```
+
+Expected: all green (the existing tests still pass with `allowCycles=false`; new behaviour is gated behind the flag).
+
+- [ ] **Step 5: Run the broader short-test suite**
+
+```bash
+go test -short ./...
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/domain/workflow/handler.go internal/domain/workflow/validate.go internal/domain/workflow/scenarios_test.go
+git commit -m "feat(workflow): add request-level allowCycles escape hatch (#259)
+
+Adds an optional 'allowCycles' boolean to the workflow-import request
+body. Default false preserves byte-identical pre-#259 behaviour.
+
+When true:
+- validateWorkflows short-circuits validateWorkflowLoops (the cycle
+  detector) for the duration of the import call.
+- All other validators (Schedule rules, processor flags, structural
+  checks) remain unconditional.
+- The handler emits a single slog.Warn naming the affected model + the
+  workflow names that were imported under the bypass.
+
+Use cases: polling-pattern workflows built on scheduled transitions
+(S1 →scheduled→ S2 →scheduled→ S1), and other workflows whose
+cyclicity is intentional. The runtime cascade safety net
+(maxStateVisits, maxCascadeDepth) is unchanged; catches actual
+runaway at fire time.
+
+Touches 8 validateWorkflows call sites in scenarios_test.go — all
+mechanical additions of ', false' to preserve the existing
+default-rejection behaviour in those tests.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Tests for `allowCycles` bypass behaviour
+
+**Files:**
+- Modify: validator test file from Task 8.
+
+- [ ] **Step 1: Write tests for the bypass matrix**
+
+Append to the validator test file:
+
+```go
+// cyclicWorkflow builds S1 -automated, no criterion-> S2 -automated, no
+// criterion-> S1. validateWorkflowLoops rejects this by default.
+func cyclicWorkflow(t *testing.T) spi.WorkflowDefinition {
+	t.Helper()
+	return spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "cyclic",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{{Name: "to-S2", Next: "S2", Manual: false}}},
+			"S2": {Transitions: []spi.TransitionDefinition{{Name: "to-S1", Next: "S1", Manual: false}}},
+		},
+	}
+}
+
+func TestValidator_DefaultFalse_RejectsCycle(t *testing.T) {
+	wf := cyclicWorkflow(t)
+	if err := validateWorkflows([]spi.WorkflowDefinition{wf}, false); err == nil {
+		t.Fatal("expected cycle rejection at default allowCycles=false")
+	}
+}
+
+func TestValidator_AllowCyclesTrue_BypassesCycleCheck(t *testing.T) {
+	wf := cyclicWorkflow(t)
+	if err := validateWorkflows([]spi.WorkflowDefinition{wf}, true); err != nil {
+		t.Errorf("expected acceptance with allowCycles=true; got: %v", err)
+	}
+}
+
+func TestValidator_AllowCyclesTrue_DoesNotBypassScheduleRules(t *testing.T) {
+	tm := int64(1000)
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "cyclic_and_incoherent",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{
+				{Name: "to-S2", Next: "S2", Manual: true, Schedule: &spi.TransitionSchedule{DelayMs: 1000, TimeoutMs: &tm}},
+			}},
+			"S2": {Transitions: []spi.TransitionDefinition{
+				{Name: "to-S1", Next: "S1", Manual: false},
+			}},
+		},
+	}
+	// validateImportRequest catches the structural (manual+schedule) rule,
+	// regardless of allowCycles. Note this calls validateImportRequest, not
+	// validateWorkflows — the Schedule rules live in validateWorkflowStructure.
+	if err := validateImportRequest([]spi.WorkflowDefinition{wf}); err == nil {
+		t.Fatal("expected manual+schedule rejection even when cyclic")
+	} else if !strings.Contains(err.Error(), "manual and scheduled are mutually exclusive") {
+		t.Errorf("expected Schedule-rule error, got: %v", err)
+	}
+}
+
+func TestValidator_AllowCyclesTrue_PollingScheduledWorkflow_Accepted(t *testing.T) {
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "polling",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{
+				{Name: "to-S2", Next: "S2", Manual: false, Schedule: &spi.TransitionSchedule{DelayMs: 1000}},
+			}},
+			"S2": {Transitions: []spi.TransitionDefinition{
+				{Name: "to-S1", Next: "S1", Manual: false, Schedule: &spi.TransitionSchedule{DelayMs: 1000}},
+			}},
+		},
+	}
+	// Default (allowCycles=false) rejects (the scheduled-polling cycle).
+	if err := validateWorkflows([]spi.WorkflowDefinition{wf}, false); err == nil {
+		t.Fatal("expected cycle rejection on polling workflow at allowCycles=false")
+	}
+	// allowCycles=true accepts.
+	if err := validateWorkflows([]spi.WorkflowDefinition{wf}, true); err != nil {
+		t.Errorf("expected polling workflow to validate with allowCycles=true; got: %v", err)
+	}
+	// Structural validation (Schedule rules) also passes.
+	if err := validateImportRequest([]spi.WorkflowDefinition{wf}); err != nil {
+		t.Errorf("expected structural validation to pass on polling workflow; got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+go test -run 'TestValidator_(DefaultFalse|AllowCyclesTrue)' -v ./internal/domain/workflow/
+```
+
+Expected: all four PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/domain/workflow/validate_test.go
+git commit -m "test(workflow): pin allowCycles bypass behaviour (#259)
+
+Four assertions:
+- Default allowCycles=false rejects unguarded automated cycles
+  (regression guard for existing cycle-detector behaviour).
+- allowCycles=true accepts the same cyclic workflow.
+- allowCycles=true does NOT bypass Schedule-coherence rules
+  (manual+schedule still rejected via validateImportRequest).
+- Polling-pattern scheduled workflow imports with allowCycles=true.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 6 — Engine cascade-skip
+
+## Task 13: Cascade silent-skip for scheduled transitions
+
+**Files:**
+- Modify: `internal/domain/workflow/engine.go` — line 528 cascade-skip filter.
+- Modify: engine test file (find with `grep -l 'TestCascade\|cascadeAutomated' internal/domain/workflow/*_test.go`).
+
+- [ ] **Step 1: Write failing test — only-scheduled state rests**
+
+Find the engine test file. Append:
+
+```go
+func TestEngine_CascadeSkipsScheduled_RestsInState(t *testing.T) {
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "test",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{
+				{Name: "scheduledOnly", Next: "S2", Manual: false, Schedule: &spi.TransitionSchedule{DelayMs: 1000}},
+			}},
+			"S2": {},
+		},
+	}
+	e, _, _ := newTestEngine(t) // <- if a builder exists; else inline-build per engine_test.go's pattern
+	entity := &spi.Entity{Meta: spi.EntityMeta{ID: "e1", State: "S1"}}
+
+	ctx := context.Background()
+	auditStore := newMemoryAuditStore() // <- inline-build per engine_test.go's pattern
+	_, _, err := e.cascadeAutomated(ctx, entity, &wf, auditStore, "tx-1")
+	if err != nil {
+		t.Fatalf("cascade returned error: %v", err)
+	}
+	if entity.Meta.State != "S1" {
+		t.Errorf("expected entity to rest in S1; got %q", entity.Meta.State)
+	}
+}
+```
+
+(If `newTestEngine`/`newMemoryAuditStore` builders don't already exist in the test file, replace with whatever the existing engine tests use. Use `grep -A 20 'func TestEngine_' internal/domain/workflow/engine_test.go` to find the pattern.)
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+go test -run TestEngine_CascadeSkipsScheduled_RestsInState -v ./internal/domain/workflow/
+```
+
+Expected outcome: depends on current cascade behaviour. Most likely the cascade will fire the scheduled transition (since cascade doesn't yet skip on `Schedule != nil`) → entity ends in `S2` → test fails with `expected entity to rest in S1; got "S2"`.
+
+- [ ] **Step 3: Add the cascade-skip filter**
+
+Edit `internal/domain/workflow/engine.go` at line 528 (the skip filter inside `cascadeAutomated`'s per-transition loop). Change:
+
+```go
+			if tr.Disabled || tr.Manual {
+				continue
+			}
+```
+
+…to:
+
+```go
+			if tr.Disabled || tr.Manual || tr.Schedule != nil {
+				continue
+			}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+go test -run TestEngine_CascadeSkipsScheduled_RestsInState -v ./internal/domain/workflow/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add a second test — scheduled coexists with regular automated**
+
+Append to the engine test file:
+
+```go
+func TestEngine_CascadeSkipsScheduled_FiresRegularSibling(t *testing.T) {
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "test",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{
+				{Name: "scheduled", Next: "S2", Manual: false, Schedule: &spi.TransitionSchedule{DelayMs: 1000}},
+				{Name: "regular", Next: "Sfinal", Manual: false},
+			}},
+			"S2":     {},
+			"Sfinal": {},
+		},
+	}
+	e, _, _ := newTestEngine(t)
+	entity := &spi.Entity{Meta: spi.EntityMeta{ID: "e1", State: "S1"}}
+
+	ctx := context.Background()
+	auditStore := newMemoryAuditStore()
+	_, _, err := e.cascadeAutomated(ctx, entity, &wf, auditStore, "tx-1")
+	if err != nil {
+		t.Fatalf("cascade returned error: %v", err)
+	}
+	if entity.Meta.State != "Sfinal" {
+		t.Errorf("expected entity to land in Sfinal via the regular sibling; got %q", entity.Meta.State)
+	}
+}
+```
+
+Run:
+
+```bash
+go test -run 'TestEngine_CascadeSkipsScheduled_' -v ./internal/domain/workflow/
+```
+
+Expected: both PASS.
+
+- [ ] **Step 6: Run the broader test suite**
+
+```bash
+go test -short ./internal/domain/workflow/...
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/domain/workflow/engine.go internal/domain/workflow/engine_test.go
+git commit -m "feat(workflow): cascade silently skips scheduled transitions (#259)
+
+One-line extension to the existing Disabled/Manual skip filter in
+cascadeAutomated's per-transition loop. Schedule != nil transitions
+are not eligible for automated cascade selection — they wait for
+their timer.
+
+Until the timer runtime ships (#251), scheduled transitions are
+invisible to cascade. An entity whose only exit is scheduled rests
+in its source state. Other automated/manual exits out of the same
+state fire normally.
+
+No audit event for the skip — matches existing silent-skip semantics
+for Disabled and Manual transitions.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 7 — Engine explicit-fire reject
+
+## Task 14: Explicit-fire reject for scheduled transitions
+
+**Files:**
+- Modify: `internal/domain/workflow/engine.go` — `attemptTransition` after the `Disabled` check at lines 449-453.
+- Modify: engine test file from Task 13.
+
+- [ ] **Step 1: Write failing test — explicit fire of scheduled returns ErrTransitionNotFound**
+
+Append to the engine test file:
+
+```go
+func TestEngine_AttemptTransition_Scheduled_ReturnsTransitionNotFound(t *testing.T) {
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "test",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{
+				{Name: "AutoClose", Next: "Closed", Manual: false, Schedule: &spi.TransitionSchedule{DelayMs: 1000}},
+			}},
+			"Closed": {},
+		},
+	}
+	e, _, _ := newTestEngine(t)
+	entity := &spi.Entity{Meta: spi.EntityMeta{ID: "e1", State: "S1"}}
+	auditStore := newMemoryAuditStore()
+
+	_, _, err := e.attemptTransition(context.Background(), entity, &wf, "AutoClose", auditStore, "tx-1")
+	if err == nil {
+		t.Fatal("expected error firing a scheduled transition by name")
+	}
+	if !errors.Is(err, ErrTransitionNotFound) {
+		t.Errorf("expected error to wrap ErrTransitionNotFound (mirrors Disabled precedent); got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "scheduled transitions are not yet implemented") {
+		t.Errorf("expected error message to name the unavailability; got: %v", err)
+	}
+	if entity.Meta.State != "S1" {
+		t.Errorf("expected entity to stay in source state S1; got %q", entity.Meta.State)
+	}
+
+	// Audit trail: exactly one SMEventTransitionNotFound row, no
+	// SMEventTransitionMade, no SMEventStateProcessResult.
+	events := auditStore.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected exactly 1 audit event; got %d: %+v", len(events), events)
+	}
+	if events[0].EventType != spi.SMEventTransitionNotFound {
+		t.Errorf("expected SMEventTransitionNotFound; got %q", events[0].EventType)
+	}
+	if !strings.Contains(events[0].Details, "scheduled transitions are not yet implemented") {
+		t.Errorf("expected Details to carry rejection cause; got %q", events[0].Details)
+	}
+}
+```
+
+(Adapt `auditStore.Events()` to whichever accessor the test's audit store exposes — e.g. `auditStore.records` directly, or a helper. Grep `internal/domain/workflow/engine_test.go` for an existing audit-trail-assertion test for the shape.)
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+go test -run TestEngine_AttemptTransition_Scheduled_ReturnsTransitionNotFound -v ./internal/domain/workflow/
+```
+
+Expected: FAIL. The current `attemptTransition` will progress past the missing schedule check, evaluate criterion (none, accepts), call `executeProcessors` (no processors, succeeds), and FIRE the transition → entity moves to `Closed`. So the test fails on `entity.Meta.State` assertion.
+
+- [ ] **Step 3: Add the explicit-fire reject branch**
+
+Edit `internal/domain/workflow/engine.go`. Find `attemptTransition`'s `Disabled` check (lines 449-453). Immediately after the `if transition.Disabled { ... }` block, insert a new branch BEFORE the criterion evaluation:
+
+```go
+	if transition.Schedule != nil {
+		e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
+			spi.SMEventTransitionNotFound,
+			fmt.Sprintf(
+				"Transition %q is scheduled; scheduled transitions are not yet implemented",
+				transitionName), nil)
+		return ctx, txID, fmt.Errorf(
+			"transition %q in state %q is scheduled; scheduled transitions are not yet implemented: %w",
+			transitionName, entity.Meta.State, ErrTransitionNotFound)
+	}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+```bash
+go test -run TestEngine_AttemptTransition_Scheduled_ReturnsTransitionNotFound -v ./internal/domain/workflow/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the package suite**
+
+```bash
+go test -short ./internal/domain/workflow/...
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/domain/workflow/engine.go internal/domain/workflow/engine_test.go
+git commit -m "feat(workflow): reject explicit fire of scheduled transitions (#259)
+
+attemptTransition gains a new branch after the existing Disabled check.
+Mirrors the Disabled precedent byte-for-byte:
+- Emit SMEventTransitionNotFound with Details naming the rejection
+  cause.
+- Return error wrapping ErrTransitionNotFound sentinel.
+- classifyWorkflowError maps to 400 TRANSITION_NOT_FOUND.
+
+Per project lead: TRANSITION_NOT_FOUND is the right code for
+'transition exists but is not currently dispatchable from the
+caller's POV' — exactly the scheduled-but-runtime-not-yet-implemented
+case. Same code Disabled returns. Audit consumers searching for
+'transition not currently dispatchable' events see a uniform shape
+across missing-by-name, disabled, and scheduled cases; the Details
+substring distinguishes them.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 8 — Round-trip preservation
+
+## Task 15: Round-trip test across the three `TimeoutMs` pointer states
+
+**Files:**
+- Modify: workflow test file (e.g. `internal/domain/workflow/handler_test.go` or whichever file hosts existing import/export round-trip tests; check with `grep -l 'TestImport\|RoundTrip' internal/domain/workflow/*_test.go`).
+
+- [ ] **Step 1: Write round-trip tests for the three pointer states**
+
+The test asserts JSON byte-equivalence for each of the three states via Go-level marshal/unmarshal cycles:
+
+```go
+func TestSchedule_RoundTrip_TimeoutMsPointerStates(t *testing.T) {
+	tm := int64(90000000)
+	tmZero := int64(0)
+
+	cases := []struct {
+		name        string
+		schedule    *spi.TransitionSchedule
+		wantInJSON  string  // substring that MUST appear in marshalled JSON
+		wantNotInJSON string  // substring that MUST NOT appear
+	}{
+		{
+			name:       "timeoutMs_non_nil_positive",
+			schedule:   &spi.TransitionSchedule{DelayMs: 86400000, TimeoutMs: &tm},
+			wantInJSON: `"timeoutMs":90000000`,
+		},
+		{
+			name:       "timeoutMs_non_nil_zero",
+			schedule:   &spi.TransitionSchedule{DelayMs: 86400000, TimeoutMs: &tmZero},
+			wantInJSON: `"timeoutMs":0`,
+		},
+		{
+			name:          "timeoutMs_nil",
+			schedule:      &spi.TransitionSchedule{DelayMs: 86400000},
+			wantNotInJSON: "timeoutMs",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := spi.TransitionDefinition{
+				Name:     "AutoClose",
+				Next:     "Closed",
+				Manual:   false,
+				Schedule: tc.schedule,
+			}
+			bs, err := json.Marshal(tr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.wantInJSON != "" && !strings.Contains(string(bs), tc.wantInJSON) {
+				t.Errorf("expected JSON to contain %q; got %s", tc.wantInJSON, bs)
+			}
+			if tc.wantNotInJSON != "" && strings.Contains(string(bs), tc.wantNotInJSON) {
+				t.Errorf("expected JSON NOT to contain %q; got %s", tc.wantNotInJSON, bs)
+			}
+
+			var back spi.TransitionDefinition
+			if err := json.Unmarshal(bs, &back); err != nil {
+				t.Fatal(err)
+			}
+			if back.Schedule == nil {
+				t.Fatal("Schedule lost on round-trip")
+			}
+			if back.Schedule.DelayMs != tc.schedule.DelayMs {
+				t.Errorf("DelayMs lost: got %d", back.Schedule.DelayMs)
+			}
+			// Pointer-state-preserving equality check.
+			gotPtr := back.Schedule.TimeoutMs
+			wantPtr := tc.schedule.TimeoutMs
+			if (gotPtr == nil) != (wantPtr == nil) {
+				t.Errorf("TimeoutMs pointer-presence mismatched: got %v, want %v", gotPtr, wantPtr)
+			}
+			if gotPtr != nil && wantPtr != nil && *gotPtr != *wantPtr {
+				t.Errorf("TimeoutMs value mismatched: got %d, want %d", *gotPtr, *wantPtr)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+go test -run TestSchedule_RoundTrip_TimeoutMsPointerStates -v ./internal/domain/workflow/
+```
+
+Expected: all three sub-tests PASS — this is a regression guard, the round-trip already works given the SPI-level pointer field added in Task 2.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/domain/workflow/*_test.go
+git commit -m "test(workflow): pin Schedule round-trip across TimeoutMs pointer states (#259)
+
+Regression guard for the *int64 pointer pattern's round-trip fidelity:
+- non-nil positive: marshals as 'timeoutMs:N', round-trips byte-equal.
+- non-nil zero: marshals as 'timeoutMs:0' (NOT omitted — the pointer
+  semantics are what omitempty preserves; the value is zero).
+- nil: marshals without the 'timeoutMs' key.
+
+Pins the entire *int64+omitempty contract end-to-end.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 9 — E2E test
+
+## Task 16: E2E test — manual fire of scheduled returns 400 TRANSITION_NOT_FOUND
+
+**Files:**
+- Modify or create: a test file in `internal/e2e/` (check `ls internal/e2e/*_test.go` for the existing workflow-import E2E test file to extend; if none, create `internal/e2e/scheduled_transition_test.go`).
+
+- [ ] **Step 1: Locate the existing E2E test pattern**
+
+```bash
+ls internal/e2e/*_test.go
+grep -l "POST /model" internal/e2e/*_test.go
+```
+
+Read the existing patterns to match the auth, model-creation, and HTTP-client helper conventions. The new test should reuse the same shared `TestMain` setup (PostgreSQL via testcontainers, in-process `httptest.Server`, JWT auth).
+
+- [ ] **Step 2: Write the E2E test**
+
+Following the existing pattern, add a test that:
+
+1. Creates a model `EntityX`, version 1.
+2. POSTs a workflow with one transition: `{name: "AutoClose", next: "Closed", manual: false, schedule: {delayMs: 1000}}`. Asserts HTTP 200.
+3. POSTs to create an entity instance. Asserts the entity lands in the initial state (cascade skips the scheduled transition).
+4. POSTs `transition/AutoClose` to fire the scheduled transition by name. Asserts HTTP 400 with `error.code == "TRANSITION_NOT_FOUND"` and the message contains `"scheduled transitions are not yet implemented"`.
+5. GETs the entity and asserts the state is still the initial state.
+
+Concrete skeleton (adapt to the existing E2E harness's helpers — the test below uses placeholder helper names that you should replace with the actual ones from the existing tests):
+
+```go
+func TestE2E_ExplicitFireOfScheduledTransition_ReturnsTransitionNotFound(t *testing.T) {
+	srv := setupE2EServer(t) // reuse the existing helper
+	defer srv.Close()
+	client := srv.Client()
+	token := mintAuthToken(t)
+
+	entityName := "EntityX"
+	modelVersion := int32(1)
+
+	// (1) Create model.
+	createModel(t, client, srv.URL, token, entityName, modelVersion, defaultModelSchema())
+
+	// (2) Import workflow with a scheduled transition.
+	importBody := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1",
+			"name": "test",
+			"initialState": "Open",
+			"active": true,
+			"states": {
+				"Open": {"transitions": [{"name":"AutoClose","next":"Closed","manual":false,"schedule":{"delayMs":1000}}]},
+				"Closed": {}
+			}
+		}]
+	}`
+	resp := postJSON(t, client, srv.URL,
+		fmt.Sprintf("/api/model/%s/%d/workflow/import", entityName, modelVersion),
+		token, importBody)
+	if resp.StatusCode != 200 {
+		t.Fatalf("import returned %d; body: %s", resp.StatusCode, readBody(t, resp))
+	}
+
+	// (3) Create entity.
+	createBody := `{"data":{"foo":"bar"}}`
+	resp = postJSON(t, client, srv.URL, fmt.Sprintf("/api/entity/%s", entityName), token, createBody)
+	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+		t.Fatalf("create entity returned %d; body: %s", resp.StatusCode, readBody(t, resp))
+	}
+	var created struct {
+		ID    string `json:"id"`
+		State string `json:"state"`
+	}
+	mustDecodeJSON(t, resp.Body, &created)
+	if created.State != "Open" {
+		t.Errorf("expected entity to land in initial state 'Open' (cascade skips scheduled); got %q", created.State)
+	}
+
+	// (4) Fire the scheduled transition by name.
+	resp = postJSON(t, client, srv.URL,
+		fmt.Sprintf("/api/entity/%s/%s/transition/AutoClose", entityName, created.ID),
+		token, `{}`)
+	if resp.StatusCode != 400 {
+		t.Fatalf("expected 400 TRANSITION_NOT_FOUND; got %d, body: %s", resp.StatusCode, readBody(t, resp))
+	}
+	var errBody struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	mustDecodeJSON(t, resp.Body, &errBody)
+	if errBody.Error.Code != "TRANSITION_NOT_FOUND" {
+		t.Errorf("expected error.code TRANSITION_NOT_FOUND; got %q", errBody.Error.Code)
+	}
+	if !strings.Contains(errBody.Error.Message, "scheduled transitions are not yet implemented") {
+		t.Errorf("expected error.message to name the rejection cause; got %q", errBody.Error.Message)
+	}
+
+	// (5) GET entity asserts the state is still Open.
+	resp = getJSON(t, client, srv.URL, fmt.Sprintf("/api/entity/%s/%s", entityName, created.ID), token)
+	var fetched struct {
+		State string `json:"state"`
+	}
+	mustDecodeJSON(t, resp.Body, &fetched)
+	if fetched.State != "Open" {
+		t.Errorf("expected entity to remain in initial state after rejection; got %q", fetched.State)
+	}
+}
+```
+
+> **Note for the implementer.** The helper functions above (`setupE2EServer`, `mintAuthToken`, `createModel`, `postJSON`, `getJSON`, `readBody`, `mustDecodeJSON`, `defaultModelSchema`) are placeholders. Use whatever the existing E2E tests use. If no equivalent exists for some, factor what you need from an existing test rather than inventing a new style — these helpers exist as a pattern, not a contract.
+
+- [ ] **Step 3: Run the E2E test (requires Docker)**
+
+```bash
+go test -run TestE2E_ExplicitFireOfScheduledTransition_ReturnsTransitionNotFound -v ./internal/e2e/
+```
+
+Expected: PASS (after the helper adaptations).
+
+- [ ] **Step 4: Run the full E2E suite to confirm no regressions**
+
+```bash
+go test ./internal/e2e/ -v
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/e2e/
+git commit -m "test(e2e): explicit-fire of scheduled transition returns 400 TRANSITION_NOT_FOUND (#259)
+
+End-to-end coverage through the full HTTP stack:
+1. Create model.
+2. Import workflow with one scheduled transition. Assert 200.
+3. Create entity instance. Assert it rests in initial state
+   (cascade skips scheduled).
+4. POST transition/AutoClose. Assert 400 TRANSITION_NOT_FOUND with
+   the 'scheduled transitions are not yet implemented' message
+   substring.
+5. GET entity. Assert state unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 10 — Parity scenarios
+
+## Task 17: Add `wf-import/07`, `wf-import/08`, `wf-import/09` to scenario 08
+
+**Files:**
+- Modify: `e2e/externalapi/scenarios/08-workflow-import-export.yaml`.
+
+- [ ] **Step 1: Confirm the next free slot**
+
+```bash
+grep -n "wf-import/" e2e/externalapi/scenarios/08-workflow-import-export.yaml | sort -u
+```
+
+Expected: slots `01..06` populated. Next free is `07`.
+
+- [ ] **Step 2: Append the three scenarios**
+
+At the end of the YAML file, after the last existing wf-import entry, append:
+
+```yaml
+  - id: wf-import/07-scheduled-transition-roundtrip
+    description: |
+      Round-trip preservation across the three TimeoutMs pointer states:
+      non-nil positive, non-nil zero, and absent (nil).
+    auth: admin
+    requests:
+      - method: POST
+        path: /api/model/RoundTripModel/1
+        body_json: {}
+      - method: POST
+        path: /api/model/RoundTripModel/1/workflow/import
+        body_json:
+          importMode: REPLACE
+          workflows:
+            - version: "1"
+              name: roundtrip
+              initialState: Open
+              active: true
+              states:
+                Open:
+                  transitions:
+                    - name: schedNonNilPositive
+                      next: Closed
+                      manual: false
+                      schedule:
+                        delayMs: 86400000
+                        timeoutMs: 90000000
+                    - name: schedNonNilZero
+                      next: Closed
+                      manual: false
+                      schedule:
+                        delayMs: 86400000
+                        timeoutMs: 0
+                    - name: schedNil
+                      next: Closed
+                      manual: false
+                      schedule:
+                        delayMs: 86400000
+                Closed: {}
+          allowCycles: false
+        assert_status: 200
+      - method: GET
+        path: /api/model/RoundTripModel/1/workflow
+        assert_status: 200
+        assert_json_equals_normalized:
+          workflows:
+            - version: "1"
+              name: roundtrip
+              initialState: Open
+              active: true
+              states:
+                Open:
+                  transitions:
+                    - name: schedNonNilPositive
+                      next: Closed
+                      manual: false
+                      schedule:
+                        delayMs: 86400000
+                        timeoutMs: 90000000
+                    - name: schedNonNilZero
+                      next: Closed
+                      manual: false
+                      schedule:
+                        delayMs: 86400000
+                        timeoutMs: 0
+                    - name: schedNil
+                      next: Closed
+                      manual: false
+                      schedule:
+                        delayMs: 86400000
+                Closed: {}
+
+  - id: wf-import/08-scheduled-transition-rejects
+    description: |
+      Validator rejection matrix — manual+schedule mutually exclusive
+      and delayMs <= 0. (Rev 1's third rule TimeoutMs >= DelayMs was
+      removed in rev 3 as bogus.)
+    auth: admin
+    requests:
+      - method: POST
+        path: /api/model/RejectModel/1
+        body_json: {}
+      - method: POST
+        path: /api/model/RejectModel/1/workflow/import
+        body_json:
+          importMode: REPLACE
+          workflows:
+            - version: "1"
+              name: bad
+              initialState: S1
+              active: true
+              states:
+                S1:
+                  transitions:
+                    - name: T1
+                      next: S1
+                      manual: true
+                      schedule:
+                        delayMs: 1000
+        assert_status: 400
+        assert_json_contains:
+          error:
+            code: VALIDATION_FAILED
+            message: "manual and scheduled are mutually exclusive"
+      - method: POST
+        path: /api/model/RejectModel/1/workflow/import
+        body_json:
+          importMode: REPLACE
+          workflows:
+            - version: "1"
+              name: bad2
+              initialState: S1
+              active: true
+              states:
+                S1:
+                  transitions:
+                    - name: T1
+                      next: S1
+                      manual: false
+                      schedule:
+                        delayMs: 0
+        assert_status: 400
+        assert_json_contains:
+          error:
+            code: VALIDATION_FAILED
+            message: "delayMs must be > 0"
+
+  - id: wf-import/09-allowcycles-bypass
+    description: |
+      Polling-pattern scheduled workflow imports only with
+      allowCycles=true. Default false preserves the cycle rejection.
+    auth: admin
+    requests:
+      - method: POST
+        path: /api/model/PollingModel/1
+        body_json: {}
+      - method: POST
+        path: /api/model/PollingModel/1/workflow/import
+        body_json:
+          importMode: REPLACE
+          workflows:
+            - version: "1"
+              name: polling
+              initialState: S1
+              active: true
+              states:
+                S1:
+                  transitions:
+                    - name: toS2
+                      next: S2
+                      manual: false
+                      schedule:
+                        delayMs: 1000
+                S2:
+                  transitions:
+                    - name: toS1
+                      next: S1
+                      manual: false
+                      schedule:
+                        delayMs: 1000
+        assert_status: 400
+        assert_json_contains:
+          error:
+            code: VALIDATION_FAILED
+      - method: POST
+        path: /api/model/PollingModel/1/workflow/import
+        body_json:
+          importMode: REPLACE
+          allowCycles: true
+          workflows:
+            - version: "1"
+              name: polling
+              initialState: S1
+              active: true
+              states:
+                S1:
+                  transitions:
+                    - name: toS2
+                      next: S2
+                      manual: false
+                      schedule:
+                        delayMs: 1000
+                S2:
+                  transitions:
+                    - name: toS1
+                      next: S1
+                      manual: false
+                      schedule:
+                        delayMs: 1000
+        assert_status: 200
+```
+
+> **Note.** If the parity test harness uses slightly different keys (e.g. `assert_body_contains` instead of `assert_json_contains`, or `expect_status` instead of `assert_status`), adjust to match the existing scenarios at `wf-import/01..06`. The structural shape (three scenarios, the round-trip / reject / bypass split) stays unchanged.
+
+- [ ] **Step 3: Run the parity suite**
+
+Find the parity-suite run command:
+
+```bash
+grep -rn "externalapi\|parity" Makefile
+```
+
+…and run that target. Expected: all scenarios green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/externalapi/scenarios/08-workflow-import-export.yaml
+git commit -m "test(parity): add wf-import/07..09 scheduled-transition scenarios (#259)
+
+Three new scenarios at slots 07-09:
+- 07: round-trip preservation across the three TimeoutMs pointer
+  states (non-nil positive, non-nil zero, nil).
+- 08: validator rejection matrix (manual+schedule, delayMs <= 0).
+- 09: allowCycles=true bypasses the cycle rejection for a polling-
+  pattern scheduled workflow.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 11 — Documentation
+
+## Task 18: Add `## SCHEDULED TRANSITIONS` section to the workflows help topic
+
+**Files:**
+- Modify: `cmd/cyoda/help/content/workflows.md`.
+
+- [ ] **Step 1: Locate the insertion point**
+
+```bash
+grep -n "^## " cmd/cyoda/help/content/workflows.md
+```
+
+Expected: a list of `## TRANSITIONS`, `## PROCESSORS`, `## CRITERIA`, etc. Insert the new section AFTER the last line of `## PROCESSORS`, BEFORE `## CRITERIA`.
+
+- [ ] **Step 2: Add the new section**
+
+Insert at that location (preserve heading level 2 to match siblings):
+
+````markdown
+## SCHEDULED TRANSITIONS
+
+A transition may carry an optional `schedule` object marking it as
+scheduled. Presence of `schedule` declares that the transition fires
+automatically at `scheduledTime = stateEntryTime + delayMs`. The
+`schedule` shape is:
+
+```json
+{
+  "name": "AutoClose",
+  "next": "Closed",
+  "manual": false,
+  "schedule": {
+    "delayMs": 86400000,
+    "timeoutMs": 600000
+  }
+}
+```
+
+**Fields:**
+
+- `delayMs` (integer, required) — delay between source-state entry
+  and the scheduled execution time, in milliseconds. Must be `> 0`.
+- `timeoutMs` (integer, optional) — late-tolerance window past the
+  scheduled execution time, in milliseconds. When the scheduler
+  picks the task up, if `(executionTime - scheduledTime) > timeoutMs`
+  the task is dropped and the transition is NOT attempted. Absent
+  (omitted) means no timeout — fire whenever the scheduler
+  eventually picks it up. Explicit `0` is the strictest setting —
+  drop on any lateness. Independent of `delayMs`; the two measure
+  different quantities.
+
+**Import-time validation rules:**
+
+- `manual: true` and `schedule` present are mutually exclusive
+  (`VALIDATION_FAILED`).
+- `schedule.delayMs <= 0` is rejected (`VALIDATION_FAILED`).
+- No further rule on `timeoutMs` beyond `>= 0` (enforced at the DTO
+  boundary).
+
+**Engine behaviour (runtime not yet implemented).** The scheduler
+that arms and fires scheduled transitions is not yet implemented.
+Two guards govern behaviour until it ships:
+
+- During automated cascade evaluation, scheduled transitions are
+  silently skipped — they are never selected for immediate firing.
+  Other automated/manual transitions out of the same state fire
+  normally. An entity whose only exit is scheduled rests in its
+  current state.
+- Explicitly firing a scheduled transition by name returns HTTP 400
+  `TRANSITION_NOT_FOUND` with the message `transition "X" in state
+  "Y" is scheduled; scheduled transitions are not yet implemented`.
+  Same code returned when a transition is `disabled: true` — same
+  semantic: "the transition exists but is not currently dispatchable
+  from the caller's POV." The entity remains in the source state.
+
+**Importing cyclic scheduled workflows.** A canonical scheduled-
+transition use case is a polling pattern such as `S1 →scheduled→ S2
+→scheduled→ S1`. The import-time cycle detector rejects unguarded
+automated cycles by default — including this one, because a delayed
+cycle is still a cycle. To import such a workflow, set the request-
+level field `allowCycles: true` on the import body:
+
+```json
+{
+  "importMode": "REPLACE",
+  "allowCycles": true,
+  "workflows": [ /* ... */ ]
+}
+```
+
+`allowCycles: true` bypasses only the cycle-detection check. Schedule
+shape rules (manual+schedule, delayMs) and all other validators
+remain unconditional. The runtime cascade-depth and per-state visit
+caps still catch actual runaway at fire time. Use only for workflows
+whose cyclicity is intentional.
+````
+
+- [ ] **Step 3: Verify the help-topic builds**
+
+If there's a help-topic test or build step (check the Makefile):
+
+```bash
+grep -n "help\|content" Makefile | head -10
+```
+
+Run whatever target exists. If none, render the topic by running:
+
+```bash
+go run ./cmd/cyoda help workflows | head -100
+```
+
+Expected: the new section appears in the rendered output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/cyoda/help/content/workflows.md
+git commit -m "docs(help): document scheduled transitions in workflows topic (#259)
+
+Adds a new ## SCHEDULED TRANSITIONS section between ## PROCESSORS and
+## CRITERIA. Documents:
+- The schedule object shape (delayMs required, timeoutMs optional).
+- The late-tolerance semantic for timeoutMs (scheduledTime, lateness,
+  drop-if-late).
+- The two import-time validation rules.
+- The v0.8.0 engine behaviour: cascade silently skips, explicit-fire
+  returns 400 TRANSITION_NOT_FOUND.
+- The allowCycles request-level escape hatch for polling-pattern
+  workflows.
+
+No issue IDs in shipped content per project policy.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+# Phase 12 — Verification + PR
+
+## Task 19: Run full verification + open the cyoda-go PR
+
+- [ ] **Step 1: Full test sweep (root module)**
+
+```bash
+go vet ./...
+go test -short ./...
+```
+
+Expected: both clean.
+
+- [ ] **Step 2: E2E suite (Docker required)**
+
+```bash
+go test ./internal/e2e/... -v
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Plugin submodule sweep**
+
+```bash
+make test-all
+```
+
+(Or per-plugin manually: `cd plugins/memory && go test ./... && cd ../sqlite && go test ./... && cd ../postgres && go test ./...`. Postgres requires Docker.)
+
+Expected: all green.
+
+- [ ] **Step 4: Race detector**
+
+```bash
+go test -race ./...
+```
+
+Expected: clean. This is the per-`.claude/rules/race-testing.md` one-shot pre-PR sanity check.
+
+- [ ] **Step 5: Confirm no TODOs were added**
+
+```bash
+make todos 2>&1 || git grep -n 'TODO(plan-' -- '*.go'
+```
+
+Expected: no new TODOs from this work.
+
+- [ ] **Step 6: Re-verify the SPI pin is on SPI main HEAD**
+
+```bash
+git -C /Users/paul/go-projects/cyoda-light/cyoda-go-spi fetch origin
+git -C /Users/paul/go-projects/cyoda-light/cyoda-go-spi rev-parse --short origin/main
+grep "cyoda-go-spi v" go.mod
+```
+
+Expected: the SPI HEAD short-SHA matches the SHA fragment in the pseudo-version pin. If they don't match (e.g. someone else merged to SPI main between Phase 2 and now), repeat Task 5's `go get … @main` + `go mod tidy` across all four go.mods and commit a final bump.
+
+- [ ] **Step 7: Push the branch**
+
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+(The worktree's current branch is `worktree-259-scheduled-transition-config-shape`. The push will create the same name on `origin`. If you want a different name on push, rename first: `git branch -m feat/259-scheduled-transition-shape && git push -u origin feat/259-scheduled-transition-shape`.)
+
+- [ ] **Step 8: Open the cyoda-go PR**
+
+```bash
+gh pr create --base release/v0.8.0 \
+  --title "feat(workflow): scheduled-transition configuration shape + SPI" \
+  --milestone "v0.8.0" \
+  --body "$(cat <<'EOF'
+Closes #259.
+
+## What this adds
+
+Implements the scheduled-transition configuration shape and SPI per
+the spec at \`docs/superpowers/specs/2026-06-15-issue-259-scheduled-transition-shape-design.md\` rev 3.
+
+- New \`TransitionScheduleDto\` schema (api/openapi.yaml) + regenerated
+  DTO.
+- Optional \`schedule\` property on \`TransitionDefinitionDto\`.
+- Two validator rules: \`manual+schedule\` mutually exclusive,
+  \`delayMs <= 0\` rejected.
+- Cascade silently skips \`Schedule != nil\` transitions (one-line
+  extension to existing Disabled/Manual filter).
+- Explicit-fire of a scheduled transition returns
+  \`400 TRANSITION_NOT_FOUND\` with message
+  \"scheduled transitions are not yet implemented\" (mirrors the
+  Disabled precedent byte-for-byte).
+- Request-level \`allowCycles\` escape hatch on the import body for
+  polling-pattern scheduled workflows. Bypasses only
+  \`validateWorkflowLoops\`; emits one \`slog.Warn\` per import call.
+- New help-topic section \`## SCHEDULED TRANSITIONS\` in
+  \`cmd/cyoda/help/content/workflows.md\`.
+- Three new parity scenarios \`wf-import/07..09\`.
+- E2E test for the explicit-fire reject.
+
+## What this does NOT do
+
+- No timer runtime — that's #251 (deferred beyond v0.8.0).
+- No new \`SMEventScheduledTransition*\` events — also #251.
+- No per-workflow \`AllowCycles\` field — request-level only by
+  design.
+
+## SPI coordination
+
+- Bundled SPI changes landed in cyoda-go-spi (PR <fill in once
+  merged>): new \`TransitionSchedule\` type + \`Schedule\` field +
+  deferred \`ProcessorDefinition.Type\` docstring from #250.
+- This PR bumps the cyoda-go-spi pseudo-version pin across all
+  four go.mod files (root + plugins/memory|sqlite|postgres).
+- No SPI tag cut — bundled into v0.8.0's end-of-milestone tag per
+  \`cyoda-go-spi/MAINTAINING.md\`.
+
+## TimeoutMs semantic
+
+Per project lead's clarification:
+- \`scheduledTime = stateEntryTime + delayMs\`
+- \`lateness = executionTime - scheduledTime\`
+- if \`lateness > timeoutMs\` → drop the task, transition NOT
+  attempted
+
+\`TimeoutMs\` is \`*int64\`. \`nil\` = no timeout (always eventually
+fire), \`&0\` = strictest (drop on any lateness), \`&N\` = drop if
+late > N ms. Pointer pattern matches precedent
+\`ProcessorConfig.StartNewTxOnDispatch *bool\`. All three states
+round-trip byte-equivalent.
+
+## Verification
+
+- \`go vet ./...\` clean.
+- \`go test -short ./...\` green.
+- \`go test ./internal/e2e/...\` green (Docker).
+- \`make test-all\` green (all plugins).
+- \`go test -race ./...\` clean (one-shot pre-PR sanity check).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+- [ ] **Step 9: Hand off**
+
+> **DONE.** Notify the human reviewer. The cyoda-go PR awaits review on the `release/v0.8.0` milestone branch. The PR description references the SPI PR which must be merged first; if not yet merged at PR-open time, leave the PR in draft until the SPI side merges and the pseudo-version pin is final.
+
+---
+
+## Self-review
+
+- **Spec coverage:** every section of the rev 3 spec maps to one or more tasks per the cross-reference table at the top of this plan. The `[Removed in rev 3]` test 4 in the spec corresponds to no task in this plan — deliberately, because the rule it tested no longer exists.
+- **Placeholder scan:** no TBDs, no TODOs, no "implement later"; every step has either concrete code or a concrete command.
+- **Type consistency:** `TransitionSchedule`, `TransitionDefinition.Schedule`, `importRequest.AllowCycles`, `validateWorkflows(workflows, allowCycles bool)`, `ErrTransitionNotFound`, `SMEventTransitionNotFound` — names match across all tasks.
+- **Cross-repo handoff:** Task 4 step 5 explicitly halts for human review of the SPI PR before Task 5 (the pin bump) can begin.

--- a/docs/superpowers/specs/2026-06-15-issue-259-scheduled-transition-shape-design.md
+++ b/docs/superpowers/specs/2026-06-15-issue-259-scheduled-transition-shape-design.md
@@ -10,6 +10,27 @@
 > **Revision history**
 >
 > - **Revision 1 (2026-06-15):** initial spec.
+> - **Revision 2 (2026-06-15):** incorporated independent design review.
+>   Six load-bearing / medium defects fixed: (L1) parity-scenario slot
+>   collision — `wf-import/04` was already populated, switched to
+>   `wf-import/07`; (L2) explicit acknowledgement that acceptance bullet 5's
+>   "link to #251" wording is satisfied by self-contained "not yet
+>   implemented" phrasing per project policy on no issue IDs in shipped
+>   artefacts; (L3) §8 risk bullet 1 rewritten to separate wire-decoded
+>   from in-process-construction paths; (L4) cycle-detector behaviour kept
+>   unchanged (rev 1's reasoning was inverted but the rejection IS correct
+>   — once #251 lands, a scheduled-only cycle IS an infinite loop), and a
+>   new request-level `allowCycles` escape hatch added so polling-pattern
+>   workflows have a documented bypass; (M1) help-text heading lifted to
+>   `## SCHEDULED TRANSITIONS` (level 2) to match `## PROCESSORS` /
+>   `## CRITERIA`; (M2) version label dropped from the heading; (M6)
+>   round-trip test 8 switched from byte-exact substring match to
+>   `json_equals_normalized`; (M7) one-line clarification that the
+>   Schedule rules sit in `validateWorkflowStructure` (incoming-only) by
+>   design; (O1) conditional note on the bundled #250 docstring (drop if
+>   #260 lands first); (O2, O3) editorial trim. M3 (audit-event choice
+>   for explicit-fire reject) and M4 (TimeoutMs scope) preserved at rev 1
+>   pending owner review.
 
 ---
 
@@ -77,6 +98,17 @@ unavailability of the feature in self-contained terms.
 - Update the help topic `cmd/cyoda/help/content/workflows.md` to document
   the shape, the validator rules, and the v0.8.0 behavioural status. No
   issue IDs.
+- Add a request-level `allowCycles` boolean to the workflow import body
+  as an escape hatch for unguarded automated cycles (the canonical
+  scheduled-transition use case is a polling pattern `S1 →scheduled→ S2
+  →scheduled→ S1` which the existing `validateWorkflowLoops` rejects).
+  The flag bypasses only `validateWorkflowLoops`; all other validators
+  (the three new Schedule rules, processor flags, structural checks)
+  remain unconditional. Request-level (not workflow-level) — each
+  import re-asserts intent; the durable schema does not carry a
+  "skip safety check" knob. Runtime safety net (`maxStateVisits`,
+  `maxCascadeDepth`) is unchanged and catches actual runaway at fire
+  time.
 
 ## 3. Non-goals
 
@@ -109,6 +141,9 @@ unavailability of the feature in self-contained terms.
 | SPI tagging | **None forced.** Bundled into v0.8.0's end-of-milestone tag per `MAINTAINING.md` "Coordinated release" cadence. cyoda-go pseudo-version-pins to SPI `main` HEAD across all four `go.mod` files per memory `project_v0_8_0_milestone_state`. |
 | Cassandra plugin | **Untouched in this PR.** Additive SPI fields are non-breaking; courtesy refresh via the end-of-milestone tag, not from this PR (memory `feedback_courtesy_pr_scope`). |
 | Source of truth for field names | **OpenAPI and SPI agreed on lowercase camelCase wire form** (`schedule`, `delayMs`, `timeoutMs`). Go-side: `Schedule`, `DelayMs`, `TimeoutMs`. |
+| `allowCycles` escape hatch (added rev 2) | **Request-level `bool` on the import body envelope**, default `false`. Bypasses only `validateWorkflowLoops`. Default-false behaviour is byte-identical to today; the flag is purely opt-in. Composes with `importMode`. Not persisted on `WorkflowDefinition`. |
+| `allowCycles` operator signal | **One `slog.Warn`** per import call when `allowCycles=true` is observed, naming the workflow(s) whose cycles were bypassed. No audit event (audit is for entity lifecycle, not import-time config). |
+| Acceptance bullet 5's "link to #251" | **Deliberately satisfied by self-contained wording.** The shipped error / help text / OpenAPI description carry the phrase `"scheduled transitions are not yet implemented"` (no issue ID). Issue IDs are referenced only in the spec doc, PR body, and commit message per memory `feedback_no_issue_ids_in_code`. |
 
 ## 5. Detailed design
 
@@ -163,6 +198,28 @@ schedule:
 
 The `schedule` property is **not added to `required`**. Its absence
 denotes a regular transition.
+
+**Workflow-import request body** — add an optional `allowCycles` field
+to the existing import-request schema (the exact name depends on the
+current OpenAPI generator output; the schema is the request body of the
+`POST /model/{name}/{version}/workflow/import` operation):
+
+```yaml
+allowCycles:
+  type: boolean
+  default: false
+  description: |
+    When true, bypasses the import-time check that rejects workflows
+    containing unguarded automated cycles (transitions with manual=false
+    and no criterion that form a closed loop). The runtime cascade
+    safety net — per-state visit cap and total cascade depth limit —
+    remains in effect and catches actual runaway at fire time. Use
+    when the cyclicity is intentional, e.g. polling patterns built on
+    scheduled transitions. Default false preserves the pre-v0.8.0
+    rejection behaviour exactly.
+```
+
+The field is not added to `required`; absence is equivalent to `false`.
 
 ### 5.2 Generated DTOs (`api/generated.go`)
 
@@ -313,18 +370,100 @@ All three errors propagate through the existing import handler to a
 `400 VALIDATION_FAILED` response (`handler.go:65-90` import path; the
 specific error code is set by the boundary classification).
 
+**Placement rationale (M7).** The three Schedule rules sit in
+`validateWorkflowStructure`, which is invoked by `validateImportRequest`
+on the incoming workflow set only — not on the merged-after-importMode
+result. This matches `validateImportRequest`'s scope: structural shape
+is a property of an individual workflow definition, asserted on what the
+client sends. Cross-workflow concerns (cycle detection, name collisions
+post-merge) sit in `validateWorkflows`, which runs on the merged result.
+Schedule coherence is per-transition, so the incoming-only placement is
+correct.
+
 `validateProcessorFlags` is **unchanged.** It still enforces only
 `StartNewTxOnDispatch` / `ExecutionMode` coherence.
 
-`validateWorkflowLoops` (`validate.go:242-295`) is **unchanged.** DFS
-cycle detection skips `Manual` and `Disabled` transitions today; per
-§5.5 cascade semantics, scheduled transitions are similarly never fired
-automatically in v0.8.0. The cycle detector's role is to prevent
-infinite cascade — adding scheduled to its skip filter is unnecessary
-because the engine cascade skip already removes them from consideration,
-and adding the skip in the validator would falsely allow workflows that
-become cycle-unsafe once #251 lands. Leaving the cycle detector intact
-preserves a forward-compatible safety property.
+**`validateWorkflowLoops` behaviour for scheduled transitions.** The
+DFS today treats a `Manual=false, Disabled=false, Criterion=null`
+transition as an unguarded automated edge — that includes any scheduled
+transition with no criterion. A workflow `S1 →scheduled→ S2 →scheduled
+→ S1` is rejected today and continues to be rejected by default after
+this PR.
+
+This is the correct default. Once #251 lands and the timer runtime
+arms scheduled transitions, a delayed cycle becomes an actual infinite
+loop — identical to today's unguarded automated cascade hazard, just
+slowed by `DelayMs`. The cycle detector's job is to catch that. The
+v0.8.0 cascade silent-skip (§5.5(a)) is a stopgap that hides the cycle
+at runtime; the validator preserves the design-time invariant.
+
+**`allowCycles` escape hatch.** Polling-pattern workflows
+(`S1 →scheduled→ S2 →scheduled→ S1` with `S2`'s scheduled transition
+gated on entity state, or unconditionally cyclic by author intent) are
+a legitimate use case the cycle detector cannot distinguish from
+accidental runaway. The import request grows an optional boolean
+`AllowCycles` field that, when true, bypasses `validateWorkflowLoops`
+for the duration of that import call only.
+
+```go
+// handler.go:32-46 (import request envelope)
+type importRequest struct {
+    ImportMode  string                   `json:"importMode"`
+    AllowCycles bool                     `json:"allowCycles,omitempty"`
+    Workflows   []spi.WorkflowDefinition `json:"workflows"`
+}
+
+// validate.go (signature change to validateWorkflows)
+func validateWorkflows(workflows []spi.WorkflowDefinition, allowCycles bool) error {
+    for _, wf := range workflows {
+        if !allowCycles {
+            if err := validateWorkflowLoops(wf); err != nil {
+                return err
+            }
+        }
+        if err := validateProcessorFlags(wf); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+```
+
+The handler's import path threads `req.AllowCycles` into the
+`validateWorkflows` call (the existing call site in `handler.go`
+around the post-merge validation step).
+
+Other validators — `validateImportRequest` /
+`validateWorkflowStructure` (including the three Schedule rules
+above), `validateProcessorFlags` — remain **unconditional**. The flag
+is specifically a cycle-detection bypass, not a general validation
+override. A workflow with both an unguarded cycle and a
+`Manual=true, Schedule!=nil` transition still gets rejected on the
+Schedule rule with `AllowCycles=true`.
+
+**Operator signal.** When `req.AllowCycles == true`, the handler emits
+a single `slog.Warn` line per import call:
+
+```go
+slog.WarnContext(ctx, "workflow import: cycle validation bypassed",
+    "pkg", "workflow",
+    "entityName", entityName,
+    "modelVersion", modelVersion,
+    "importMode", req.ImportMode,
+    "workflows", workflowNames)  // []string of req.Workflows[i].Name
+```
+
+One log line per import call — not per workflow — keeps audit volume
+bounded. No SPI audit event (audit covers entity-lifecycle, not
+import-time config). No log emission when `AllowCycles=false` or omitted.
+
+**Runtime safety net unchanged.** `cascadeAutomated`'s `maxStateVisits`
+(engine.go:513) and `maxCascadeDepth` (line 510) limits remain in
+effect. A cyclic workflow that was force-imported and whose cycle
+actually fires at runtime still aborts at the visit cap with the
+existing `SMEventCancelled "state machine aborted: state X visited N
+times"` event. The `allowCycles` flag only opens the import gate; it
+does not weaken runtime runaway protection.
 
 ### 5.5 Engine guards (`internal/domain/workflow/engine.go`)
 
@@ -405,14 +544,15 @@ and the absence of an implementation; it does not link to a tracker.
 
 ### 5.6 Help text (`cmd/cyoda/help/content/workflows.md`)
 
-Add a new subsection after the existing per-transition field listing
-(after the closing of the `processors[]` discussion around line 175).
-Suggested heading: `### Scheduled transitions (v0.8.0: shape only)`.
+Add a new top-level subsection after the existing `## PROCESSORS`
+discussion (before `## CRITERIA`). The heading level matches the
+sibling sections `## PROCESSORS` and `## CRITERIA` — level 2, not
+level 3, so the content is not visually orphaned under `## PROCESSORS`.
 
 Content:
 
-```markdown
-### Scheduled transitions (shape only — runtime not yet implemented)
+````markdown
+## SCHEDULED TRANSITIONS
 
 A transition may carry an optional `schedule` object marking it as
 scheduled. Presence of `schedule` declares that the transition fires
@@ -447,9 +587,9 @@ source state. The `schedule` shape is:
 - `schedule.timeoutMs > 0 && schedule.timeoutMs < schedule.delayMs` is
   rejected (`VALIDATION_FAILED`).
 
-**v0.8.0 engine behaviour.** The timer runtime that arms and fires
-scheduled transitions is not yet implemented. Two guards govern
-behaviour until it ships:
+**Engine behaviour (runtime not yet implemented).** The timer runtime
+that arms and fires scheduled transitions is not yet implemented. Two
+guards govern behaviour until it ships:
 
 - During automated cascade evaluation, scheduled transitions are
   silently skipped — they are never selected for immediate firing.
@@ -460,23 +600,57 @@ behaviour until it ships:
   `WORKFLOW_FAILED` with the message `transition "X" in state "Y" is
   scheduled; scheduled transitions are not yet implemented`. The
   entity remains in the source state.
+
+**Importing cyclic scheduled workflows.** A canonical scheduled-
+transition use case is a polling pattern such as `S1 →scheduled→ S2
+→scheduled→ S1`. The import-time cycle detector rejects unguarded
+automated cycles by default — including this one, because a delayed
+cycle is still a cycle. To import such a workflow, set the request-
+level field `allowCycles: true` on the import body:
+
+```json
+{
+  "importMode": "REPLACE",
+  "allowCycles": true,
+  "workflows": [ /* ... */ ]
+}
 ```
+
+`allowCycles: true` bypasses only the cycle-detection check. Schedule
+shape rules (manual+schedule, delayMs, timeoutMs) and all other
+validators remain unconditional. The runtime cascade-depth and per-
+state visit caps still catch actual runaway at fire time. Use only
+for workflows whose cyclicity is intentional.
+````
 
 ### 5.7 Parity scenario (`e2e/externalapi/scenarios/08-workflow-import-export.yaml`)
 
-Add a new test entry (`wf-import/04` or next free slot) exercising
-round-trip of a transition with `schedule`. Two import payloads:
+Slots `wf-import/01..06` are already populated. Add new entries at the
+next free slots. Three new scenarios:
 
-1. **Round-trip preservation.** A workflow with one regular and one
-   scheduled transition. Assert `json_equals_normalized` round-trip
-   equality on import + export.
-2. **Validator rejection.** Three sub-cases (`manual: true + schedule`,
-   `delayMs: 0`, `timeoutMs < delayMs`) — each asserts HTTP 400 with
-   `VALIDATION_FAILED` and the rule-specific error substring.
+- **`wf-import/07-scheduled-transition-roundtrip`** — round-trip
+  preservation. A workflow with one regular and one scheduled
+  transition (`Schedule: {DelayMs: 86400000, TimeoutMs: 90000000}` and
+  another with `Schedule: {DelayMs: 1000}` to exercise the
+  `TimeoutMs:0` omitempty path). Assert `json_equals_normalized`
+  round-trip equality on import + export.
+- **`wf-import/08-scheduled-transition-rejects`** — validator rejection
+  matrix. Three sub-cases per the validator rules (`manual: true +
+  schedule`, `delayMs: 0`, `timeoutMs < delayMs`); each asserts
+  HTTP 400 `VALIDATION_FAILED` with the rule-specific error substring.
+- **`wf-import/09-allowcycles-bypass`** — request-level cycle bypass.
+  Workflow `S1 →scheduled→ S2 →scheduled→ S1`. Without
+  `allowCycles: true` import returns `400 VALIDATION_FAILED` with the
+  cycle error. With `allowCycles: true` import returns `200 OK` and
+  round-trip preserves the workflow. The `allowCycles` field itself
+  is request-only and does not appear in the exported workflow set.
 
 The existing `wf-import/03` test (the post-#250 group-criterion +
-function-criterion + externalized-processor case) is **unchanged.** No
-follow-up edit there.
+function-criterion + externalized-processor case) and `wf-import/01..06`
+are **unchanged.** No follow-up edits to the existing entries. (Free
+slot enumeration confirmed at spec-write time; re-verify at
+implementation time and pick the next-free integer prefix if the file
+has gained entries since.)
 
 ### 5.8 Docs hygiene & test-fixture sweep (Gate 4 + Gate 6)
 
@@ -492,24 +666,12 @@ follow-up edit there.
 - **`docs/WORKFLOW_IMPORT_EXPORT_AUDIT.md`** — §H1 already references
   #259 as the carve-out. After this PR merges, the audit's tracking is
   accurate; no edit required.
-- **Test-fixture sweep (`internal/domain/workflow/*_test.go`).** Grep
-  for `schedule`, `delayMs`, `timeoutMs`, `Schedule`:
-  ```bash
-  grep -rn 'schedule\|delayMs\|timeoutMs' --include="*_test.go" \
-       internal/domain/workflow/
-  ```
-  Expected matches (intentional, leave as-is):
-  - `engine_processors_type_test.go:147` — comment annotating
-    `"scheduled"` as a legacy value removed by #250.
-  - `engine_processors_type_test.go:152` — `"scheduled"` string in
-    `TestType_UnknownValues_FallThrough`.
-  - `engine_processors_type_test.go:308-313` — comment + test fixture
-    for `"scheduled"` as an unknown-Type round-trip value.
-
-  These are #250's intentional fall-through coverage — they prove that
-  the SPI's free-string `Type` accepts a legacy `"scheduled"` value
-  without rejection. New tests added by §6.1 cover the new
-  `Schedule` field and do not regress these.
+- **Test-fixture sweep (`internal/domain/workflow/*_test.go`).** A grep
+  for `schedule|delayMs|timeoutMs|Schedule` returns only #250's
+  intentional fall-through coverage at `engine_processors_type_test.go`
+  (lines 147, 152, 308-313, 313 — `"scheduled"` as a legacy-value
+  unknown-Type round-trip fixture). Leave as-is; new tests added by
+  §6.1 cover the `TransitionDefinition.Schedule` field.
 
 ## 6. Test plan (TDD)
 
@@ -562,12 +724,12 @@ authored first, run to confirm RED, then driven GREEN.
 
 8. **Round-trip preservation.** Import a workflow with a transition
    carrying `Schedule: {DelayMs: 86400000, TimeoutMs: 90000000}`,
-   export, assert the exported JSON contains
-   `"schedule":{"delayMs":86400000,"timeoutMs":90000000}` byte-for-byte
-   on the round-trip. Variant: `Schedule: {DelayMs: 1000}` (no
-   TimeoutMs) — assert exported JSON contains
-   `"schedule":{"delayMs":1000}` (omitempty drops the zero
-   `timeoutMs`).
+   export, assert `json_equals_normalized` round-trip equality (parse
+   both JSONs, compare structurally — robust against future field-
+   ordering refactors of `TransitionDefinition`). Variant: `Schedule:
+   {DelayMs: 1000}` (no TimeoutMs) — assert exported JSON's `schedule`
+   object has `delayMs: 1000` and no `timeoutMs` key (the `omitempty`
+   contract on the zero `TimeoutMs`).
 
 9. **E2E — explicit fire of scheduled transition returns 400.**
    Integration test in `internal/e2e/` mirroring #250's test 8 shape:
@@ -586,7 +748,47 @@ authored first, run to confirm RED, then driven GREEN.
    5. `GET /entity/X/<id>` returns the entity in the initial state
       (cascade rested there; explicit fire rejected).
 
-10. **Parity — scenario 08/wf-import/04 round-trip passes.** Per §5.7.
+10. **Parity — scenarios `wf-import/07..09` pass.** Per §5.7.
+
+11. **`allowCycles` default-false rejects unguarded automated cycle.**
+    Import payload `{importMode: "REPLACE", workflows: [<cyclic
+    workflow>]}` — `allowCycles` omitted (default false). Workflow is
+    `S1 →automated, no criterion→ S2 →automated, no criterion→ S1`
+    (regular non-scheduled transitions). Assert `400 VALIDATION_FAILED`
+    with cycle-detection error from `validateWorkflowLoops`.
+
+12. **`allowCycles: true` bypasses the cycle rejection.** Same workflow
+    as test 11, with `{importMode: "REPLACE", allowCycles: true,
+    workflows: [...]}`. Assert `200 OK`; the workflow persists; round-
+    trip preserves shape (the exported workflow set does not carry the
+    `allowCycles` flag — it's request-only). Assert a `slog.Warn` line
+    matching `"workflow import: cycle validation bypassed"` is emitted
+    exactly once via a test log handler.
+
+13. **`allowCycles: true` on polling scheduled-transition workflow
+    succeeds.** Workflow `S1 →scheduled→ S2 →scheduled→ S1` (both
+    transitions have `Manual: false, Schedule: {DelayMs: 1000}`,
+    no criterion). Assert without `allowCycles`: `400 VALIDATION_FAILED`
+    cycle error. With `allowCycles: true`: `200 OK`. Create an entity
+    via `POST /entity/X`; assert entity lands in initial state and
+    rests there (cascade silently skips both scheduled transitions, no
+    cycle fires).
+
+14. **`allowCycles: true` does NOT bypass Schedule-coherence rules.**
+    Workflow with a cyclic shape AND a `Manual: true, Schedule:
+    {DelayMs: 1000}` transition. Import with `allowCycles: true`.
+    Assert `400 VALIDATION_FAILED` with the manual+schedule error —
+    not the cycle error. Demonstrates that the bypass is scoped to
+    `validateWorkflowLoops` only.
+
+15. **Runtime safety net unchanged.** Import with `allowCycles: true`
+    a cyclic regular (non-scheduled) workflow whose cycle actually
+    fires at runtime (`S1 →automated→ S2 →automated→ S1`, no criteria,
+    no schedule). Create an entity. Assert the cascade aborts at the
+    per-state visit cap with `SMEventCancelled "state machine aborted:
+    state ... visited ... times"`. (May piggyback an existing cascade-
+    limit test rather than add a new one — the assertion is that the
+    runtime guard still fires when the import-time guard is bypassed.)
 
 ### 6.2 Coverage gaps explicitly NOT closed in #259
 
@@ -598,12 +800,18 @@ authored first, run to confirm RED, then driven GREEN.
   transitions coexist in the same state with overlapping firing
   windows. (#251 scope — currently moot because v0.8.0 silently skips
   scheduled transitions.)
-- Cycle detection awareness of scheduled transitions. The DFS in
-  `validateWorkflowLoops` does not skip scheduled transitions; the
-  conservative choice is to preserve cycle detection's existing
-  reachability assumption so workflows that would become cycle-unsafe
-  once #251 lands are caught at v0.8.0 import time. (Documented in
-  §5.4.)
+- Per-workflow `AllowCycles` field on `WorkflowDefinition` (persistent
+  escape hatch). Request-level was chosen deliberately so the durable
+  schema does not carry a "skip safety check" knob. Revisit if
+  operators need set-and-forget cyclicity declarations.
+- Initial-state-with-only-scheduled-exits special-case. Covered
+  incidentally by tests 6 and 9 (the entity simply rests in the
+  initial state after create); no dedicated test.
+- Scheduled transition with a non-null `criterion`. Spec accepts the
+  combination (criterion is uninterpreted by v0.8.0 cascade because
+  Schedule!=nil already takes precedence in the skip filter); a
+  dedicated test is omitted for brevity, but reviewers may add one
+  if the semantics warrant pinning.
 
 ## 7. Backwards compatibility
 
@@ -614,6 +822,8 @@ authored first, run to confirm RED, then driven GREEN.
 | `TransitionDefinitionDto.schedule: {delayMs: 0}` | Silently dropped | **Rejected at import** with `VALIDATION_FAILED`. |
 | `TransitionDefinitionDto` with `manual: true, schedule: {...}` | Silently dropped (schedule lost) | **Rejected at import** with `VALIDATION_FAILED`. |
 | Legacy `processors[]` with `{type: "scheduled", config: {delayMs, transition, timeoutMs}}` (raw-JSON path; pre-#250 shape) | After #250: SPI's free-string `Type` accepts; scheduled config fields silently dropped by `ProcessorConfig` unmarshal; dispatched as externalized | **Same as post-#250.** The new `TransitionDefinition.Schedule` field does not interact with `Processors[].Type` or `ProcessorConfig`. Carried-over technical debt from §H1's silent-drop. |
+| Import request body with `allowCycles` field | Field unknown to importRequest struct; silently dropped by `json.Unmarshal` (Go default behaviour) | **Read as a bool;** when true, bypasses `validateWorkflowLoops` for that request. When false / omitted: byte-identical pre-#259 behaviour. |
+| Import request body with cyclic workflow, no `allowCycles` flag | Rejected at import with `VALIDATION_FAILED` (cycle detection) | **Same** — default `allowCycles: false` preserves the rejection. |
 
 The wire surface is **strictly wider** in exactly one place
 (`TransitionDefinitionDto.schedule` is a new optional field on a
@@ -632,37 +842,64 @@ shape is now well-defined) and become inert at runtime per §5.5.
 
 ## 8. Risks
 
-- **`*TransitionSchedule` pointer JSON edge case.** A pointer with all
-  fields zero-valued (`&TransitionSchedule{}`) marshals as
-  `"schedule":{"delayMs":0,"timeoutMs":0}` (omitempty drops the
-  `timeoutMs:0` but not the empty struct itself). If callers construct
-  such a value, the validator catches it via the `DelayMs <= 0` rule.
-  No silent acceptance.
+- **`*TransitionSchedule` zero-value pointer handling — wire vs.
+  in-process paths.** Two distinct concerns are sometimes conflated.
+  (a) **Wire path.** A client POSTing `"schedule":{}` (empty object)
+  unmarshals into `&TransitionSchedule{DelayMs: 0, TimeoutMs: 0}` —
+  the validator's `DelayMs <= 0` rule catches this with
+  `VALIDATION_FAILED`. Same for `"schedule":{"delayMs":0}`. No silent
+  acceptance from any wire payload. (b) **In-process construction.**
+  A direct Go-code construction of `&TransitionSchedule{}` in a test
+  fixture or a future SPI consumer is a fixture-author concern, not a
+  wire risk — fixture code is reviewed and tested directly. The
+  validator catches it only if `validateImportRequest` runs on that
+  path, which is the standard import handler path but not necessarily
+  every internal code path. Author-discipline matter; not a system
+  vulnerability.
 - **OpenAPI generator behaviour for the new `schedule` field.** Some
   `oapi-codegen` versions emit `*TransitionScheduleDto` (pointer) for
   optional non-required object fields, matching the SPI pointer choice.
   Verify in the regeneration spike (§5.2). If a value-type is emitted,
   there is no behavioural divergence (zero-value still goes through
   validator), but the generated code may need a manual nudge.
-- **Cycle-detector blind spot.** `validateWorkflowLoops` does not
-  account for scheduled transitions. Once #251 ships, a workflow with
-  `S1 --scheduled--> S2 --scheduled--> S1` becomes a delayed-cycle.
-  The cycle detector today treats both edges as eligible and rejects.
-  This is the conservative choice (preserve detection); revisit when
-  #251 lands.
+- **Cycle-detector blind spot (resolved via `allowCycles`).** A
+  workflow `S1 --scheduled--> S2 --scheduled--> S1` is rejected by
+  `validateWorkflowLoops` today; once #251 ships and the timer arms
+  scheduled transitions, that's an actual infinite loop, so the
+  rejection is correct (delayed cycle = cycle). The request-level
+  `allowCycles` escape hatch (§5.4) gives operators a documented path
+  to import intentionally-cyclic workflows. No code change in
+  `validateWorkflowLoops` itself.
+- **`allowCycles: true` footgun.** Operators who set the flag bypass
+  the import-time cycle check; a buggy workflow with an unintended
+  unguarded cycle can be imported. Mitigations: (a) the runtime
+  cascade safety net (`maxStateVisits`, `maxCascadeDepth`) catches
+  actual runaway at fire time and emits `SMEventCancelled`; (b) one
+  `slog.Warn` per import call surfaces the bypass to operators
+  reviewing logs; (c) the flag is request-level only — each import
+  re-asserts intent; the durable schema does not carry the bypass.
 - **`*int64` vs `int64` for `TimeoutMs` round-trip.** Choosing `int64`
   with `omitempty` (per §5.3) means the JSON omits `timeoutMs` only
   when the Go value is exactly 0. A client that explicitly sets
   `timeoutMs: 0` in import JSON, exports, and gets back JSON without
   `timeoutMs` is technically a lossy round-trip — but the SPI and
   OpenAPI both document `0 == no timeout`, so this is semantically
-  equivalent. Round-trip preservation test 8 (§6.1) pins the
-  byte-exact shape for non-zero values; the zero-value case is
-  semantically equivalent both directions.
+  equivalent. Round-trip preservation test 8 (§6.1) uses
+  `json_equals_normalized` rather than byte-exact substring matching,
+  so this case is asserted to be semantically equivalent both
+  directions.
 - **SPI tag coupling.** #259 bundles the deferred #250 docstring; if
   this PR is reverted, #250's docstring is also lost from SPI main.
   Acceptable because the bundling is intentional per #250 spec §5.3,
   and a revert would similarly carry the new shape work.
+- **#260 racing #259 on the docstring (O1).** If #260's SPI PR lands
+  before #259's, #260 picks up #250's docstring under its own banner
+  and #259's §5.3(c) becomes a no-op. The implementer of #259 should
+  check SPI `main` immediately before opening the SPI PR; if the
+  docstring is already present, drop §5.3(c) from #259's SPI commit
+  set and update the CHANGELOG `[Unreleased]` entry to remove the
+  "Changed" subsection. The substantive shape work (5.3(a), 5.3(b))
+  is unaffected.
 
 ## 9. Out of scope (sanity check)
 
@@ -678,6 +915,13 @@ shape is now well-defined) and become inert at runtime per §5.5.
 - Vendored upstream OpenAPI copies under `docs/cyoda/`.
 - Cassandra plugin coordination — additive SPI; refresh via end-of-milestone
   tag bump, not from this PR.
+- Per-workflow `AllowCycles` field on `WorkflowDefinition` (persistent
+  / round-tripped escape hatch). #259 lands request-level only.
+- Per-transition cycle-allowance markers. Same reason.
+- A general-purpose validation-bypass mechanism (e.g. an `unsafe: true`
+  flag that disables all validators). `allowCycles` is deliberately
+  cycle-specific; structural rules (Schedule coherence, processor
+  flags, name uniqueness) remain unconditional.
 
 ## 10. Cross-repo coordination
 
@@ -727,13 +971,14 @@ repos":
 | `cyoda-go-spi/CHANGELOG.md` (sibling repo) | Add `[Unreleased]` Added + Changed entries per §5.3. |
 | `api/openapi.yaml` | Add `TransitionScheduleDto` schema; add optional `schedule` property to `TransitionDefinitionDto`. |
 | `api/generated.go` | Regenerated from above. |
-| `internal/domain/workflow/validate.go` | Add three Schedule-coherence checks in `validateWorkflowStructure` per-transition loop (between lines 193 and 198). |
+| `internal/domain/workflow/validate.go` | Add three Schedule-coherence checks in `validateWorkflowStructure` per-transition loop (between lines 193 and 198); add `allowCycles bool` parameter to `validateWorkflows` and short-circuit `validateWorkflowLoops` when true. |
+| `internal/domain/workflow/handler.go` | Add `AllowCycles bool` field to `importRequest` struct (lines 32-46); thread `req.AllowCycles` into the `validateWorkflows` call; emit `slog.Warn "workflow import: cycle validation bypassed"` when `req.AllowCycles == true`. |
 | `internal/domain/workflow/engine.go` | Cascade-skip filter at line 528 (one-line addition); explicit-fire reject branch in `attemptTransition` after the `Disabled` check (between lines 453 and 455). |
-| `internal/domain/workflow/validate_test.go` (or sibling) | TDD tests per §6.1 items 1–4. |
+| `internal/domain/workflow/validate_test.go` (or sibling) | TDD tests per §6.1 items 1–4, 11–15. |
 | `internal/domain/workflow/engine_test.go` (or sibling) | TDD tests per §6.1 items 5–8. |
-| `internal/e2e/` | E2E test per §6.1 item 9. |
-| `cmd/cyoda/help/content/workflows.md` | New `### Scheduled transitions` subsection per §5.6. |
-| `e2e/externalapi/scenarios/08-workflow-import-export.yaml` | Add `wf-import/04` round-trip + reject scenario per §5.7. |
+| `internal/e2e/` | E2E test per §6.1 item 9; additional E2E for `allowCycles` if not covered by the unit tests at items 11–15. |
+| `cmd/cyoda/help/content/workflows.md` | New `## SCHEDULED TRANSITIONS` section per §5.6 (level 2, mirroring `## PROCESSORS` / `## CRITERIA`). |
+| `e2e/externalapi/scenarios/08-workflow-import-export.yaml` | Add `wf-import/07..09` (round-trip, validator rejects, `allowCycles` bypass) per §5.7. |
 | `README.md`, `CLAUDE.md`, `COMPATIBILITY.md`, `docs/PROCESSOR_EXECUTION_MODES.md` | Untouched. Re-grep as Gate 4 hygiene. |
 | `docs/cyoda/openapi.yml` and vendored copies | Out of scope. |
 | `go.mod` (root + `plugins/memory|sqlite|postgres`) | Bump pseudo-version pin to cyoda-go-spi `main` HEAD post-SPI-PR-merge. |
@@ -753,7 +998,6 @@ Per `superpowers:verification-before-completion`:
   `.claude/rules/race-testing.md`.
 - `make test-all` — covers root + `plugins/memory|sqlite|postgres` per
   CLAUDE.md.
-- `make todos` — no new TODOs introduced.
 
 ## Appendix C: Out-of-tree plugin impact
 

--- a/docs/superpowers/specs/2026-06-15-issue-259-scheduled-transition-shape-design.md
+++ b/docs/superpowers/specs/2026-06-15-issue-259-scheduled-transition-shape-design.md
@@ -1,0 +1,771 @@
+# Issue #259 — Scheduled-transition configuration shape + SPI
+
+**Date:** 2026-06-15
+**Milestone:** v0.8.0
+**Issue:** #259 (closed-by this PR)
+**Parent (deferred runtime):** #251
+**Prerequisite (landed):** #250 — processor execution-location split
+**Audit reference:** `docs/WORKFLOW_IMPORT_EXPORT_AUDIT.md` §H1
+
+> **Revision history**
+>
+> - **Revision 1 (2026-06-15):** initial spec.
+
+---
+
+## 1. Problem
+
+The workflow import/export audit (§H1) records that the pre-#250 OpenAPI
+surfaced a `ScheduledTransitionProcessorDefinitionDto` inside `processors[]`
+carrying `{delayMs, transition, timeoutMs}` — modelled as one of two
+`oneOf` variants on `ProcessorDefinitionDto`. Three compounding problems
+made it inert at the runtime: the SPI flattened both variants into a single
+`ProcessorDefinition`; the engine never consulted `proc.Type`; and the
+scheduling config fields were silently dropped by `json.Unmarshal`. The
+audit graded this HIGH severity for contract↔implementation divergence.
+
+#250 (merged in #265) executed the schema cleanup: `processors[].type` is
+now the execution-location axis only (`externalized` today, `internalized`
+reserved). `ScheduledTransitionProcessorDefinitionDto` and
+`ScheduledTransitionConfigDto` were removed entirely from the OpenAPI
+surface. The scheduled-transition primitive has no home today.
+
+#259 re-introduces the primitive at its proper home — a sibling field on
+`TransitionDefinition` — while explicitly **not** implementing the timer
+runtime (timer durability across restarts, cluster ownership / failover,
+work-stealing recovery, cancellation on state change, audit events for
+arming / firing / cancellation). That runtime is parent issue #251, deferred
+beyond v0.8.0.
+
+The acceptance criteria recorded on #259 require:
+
+- SPI types tagged for cyoda-go-spi v0.8.0 (the milestone tag, not a
+  per-PR tag — see §11).
+- OpenAPI + generated DTOs updated.
+- Import validation accepts the shape.
+- Export round-trip preserves the shape.
+- Engine rejects use at runtime.
+- Help-topic + release notes updated.
+
+This spec covers all six. Per memory `feedback_no_issue_ids_in_code`,
+no shipped artefact references issue IDs; the rejection error names the
+unavailability of the feature in self-contained terms.
+
+## 2. Goals
+
+- Define `TransitionSchedule` as a new SPI type and add an optional
+  `Schedule *TransitionSchedule` field to `TransitionDefinition`.
+- Match the SPI change in `api/openapi.yaml` via a new
+  `TransitionScheduleDto` schema and an optional `schedule` field on
+  `TransitionDefinitionDto`.
+- Land import-time validator rules for the shape's internal coherence:
+  `Manual=true && Schedule!=nil` is rejected (structurally incoherent);
+  `Schedule!=nil && DelayMs<=0` is rejected; `Schedule!=nil &&
+  TimeoutMs>0 && TimeoutMs<DelayMs` is rejected.
+- Land two-pronged engine guards:
+  - The cascade-automatic loop silently treats `Schedule!=nil` as ineligible
+    (mirroring how it already treats `Disabled` and `Manual`). No audit
+    signal; entity progress through other automated/manual transitions out
+    of the same state is unaffected.
+  - The explicit-fire-by-name path (`attemptTransition`) rejects any
+    transition with `Schedule!=nil` with `WORKFLOW_FAILED 400` and a
+    self-contained error message. Mirrors #250's pattern for `Type:
+    internalized` rejection.
+- Bundle #250's deferred `ProcessorDefinition.Type` docstring update into
+  the same SPI PR — per #250 spec §5.3 the docstring was intentionally
+  held back for the first carve-out that needs a substantive SPI change.
+- Update the help topic `cmd/cyoda/help/content/workflows.md` to document
+  the shape, the validator rules, and the v0.8.0 behavioural status. No
+  issue IDs.
+
+## 3. Non-goals
+
+- Implement scheduled-transition firing. (#251 owns the runtime — timer
+  persistence, cluster ownership, work-stealing recovery, cancellation on
+  state change, audit surface for armed / fired / cancelled events.)
+- Add new `SMEventScheduledTransition*` SPI event types. (#251 scope.)
+- Tighten import-time validation for unknown processor `Type` values.
+  (#255's scope — closed in v0.8.0 already.)
+- Modify the vendored upstream OpenAPI copies under `docs/cyoda/`. They
+  are point-in-time snapshots maintained upstream.
+- Add a v0.8.0 SPI tag in isolation. The bundled v0.8.0 milestone tag at
+  the end of the release cycle covers this change together with the
+  deferred #250 docstring, #260's internalized SPI shape, and any other
+  v0.8.0 SPI work that lands in the same window.
+
+## 4. Decision summary (post-brainstorm)
+
+| Question | Decision |
+|---|---|
+| Where does scheduling data live? | **Optional `Schedule *TransitionSchedule` field on `TransitionDefinition`.** Presence marks the transition as scheduled. One declaration encodes both "what fires" and "when". Engine state-entry hook (in #251) reads `tr.Schedule` to arm a timer. |
+| Cascade semantics for `Schedule!=nil` (`cascadeAutomated`, `engine.go:528`) | **Silent skip.** Add `\|\| tr.Schedule != nil` to the existing `Disabled \|\| Manual` skip filter. No audit event. An entity whose only exit is scheduled rests in the source state. |
+| Explicit-fire semantics for `Schedule!=nil` (`attemptTransition`, `engine.go:443-453`) | **Reject with `WORKFLOW_FAILED 400`.** Free-string error → `classifyWorkflowError` default branch returns `Operational(400, WORKFLOW_FAILED, msg)`. Entity stays in source state. Single `SMEventStateProcessResult{success:false}` audit row. |
+| Validator coherence (`validate.go:178-211`) | **Three new rules** inside the existing per-transition loop, placed between the Next-state check (line 193) and the processor loop (line 198): (a) `Manual && Schedule != nil` → reject; (b) `Schedule != nil && DelayMs <= 0` → reject; (c) `Schedule != nil && TimeoutMs > 0 && TimeoutMs < DelayMs` → reject. All `VALIDATION_FAILED 400`. |
+| `TimeoutMs == 0` semantics | **"No timeout."** Documented in SPI docstring and OpenAPI description. Allowed by the validator (the `TimeoutMs > 0` guard). |
+| OpenAPI surface | New `TransitionScheduleDto` schema with `delayMs` (required, `minimum: 1`) and `timeoutMs` (optional, `minimum: 0`). New optional `schedule: $ref` field on `TransitionDefinitionDto`. Regenerate `api/generated.go`. |
+| Audit-event shape for explicit-fire reject | **Single `SMEventStateProcessResult{success:false}`** with a Details string naming the transition and the rejection cause. Reuses the existing event type (no new SPI events). |
+| Error wording | **Self-contained**, no issue ID. Validator messages name the rule violated; engine error names the transition, source state, and rejection cause. |
+| SPI PR bundling | **One SPI PR** combining (a) deferred `ProcessorDefinition.Type` docstring from #250, (b) new `TransitionSchedule` type, (c) new `Schedule` field on `TransitionDefinition`. CHANGELOG `[Unreleased]` entry covers all three. |
+| SPI tagging | **None forced.** Bundled into v0.8.0's end-of-milestone tag per `MAINTAINING.md` "Coordinated release" cadence. cyoda-go pseudo-version-pins to SPI `main` HEAD across all four `go.mod` files per memory `project_v0_8_0_milestone_state`. |
+| Cassandra plugin | **Untouched in this PR.** Additive SPI fields are non-breaking; courtesy refresh via the end-of-milestone tag, not from this PR (memory `feedback_courtesy_pr_scope`). |
+| Source of truth for field names | **OpenAPI and SPI agreed on lowercase camelCase wire form** (`schedule`, `delayMs`, `timeoutMs`). Go-side: `Schedule`, `DelayMs`, `TimeoutMs`. |
+
+## 5. Detailed design
+
+### 5.1 OpenAPI changes (`api/openapi.yaml`)
+
+New schema (insert near `TransitionDefinitionDto`, alphabetical placement
+in `components.schemas`):
+
+```yaml
+TransitionScheduleDto:
+  type: object
+  description: |
+    Scheduling configuration for an automatic future state transition.
+    Presence of this object marks the parent transition as scheduled —
+    it fires automatically delayMs milliseconds after the entity enters
+    the source state. Mutually exclusive with parent transition's
+    manual=true.
+
+    The runtime that arms and fires the timer is not yet implemented.
+    Until it ships, the engine silently skips scheduled transitions
+    during automated cascade selection, and explicit fires by name are
+    rejected with HTTP 400 WORKFLOW_FAILED.
+  properties:
+    delayMs:
+      type: integer
+      format: int64
+      minimum: 1
+      description: |
+        Delay before firing, in milliseconds. Must be a positive integer.
+    timeoutMs:
+      type: integer
+      format: int64
+      minimum: 0
+      description: |
+        Maximum age of the armed timer before abandonment, in
+        milliseconds. 0 (default) means no timeout. When non-zero, must
+        be greater than or equal to delayMs.
+  required:
+    - delayMs
+```
+
+Add an optional property to `TransitionDefinitionDto`:
+
+```yaml
+schedule:
+  $ref: "#/components/schemas/TransitionScheduleDto"
+  description: |
+    Optional scheduling configuration. Presence marks the transition as
+    scheduled; mutually exclusive with manual=true. Runtime not yet
+    implemented — see TransitionScheduleDto for v0.8.0 engine behaviour.
+```
+
+The `schedule` property is **not added to `required`**. Its absence
+denotes a regular transition.
+
+### 5.2 Generated DTOs (`api/generated.go`)
+
+Regenerated from the updated `openapi.yaml`. New entries:
+
+- `type TransitionScheduleDto struct { ... }` with fields `DelayMs int64`
+  and `TimeoutMs *int64` (pointer because non-required).
+- `TransitionDefinitionDto.Schedule *TransitionScheduleDto`.
+
+Validation spike (per `make generate`):
+
+1. `make generate` runs to completion without error.
+2. `go build ./...` is clean post-regeneration.
+3. `api/generated.go` has `TransitionScheduleDto` and the new field on
+   `TransitionDefinitionDto`.
+4. No legacy `ScheduledTransition*Dto` symbols reappear (sanity check).
+
+### 5.3 SPI changes (`cyoda-go-spi/types.go`)
+
+Repo: `https://github.com/Cyoda-platform/cyoda-go-spi`. Co-located at
+`../cyoda-go-spi`. Single bundled PR with three changes:
+
+**(a) New `TransitionSchedule` type.** Inserted alongside the other
+workflow types (after `TransitionDefinition`, before the
+`SMEvent*` constants block):
+
+```go
+// TransitionSchedule configures automatic firing of a future state
+// transition. Presence of this struct on a TransitionDefinition marks
+// the transition as scheduled: the engine arms a timer when the entity
+// enters the source state, and the transition fires automatically after
+// DelayMs milliseconds.
+//
+// Scheduled transitions are mutually exclusive with Manual=true.
+//
+// The runtime that arms and fires the timer is not yet implemented.
+// Engine behaviour in the absence of that runtime is defined by the
+// cyoda-go engine package: scheduled transitions are silently skipped
+// during automated cascade selection, and explicit fires by name are
+// rejected with HTTP 400.
+type TransitionSchedule struct {
+    // DelayMs is the delay before firing, in milliseconds. Must be > 0.
+    DelayMs int64 `json:"delayMs"`
+
+    // TimeoutMs is the maximum age of the armed timer before abandonment,
+    // in milliseconds. 0 means no timeout. When non-zero, must be >=
+    // DelayMs.
+    TimeoutMs int64 `json:"timeoutMs,omitempty"`
+}
+```
+
+**(b) New `Schedule` field on `TransitionDefinition`.** Appended after
+`Processors`:
+
+```go
+type TransitionDefinition struct {
+    Name       string                `json:"name"`
+    Next       string                `json:"next"`
+    Manual     bool                  `json:"manual"`
+    Disabled   bool                  `json:"disabled,omitempty"`
+    Criterion  json.RawMessage       `json:"criterion,omitempty"`
+    Processors []ProcessorDefinition `json:"processors,omitempty"`
+    Schedule   *TransitionSchedule   `json:"schedule,omitempty"`
+}
+```
+
+Pointer (not value) because `omitempty` on a non-pointer struct doesn't
+omit the JSON field for zero values — that would emit
+`"schedule":{"delayMs":0,"timeoutMs":0}` for every transition. The
+pointer makes "absent vs zero-default" round-trippable.
+
+**(c) Deferred `ProcessorDefinition.Type` docstring** from #250 spec
+§5.3, sitting on branch `spi-docstring-processor-type-250` at commit
+`cc715ef`. Apply verbatim. Quoted here for completeness (no semantic
+divergence):
+
+```go
+type ProcessorDefinition struct {
+    // Type is the execution-location axis. Recognised values are defined
+    // by the cyoda-go engine package; canonical values are "externalized"
+    // (dispatched via gRPC to a calculation node selected by
+    // Config.CalculationNodesTags) and "internalized" (reserved for an
+    // in-process execution location, currently rejected at engine
+    // dispatch as not yet implemented). Empty is treated as "externalized".
+    // Any value other than "internalized" falls through to the
+    // ExecutionMode dispatch path; import-time validation does not
+    // constrain this field.
+    Type          string          `json:"type"`
+    Name          string          `json:"name"`
+    ExecutionMode string          `json:"executionMode,omitempty"`
+    Config        ProcessorConfig `json:"config,omitempty"`
+}
+```
+
+**CHANGELOG entry.** `cyoda-go-spi/CHANGELOG.md` `[Unreleased]` section
+gains:
+
+```markdown
+### Added
+- `TransitionSchedule` type + `TransitionDefinition.Schedule` field for
+  the v0.8.0 scheduled-transition shape carve-out (cyoda-go #259).
+  Runtime not yet wired — see cyoda-go #251 for full feature tracking.
+
+### Changed
+- Document `ProcessorDefinition.Type` field (deferred from cyoda-go #250
+  per its spec §5.3, intentionally bundled with the first substantive
+  SPI carve-out).
+```
+
+**Cross-repo coordination.** This SPI PR contains additive surface
+(one new exported type, one new field on an existing exported type,
+one docstring update). Per `MAINTAINING.md` pre-1.0 policy, additive
+is non-breaking. No SPI tag is cut for this PR alone; the v0.8.0
+milestone tag at end-of-cycle captures it together with #260 and any
+other v0.8.0 SPI changes (per memory `project_v0_8_0_milestone_state`
+the cyoda-go side pseudo-version-pins to SPI `main` HEAD during the
+milestone flight).
+
+### 5.4 Validator (`internal/domain/workflow/validate.go`)
+
+Three new checks inside the existing per-transition loop in
+`validateWorkflowStructure` (lines 178–211 today). Insertion point is
+between the Next-state check (line 193–196) and the processor loop
+(line 198).
+
+```go
+// Schedule shape coherence.
+if tr.Manual && tr.Schedule != nil {
+    return fmt.Errorf(
+        "workflow %q state %q transition %q: manual and scheduled are mutually exclusive",
+        wf.Name, stateName, tr.Name)
+}
+if tr.Schedule != nil {
+    if tr.Schedule.DelayMs <= 0 {
+        return fmt.Errorf(
+            "workflow %q state %q transition %q: schedule.delayMs must be > 0 (got %d)",
+            wf.Name, stateName, tr.Name, tr.Schedule.DelayMs)
+    }
+    if tr.Schedule.TimeoutMs > 0 && tr.Schedule.TimeoutMs < tr.Schedule.DelayMs {
+        return fmt.Errorf(
+            "workflow %q state %q transition %q: schedule.timeoutMs (%d) must be >= schedule.delayMs (%d)",
+            wf.Name, stateName, tr.Name, tr.Schedule.TimeoutMs, tr.Schedule.DelayMs)
+    }
+}
+```
+
+All three errors propagate through the existing import handler to a
+`400 VALIDATION_FAILED` response (`handler.go:65-90` import path; the
+specific error code is set by the boundary classification).
+
+`validateProcessorFlags` is **unchanged.** It still enforces only
+`StartNewTxOnDispatch` / `ExecutionMode` coherence.
+
+`validateWorkflowLoops` (`validate.go:242-295`) is **unchanged.** DFS
+cycle detection skips `Manual` and `Disabled` transitions today; per
+§5.5 cascade semantics, scheduled transitions are similarly never fired
+automatically in v0.8.0. The cycle detector's role is to prevent
+infinite cascade — adding scheduled to its skip filter is unnecessary
+because the engine cascade skip already removes them from consideration,
+and adding the skip in the validator would falsely allow workflows that
+become cycle-unsafe once #251 lands. Leaving the cycle detector intact
+preserves a forward-compatible safety property.
+
+### 5.5 Engine guards (`internal/domain/workflow/engine.go`)
+
+**(a) Cascade-skip** at `engine.go:528`. One-line addition to the
+existing skip filter:
+
+```go
+// before
+if tr.Disabled || tr.Manual {
+    continue
+}
+
+// after
+if tr.Disabled || tr.Manual || tr.Schedule != nil {
+    continue
+}
+```
+
+No audit event. This matches the existing silent-skip semantics for
+`Disabled` and `Manual` transitions. The cascade loop iterates state
+transitions for automated firing; scheduled transitions are by
+definition not eligible for immediate automated firing — they wait for
+their timer. Until the timer runtime ships, they remain ineligible
+forever, which is the correct degenerate behaviour for v0.8.0.
+
+**(b) Explicit-fire reject** at `engine.go:443-453` precedent. New
+branch immediately after the `Disabled` check (currently the rejection
+for `transition.Disabled` at lines 449-453), before criterion evaluation:
+
+```go
+if transition.Schedule != nil {
+    e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
+        spi.SMEventStateProcessResult,
+        fmt.Sprintf(
+            "Transition %q in state %q is scheduled; scheduled transitions are not yet implemented",
+            transitionName, entity.Meta.State),
+        map[string]any{"success": false})
+    return ctx, txID, fmt.Errorf(
+        "transition %q in state %q is scheduled; scheduled transitions are not yet implemented",
+        transitionName, entity.Meta.State)
+}
+```
+
+**Failure surface.** The wrapped error wraps no specific sentinel.
+`classifyWorkflowError` (`internal/domain/entity/service.go:1449-1457`
+per #250 spec §5.4) falls through to its default branch and returns
+`common.Operational(http.StatusBadRequest, common.ErrCodeWorkflowFailed,
+err.Error())`. HTTP response: `400 WORKFLOW_FAILED`. Entity stays in
+source state because the function returns before line 486
+(`entity.Meta.State = transition.Next`).
+
+**Audit-event shape.** The explicit-fire reject emits one
+`SMEventStateProcessResult` with `Data: {success: false}` and a Details
+string naming the transition, source state, and rejection cause.
+Reusing the existing event type (no new SPI event constants) is the
+deliberate choice — the rejection is fundamentally a "transition could
+not complete" failure mode, structurally identical to the post-#250
+internalized-processor failure path that also emits
+`SMEventStateProcessResult{success:false}`. An audit consumer searching
+for failure events does not need a new event-type vocabulary; the
+Details substring `"scheduled transitions are not yet implemented"` is
+the unique fingerprint. The calling handler's failure path
+(`engine.go:474-477` for manual, `:562-566` for cascade) emits its own
+follow-up `SMEventStateProcessResult` per the existing two-event
+shape — but it is **never reached** for this rejection because the new
+branch sits earlier in `attemptTransition` (before
+`executeProcessors`), and the cascade path silently skips and never
+calls `attemptTransition` on a `Schedule!=nil` entry. Net audit trail
+for the explicit-fire reject: **one** `SMEventStateProcessResult` row.
+
+**Operator-side slog.** No `slog.Warn`. Consistent with #250 spec §5.4:
+fatal failure paths write the audit event and the API error; they do
+not duplicate to slog. The `WORKFLOW_FAILED 400` response is sufficient
+operator-facing signal.
+
+**No issue IDs in the error message.** The message names the transition
+and the absence of an implementation; it does not link to a tracker.
+
+### 5.6 Help text (`cmd/cyoda/help/content/workflows.md`)
+
+Add a new subsection after the existing per-transition field listing
+(after the closing of the `processors[]` discussion around line 175).
+Suggested heading: `### Scheduled transitions (v0.8.0: shape only)`.
+
+Content:
+
+```markdown
+### Scheduled transitions (shape only — runtime not yet implemented)
+
+A transition may carry an optional `schedule` object marking it as
+scheduled. Presence of `schedule` declares that the transition fires
+automatically `delayMs` milliseconds after the entity enters the
+source state. The `schedule` shape is:
+
+```json
+{
+  "name": "AutoClose",
+  "next": "Closed",
+  "manual": false,
+  "schedule": {
+    "delayMs": 86400000,
+    "timeoutMs": 90000000
+  }
+}
+```
+
+**Fields:**
+
+- `delayMs` (integer, required) — delay before firing, in milliseconds.
+  Must be `> 0`.
+- `timeoutMs` (integer, optional) — maximum age of the armed timer
+  before abandonment, in milliseconds. `0` (default) means no timeout.
+  When non-zero, must be `>= delayMs`.
+
+**Import-time validation rules:**
+
+- `manual: true` and `schedule` present are mutually exclusive
+  (`VALIDATION_FAILED`).
+- `schedule.delayMs <= 0` is rejected (`VALIDATION_FAILED`).
+- `schedule.timeoutMs > 0 && schedule.timeoutMs < schedule.delayMs` is
+  rejected (`VALIDATION_FAILED`).
+
+**v0.8.0 engine behaviour.** The timer runtime that arms and fires
+scheduled transitions is not yet implemented. Two guards govern
+behaviour until it ships:
+
+- During automated cascade evaluation, scheduled transitions are
+  silently skipped — they are never selected for immediate firing.
+  Other automated/manual transitions out of the same state fire
+  normally. An entity whose only exit is scheduled rests in its
+  current state.
+- Explicitly firing a scheduled transition by name returns HTTP 400
+  `WORKFLOW_FAILED` with the message `transition "X" in state "Y" is
+  scheduled; scheduled transitions are not yet implemented`. The
+  entity remains in the source state.
+```
+
+### 5.7 Parity scenario (`e2e/externalapi/scenarios/08-workflow-import-export.yaml`)
+
+Add a new test entry (`wf-import/04` or next free slot) exercising
+round-trip of a transition with `schedule`. Two import payloads:
+
+1. **Round-trip preservation.** A workflow with one regular and one
+   scheduled transition. Assert `json_equals_normalized` round-trip
+   equality on import + export.
+2. **Validator rejection.** Three sub-cases (`manual: true + schedule`,
+   `delayMs: 0`, `timeoutMs < delayMs`) — each asserts HTTP 400 with
+   `VALIDATION_FAILED` and the rule-specific error substring.
+
+The existing `wf-import/03` test (the post-#250 group-criterion +
+function-criterion + externalized-processor case) is **unchanged.** No
+follow-up edit there.
+
+### 5.8 Docs hygiene & test-fixture sweep (Gate 4 + Gate 6)
+
+- **`README.md`** — grep confirmed no scheduled-transition or
+  `delayMs` references. No change required; re-verify as hygiene.
+- **`CLAUDE.md`** — grep confirmed clean. No change.
+- **`docs/PROCESSOR_EXECUTION_MODES.md`** — out of scope; this doc
+  covers processor `type` × `executionMode`, not scheduled transitions.
+- **`COMPATIBILITY.md`** — untouched. SPI tag bumps at end-of-milestone;
+  this PR doesn't force a tag.
+- **`docs/cyoda/openapi.yml`** and vendored copies — explicitly out of
+  scope (point-in-time Cloud snapshots maintained upstream).
+- **`docs/WORKFLOW_IMPORT_EXPORT_AUDIT.md`** — §H1 already references
+  #259 as the carve-out. After this PR merges, the audit's tracking is
+  accurate; no edit required.
+- **Test-fixture sweep (`internal/domain/workflow/*_test.go`).** Grep
+  for `schedule`, `delayMs`, `timeoutMs`, `Schedule`:
+  ```bash
+  grep -rn 'schedule\|delayMs\|timeoutMs' --include="*_test.go" \
+       internal/domain/workflow/
+  ```
+  Expected matches (intentional, leave as-is):
+  - `engine_processors_type_test.go:147` — comment annotating
+    `"scheduled"` as a legacy value removed by #250.
+  - `engine_processors_type_test.go:152` — `"scheduled"` string in
+    `TestType_UnknownValues_FallThrough`.
+  - `engine_processors_type_test.go:308-313` — comment + test fixture
+    for `"scheduled"` as an unknown-Type round-trip value.
+
+  These are #250's intentional fall-through coverage — they prove that
+  the SPI's free-string `Type` accepts a legacy `"scheduled"` value
+  without rejection. New tests added by §6.1 cover the new
+  `Schedule` field and do not regress these.
+
+## 6. Test plan (TDD)
+
+The TDD protocol (`.claude/rules/tdd.md`) drives this work: tests are
+authored first, run to confirm RED, then driven GREEN.
+
+### 6.1 Failing-test-first sequence
+
+1. **Validator — manual + schedule coherence.** Import payload with
+   `Manual: true, Schedule: {DelayMs: 1000}`. Assert
+   `400 VALIDATION_FAILED`, error substring
+   `"manual and scheduled are mutually exclusive"`.
+
+2. **Validator — DelayMs <= 0.** Import payload with `Schedule:
+   {DelayMs: 0}` and another with `DelayMs: -100`. Both assert
+   `400 VALIDATION_FAILED`, error substring `"delayMs must be > 0"`.
+
+3. **Validator — TimeoutMs < DelayMs (non-zero).** Import payload with
+   `Schedule: {DelayMs: 1000, TimeoutMs: 500}`. Assert
+   `400 VALIDATION_FAILED`, error substring
+   `"timeoutMs (500) must be >= delayMs (1000)"`.
+
+4. **Validator — happy paths.** Three sub-cases that must pass import:
+   - `Schedule: {DelayMs: 1000}` (TimeoutMs omitted)
+   - `Schedule: {DelayMs: 1000, TimeoutMs: 0}` (TimeoutMs explicit zero)
+   - `Schedule: {DelayMs: 1000, TimeoutMs: 5000}` (TimeoutMs > DelayMs)
+
+5. **Cascade — silent skip.** Workflow with state `S` containing two
+   automated transitions: `Tsched` (scheduled, declared first) and
+   `Treg` (regular, declared second, leading to `T`). Cascade enters
+   `S`, must select `Treg`. Assert: entity ends in `T`; no audit event
+   for `Tsched` (no `SMEventTransitionCriterionNoMatch`, no
+   `SMEventStateProcessResult`, no skip-reason event); the
+   `Tsched` transition is invisible to selection.
+
+6. **Cascade — only-scheduled rests.** Workflow with state `S`
+   containing one automated transition that is scheduled, and no other
+   exits. Cascade enters `S`, must rest there. Assert: entity in `S`;
+   `cascadeAutomated` returns no error; no `SMEventCancelled`.
+
+7. **Explicit-fire reject — manual=false + Schedule.** Workflow as test
+   5 but the scheduled transition is fired by name. Assert:
+   - HTTP `400 WORKFLOW_FAILED`.
+   - Error body contains `"scheduled transitions are not yet implemented"`.
+   - Entity in source state (`Get` returns unchanged state).
+   - Audit trail contains exactly one `SMEventStateProcessResult` with
+     `Data.success == false` and Details matching the rejection
+     substring. No `SMEventTransitionMade`, no
+     `SMEventStateMachineFinish`.
+
+8. **Round-trip preservation.** Import a workflow with a transition
+   carrying `Schedule: {DelayMs: 86400000, TimeoutMs: 90000000}`,
+   export, assert the exported JSON contains
+   `"schedule":{"delayMs":86400000,"timeoutMs":90000000}` byte-for-byte
+   on the round-trip. Variant: `Schedule: {DelayMs: 1000}` (no
+   TimeoutMs) — assert exported JSON contains
+   `"schedule":{"delayMs":1000}` (omitempty drops the zero
+   `timeoutMs`).
+
+9. **E2E — explicit fire of scheduled transition returns 400.**
+   Integration test in `internal/e2e/` mirroring #250's test 8 shape:
+   1. Create an entity model.
+   2. `POST /model/X/1/workflow/import` with a workflow whose initial
+      state has exactly one transition: `{name: "AutoClose", next:
+      "Closed", manual: false, schedule: {delayMs: 1000}}`. Assert
+      HTTP 200 (the validator accepts shape-coherent scheduled
+      transitions).
+   3. `POST /entity/X` to create an instance — entity lands in the
+      initial state because the cascade silently skips the scheduled
+      transition and finds no other automated exit.
+   4. `POST /entity/X/<id>/transition/AutoClose` — assert HTTP 400
+      with error code `WORKFLOW_FAILED` and message substring
+      `scheduled transitions are not yet implemented`.
+   5. `GET /entity/X/<id>` returns the entity in the initial state
+      (cascade rested there; explicit fire rejected).
+
+10. **Parity — scenario 08/wf-import/04 round-trip passes.** Per §5.7.
+
+### 6.2 Coverage gaps explicitly NOT closed in #259
+
+- Timer runtime behaviour: arming, firing, cancellation, durability
+  across restarts, cluster ownership, work-stealing recovery. (#251
+  scope.)
+- Audit-event semantics for armed/fired/cancelled. (#251 scope.)
+- Interaction tie-breaking when manual non-scheduled and scheduled
+  transitions coexist in the same state with overlapping firing
+  windows. (#251 scope — currently moot because v0.8.0 silently skips
+  scheduled transitions.)
+- Cycle detection awareness of scheduled transitions. The DFS in
+  `validateWorkflowLoops` does not skip scheduled transitions; the
+  conservative choice is to preserve cycle detection's existing
+  reachability assumption so workflows that would become cycle-unsafe
+  once #251 lands are caught at v0.8.0 import time. (Documented in
+  §5.4.)
+
+## 7. Backwards compatibility
+
+| Inbound payload shape | Behaviour before #259 | Behaviour after #259 |
+|---|---|---|
+| `TransitionDefinitionDto` with no `schedule` | Accepted, fired normally | Same |
+| `TransitionDefinitionDto.schedule: {delayMs: N>0}` | Field unknown to OpenAPI; silently dropped by `json.Unmarshal` into `spi.TransitionDefinition`; transition behaves as a regular one | **Accepted, stored, round-tripped.** Validator enforces the three coherence rules. Cascade silently skips; explicit-fire returns 400. |
+| `TransitionDefinitionDto.schedule: {delayMs: 0}` | Silently dropped | **Rejected at import** with `VALIDATION_FAILED`. |
+| `TransitionDefinitionDto` with `manual: true, schedule: {...}` | Silently dropped (schedule lost) | **Rejected at import** with `VALIDATION_FAILED`. |
+| Legacy `processors[]` with `{type: "scheduled", config: {delayMs, transition, timeoutMs}}` (raw-JSON path; pre-#250 shape) | After #250: SPI's free-string `Type` accepts; scheduled config fields silently dropped by `ProcessorConfig` unmarshal; dispatched as externalized | **Same as post-#250.** The new `TransitionDefinition.Schedule` field does not interact with `Processors[].Type` or `ProcessorConfig`. Carried-over technical debt from §H1's silent-drop. |
+
+The wire surface is **strictly wider** in exactly one place
+(`TransitionDefinitionDto.schedule` is a new optional field on a
+previously-fixed schema). All existing payloads continue to parse and
+behave identically. No upgrade migration required: workflows persisted
+under v0.7.x or pre-#250 v0.8.0 carry no `Schedule` field; new imports
+under v0.8.0 may add it; both round-trip cleanly.
+
+**Cyoda Cloud parity.** Cloud regenerates its OpenAPI client at v0.8.0
+and picks up the new `TransitionScheduleDto` and the `schedule` field
+together with #260's `internalized` subtype and #250's docstring update.
+Cloud-side runtime for scheduled transitions remains a Cloud-only
+feature until cyoda-go's #251 lands; in the meantime, Cloud-emitted
+workflows with `schedule` round-trip cleanly through cyoda-go (the
+shape is now well-defined) and become inert at runtime per §5.5.
+
+## 8. Risks
+
+- **`*TransitionSchedule` pointer JSON edge case.** A pointer with all
+  fields zero-valued (`&TransitionSchedule{}`) marshals as
+  `"schedule":{"delayMs":0,"timeoutMs":0}` (omitempty drops the
+  `timeoutMs:0` but not the empty struct itself). If callers construct
+  such a value, the validator catches it via the `DelayMs <= 0` rule.
+  No silent acceptance.
+- **OpenAPI generator behaviour for the new `schedule` field.** Some
+  `oapi-codegen` versions emit `*TransitionScheduleDto` (pointer) for
+  optional non-required object fields, matching the SPI pointer choice.
+  Verify in the regeneration spike (§5.2). If a value-type is emitted,
+  there is no behavioural divergence (zero-value still goes through
+  validator), but the generated code may need a manual nudge.
+- **Cycle-detector blind spot.** `validateWorkflowLoops` does not
+  account for scheduled transitions. Once #251 ships, a workflow with
+  `S1 --scheduled--> S2 --scheduled--> S1` becomes a delayed-cycle.
+  The cycle detector today treats both edges as eligible and rejects.
+  This is the conservative choice (preserve detection); revisit when
+  #251 lands.
+- **`*int64` vs `int64` for `TimeoutMs` round-trip.** Choosing `int64`
+  with `omitempty` (per §5.3) means the JSON omits `timeoutMs` only
+  when the Go value is exactly 0. A client that explicitly sets
+  `timeoutMs: 0` in import JSON, exports, and gets back JSON without
+  `timeoutMs` is technically a lossy round-trip — but the SPI and
+  OpenAPI both document `0 == no timeout`, so this is semantically
+  equivalent. Round-trip preservation test 8 (§6.1) pins the
+  byte-exact shape for non-zero values; the zero-value case is
+  semantically equivalent both directions.
+- **SPI tag coupling.** #259 bundles the deferred #250 docstring; if
+  this PR is reverted, #250's docstring is also lost from SPI main.
+  Acceptable because the bundling is intentional per #250 spec §5.3,
+  and a revert would similarly carry the new shape work.
+
+## 9. Out of scope (sanity check)
+
+- Scheduled-transition runtime (timer arming, firing, durability,
+  cluster ownership, work-stealing recovery, cancellation on state
+  change) — #251.
+- `SMEventScheduledTransition*` SPI event types — #251.
+- Internalized processor execution-location shape + SPI — #260.
+- Import-time validation tightening for other shape fields — #255
+  (already closed in v0.8.0).
+- `ProcessorConfig.Context` / `RetryPolicy` wiring — #253, #254, #262.
+- `WorkflowStore.CompareAndSave` SPI addition — #35.
+- Vendored upstream OpenAPI copies under `docs/cyoda/`.
+- Cassandra plugin coordination — additive SPI; refresh via end-of-milestone
+  tag bump, not from this PR.
+
+## 10. Cross-repo coordination
+
+Per memory `feedback_spi_coordinated_release_procedure` and
+`cyoda-go-spi/MAINTAINING.md` "Coordinated release across sibling
+repos":
+
+1. **cyoda-go-spi PR first.** Bundled change: deferred #250 docstring +
+   `TransitionSchedule` type + `Schedule` field on `TransitionDefinition`.
+   `CHANGELOG.md` `[Unreleased]` entry per §5.3. Merged to `main`. No
+   tag.
+
+2. **cyoda-go PR second.** Steps:
+   - Refresh pseudo-version pin to SPI `main` HEAD across all four
+     `go.mod` files (root + `plugins/memory|sqlite|postgres`).
+   - Implement validator rules + engine guards + tests + help text +
+     parity scenario.
+   - Regenerate `api/generated.go` from the updated `openapi.yaml`.
+   - Single PR targeting `release/v0.8.0` per memory
+     `feedback_release_branch_for_milestones`.
+
+3. **Cassandra plugin (commercial backend, separate repo).** Additive
+   SPI is non-breaking; no per-PR refresh required. End-of-milestone
+   v0.8.0 SPI tag triggers a courtesy bump in the cassandra repo per
+   memory `feedback_courtesy_pr_scope` — strictly in-scope, no
+   drive-by fixes.
+
+4. **PR body conventions.**
+   - cyoda-go-spi PR: title `feat(types): scheduled-transition shape +
+     ProcessorDefinition.Type docstring`. Body references cyoda-go
+     #259 (parent) and #250 (deferred docstring origin). No issue IDs
+     in the docstring text or CHANGELOG entry — only in the PR body
+     and commit message.
+   - cyoda-go PR: title `feat(workflow): scheduled-transition
+     configuration shape + SPI`. Body has `Closes #259`. Milestone:
+     `v0.8.0`. Target branch: `release/v0.8.0`. Per memory
+     `feedback_release_milestone_invariant`, ensure the milestone is
+     applied at PR-merge time.
+
+---
+
+## Appendix A: File-level impact summary
+
+| File | Change |
+|---|---|
+| `cyoda-go-spi/types.go` (sibling repo) | Add `TransitionSchedule` struct + `TransitionDefinition.Schedule` field; add docstring on `ProcessorDefinition.Type` from `spi-docstring-processor-type-250` branch. |
+| `cyoda-go-spi/CHANGELOG.md` (sibling repo) | Add `[Unreleased]` Added + Changed entries per §5.3. |
+| `api/openapi.yaml` | Add `TransitionScheduleDto` schema; add optional `schedule` property to `TransitionDefinitionDto`. |
+| `api/generated.go` | Regenerated from above. |
+| `internal/domain/workflow/validate.go` | Add three Schedule-coherence checks in `validateWorkflowStructure` per-transition loop (between lines 193 and 198). |
+| `internal/domain/workflow/engine.go` | Cascade-skip filter at line 528 (one-line addition); explicit-fire reject branch in `attemptTransition` after the `Disabled` check (between lines 453 and 455). |
+| `internal/domain/workflow/validate_test.go` (or sibling) | TDD tests per §6.1 items 1–4. |
+| `internal/domain/workflow/engine_test.go` (or sibling) | TDD tests per §6.1 items 5–8. |
+| `internal/e2e/` | E2E test per §6.1 item 9. |
+| `cmd/cyoda/help/content/workflows.md` | New `### Scheduled transitions` subsection per §5.6. |
+| `e2e/externalapi/scenarios/08-workflow-import-export.yaml` | Add `wf-import/04` round-trip + reject scenario per §5.7. |
+| `README.md`, `CLAUDE.md`, `COMPATIBILITY.md`, `docs/PROCESSOR_EXECUTION_MODES.md` | Untouched. Re-grep as Gate 4 hygiene. |
+| `docs/cyoda/openapi.yml` and vendored copies | Out of scope. |
+| `go.mod` (root + `plugins/memory|sqlite|postgres`) | Bump pseudo-version pin to cyoda-go-spi `main` HEAD post-SPI-PR-merge. |
+
+## Appendix B: Verification before completion
+
+Per `superpowers:verification-before-completion`:
+
+- `go build ./...` — clean.
+- `go vet ./...` — clean (root and per-plugin per
+  `per-module-hygiene` CI job).
+- `go test -short ./...` — green.
+- `go test ./internal/e2e/...` — green (Docker required for the
+  testcontainers Postgres backend).
+- Parity scenario suite — green.
+- `go test -race ./...` — one-shot before PR creation per
+  `.claude/rules/race-testing.md`.
+- `make test-all` — covers root + `plugins/memory|sqlite|postgres` per
+  CLAUDE.md.
+- `make todos` — no new TODOs introduced.
+
+## Appendix C: Out-of-tree plugin impact
+
+The cyoda-go-cassandra plugin (commercial backend) consumes the SPI.
+The added `TransitionSchedule` type and `Schedule` field are additive
+to the workflow types — Cassandra's `WorkflowStore` stores
+`[]WorkflowDefinition` opaquely (per the SPI conformance test
+`spitest/workflow.go`), so no behavioural change is required. Per
+memory `feedback_cross_plugin_design_verification` the design check is:
+does the Cassandra plugin read fields of `TransitionDefinition`
+beyond what's needed for storage? Answer: no — the SPI conformance
+test in `cyoda-go-spi/spitest/workflow.go` exercises `Save`/`Get`/`Delete`
+only; the plugin treats `WorkflowDefinition` as a value type without
+field-level inspection. The new field round-trips cleanly through any
+conforming implementation.

--- a/docs/superpowers/specs/2026-06-15-issue-259-scheduled-transition-shape-design.md
+++ b/docs/superpowers/specs/2026-06-15-issue-259-scheduled-transition-shape-design.md
@@ -10,6 +10,29 @@
 > **Revision history**
 >
 > - **Revision 1 (2026-06-15):** initial spec.
+> - **Revision 3 (2026-06-15):** resolved M3 and M4 from the rev 2 review.
+>   **M3** — explicit-fire rejection mirrors the `Disabled` precedent
+>   exactly: emit `SMEventTransitionNotFound`, wrap `ErrTransitionNotFound`,
+>   surface as `400 TRANSITION_NOT_FOUND`. Per project lead: TRANSITION_NOT_FOUND
+>   is the right code when "the transition does not exist or is not currently
+>   dispatchable from the caller's POV" — which is exactly the scheduled-but-
+>   runtime-not-yet-implemented case. The criterion-rejection event type
+>   (`SMEventTransitionCriterionNoMatch`) remains untouched. **M4** —
+>   `TimeoutMs` semantic clarified by project lead: it is the late-tolerance
+>   window past the scheduled-time, NOT a max-age-of-armed-timer.
+>   `scheduledTime = stateEntryTime + delayMs`; at execution time the
+>   scheduler checks `lateness = executionTime - scheduledTime`; if
+>   `lateness > timeoutMs` the task is dropped. The rev 1 / rev 2 validator
+>   rule `TimeoutMs >= DelayMs` is bogus under this semantic (the two
+>   measure different quantities) and is removed. `TimeoutMs` becomes a
+>   `*int64` pointer (precedent: `ProcessorConfig.StartNewTxOnDispatch
+>   *bool`) so that `nil` (no timeout — fire whenever the scheduler
+>   eventually picks it up), `&0` (strictest — drop if any lateness), and
+>   `&N` (drop if late > N ms) are all distinguishable on the wire and
+>   round-trip cleanly. Forward-context note from project lead: scheduled
+>   transitions are one instance of a generic ScheduledTask abstraction;
+>   timeoutMs is the same lateness-tolerance concept across all variants.
+>   #251 owns the generalisation.
 > - **Revision 2 (2026-06-15):** incorporated independent design review.
 >   Six load-bearing / medium defects fixed: (L1) parity-scenario slot
 >   collision — `wf-import/04` was already populated, switched to
@@ -81,17 +104,19 @@ unavailability of the feature in self-contained terms.
   `TransitionDefinitionDto`.
 - Land import-time validator rules for the shape's internal coherence:
   `Manual=true && Schedule!=nil` is rejected (structurally incoherent);
-  `Schedule!=nil && DelayMs<=0` is rejected; `Schedule!=nil &&
-  TimeoutMs>0 && TimeoutMs<DelayMs` is rejected.
+  `Schedule!=nil && DelayMs<=0` is rejected. (`TimeoutMs` has no
+  cross-field rule beyond `>= 0` — see §5.4.)
 - Land two-pronged engine guards:
   - The cascade-automatic loop silently treats `Schedule!=nil` as ineligible
     (mirroring how it already treats `Disabled` and `Manual`). No audit
     signal; entity progress through other automated/manual transitions out
     of the same state is unaffected.
   - The explicit-fire-by-name path (`attemptTransition`) rejects any
-    transition with `Schedule!=nil` with `WORKFLOW_FAILED 400` and a
-    self-contained error message. Mirrors #250's pattern for `Type:
-    internalized` rejection.
+    transition with `Schedule!=nil` with `TRANSITION_NOT_FOUND 400` —
+    same code the existing `Disabled` branch returns — and a
+    self-contained error message. Mirrors the `Disabled` precedent at
+    `engine.go:449-453` exactly: emit `SMEventTransitionNotFound`,
+    return error wrapping `ErrTransitionNotFound`.
 - Bundle #250's deferred `ProcessorDefinition.Type` docstring update into
   the same SPI PR — per #250 spec §5.3 the docstring was intentionally
   held back for the first carve-out that needs a substantive SPI change.
@@ -103,7 +128,7 @@ unavailability of the feature in self-contained terms.
   scheduled-transition use case is a polling pattern `S1 →scheduled→ S2
   →scheduled→ S1` which the existing `validateWorkflowLoops` rejects).
   The flag bypasses only `validateWorkflowLoops`; all other validators
-  (the three new Schedule rules, processor flags, structural checks)
+  (the two new Schedule rules, processor flags, structural checks)
   remain unconditional. Request-level (not workflow-level) — each
   import re-asserts intent; the durable schema does not carry a
   "skip safety check" knob. Runtime safety net (`maxStateVisits`,
@@ -131,11 +156,12 @@ unavailability of the feature in self-contained terms.
 |---|---|
 | Where does scheduling data live? | **Optional `Schedule *TransitionSchedule` field on `TransitionDefinition`.** Presence marks the transition as scheduled. One declaration encodes both "what fires" and "when". Engine state-entry hook (in #251) reads `tr.Schedule` to arm a timer. |
 | Cascade semantics for `Schedule!=nil` (`cascadeAutomated`, `engine.go:528`) | **Silent skip.** Add `\|\| tr.Schedule != nil` to the existing `Disabled \|\| Manual` skip filter. No audit event. An entity whose only exit is scheduled rests in the source state. |
-| Explicit-fire semantics for `Schedule!=nil` (`attemptTransition`, `engine.go:443-453`) | **Reject with `WORKFLOW_FAILED 400`.** Free-string error → `classifyWorkflowError` default branch returns `Operational(400, WORKFLOW_FAILED, msg)`. Entity stays in source state. Single `SMEventStateProcessResult{success:false}` audit row. |
-| Validator coherence (`validate.go:178-211`) | **Three new rules** inside the existing per-transition loop, placed between the Next-state check (line 193) and the processor loop (line 198): (a) `Manual && Schedule != nil` → reject; (b) `Schedule != nil && DelayMs <= 0` → reject; (c) `Schedule != nil && TimeoutMs > 0 && TimeoutMs < DelayMs` → reject. All `VALIDATION_FAILED 400`. |
-| `TimeoutMs == 0` semantics | **"No timeout."** Documented in SPI docstring and OpenAPI description. Allowed by the validator (the `TimeoutMs > 0` guard). |
+| Explicit-fire semantics for `Schedule!=nil` (`attemptTransition`, mirror of `Disabled` precedent at `engine.go:449-453`) | **Reject with `TRANSITION_NOT_FOUND 400`.** Emit `SMEventTransitionNotFound`; return error wrapping `ErrTransitionNotFound`; `classifyWorkflowError` maps the sentinel to `Operational(400, ErrCodeTransitionNotFound, msg)`. Entity stays in source state. Single audit row. Per project lead: TRANSITION_NOT_FOUND is the correct code for "transition exists but is not currently dispatchable from the caller's POV" — exactly the scheduled-but-runtime-not-yet-implemented case; same code Disabled returns. (Rev 1 / rev 2 chose `WORKFLOW_FAILED` + `SMEventStateProcessResult` — wrong by analogy to processor-failure paths. Rev 3 fix.) |
+| Validator coherence (`validate.go:178-211`) | **Two new rules** inside the existing per-transition loop, placed between the Next-state check (line 193) and the processor loop (line 198): (a) `Manual && Schedule != nil` → reject; (b) `Schedule != nil && DelayMs <= 0` → reject. All `VALIDATION_FAILED 400`. (Rev 1's third rule `TimeoutMs >= DelayMs` was removed in rev 3 — bogus under the late-tolerance semantic.) |
+| `TimeoutMs` semantic | **Late-tolerance window past scheduled time.** `scheduledTime = stateEntryTime + delayMs`. At actual execution time the scheduler computes `lateness = executionTime - scheduledTime`; if `lateness > timeoutMs` the task is dropped (the transition is NOT attempted). Gives operators control over backlog / intermittent-offline behaviour. **Not** a max execution time, **not** a max age of the armed timer, **not** a hard wall-clock deadline. |
+| `TimeoutMs` shape | **`*int64` pointer** (`omitempty`). `nil` → no timeout, always fire whenever the scheduler eventually picks it up. `&0` → strictest, drop if any lateness. `&N` (N>0) → drop if lateness > N ms. Precedent: `ProcessorConfig.StartNewTxOnDispatch *bool`. |
 | OpenAPI surface | New `TransitionScheduleDto` schema with `delayMs` (required, `minimum: 1`) and `timeoutMs` (optional, `minimum: 0`). New optional `schedule: $ref` field on `TransitionDefinitionDto`. Regenerate `api/generated.go`. |
-| Audit-event shape for explicit-fire reject | **Single `SMEventStateProcessResult{success:false}`** with a Details string naming the transition and the rejection cause. Reuses the existing event type (no new SPI events). |
+| Audit-event shape for explicit-fire reject | **Single `SMEventTransitionNotFound`** with a Details string naming the transition and rejection cause. Reuses the existing event type that already covers "named-transition-not-found" AND "Disabled-and-thus-not-dispatchable" cases. No new SPI events. |
 | Error wording | **Self-contained**, no issue ID. Validator messages name the rule violated; engine error names the transition, source state, and rejection cause. |
 | SPI PR bundling | **One SPI PR** combining (a) deferred `ProcessorDefinition.Type` docstring from #250, (b) new `TransitionSchedule` type, (c) new `Schedule` field on `TransitionDefinition`. CHANGELOG `[Unreleased]` entry covers all three. |
 | SPI tagging | **None forced.** Bundled into v0.8.0's end-of-milestone tag per `MAINTAINING.md` "Coordinated release" cadence. cyoda-go pseudo-version-pins to SPI `main` HEAD across all four `go.mod` files per memory `project_v0_8_0_milestone_state`. |
@@ -157,30 +183,43 @@ TransitionScheduleDto:
   type: object
   description: |
     Scheduling configuration for an automatic future state transition.
-    Presence of this object marks the parent transition as scheduled —
-    it fires automatically delayMs milliseconds after the entity enters
-    the source state. Mutually exclusive with parent transition's
-    manual=true.
+    Presence of this object marks the parent transition as scheduled.
+    The transition is scheduled to fire at `stateEntryTime + delayMs`
+    (the "scheduledTime"). When the scheduler picks the task up for
+    execution at `executionTime`, it computes `lateness = executionTime
+    - scheduledTime`; if `lateness > timeoutMs` the task is dropped
+    and the transition is NOT attempted. `timeoutMs` gives operators
+    control over how the system should handle backlog or intermittent-
+    offline conditions: short timeoutMs values prefer freshness over
+    eventual execution; absent timeoutMs always eventually fires.
+
+    Mutually exclusive with parent transition's manual=true.
 
     The runtime that arms and fires the timer is not yet implemented.
     Until it ships, the engine silently skips scheduled transitions
     during automated cascade selection, and explicit fires by name are
-    rejected with HTTP 400 WORKFLOW_FAILED.
+    rejected with HTTP 400 TRANSITION_NOT_FOUND.
   properties:
     delayMs:
       type: integer
       format: int64
       minimum: 1
       description: |
-        Delay before firing, in milliseconds. Must be a positive integer.
+        Delay between source-state entry and the scheduled execution
+        time, in milliseconds. Must be a positive integer (zero or
+        negative would make this a regular automated transition).
     timeoutMs:
       type: integer
       format: int64
       minimum: 0
       description: |
-        Maximum age of the armed timer before abandonment, in
-        milliseconds. 0 (default) means no timeout. When non-zero, must
-        be greater than or equal to delayMs.
+        Late-tolerance window past the scheduled execution time, in
+        milliseconds. When the scheduler picks the task up, if
+        `(executionTime - scheduledTime) > timeoutMs` the task is
+        dropped. Absent (omitted) means no timeout — the task fires
+        whenever the scheduler eventually picks it up. Explicit zero
+        is the strictest setting — drop on any lateness. Independent
+        of `delayMs`; the two measure different quantities.
   required:
     - delayMs
 ```
@@ -226,7 +265,9 @@ The field is not added to `required`; absence is equivalent to `false`.
 Regenerated from the updated `openapi.yaml`. New entries:
 
 - `type TransitionScheduleDto struct { ... }` with fields `DelayMs int64`
-  and `TimeoutMs *int64` (pointer because non-required).
+  (required) and `TimeoutMs *int64` (pointer because non-required, and
+  the absent-vs-zero distinction is semantically meaningful per §4 and
+  §5.3 below).
 - `TransitionDefinitionDto.Schedule *TransitionScheduleDto`.
 
 Validation spike (per `make generate`):
@@ -249,25 +290,45 @@ workflow types (after `TransitionDefinition`, before the
 ```go
 // TransitionSchedule configures automatic firing of a future state
 // transition. Presence of this struct on a TransitionDefinition marks
-// the transition as scheduled: the engine arms a timer when the entity
-// enters the source state, and the transition fires automatically after
-// DelayMs milliseconds.
+// the transition as scheduled.
+//
+// Semantics. The scheduled execution time of the transition is
+// scheduledTime = stateEntryTime + DelayMs. When the scheduler picks
+// the task up at executionTime, it computes
+// lateness = executionTime - scheduledTime.
+//   - If TimeoutMs is nil, the task is always attempted (no timeout).
+//   - If TimeoutMs is non-nil and lateness > *TimeoutMs, the task is
+//     dropped and the transition is NOT attempted.
+//   - If TimeoutMs is non-nil and lateness <= *TimeoutMs (including
+//     *TimeoutMs == 0 when lateness is 0), the transition fires.
+//
+// TimeoutMs gives operators control over how the system handles
+// backlog and intermittent-offline conditions. Short positive values
+// prefer freshness — stale tasks are discarded rather than fired
+// against a possibly-changed entity. Nil prefers eventual execution.
 //
 // Scheduled transitions are mutually exclusive with Manual=true.
 //
-// The runtime that arms and fires the timer is not yet implemented.
-// Engine behaviour in the absence of that runtime is defined by the
-// cyoda-go engine package: scheduled transitions are silently skipped
-// during automated cascade selection, and explicit fires by name are
-// rejected with HTTP 400.
+// Scheduled transitions are a special case of a generic ScheduledTask
+// abstraction. The lateness-tolerance concept (TimeoutMs) applies
+// uniformly across all ScheduledTask variants. The generic
+// abstraction and the runtime that implements it ship in a later
+// release; the v0.8.0 engine silently skips scheduled transitions
+// during automated cascade selection, and rejects explicit fires by
+// name with HTTP 400 TRANSITION_NOT_FOUND.
 type TransitionSchedule struct {
-    // DelayMs is the delay before firing, in milliseconds. Must be > 0.
+    // DelayMs is the delay between source-state entry and the
+    // scheduled execution time, in milliseconds. Must be > 0.
     DelayMs int64 `json:"delayMs"`
 
-    // TimeoutMs is the maximum age of the armed timer before abandonment,
-    // in milliseconds. 0 means no timeout. When non-zero, must be >=
-    // DelayMs.
-    TimeoutMs int64 `json:"timeoutMs,omitempty"`
+    // TimeoutMs is the late-tolerance window past the scheduled
+    // execution time, in milliseconds. Nil means no timeout — the
+    // task fires whenever the scheduler eventually picks it up.
+    // Non-nil zero is the strictest setting — drop on any lateness.
+    // Non-nil positive N drops the task if it picks up more than N
+    // milliseconds after scheduledTime. Independent of DelayMs; the
+    // two measure different quantities.
+    TimeoutMs *int64 `json:"timeoutMs,omitempty"`
 }
 ```
 
@@ -340,7 +401,7 @@ milestone flight).
 
 ### 5.4 Validator (`internal/domain/workflow/validate.go`)
 
-Three new checks inside the existing per-transition loop in
+Two new checks inside the existing per-transition loop in
 `validateWorkflowStructure` (lines 178–211 today). Insertion point is
 between the Next-state check (line 193–196) and the processor loop
 (line 198).
@@ -352,25 +413,26 @@ if tr.Manual && tr.Schedule != nil {
         "workflow %q state %q transition %q: manual and scheduled are mutually exclusive",
         wf.Name, stateName, tr.Name)
 }
-if tr.Schedule != nil {
-    if tr.Schedule.DelayMs <= 0 {
-        return fmt.Errorf(
-            "workflow %q state %q transition %q: schedule.delayMs must be > 0 (got %d)",
-            wf.Name, stateName, tr.Name, tr.Schedule.DelayMs)
-    }
-    if tr.Schedule.TimeoutMs > 0 && tr.Schedule.TimeoutMs < tr.Schedule.DelayMs {
-        return fmt.Errorf(
-            "workflow %q state %q transition %q: schedule.timeoutMs (%d) must be >= schedule.delayMs (%d)",
-            wf.Name, stateName, tr.Name, tr.Schedule.TimeoutMs, tr.Schedule.DelayMs)
-    }
+if tr.Schedule != nil && tr.Schedule.DelayMs <= 0 {
+    return fmt.Errorf(
+        "workflow %q state %q transition %q: schedule.delayMs must be > 0 (got %d)",
+        wf.Name, stateName, tr.Name, tr.Schedule.DelayMs)
 }
 ```
 
-All three errors propagate through the existing import handler to a
+No `TimeoutMs` validator rule beyond what OpenAPI's `minimum: 0`
+enforces at the DTO boundary. The rev 1 / rev 2 rule `TimeoutMs >=
+DelayMs` was removed in rev 3: under the late-tolerance semantic
+(§5.3), `DelayMs` and `TimeoutMs` measure unrelated quantities, so
+the rule was bogus. A workflow with `DelayMs: 60000, TimeoutMs: &500`
+is coherent (fire 60s after entry; drop if the scheduler is more than
+500ms late picking it up).
+
+Both errors propagate through the existing import handler to a
 `400 VALIDATION_FAILED` response (`handler.go:65-90` import path; the
 specific error code is set by the boundary classification).
 
-**Placement rationale (M7).** The three Schedule rules sit in
+**Placement rationale (M7).** The two Schedule rules sit in
 `validateWorkflowStructure`, which is invoked by `validateImportRequest`
 on the incoming workflow set only — not on the merged-after-importMode
 result. This matches `validateImportRequest`'s scope: structural shape
@@ -434,7 +496,7 @@ The handler's import path threads `req.AllowCycles` into the
 around the post-merge validation step).
 
 Other validators — `validateImportRequest` /
-`validateWorkflowStructure` (including the three Schedule rules
+`validateWorkflowStructure` (including the two Schedule rules
 above), `validateProcessorFlags` — remain **unconditional**. The flag
 is specifically a cycle-detection bypass, not a general validation
 override. A workflow with both an unguarded cycle and a
@@ -489,55 +551,78 @@ definition not eligible for immediate automated firing — they wait for
 their timer. Until the timer runtime ships, they remain ineligible
 forever, which is the correct degenerate behaviour for v0.8.0.
 
-**(b) Explicit-fire reject** at `engine.go:443-453` precedent. New
-branch immediately after the `Disabled` check (currently the rejection
-for `transition.Disabled` at lines 449-453), before criterion evaluation:
+**(b) Explicit-fire reject** — mirror of the `Disabled` precedent at
+`engine.go:449-453`. New branch immediately after the existing
+`Disabled` check, before criterion evaluation. The shape is byte-for-
+byte structurally identical to the `Disabled` branch, differing only
+in the trigger predicate and the Details substring:
 
 ```go
+// Reference: existing Disabled branch at engine.go:449-453.
+//
+//     if transition.Disabled {
+//         e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
+//             spi.SMEventTransitionNotFound,
+//             fmt.Sprintf("Transition %q is disabled", transitionName), nil)
+//         return ctx, txID, fmt.Errorf("transition %q is disabled in state %q: %w",
+//             transitionName, entity.Meta.State, ErrTransitionNotFound)
+//     }
+
 if transition.Schedule != nil {
     e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
-        spi.SMEventStateProcessResult,
+        spi.SMEventTransitionNotFound,
         fmt.Sprintf(
-            "Transition %q in state %q is scheduled; scheduled transitions are not yet implemented",
-            transitionName, entity.Meta.State),
-        map[string]any{"success": false})
+            "Transition %q is scheduled; scheduled transitions are not yet implemented",
+            transitionName), nil)
     return ctx, txID, fmt.Errorf(
-        "transition %q in state %q is scheduled; scheduled transitions are not yet implemented",
-        transitionName, entity.Meta.State)
+        "transition %q in state %q is scheduled; scheduled transitions are not yet implemented: %w",
+        transitionName, entity.Meta.State, ErrTransitionNotFound)
 }
 ```
 
-**Failure surface.** The wrapped error wraps no specific sentinel.
-`classifyWorkflowError` (`internal/domain/entity/service.go:1449-1457`
-per #250 spec §5.4) falls through to its default branch and returns
-`common.Operational(http.StatusBadRequest, common.ErrCodeWorkflowFailed,
-err.Error())`. HTTP response: `400 WORKFLOW_FAILED`. Entity stays in
-source state because the function returns before line 486
+**Failure surface.** The wrapped error carries `ErrTransitionNotFound`
+as its sentinel. `classifyWorkflowError`
+(`internal/domain/entity/service.go:1449-1457`) maps this sentinel to
+`common.Operational(http.StatusBadRequest, common.ErrCodeTransitionNotFound,
+err.Error())`. HTTP response: `400 TRANSITION_NOT_FOUND`. Same code
+the `Disabled` branch returns today. Entity stays in source state
+because the function returns before line 486
 (`entity.Meta.State = transition.Next`).
 
-**Audit-event shape.** The explicit-fire reject emits one
-`SMEventStateProcessResult` with `Data: {success: false}` and a Details
-string naming the transition, source state, and rejection cause.
-Reusing the existing event type (no new SPI event constants) is the
-deliberate choice — the rejection is fundamentally a "transition could
-not complete" failure mode, structurally identical to the post-#250
-internalized-processor failure path that also emits
-`SMEventStateProcessResult{success:false}`. An audit consumer searching
-for failure events does not need a new event-type vocabulary; the
-Details substring `"scheduled transitions are not yet implemented"` is
-the unique fingerprint. The calling handler's failure path
-(`engine.go:474-477` for manual, `:562-566` for cascade) emits its own
-follow-up `SMEventStateProcessResult` per the existing two-event
-shape — but it is **never reached** for this rejection because the new
-branch sits earlier in `attemptTransition` (before
-`executeProcessors`), and the cascade path silently skips and never
-calls `attemptTransition` on a `Schedule!=nil` entry. Net audit trail
-for the explicit-fire reject: **one** `SMEventStateProcessResult` row.
+**Why TRANSITION_NOT_FOUND, not WORKFLOW_FAILED.** Per project lead:
+TRANSITION_NOT_FOUND is the correct code for "the named transition
+exists in the workflow definition but is not currently dispatchable
+from the caller's POV." That's exactly the Disabled semantics; that's
+exactly the scheduled-but-runtime-not-yet-implemented semantics. The
+criterion-rejection case (`SMEventTransitionCriterionNoMatch`) is
+intentionally NOT covered by TRANSITION_NOT_FOUND because criterion
+mismatch is a runtime decision based on entity state, not a static
+"this can't be dispatched" property. Rev 1 / rev 2 incorrectly chose
+WORKFLOW_FAILED + SMEventStateProcessResult by analogy to processor-
+failure paths — but no processor is involved here; the rejection
+happens before `executeProcessors` is reached.
 
-**Operator-side slog.** No `slog.Warn`. Consistent with #250 spec §5.4:
-fatal failure paths write the audit event and the API error; they do
-not duplicate to slog. The `WORKFLOW_FAILED 400` response is sufficient
-operator-facing signal.
+**Audit-event shape.** Single `SMEventTransitionNotFound` row with
+Details `Transition "<name>" is scheduled; scheduled transitions are
+not yet implemented`. Reuses the event type the existing
+`TransitionNotFound`-via-name and `Disabled` branches both emit. No
+new SPI event constants needed. An audit consumer searching for
+"transition not currently dispatchable" failure events sees a
+uniform shape across all three reasons (missing name, disabled,
+scheduled); the Details substring distinguishes them.
+
+The caller-level failure emit at `engine.go:474-477` (manual) /
+`:562-566` (cascade) targets `SMEventStateProcessResult` and only
+fires after `executeProcessors` returns an error. Our new branch
+returns before `executeProcessors`, so the caller-level emit is
+never reached for this rejection. Net audit trail for the explicit-
+fire reject: one `SMEventTransitionNotFound` row.
+
+**Operator-side slog.** No `slog.Warn`. Consistent with the existing
+`Disabled` branch's silence and #250 spec §5.4: predictable 4xx
+rejection paths write the audit event and the API error; they do
+not duplicate to slog. The `400 TRANSITION_NOT_FOUND` response is
+sufficient operator-facing signal.
 
 **No issue IDs in the error message.** The message names the transition
 and the absence of an implementation; it does not link to a tracker.
@@ -556,8 +641,8 @@ Content:
 
 A transition may carry an optional `schedule` object marking it as
 scheduled. Presence of `schedule` declares that the transition fires
-automatically `delayMs` milliseconds after the entity enters the
-source state. The `schedule` shape is:
+automatically at `scheduledTime = stateEntryTime + delayMs`. The
+`schedule` shape is:
 
 ```json
 {
@@ -566,30 +651,35 @@ source state. The `schedule` shape is:
   "manual": false,
   "schedule": {
     "delayMs": 86400000,
-    "timeoutMs": 90000000
+    "timeoutMs": 600000
   }
 }
 ```
 
 **Fields:**
 
-- `delayMs` (integer, required) — delay before firing, in milliseconds.
-  Must be `> 0`.
-- `timeoutMs` (integer, optional) — maximum age of the armed timer
-  before abandonment, in milliseconds. `0` (default) means no timeout.
-  When non-zero, must be `>= delayMs`.
+- `delayMs` (integer, required) — delay between source-state entry
+  and the scheduled execution time, in milliseconds. Must be `> 0`.
+- `timeoutMs` (integer, optional) — late-tolerance window past the
+  scheduled execution time, in milliseconds. When the scheduler
+  picks the task up, if `(executionTime - scheduledTime) > timeoutMs`
+  the task is dropped and the transition is NOT attempted. Absent
+  (omitted) means no timeout — fire whenever the scheduler
+  eventually picks it up. Explicit `0` is the strictest setting —
+  drop on any lateness. Independent of `delayMs`; the two measure
+  different quantities.
 
 **Import-time validation rules:**
 
 - `manual: true` and `schedule` present are mutually exclusive
   (`VALIDATION_FAILED`).
 - `schedule.delayMs <= 0` is rejected (`VALIDATION_FAILED`).
-- `schedule.timeoutMs > 0 && schedule.timeoutMs < schedule.delayMs` is
-  rejected (`VALIDATION_FAILED`).
+- No further rule on `timeoutMs` beyond `>= 0` (enforced at the DTO
+  boundary).
 
-**Engine behaviour (runtime not yet implemented).** The timer runtime
-that arms and fires scheduled transitions is not yet implemented. Two
-guards govern behaviour until it ships:
+**Engine behaviour (runtime not yet implemented).** The scheduler
+that arms and fires scheduled transitions is not yet implemented.
+Two guards govern behaviour until it ships:
 
 - During automated cascade evaluation, scheduled transitions are
   silently skipped — they are never selected for immediate firing.
@@ -597,9 +687,11 @@ guards govern behaviour until it ships:
   normally. An entity whose only exit is scheduled rests in its
   current state.
 - Explicitly firing a scheduled transition by name returns HTTP 400
-  `WORKFLOW_FAILED` with the message `transition "X" in state "Y" is
-  scheduled; scheduled transitions are not yet implemented`. The
-  entity remains in the source state.
+  `TRANSITION_NOT_FOUND` with the message `transition "X" in state
+  "Y" is scheduled; scheduled transitions are not yet implemented`.
+  Same code returned when a transition is `disabled: true` — same
+  semantic: "the transition exists but is not currently dispatchable
+  from the caller's POV." The entity remains in the source state.
 
 **Importing cyclic scheduled workflows.** A canonical scheduled-
 transition use case is a polling pattern such as `S1 →scheduled→ S2
@@ -629,15 +721,19 @@ Slots `wf-import/01..06` are already populated. Add new entries at the
 next free slots. Three new scenarios:
 
 - **`wf-import/07-scheduled-transition-roundtrip`** — round-trip
-  preservation. A workflow with one regular and one scheduled
-  transition (`Schedule: {DelayMs: 86400000, TimeoutMs: 90000000}` and
-  another with `Schedule: {DelayMs: 1000}` to exercise the
-  `TimeoutMs:0` omitempty path). Assert `json_equals_normalized`
-  round-trip equality on import + export.
+  preservation across the three `TimeoutMs` pointer states. A workflow
+  with three scheduled transitions: one with `TimeoutMs: 90000000`
+  (non-nil positive), one with `TimeoutMs: 0` (non-nil zero — must
+  survive the pointer's `omitempty`), one with `TimeoutMs` absent
+  (`nil`). Assert `json_equals_normalized` round-trip equality on
+  import + export; assert byte-level the absent case stays absent,
+  the explicit-zero case stays as `"timeoutMs": 0`, and the positive
+  case stays as `"timeoutMs": 90000000`.
 - **`wf-import/08-scheduled-transition-rejects`** — validator rejection
-  matrix. Three sub-cases per the validator rules (`manual: true +
-  schedule`, `delayMs: 0`, `timeoutMs < delayMs`); each asserts
-  HTTP 400 `VALIDATION_FAILED` with the rule-specific error substring.
+  matrix. Two sub-cases per the rev 3 validator rules (`manual: true +
+  schedule`, `delayMs: 0`); each asserts HTTP 400 `VALIDATION_FAILED`
+  with the rule-specific error substring. (Rev 1's third
+  `timeoutMs < delayMs` rule was removed in rev 3 as bogus.)
 - **`wf-import/09-allowcycles-bypass`** — request-level cycle bypass.
   Workflow `S1 →scheduled→ S2 →scheduled→ S1`. Without
   `allowCycles: true` import returns `400 VALIDATION_FAILED` with the
@@ -689,15 +785,22 @@ authored first, run to confirm RED, then driven GREEN.
    {DelayMs: 0}` and another with `DelayMs: -100`. Both assert
    `400 VALIDATION_FAILED`, error substring `"delayMs must be > 0"`.
 
-3. **Validator — TimeoutMs < DelayMs (non-zero).** Import payload with
-   `Schedule: {DelayMs: 1000, TimeoutMs: 500}`. Assert
-   `400 VALIDATION_FAILED`, error substring
-   `"timeoutMs (500) must be >= delayMs (1000)"`.
-
-4. **Validator — happy paths.** Three sub-cases that must pass import:
-   - `Schedule: {DelayMs: 1000}` (TimeoutMs omitted)
-   - `Schedule: {DelayMs: 1000, TimeoutMs: 0}` (TimeoutMs explicit zero)
+3. **Validator — happy paths across `TimeoutMs` pointer states.** Four
+   sub-cases that must all pass import (no `TimeoutMs` rule beyond
+   `>= 0`):
+   - `Schedule: {DelayMs: 1000}` (TimeoutMs absent → `nil` in Go → no
+     timeout semantic)
+   - `Schedule: {DelayMs: 1000, TimeoutMs: 0}` (TimeoutMs explicit zero
+     → `&0` in Go → strictest semantic)
+   - `Schedule: {DelayMs: 1000, TimeoutMs: 500}` (TimeoutMs < DelayMs
+     — perfectly coherent under late-tolerance semantic; rev 1's
+     rejection rule was bogus)
    - `Schedule: {DelayMs: 1000, TimeoutMs: 5000}` (TimeoutMs > DelayMs)
+
+4. **(Removed in rev 3.)** Rev 1's `TimeoutMs >= DelayMs` validator
+   rule was bogus under the late-tolerance semantic; no test replaces
+   it. Test numbering preserved for cross-reference continuity with
+   rev 1/rev 2.
 
 5. **Cascade — silent skip.** Workflow with state `S` containing two
    automated transitions: `Tsched` (scheduled, declared first) and
@@ -714,22 +817,33 @@ authored first, run to confirm RED, then driven GREEN.
 
 7. **Explicit-fire reject — manual=false + Schedule.** Workflow as test
    5 but the scheduled transition is fired by name. Assert:
-   - HTTP `400 WORKFLOW_FAILED`.
+   - HTTP `400 TRANSITION_NOT_FOUND` (same code Disabled returns).
    - Error body contains `"scheduled transitions are not yet implemented"`.
+   - The returned error wraps `ErrTransitionNotFound` (use `errors.Is`).
    - Entity in source state (`Get` returns unchanged state).
-   - Audit trail contains exactly one `SMEventStateProcessResult` with
-     `Data.success == false` and Details matching the rejection
-     substring. No `SMEventTransitionMade`, no
+   - Audit trail contains exactly one `SMEventTransitionNotFound` row
+     with Details matching the rejection substring. No
+     `SMEventTransitionMade`, no `SMEventStateProcessResult`, no
      `SMEventStateMachineFinish`.
 
-8. **Round-trip preservation.** Import a workflow with a transition
-   carrying `Schedule: {DelayMs: 86400000, TimeoutMs: 90000000}`,
-   export, assert `json_equals_normalized` round-trip equality (parse
-   both JSONs, compare structurally — robust against future field-
-   ordering refactors of `TransitionDefinition`). Variant: `Schedule:
-   {DelayMs: 1000}` (no TimeoutMs) — assert exported JSON's `schedule`
-   object has `delayMs: 1000` and no `timeoutMs` key (the `omitempty`
-   contract on the zero `TimeoutMs`).
+8. **Round-trip preservation across the three TimeoutMs pointer states.**
+   For each of:
+   - `Schedule: {DelayMs: 86400000, TimeoutMs: &90000000}` (non-nil
+     positive)
+   - `Schedule: {DelayMs: 86400000, TimeoutMs: &0}` (non-nil zero,
+     strictest)
+   - `Schedule: {DelayMs: 86400000, TimeoutMs: nil}` (absent, no
+     timeout)
+
+   import, export, assert `json_equals_normalized` round-trip equality
+   (parse both JSONs, compare structurally — robust against future
+   field-ordering refactors of `TransitionDefinition`). Additional
+   byte-level assertions:
+   - Non-nil positive case: exported JSON has `"timeoutMs": 90000000`.
+   - Non-nil zero case: exported JSON has `"timeoutMs": 0` (the
+     pointer-with-zero must survive `omitempty`; this is the
+     `*int64`-pattern's whole point).
+   - Nil case: exported JSON has no `timeoutMs` key under `schedule`.
 
 9. **E2E — explicit fire of scheduled transition returns 400.**
    Integration test in `internal/e2e/` mirroring #250's test 8 shape:
@@ -743,7 +857,8 @@ authored first, run to confirm RED, then driven GREEN.
       initial state because the cascade silently skips the scheduled
       transition and finds no other automated exit.
    4. `POST /entity/X/<id>/transition/AutoClose` — assert HTTP 400
-      with error code `WORKFLOW_FAILED` and message substring
+      with error code `TRANSITION_NOT_FOUND` (same code Disabled
+      returns) and message substring
       `scheduled transitions are not yet implemented`.
    5. `GET /entity/X/<id>` returns the entity in the initial state
       (cascade rested there; explicit fire rejected).
@@ -818,7 +933,7 @@ authored first, run to confirm RED, then driven GREEN.
 | Inbound payload shape | Behaviour before #259 | Behaviour after #259 |
 |---|---|---|
 | `TransitionDefinitionDto` with no `schedule` | Accepted, fired normally | Same |
-| `TransitionDefinitionDto.schedule: {delayMs: N>0}` | Field unknown to OpenAPI; silently dropped by `json.Unmarshal` into `spi.TransitionDefinition`; transition behaves as a regular one | **Accepted, stored, round-tripped.** Validator enforces the three coherence rules. Cascade silently skips; explicit-fire returns 400. |
+| `TransitionDefinitionDto.schedule: {delayMs: N>0}` | Field unknown to OpenAPI; silently dropped by `json.Unmarshal` into `spi.TransitionDefinition`; transition behaves as a regular one | **Accepted, stored, round-tripped.** Validator enforces the two coherence rules. Cascade silently skips; explicit-fire returns `400 TRANSITION_NOT_FOUND`. |
 | `TransitionDefinitionDto.schedule: {delayMs: 0}` | Silently dropped | **Rejected at import** with `VALIDATION_FAILED`. |
 | `TransitionDefinitionDto` with `manual: true, schedule: {...}` | Silently dropped (schedule lost) | **Rejected at import** with `VALIDATION_FAILED`. |
 | Legacy `processors[]` with `{type: "scheduled", config: {delayMs, transition, timeoutMs}}` (raw-JSON path; pre-#250 shape) | After #250: SPI's free-string `Type` accepts; scheduled config fields silently dropped by `ProcessorConfig` unmarshal; dispatched as externalized | **Same as post-#250.** The new `TransitionDefinition.Schedule` field does not interact with `Processors[].Type` or `ProcessorConfig`. Carried-over technical debt from §H1's silent-drop. |
@@ -878,16 +993,15 @@ shape is now well-defined) and become inert at runtime per §5.5.
   `slog.Warn` per import call surfaces the bypass to operators
   reviewing logs; (c) the flag is request-level only — each import
   re-asserts intent; the durable schema does not carry the bypass.
-- **`*int64` vs `int64` for `TimeoutMs` round-trip.** Choosing `int64`
-  with `omitempty` (per §5.3) means the JSON omits `timeoutMs` only
-  when the Go value is exactly 0. A client that explicitly sets
-  `timeoutMs: 0` in import JSON, exports, and gets back JSON without
-  `timeoutMs` is technically a lossy round-trip — but the SPI and
-  OpenAPI both document `0 == no timeout`, so this is semantically
-  equivalent. Round-trip preservation test 8 (§6.1) uses
-  `json_equals_normalized` rather than byte-exact substring matching,
-  so this case is asserted to be semantically equivalent both
-  directions.
+- **`*int64` pointer for `TimeoutMs` (rev 3).** Chose pointer over
+  value to disambiguate three meaningful states (nil = no timeout,
+  &0 = strictest, &N = N-ms tolerance) on the wire. With `*int64+omitempty`
+  Go's standard `encoding/json` correctly emits absent for nil,
+  `"timeoutMs":0` for `&0`, and `"timeoutMs":N` for `&N` — all three
+  round-trip byte-equivalent. Precedent: `ProcessorConfig.StartNewTxOnDispatch
+  *bool` (same pattern, same rationale). The earlier rev 2 risk-bullet
+  about "explicit zero exporting as absent" no longer applies once
+  the pointer is used.
 - **SPI tag coupling.** #259 bundles the deferred #250 docstring; if
   this PR is reverted, #250's docstring is also lost from SPI main.
   Acceptable because the bundling is intentional per #250 spec §5.3,
@@ -971,9 +1085,9 @@ repos":
 | `cyoda-go-spi/CHANGELOG.md` (sibling repo) | Add `[Unreleased]` Added + Changed entries per §5.3. |
 | `api/openapi.yaml` | Add `TransitionScheduleDto` schema; add optional `schedule` property to `TransitionDefinitionDto`. |
 | `api/generated.go` | Regenerated from above. |
-| `internal/domain/workflow/validate.go` | Add three Schedule-coherence checks in `validateWorkflowStructure` per-transition loop (between lines 193 and 198); add `allowCycles bool` parameter to `validateWorkflows` and short-circuit `validateWorkflowLoops` when true. |
+| `internal/domain/workflow/validate.go` | Add two Schedule-coherence checks (manual+schedule exclusion, DelayMs > 0) in `validateWorkflowStructure` per-transition loop (between lines 193 and 198); add `allowCycles bool` parameter to `validateWorkflows` and short-circuit `validateWorkflowLoops` when true. |
 | `internal/domain/workflow/handler.go` | Add `AllowCycles bool` field to `importRequest` struct (lines 32-46); thread `req.AllowCycles` into the `validateWorkflows` call; emit `slog.Warn "workflow import: cycle validation bypassed"` when `req.AllowCycles == true`. |
-| `internal/domain/workflow/engine.go` | Cascade-skip filter at line 528 (one-line addition); explicit-fire reject branch in `attemptTransition` after the `Disabled` check (between lines 453 and 455). |
+| `internal/domain/workflow/engine.go` | Cascade-skip filter at line 528 (one-line addition); explicit-fire reject branch in `attemptTransition` immediately after the `Disabled` check at lines 449-453 (mirrors `Disabled` exactly: emits `SMEventTransitionNotFound`, returns error wrapping `ErrTransitionNotFound` → `400 TRANSITION_NOT_FOUND`). |
 | `internal/domain/workflow/validate_test.go` (or sibling) | TDD tests per §6.1 items 1–4, 11–15. |
 | `internal/domain/workflow/engine_test.go` (or sibling) | TDD tests per §6.1 items 5–8. |
 | `internal/e2e/` | E2E test per §6.1 item 9; additional E2E for `allowCycles` if not covered by the unit tests at items 11–15. |

--- a/e2e/externalapi/scenarios/08-workflow-import-export.yaml
+++ b/e2e/externalapi/scenarios/08-workflow-import-export.yaml
@@ -214,3 +214,172 @@ scenarios:
       - type: length
         target: "exp.workflows[name=Initial Workflow].states.pending.transitions"
         expected: 1
+
+  - id: wf-import/07-scheduled-transition-roundtrip
+    name: Scheduled transition — round-trip preservation across the three TimeoutMs pointer states
+    description: |
+      A scheduled transition (manual=false, schedule.delayMs > 0) is a
+      sibling primitive on TransitionDefinition, distinct from processors[].
+      Schedule.TimeoutMs is a *pointer* on the wire so the three semantic
+      states are distinguishable through import/export:
+        - non-nil positive ("fire by deadline; drop if late")
+        - non-nil zero     ("strictest; drop the moment we are late")
+        - absent / nil     ("no timeout; fire indefinitely late")
+      All three states must round-trip exactly — non-nil zero must be
+      preserved in the exported JSON (key present with value 0), and the
+      nil case must have no `timeoutMs` key at all.
+    data:
+      model: { name: wfSchedRT, version: 1 }
+      import_body: |
+        {"workflows":[{
+          "version":"1.0","name":"Scheduled Round-Trip Workflow",
+          "desc":"Three scheduled transitions covering the TimeoutMs pointer states",
+          "initialState":"start","active":true,
+          "states":{
+            "start":{"transitions":[
+              {"name":"WithPositiveTimeout","next":"a","manual":false,
+               "schedule":{"delayMs":1000,"timeoutMs":90000000}},
+              {"name":"WithZeroTimeout","next":"b","manual":false,
+               "schedule":{"delayMs":1000,"timeoutMs":0}},
+              {"name":"WithoutTimeout","next":"c","manual":false,
+               "schedule":{"delayMs":1000}}
+            ]},
+            "a":{"transitions":[]},
+            "b":{"transitions":[]},
+            "c":{"transitions":[]}
+          }
+        }]}
+    steps:
+      - { action: import_workflow, endpoint: { rest: POST /entity/wfSchedRT/1/workflow/import }, body_ref: data.import_body }
+      - { action: export_workflow, endpoint: { rest: GET /entity/wfSchedRT/1/workflow/export }, capture: exp }
+    assertions:
+      - type: json_equals_normalized
+        target: exp.workflows
+        expected_ref: data.import_body.workflows
+      - type: field_equals
+        target: "exp.workflows[0].states.start.transitions[name=WithPositiveTimeout].schedule.timeoutMs"
+        expected: 90000000
+      - type: field_equals
+        target: "exp.workflows[0].states.start.transitions[name=WithZeroTimeout].schedule.timeoutMs"
+        expected: 0
+      - type: field_absent
+        target: "exp.workflows[0].states.start.transitions[name=WithoutTimeout].schedule.timeoutMs"
+
+  - id: wf-import/08-scheduled-transition-rejects
+    name: Scheduled transition — validator rejection matrix
+    description: |
+      Validator rules covering the two structural invariants on
+      TransitionSchedule:
+        1. `manual` and `schedule` are mutually exclusive — a transition
+           cannot be both human-driven and scheduled.
+        2. `schedule.delayMs` must be strictly greater than zero — zero
+           or negative delays are rejected as a configuration error
+           (an instant scheduled transition is meaningless).
+      Both sub-cases return HTTP 400 with a `VALIDATION_FAILED` error
+      class and a message substring identifying the broken rule.
+    data:
+      model: { name: wfSchedRej, version: 1 }
+      manual_plus_schedule_body: |
+        {"workflows":[{
+          "version":"1.0","name":"Manual Plus Schedule",
+          "initialState":"start","active":true,
+          "states":{
+            "start":{"transitions":[{
+              "name":"BadManualScheduled","next":"end","manual":true,
+              "schedule":{"delayMs":1000}
+            }]},
+            "end":{"transitions":[]}
+          }
+        }]}
+      zero_delay_body: |
+        {"workflows":[{
+          "version":"1.0","name":"Zero Delay Schedule",
+          "initialState":"start","active":true,
+          "states":{
+            "start":{"transitions":[{
+              "name":"BadZeroDelay","next":"end","manual":false,
+              "schedule":{"delayMs":0}
+            }]},
+            "end":{"transitions":[]}
+          }
+        }]}
+    steps:
+      - { action: import_workflow, endpoint: { rest: POST /entity/wfSchedRej/1/workflow/import }, body_ref: data.manual_plus_schedule_body, capture: respManual }
+      - { action: import_workflow, endpoint: { rest: POST /entity/wfSchedRej/1/workflow/import }, body_ref: data.zero_delay_body, capture: respZero }
+    assertions:
+      - type: http_status
+        target: respManual
+        expected: 400
+      - type: error_class
+        target: respManual
+        expected: VALIDATION_FAILED
+      - type: error_message_contains
+        target: respManual
+        expected: "manual and scheduled are mutually exclusive"
+      - type: http_status
+        target: respZero
+        expected: 400
+      - type: error_class
+        target: respZero
+        expected: VALIDATION_FAILED
+      - type: error_message_contains
+        target: respZero
+        expected: "delayMs must be > 0"
+
+  - id: wf-import/09-allowcycles-bypass
+    name: Scheduled polling workflow — allowCycles=true bypasses cycle rejection
+    description: |
+      The validator rejects unguarded cycles in automated transitions to
+      prevent FSM runaway loops. A scheduled-polling pattern (S1 -fires
+      after delay-> S2 -fires after delay-> S1) is structurally a cycle,
+      but is a legitimate idiom because each hop is rate-limited by
+      `schedule.delayMs`. The import envelope therefore carries an
+      `allowCycles` flag (default false) that opts in to permitting such
+      cycles when they are intentional.
+      Default `allowCycles=false` (omitted) must reject the polling
+      workflow with HTTP 400 / VALIDATION_FAILED. Explicit
+      `allowCycles=true` must accept the same workflow.
+    data:
+      model: { name: wfAllowCycles, version: 1 }
+      polling_body_default: |
+        {"workflows":[{
+          "version":"1.0","name":"Polling Scheduled Workflow",
+          "initialState":"S1","active":true,
+          "states":{
+            "S1":{"transitions":[{"name":"to-S2","next":"S2","manual":false,
+                                  "schedule":{"delayMs":1000}}]},
+            "S2":{"transitions":[{"name":"to-S1","next":"S1","manual":false,
+                                  "schedule":{"delayMs":1000}}]}
+          }
+        }]}
+      polling_body_allow: |
+        {"allowCycles":true,"workflows":[{
+          "version":"1.0","name":"Polling Scheduled Workflow",
+          "initialState":"S1","active":true,
+          "states":{
+            "S1":{"transitions":[{"name":"to-S2","next":"S2","manual":false,
+                                  "schedule":{"delayMs":1000}}]},
+            "S2":{"transitions":[{"name":"to-S1","next":"S1","manual":false,
+                                  "schedule":{"delayMs":1000}}]}
+          }
+        }]}
+    steps:
+      - { action: import_workflow, endpoint: { rest: POST /entity/wfAllowCycles/1/workflow/import }, body_ref: data.polling_body_default, capture: respReject }
+      - { action: import_workflow, endpoint: { rest: POST /entity/wfAllowCycles/1/workflow/import }, body_ref: data.polling_body_allow,   capture: respAccept }
+      - { action: export_workflow, endpoint: { rest: GET /entity/wfAllowCycles/1/workflow/export }, capture: exp }
+    assertions:
+      - type: http_status
+        target: respReject
+        expected: 400
+      - type: error_class
+        target: respReject
+        expected: VALIDATION_FAILED
+      - type: http_status
+        target: respAccept
+        expected: 200
+      - type: length
+        target: exp.workflows
+        expected: 1
+      - type: field_equals
+        target: "exp.workflows[0].name"
+        expected: "Polling Scheduled Workflow"

--- a/e2e/parity/externalapi/workflow_import_export.go
+++ b/e2e/parity/externalapi/workflow_import_export.go
@@ -16,10 +16,12 @@ package externalapi
 
 import (
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/cyoda-platform/cyoda-go/e2e/externalapi/driver"
+	"github.com/cyoda-platform/cyoda-go/e2e/externalapi/errorcontract"
 	"github.com/cyoda-platform/cyoda-go/e2e/parity"
 )
 
@@ -31,6 +33,9 @@ func init() {
 		parity.NamedTest{Name: "ExternalAPI_08_04_StrategyReplace", Fn: RunExternalAPI_08_04_StrategyReplace},
 		parity.NamedTest{Name: "ExternalAPI_08_05_StrategyActivate", Fn: RunExternalAPI_08_05_StrategyActivate},
 		parity.NamedTest{Name: "ExternalAPI_08_06_StrategyMerge", Fn: RunExternalAPI_08_06_StrategyMerge},
+		parity.NamedTest{Name: "ExternalAPI_08_07_ScheduledTransitionRoundtrip", Fn: RunExternalAPI_08_07_ScheduledTransitionRoundtrip},
+		parity.NamedTest{Name: "ExternalAPI_08_08_ScheduledTransitionRejects", Fn: RunExternalAPI_08_08_ScheduledTransitionRejects},
+		parity.NamedTest{Name: "ExternalAPI_08_09_AllowCyclesBypass", Fn: RunExternalAPI_08_09_AllowCyclesBypass},
 	)
 }
 
@@ -325,5 +330,265 @@ func RunExternalAPI_08_06_StrategyMerge(t *testing.T, fixture parity.BackendFixt
 		if !strings.Contains(string(raw), `"`+name+`"`) {
 			t.Errorf("MERGE missing %s workflow in export: %s", name, string(raw))
 		}
+	}
+}
+
+// rfc9457Detail extracts the "detail" string from an RFC 9457 Problem
+// Details body. Returns "" if the body is empty or doesn't parse.
+// Used by negative-path scenarios 08/08 and 08/09 to assert on the
+// human-readable validator message.
+func rfc9457Detail(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	var p struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(body, &p); err != nil {
+		return ""
+	}
+	return p.Detail
+}
+
+// RunExternalAPI_08_07_ScheduledTransitionRoundtrip — dictionary 08/07.
+// A scheduled transition (manual=false, schedule.delayMs > 0) is a
+// sibling primitive on TransitionDefinition, distinct from processors[].
+// Schedule.TimeoutMs is a pointer on the wire so the three semantic
+// states are distinguishable through import/export:
+//   - non-nil positive ("fire by deadline; drop if late")
+//   - non-nil zero     ("strictest; drop the moment we are late")
+//   - absent / nil     ("no timeout; fire indefinitely late")
+//
+// All three states must round-trip exactly — non-nil zero must be
+// preserved in the exported JSON (key present with value 0), and the
+// nil case must have no `timeoutMs` key at all.
+func RunExternalAPI_08_07_ScheduledTransitionRoundtrip(t *testing.T, fixture parity.BackendFixture) {
+	t.Helper()
+	d := driver.NewInProcess(t, fixture)
+
+	if err := d.CreateModelFromSample("wfSchedRT", 1, `{"k":1}`); err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+
+	body := `{"workflows":[{
+		"version":"1.0","name":"Scheduled Round-Trip Workflow",
+		"desc":"Three scheduled transitions covering the TimeoutMs pointer states",
+		"initialState":"start","active":true,
+		"states":{
+			"start":{"transitions":[
+				{"name":"WithPositiveTimeout","next":"a","manual":false,
+				 "schedule":{"delayMs":1000,"timeoutMs":90000000}},
+				{"name":"WithZeroTimeout","next":"b","manual":false,
+				 "schedule":{"delayMs":1000,"timeoutMs":0}},
+				{"name":"WithoutTimeout","next":"c","manual":false,
+				 "schedule":{"delayMs":1000}}
+			]},
+			"a":{"transitions":[]},
+			"b":{"transitions":[]},
+			"c":{"transitions":[]}
+		}
+	}]}`
+
+	if err := d.ImportWorkflow("wfSchedRT", 1, body); err != nil {
+		t.Fatalf("ImportWorkflow: %v", err)
+	}
+
+	raw, err := d.ExportWorkflow("wfSchedRT", 1)
+	if err != nil {
+		t.Fatalf("ExportWorkflow: %v", err)
+	}
+
+	// Parse the exported workflow and verify the three pointer states preserved.
+	var doc struct {
+		Workflows []struct {
+			States map[string]struct {
+				Transitions []struct {
+					Name     string                 `json:"name"`
+					Schedule map[string]interface{} `json:"schedule"`
+				} `json:"transitions"`
+			} `json:"states"`
+		} `json:"workflows"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse exported workflow: %v\nraw: %s", err, raw)
+	}
+	if len(doc.Workflows) == 0 {
+		t.Fatalf("export missing workflows: %s", raw)
+	}
+	startState, ok := doc.Workflows[0].States["start"]
+	if !ok {
+		t.Fatalf("export missing 'start' state: %s", raw)
+	}
+	byName := make(map[string]map[string]interface{}, 3)
+	for _, tr := range startState.Transitions {
+		byName[tr.Name] = tr.Schedule
+	}
+
+	// WithPositiveTimeout: non-nil positive → "timeoutMs": 90000000 must be present.
+	posSched := byName["WithPositiveTimeout"]
+	if posSched == nil {
+		t.Fatal("WithPositiveTimeout schedule missing from export")
+	}
+	if v, ok := posSched["timeoutMs"]; !ok {
+		t.Errorf("WithPositiveTimeout: expected timeoutMs field present; got schedule=%v", posSched)
+	} else if f, _ := v.(float64); int64(f) != 90000000 {
+		t.Errorf("WithPositiveTimeout: expected timeoutMs=90000000; got %v", v)
+	}
+
+	// WithZeroTimeout: non-nil zero → "timeoutMs": 0 must be present (NOT omitted).
+	zeroSched := byName["WithZeroTimeout"]
+	if zeroSched == nil {
+		t.Fatal("WithZeroTimeout schedule missing from export")
+	}
+	if v, ok := zeroSched["timeoutMs"]; !ok {
+		t.Errorf("WithZeroTimeout: expected timeoutMs=0 present (non-nil zero must survive omitempty); got missing in %v", zeroSched)
+	} else if f, _ := v.(float64); int64(f) != 0 {
+		t.Errorf("WithZeroTimeout: expected timeoutMs=0; got %v", v)
+	}
+
+	// WithoutTimeout: nil → no timeoutMs key.
+	withoutSched := byName["WithoutTimeout"]
+	if withoutSched == nil {
+		t.Fatal("WithoutTimeout schedule missing from export")
+	}
+	if v, ok := withoutSched["timeoutMs"]; ok {
+		t.Errorf("WithoutTimeout: expected no timeoutMs key (nil pointer should be omitted); got %v", v)
+	}
+}
+
+// RunExternalAPI_08_08_ScheduledTransitionRejects — dictionary 08/08.
+// Validator rejection matrix:
+//  1. manual+schedule mutually exclusive — HTTP 400 + VALIDATION_FAILED
+//     with "manual and scheduled are mutually exclusive" in the detail.
+//  2. schedule.delayMs <= 0 — HTTP 400 + VALIDATION_FAILED with
+//     "delayMs must be > 0" in the detail.
+func RunExternalAPI_08_08_ScheduledTransitionRejects(t *testing.T, fixture parity.BackendFixture) {
+	t.Helper()
+	d := driver.NewInProcess(t, fixture)
+
+	if err := d.CreateModelFromSample("wfSchedRej", 1, `{"k":1}`); err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+
+	// Sub-case 1: manual+schedule.
+	manualPlusSchedule := `{"workflows":[{
+		"version":"1.0","name":"Manual Plus Schedule",
+		"initialState":"start","active":true,
+		"states":{
+			"start":{"transitions":[{
+				"name":"BadManualScheduled","next":"end","manual":true,
+				"schedule":{"delayMs":1000}
+			}]},
+			"end":{"transitions":[]}
+		}
+	}]}`
+	status, body, err := d.ImportWorkflowRaw("wfSchedRej", 1, manualPlusSchedule)
+	if err != nil {
+		t.Fatalf("ImportWorkflowRaw (manual+schedule): %v", err)
+	}
+	errorcontract.Match(t, status, body, errorcontract.ExpectedError{
+		HTTPStatus: http.StatusBadRequest,
+		ErrorCode:  "VALIDATION_FAILED",
+	})
+	if detail := rfc9457Detail(body); !strings.Contains(detail, "manual and scheduled are mutually exclusive") {
+		t.Errorf("manual+schedule: expected detail substring 'manual and scheduled are mutually exclusive'; got %q (body=%s)", detail, string(body))
+	}
+
+	// Sub-case 2: delayMs:0.
+	zeroDelay := `{"workflows":[{
+		"version":"1.0","name":"Zero Delay Schedule",
+		"initialState":"start","active":true,
+		"states":{
+			"start":{"transitions":[{
+				"name":"BadZeroDelay","next":"end","manual":false,
+				"schedule":{"delayMs":0}
+			}]},
+			"end":{"transitions":[]}
+		}
+	}]}`
+	status, body, err = d.ImportWorkflowRaw("wfSchedRej", 1, zeroDelay)
+	if err != nil {
+		t.Fatalf("ImportWorkflowRaw (zero delay): %v", err)
+	}
+	errorcontract.Match(t, status, body, errorcontract.ExpectedError{
+		HTTPStatus: http.StatusBadRequest,
+		ErrorCode:  "VALIDATION_FAILED",
+	})
+	if detail := rfc9457Detail(body); !strings.Contains(detail, "delayMs must be > 0") {
+		t.Errorf("zero-delay: expected detail substring 'delayMs must be > 0'; got %q (body=%s)", detail, string(body))
+	}
+}
+
+// RunExternalAPI_08_09_AllowCyclesBypass — dictionary 08/09.
+// The validator rejects unguarded cycles in automated transitions to
+// prevent FSM runaway loops. A scheduled-polling pattern (S1 -> S2 -> S1)
+// is structurally a cycle but legitimate because each hop is rate-limited
+// by schedule.delayMs. The import envelope carries an `allowCycles` flag
+// (default false) that opts in to permitting such cycles.
+//
+// Default allowCycles=false (omitted) must reject the polling workflow
+// with HTTP 400 + VALIDATION_FAILED. Explicit allowCycles=true must
+// accept the same workflow.
+func RunExternalAPI_08_09_AllowCyclesBypass(t *testing.T, fixture parity.BackendFixture) {
+	t.Helper()
+	d := driver.NewInProcess(t, fixture)
+
+	if err := d.CreateModelFromSample("wfAllowCycles", 1, `{"k":1}`); err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+
+	// Sub-case 1: WITHOUT allowCycles → cycle rejection.
+	defaultBody := `{"workflows":[{
+		"version":"1.0","name":"Polling Scheduled Workflow",
+		"initialState":"S1","active":true,
+		"states":{
+			"S1":{"transitions":[{"name":"to-S2","next":"S2","manual":false,
+			                      "schedule":{"delayMs":1000}}]},
+			"S2":{"transitions":[{"name":"to-S1","next":"S1","manual":false,
+			                      "schedule":{"delayMs":1000}}]}
+		}
+	}]}`
+	status, body, err := d.ImportWorkflowRaw("wfAllowCycles", 1, defaultBody)
+	if err != nil {
+		t.Fatalf("ImportWorkflowRaw (default): %v", err)
+	}
+	errorcontract.Match(t, status, body, errorcontract.ExpectedError{
+		HTTPStatus: http.StatusBadRequest,
+		ErrorCode:  "VALIDATION_FAILED",
+	})
+
+	// Sub-case 2: WITH allowCycles=true → accept. Driver's ImportWorkflow
+	// passes the body verbatim, so allowCycles slots in as a top-level
+	// envelope field.
+	allowBody := `{"allowCycles":true,"workflows":[{
+		"version":"1.0","name":"Polling Scheduled Workflow",
+		"initialState":"S1","active":true,
+		"states":{
+			"S1":{"transitions":[{"name":"to-S2","next":"S2","manual":false,
+			                      "schedule":{"delayMs":1000}}]},
+			"S2":{"transitions":[{"name":"to-S1","next":"S1","manual":false,
+			                      "schedule":{"delayMs":1000}}]}
+		}
+	}]}`
+	if err := d.ImportWorkflow("wfAllowCycles", 1, allowBody); err != nil {
+		t.Fatalf("ImportWorkflow (allowCycles=true): expected acceptance; got: %v", err)
+	}
+
+	raw, err := d.ExportWorkflow("wfAllowCycles", 1)
+	if err != nil {
+		t.Fatalf("ExportWorkflow: %v", err)
+	}
+	var exp struct {
+		Workflows []struct {
+			Name string `json:"name"`
+		} `json:"workflows"`
+	}
+	if err := json.Unmarshal(raw, &exp); err != nil {
+		t.Fatalf("parse export: %v\nraw: %s", err, raw)
+	}
+	if len(exp.Workflows) != 1 {
+		t.Errorf("expected 1 workflow in export; got %d (raw=%s)", len(exp.Workflows), raw)
+	} else if exp.Workflows[0].Name != "Polling Scheduled Workflow" {
+		t.Errorf("expected workflow name 'Polling Scheduled Workflow'; got %q", exp.Workflows[0].Name)
 	}
 }

--- a/e2e/parity/fixtureutil/fixtureutil.go
+++ b/e2e/parity/fixtureutil/fixtureutil.go
@@ -413,7 +413,7 @@ func LaunchCyodaAndComputeWithBinaries(cyodaBin, computeBin string, ks *JWTKeySe
 	}
 	cyodaReadinessTimeout := opt.ReadinessTimeout
 	if cyodaReadinessTimeout == 0 {
-		cyodaReadinessTimeout = 30 * time.Second
+		cyodaReadinessTimeout = defaultCyodaReadinessTimeout
 	}
 
 	// Launch cyoda-go. Subprocess stdout/stderr flow to the test runner's
@@ -520,8 +520,13 @@ type ClusterLaunchResult struct {
 }
 
 // defaultCyodaReadinessTimeout is the default time to wait for each
-// cyoda-go node to pass its /api/health check.
-const defaultCyodaReadinessTimeout = 30 * time.Second
+// cyoda-go node to pass its /api/health check. Sized to accommodate
+// race-detector instrumentation overhead (2-10x slower) on CI runners
+// under load: the prior 30s value flaked on the multinode launch path
+// when node 2 missed its probe window. Single-node runs in the same
+// suite settle in well under 30s; the headroom is for race-instrumented
+// runs of TestMultiNode and friends.
+const defaultCyodaReadinessTimeout = 120 * time.Second
 
 // defaultComputeHealthAddrTimeout is the default time to wait for the
 // compute-test-client to print its HEALTH_ADDR line on stdout.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	github.com/charmbracelet/glamour v1.0.0
-	github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a
+	github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b
 	github.com/getkin/kin-openapi v0.139.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -100,9 +100,9 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
-	github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.1
-	github.com/cyoda-platform/cyoda-go/plugins/postgres v0.7.1
-	github.com/cyoda-platform/cyoda-go/plugins/sqlite v0.7.1
+	github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.2-0.20260615153318-6e8c833632f7
+	github.com/cyoda-platform/cyoda-go/plugins/postgres v0.7.2-0.20260615153318-6e8c833632f7
+	github.com/cyoda-platform/cyoda-go/plugins/sqlite v0.7.2-0.20260615153318-6e8c833632f7
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GK
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
-github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a h1:TC8koQ/W5Ylk0IPQ0pCOajsKzftJkjPU3t4A3jmLuD4=
-github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b h1:VoC0mAecMXc1PHS8VP+Sel45mBNMrsLfKJTY4VzjhBg=
+github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.1 h1:V0YfAg8XzlSqDtAidYa4B/H+LU9dnxce9hEsl4wahOw=
 github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.1/go.mod h1:4VA39DOyLB8iU212SFPuFxsqjdl1unc9vhgV7fjlLwc=
 github.com/cyoda-platform/cyoda-go/plugins/postgres v0.7.1 h1:Rpa0Um1InbrfNJ38l2ktEqTjaGvjFxgJQqgQzaToRUc=

--- a/go.sum
+++ b/go.sum
@@ -79,10 +79,16 @@ github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b h1:V
 github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.1 h1:V0YfAg8XzlSqDtAidYa4B/H+LU9dnxce9hEsl4wahOw=
 github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.1/go.mod h1:4VA39DOyLB8iU212SFPuFxsqjdl1unc9vhgV7fjlLwc=
+github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.2-0.20260615153318-6e8c833632f7 h1:YoxZN7g2y+v/IVfOn+b6gXcP5g7SvgzbABsGJJIHSKU=
+github.com/cyoda-platform/cyoda-go/plugins/memory v0.7.2-0.20260615153318-6e8c833632f7/go.mod h1:dI7XkpXIC/2VaIN12BqFii+kJJzj7qxU2KMgAhRbOS8=
 github.com/cyoda-platform/cyoda-go/plugins/postgres v0.7.1 h1:Rpa0Um1InbrfNJ38l2ktEqTjaGvjFxgJQqgQzaToRUc=
 github.com/cyoda-platform/cyoda-go/plugins/postgres v0.7.1/go.mod h1:4cTh4h72oQrRP4owTkHvUEhbrnzNySiNcHVAcwVEhP4=
+github.com/cyoda-platform/cyoda-go/plugins/postgres v0.7.2-0.20260615153318-6e8c833632f7 h1:TsbXsmaLp3KKNS2MQKYhhFO4htAaDdcfyY5ifeNd1H0=
+github.com/cyoda-platform/cyoda-go/plugins/postgres v0.7.2-0.20260615153318-6e8c833632f7/go.mod h1:VZDBW8KjgBNiEdA+I5bIKChKrAb6un0TospVD9ffaC8=
 github.com/cyoda-platform/cyoda-go/plugins/sqlite v0.7.1 h1:avS0jY/z7k6nNV0wyf/TunOEKUMNeXPuGy/ffxIGV7U=
 github.com/cyoda-platform/cyoda-go/plugins/sqlite v0.7.1/go.mod h1:tDyKnFiI1Lp9DgeorT7XK6zGyzydS7BWEROa8wPEjbg=
+github.com/cyoda-platform/cyoda-go/plugins/sqlite v0.7.2-0.20260615153318-6e8c833632f7 h1:0Viojek9HhpekSXwp2qz71yyUNxpKCO/U03Uc16Nc9w=
+github.com/cyoda-platform/cyoda-go/plugins/sqlite v0.7.2-0.20260615153318-6e8c833632f7/go.mod h1:xSREPSIC7ouf2OE0KxDejST5SeRDzGzwlWsRNSaIVWs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -113,6 +113,13 @@ func (s *Server) FetchEntityTransitions(w http.ResponseWriter, r *http.Request, 
 	s.Unimplemented.FetchEntityTransitions(w, r, params)
 }
 
+// QueryGroupedEntityStatisticsForModel is routed directly in app/app.go before the
+// generated API mux — this method satisfies ServerInterface but is never reached in
+// production.
+func (s *Server) QueryGroupedEntityStatisticsForModel(w http.ResponseWriter, r *http.Request, entityName string, modelVersion int32) {
+	s.Unimplemented.QueryGroupedEntityStatisticsForModel(w, r, entityName, modelVersion)
+}
+
 func (s *Server) DeleteEntities(w http.ResponseWriter, r *http.Request, entityName string, modelVersion int32, params genapi.DeleteEntitiesParams) {
 	if s.Entity != nil {
 		s.Entity.DeleteEntities(w, r, entityName, modelVersion, params)

--- a/internal/api/unimplemented.go
+++ b/internal/api/unimplemented.go
@@ -266,3 +266,10 @@ func (u *Unimplemented) GetAsyncSearchStatus(w http.ResponseWriter, r *http.Requ
 func (u *Unimplemented) SearchEntities(w http.ResponseWriter, r *http.Request, entityName string, modelVersion int32, params genapi.SearchEntitiesParams) {
 	u.stub(w, r)
 }
+
+// QueryGroupedEntityStatisticsForModel is never called via this path — the real
+// handler is mounted directly on the outer mux in app/app.go before the generated
+// API handler fires.
+func (u *Unimplemented) QueryGroupedEntityStatisticsForModel(w http.ResponseWriter, r *http.Request, entityName string, modelVersion int32) {
+	u.stub(w, r)
+}

--- a/internal/domain/workflow/engine.go
+++ b/internal/domain/workflow/engine.go
@@ -452,6 +452,17 @@ func (e *Engine) attemptTransition(ctx context.Context, entity *spi.Entity, wf *
 		return ctx, txID, fmt.Errorf("transition %q is disabled in state %q: %w", transitionName, entity.Meta.State, ErrTransitionNotFound)
 	}
 
+	if transition.Schedule != nil {
+		e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
+			spi.SMEventTransitionNotFound,
+			fmt.Sprintf(
+				"Transition %q is scheduled; scheduled transitions are not yet implemented",
+				transitionName), nil)
+		return ctx, txID, fmt.Errorf(
+			"transition %q in state %q is scheduled; scheduled transitions are not yet implemented: %w",
+			transitionName, entity.Meta.State, ErrTransitionNotFound)
+	}
+
 	// Evaluate transition criterion.
 	if len(transition.Criterion) > 0 && string(transition.Criterion) != "null" {
 		matched, err := e.evaluateCriterion(transition.Criterion, entity, &criterionContext{

--- a/internal/domain/workflow/engine.go
+++ b/internal/domain/workflow/engine.go
@@ -29,10 +29,18 @@ var defaultWorkflowJSON []byte
 
 // ErrTransitionNotFound is returned by ManualTransition (and surfaces from
 // Execute) when the requested transition name is absent from the entity's
-// current state — either because no such transition exists or because it is
-// disabled. Callers can discriminate this case from other engine failures via
+// current state — either because no such transition exists, it is disabled,
+// or it is scheduled and the timer runtime is not yet implemented. Callers
+// can discriminate this case from other engine failures via
 // errors.Is(err, ErrTransitionNotFound).
 var ErrTransitionNotFound = errors.New("transition not found")
+
+// scheduledNotYetImplementedReason is the human-readable cause emitted by
+// both the audit event Details and the wrapped error message when an explicit
+// fire of a scheduled transition is rejected. Extracted as a const so the
+// rewording required when the timer runtime ships only has to happen in one
+// place.
+const scheduledNotYetImplementedReason = "scheduled transitions are not yet implemented"
 
 // maxCascadeDepth is an absolute safety net for total cascade steps.
 const maxCascadeDepth = 100
@@ -455,12 +463,11 @@ func (e *Engine) attemptTransition(ctx context.Context, entity *spi.Entity, wf *
 	if transition.Schedule != nil {
 		e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
 			spi.SMEventTransitionNotFound,
-			fmt.Sprintf(
-				"Transition %q is scheduled; scheduled transitions are not yet implemented",
-				transitionName), nil)
+			fmt.Sprintf("Transition %q is scheduled; %s",
+				transitionName, scheduledNotYetImplementedReason), nil)
 		return ctx, txID, fmt.Errorf(
-			"transition %q in state %q is scheduled; scheduled transitions are not yet implemented: %w",
-			transitionName, entity.Meta.State, ErrTransitionNotFound)
+			"transition %q in state %q is scheduled; %s: %w",
+			transitionName, entity.Meta.State, scheduledNotYetImplementedReason, ErrTransitionNotFound)
 	}
 
 	// Evaluate transition criterion.

--- a/internal/domain/workflow/engine.go
+++ b/internal/domain/workflow/engine.go
@@ -525,7 +525,7 @@ func (e *Engine) cascadeAutomated(ctx context.Context, entity *spi.Entity, wf *s
 		fired := false
 		for i := range stateDef.Transitions {
 			tr := &stateDef.Transitions[i]
-			if tr.Disabled || tr.Manual {
+			if tr.Disabled || tr.Manual || tr.Schedule != nil {
 				continue
 			}
 

--- a/internal/domain/workflow/engine_test.go
+++ b/internal/domain/workflow/engine_test.go
@@ -3117,3 +3117,75 @@ func TestEngine_CBD_FollowedBySyncFailure_RollsBackPostSegment(t *testing.T) {
 	// what the production handler does on a workflow error.
 	_ = txMgr.Rollback(txCtx, entryTxID)
 }
+
+// TestEngine_CascadeSkipsScheduled_RestsInState verifies that when a state has
+// ONLY a scheduled transition as its exit, the automated cascade silently skips
+// the scheduled transition and the entity rests in its source state. Until the
+// scheduled-task runtime ships (#251), scheduled transitions are invisible to
+// the cascade — they wait for their timer.
+func TestEngine_CascadeSkipsScheduled_RestsInState(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "sched-rest", ModelVersion: "1.0"}
+
+	wf := spi.WorkflowDefinition{
+		Version: "1.0", Name: "SchedRestWF", InitialState: "S1", Active: true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{
+				{Name: "scheduledOnly", Next: "S2", Manual: false,
+					Schedule: &spi.TransitionSchedule{DelayMs: 1000}},
+			}},
+			"S2": {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+
+	entity := makeEntity("sched-rest-e1", modelRef, map[string]any{})
+
+	result, err := engine.Execute(ctx, entity, "")
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("expected success=true")
+	}
+	if entity.Meta.State != "S1" {
+		t.Errorf("expected entity to rest in S1 (scheduled transitions are invisible to cascade); got %q", entity.Meta.State)
+	}
+}
+
+// TestEngine_CascadeSkipsScheduled_FiresRegularSibling verifies that when a
+// state has both a scheduled transition and a regular automated sibling, the
+// cascade silently skips the scheduled one and fires the regular sibling.
+func TestEngine_CascadeSkipsScheduled_FiresRegularSibling(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "sched-sibling", ModelVersion: "1.0"}
+
+	wf := spi.WorkflowDefinition{
+		Version: "1.0", Name: "SchedSiblingWF", InitialState: "S1", Active: true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{
+				{Name: "scheduled", Next: "S2", Manual: false,
+					Schedule: &spi.TransitionSchedule{DelayMs: 1000}},
+				{Name: "regular", Next: "Sfinal", Manual: false},
+			}},
+			"S2":     {},
+			"Sfinal": {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+
+	entity := makeEntity("sched-sibling-e1", modelRef, map[string]any{})
+
+	result, err := engine.Execute(ctx, entity, "")
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if !result.Success {
+		t.Errorf("expected success=true")
+	}
+	if entity.Meta.State != "Sfinal" {
+		t.Errorf("expected entity to land in Sfinal via the regular sibling; got %q", entity.Meta.State)
+	}
+}

--- a/internal/domain/workflow/engine_test.go
+++ b/internal/domain/workflow/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -3187,5 +3188,48 @@ func TestEngine_CascadeSkipsScheduled_FiresRegularSibling(t *testing.T) {
 	}
 	if entity.Meta.State != "Sfinal" {
 		t.Errorf("expected entity to land in Sfinal via the regular sibling; got %q", entity.Meta.State)
+	}
+}
+
+// TestEngine_AttemptTransition_Scheduled_ReturnsTransitionNotFound verifies
+// that an explicit fire by name of a scheduled transition is rejected with an
+// error wrapping ErrTransitionNotFound. Mirrors the Disabled precedent: the
+// transition exists in config but is not currently dispatchable from the
+// caller's POV. classifyWorkflowError maps the sentinel to
+// 400 TRANSITION_NOT_FOUND, identical to the Disabled and missing-by-name
+// cases. The audit event reuses SMEventTransitionNotFound; the Details string
+// distinguishes the scheduled case.
+func TestEngine_AttemptTransition_Scheduled_ReturnsTransitionNotFound(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "sched-explicit", ModelVersion: "1.0"}
+
+	wf := spi.WorkflowDefinition{
+		Version: "1.0", Name: "SchedExplicitWF", InitialState: "S1", Active: true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{
+				{Name: "AutoClose", Next: "Closed", Manual: false,
+					Schedule: &spi.TransitionSchedule{DelayMs: 1000}},
+			}},
+			"Closed": {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+
+	entity := makeEntity("sched-explicit-e1", modelRef, map[string]any{})
+	entity.Meta.State = "S1"
+
+	_, err := engine.ManualTransition(ctx, entity, "AutoClose")
+	if err == nil {
+		t.Fatal("expected error firing a scheduled transition by name")
+	}
+	if !errors.Is(err, ErrTransitionNotFound) {
+		t.Errorf("expected error to wrap ErrTransitionNotFound (mirrors Disabled precedent); got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "scheduled transitions are not yet implemented") {
+		t.Errorf("expected error message to name the unavailability; got: %v", err)
+	}
+	if entity.Meta.State != "S1" {
+		t.Errorf("expected entity to stay in source state S1; got %q", entity.Meta.State)
 	}
 }

--- a/internal/domain/workflow/handler.go
+++ b/internal/domain/workflow/handler.go
@@ -193,8 +193,9 @@ func (h *Handler) ImportEntityModelWorkflow(w http.ResponseWriter, r *http.Reque
 		}
 		slog.WarnContext(r.Context(), "workflow import: cycle validation bypassed",
 			"pkg", "workflow",
+			"tenant", common.TenantFromContext(r.Context()),
 			"entityName", entityName,
-			"modelVersion", modelVersion,
+			"modelVersion", ref.ModelVersion,
 			"importMode", mode,
 			"workflows", workflowNames)
 	}

--- a/internal/domain/workflow/handler.go
+++ b/internal/domain/workflow/handler.go
@@ -59,8 +59,9 @@ type workflowImportDef struct {
 
 // importRequest is the JSON body shape for workflow import.
 type importRequest struct {
-	ImportMode string              `json:"importMode"`
-	Workflows  []workflowImportDef `json:"workflows"`
+	ImportMode  string              `json:"importMode"`
+	AllowCycles bool                `json:"allowCycles,omitempty"`
+	Workflows   []workflowImportDef `json:"workflows"`
 }
 
 // ImportEntityModelWorkflow handles POST /model/{entityName}/{modelVersion}/workflow/import.
@@ -180,9 +181,22 @@ func (h *Handler) ImportEntityModelWorkflow(w http.ResponseWriter, r *http.Reque
 	// detection and StartNewTxOnDispatch coherence. A pre-existing
 	// stored workflow that violates these still surfaces here, matching
 	// pre-structural-validation behaviour.
-	if err := validateWorkflows(result); err != nil {
+	if err := validateWorkflows(result, req.AllowCycles); err != nil {
 		common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeValidationFailed, err.Error()))
 		return
+	}
+
+	if req.AllowCycles {
+		workflowNames := make([]string, len(result))
+		for i, wf := range result {
+			workflowNames[i] = wf.Name
+		}
+		slog.WarnContext(r.Context(), "workflow import: cycle validation bypassed",
+			"pkg", "workflow",
+			"entityName", entityName,
+			"modelVersion", modelVersion,
+			"importMode", mode,
+			"workflows", workflowNames)
 	}
 
 	if err := wfStore.Save(r.Context(), ref, result); err != nil {

--- a/internal/domain/workflow/handler_logging_test.go
+++ b/internal/domain/workflow/handler_logging_test.go
@@ -330,3 +330,116 @@ func TestImport_ZeroResultAfterMerge_EmitsSlogWarn(t *testing.T) {
 		t.Errorf("importMode: expected 'MERGE', got %v", r["importMode"])
 	}
 }
+
+// cyclicWorkflowImportBody returns an import request body whose workflow
+// declares an unguarded automated cycle S1 -> S2 -> S1. validateWorkflowLoops
+// rejects this shape by default. The allowCycles flag is the operator
+// opt-in.
+func cyclicWorkflowImportBody(allowCycles bool) string {
+	var allow string
+	if allowCycles {
+		allow = `"allowCycles": true,`
+	}
+	return `{
+		"importMode": "REPLACE",
+		` + allow + `
+		"workflows": [{
+			"version": "1.0",
+			"name": "cyclic",
+			"initialState": "S1",
+			"active": true,
+			"states": {
+				"S1": {"transitions": [{"name": "to-S2", "next": "S2", "manual": false}]},
+				"S2": {"transitions": [{"name": "to-S1", "next": "S1", "manual": false}]}
+			}
+		}]
+	}`
+}
+
+// TestImport_AllowCyclesTrue_EmitsBypassWarn pins the security-relevant
+// audit log line emitted when the request-level allowCycles=true bypass
+// is exercised. Operators reviewing logs must be able to see which
+// tenant/model/import-call invoked the bypass and which workflow names
+// were admitted under it.
+//
+// Asserts:
+//   - Exactly one WARN record with msg "workflow import: cycle validation
+//     bypassed".
+//   - pkg=workflow, tenant present, entityName/modelVersion/importMode
+//     match the request, workflows lists the bypassed workflow names.
+//
+// This is the negative-space pair for TestImport_Success_EmitsSlogInfo:
+// the success log says "what changed"; this log says "with what safety
+// check bypassed".
+func TestImport_AllowCyclesTrue_EmitsBypassWarn(t *testing.T) {
+	srv := newTestServer(t)
+	importModel(t, srv.URL, "Polling", 1)
+
+	getRecords := captureSlog(t, slog.LevelWarn)
+
+	resp := doWorkflowImport(t, srv.URL, "Polling", 1, cyclicWorkflowImportBody(true))
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("import with allowCycles=true expected 200, got %d: %s", resp.StatusCode, b)
+	}
+	resp.Body.Close()
+
+	warns := recordsByMsg(getRecords(), "workflow import: cycle validation bypassed")
+	if len(warns) != 1 {
+		t.Fatalf("expected exactly 1 'cycle validation bypassed' WARN record, got %d", len(warns))
+	}
+	r := warns[0]
+	if r["level"] != "WARN" {
+		t.Errorf("level: expected WARN, got %v", r["level"])
+	}
+	if r["pkg"] != "workflow" {
+		t.Errorf("pkg: expected 'workflow', got %v", r["pkg"])
+	}
+	if _, present := r["tenant"]; !present {
+		t.Errorf("tenant: field missing — bypass log must carry tenant context for multi-tenant audit")
+	}
+	if r["entityName"] != "Polling" {
+		t.Errorf("entityName: expected 'Polling', got %v", r["entityName"])
+	}
+	if r["modelVersion"] != "1" {
+		t.Errorf("modelVersion: expected '1' (string), got %v (%T)", r["modelVersion"], r["modelVersion"])
+	}
+	if r["importMode"] != "REPLACE" {
+		t.Errorf("importMode: expected 'REPLACE', got %v", r["importMode"])
+	}
+	workflows, ok := r["workflows"].([]any)
+	if !ok {
+		t.Fatalf("workflows: expected []any, got %T", r["workflows"])
+	}
+	if len(workflows) != 1 || workflows[0] != "cyclic" {
+		t.Errorf("workflows: expected ['cyclic'], got %v", workflows)
+	}
+}
+
+// TestImport_AllowCyclesAbsent_DoesNotEmitBypassWarn pins the negative
+// invariant: an import request without allowCycles=true MUST NOT emit
+// the bypass WARN line. A regression that started emitting the bypass
+// log on every import would silently elevate WARN volume and confuse
+// operators about which imports actually used the safety bypass.
+//
+// The cyclic workflow is rejected at validation time (400), so the
+// import doesn't succeed; the assertion is that no bypass-warn fired
+// regardless of the import outcome.
+func TestImport_AllowCyclesAbsent_DoesNotEmitBypassWarn(t *testing.T) {
+	srv := newTestServer(t)
+	importModel(t, srv.URL, "PollingRejected", 1)
+
+	getRecords := captureSlog(t, slog.LevelWarn)
+
+	resp := doWorkflowImport(t, srv.URL, "PollingRejected", 1, cyclicWorkflowImportBody(false))
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("import without allowCycles expected 400, got %d", resp.StatusCode)
+	}
+
+	warns := recordsByMsg(getRecords(), "workflow import: cycle validation bypassed")
+	if len(warns) != 0 {
+		t.Errorf("bypass WARN must not fire when allowCycles is absent; got %d records", len(warns))
+	}
+}

--- a/internal/domain/workflow/handler_type_validation_test.go
+++ b/internal/domain/workflow/handler_type_validation_test.go
@@ -34,7 +34,7 @@ func TestValidator_TypeInternalized_WithStartNewTxOnDispatch(t *testing.T) {
 			},
 		}
 
-		err := validateWorkflows([]spi.WorkflowDefinition{wf})
+		err := validateWorkflows([]spi.WorkflowDefinition{wf}, false)
 		if err == nil {
 			t.Fatalf("expected validator to reject startNewTxOnDispatch=true with non-CBD ExecutionMode, got nil")
 		}
@@ -67,7 +67,7 @@ func TestValidator_TypeInternalized_WithStartNewTxOnDispatch(t *testing.T) {
 			},
 		}
 
-		err := validateWorkflows([]spi.WorkflowDefinition{wf})
+		err := validateWorkflows([]spi.WorkflowDefinition{wf}, false)
 		if err != nil {
 			t.Fatalf("validator should pass for coherent CBD flags regardless of Type; got %v", err)
 		}

--- a/internal/domain/workflow/scenarios_test.go
+++ b/internal/domain/workflow/scenarios_test.go
@@ -264,7 +264,7 @@ func TestScenarioStaticLoopDetection(t *testing.T) {
 		},
 	}
 
-	err := validateWorkflows([]spi.WorkflowDefinition{wf})
+	err := validateWorkflows([]spi.WorkflowDefinition{wf}, false)
 	if err == nil {
 		t.Fatal("expected error for infinite loop")
 	}
@@ -284,7 +284,7 @@ func TestScenarioStaticLoopDetectionSelfLoop(t *testing.T) {
 		},
 	}
 
-	err := validateWorkflows([]spi.WorkflowDefinition{wf})
+	err := validateWorkflows([]spi.WorkflowDefinition{wf}, false)
 	if err == nil {
 		t.Fatal("expected error for self-loop")
 	}
@@ -310,7 +310,7 @@ func TestScenarioStaticValidationPassesGuardedCycle(t *testing.T) {
 		},
 	}
 
-	err := validateWorkflows([]spi.WorkflowDefinition{wf})
+	err := validateWorkflows([]spi.WorkflowDefinition{wf}, false)
 	if err != nil {
 		t.Fatalf("expected no error for guarded cycle, got: %v", err)
 	}
@@ -331,7 +331,7 @@ func TestScenarioStaticValidationPassesManualCycle(t *testing.T) {
 		},
 	}
 
-	err := validateWorkflows([]spi.WorkflowDefinition{wf})
+	err := validateWorkflows([]spi.WorkflowDefinition{wf}, false)
 	if err != nil {
 		t.Fatalf("expected no error for manual cycle, got: %v", err)
 	}
@@ -584,7 +584,7 @@ func TestValidateWorkflows_RejectsStartNewTxOnDispatchOnNonCommitBeforeDispatch(
 			"S2": {},
 		},
 	}
-	err := validateWorkflows([]spi.WorkflowDefinition{wf})
+	err := validateWorkflows([]spi.WorkflowDefinition{wf}, false)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -616,7 +616,7 @@ func TestValidateWorkflows_AcceptsStartNewTxOnDispatchOnCommitBeforeDispatch(t *
 			"S2": {},
 		},
 	}
-	if err := validateWorkflows([]spi.WorkflowDefinition{wf}); err != nil {
+	if err := validateWorkflows([]spi.WorkflowDefinition{wf}, false); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 }
@@ -638,7 +638,7 @@ func TestValidateWorkflows_AcceptsStartNewTxOnDispatchNilOrFalse(t *testing.T) {
 			"S2": {},
 		},
 	}
-	if err := validateWorkflows([]spi.WorkflowDefinition{wf}); err != nil {
+	if err := validateWorkflows([]spi.WorkflowDefinition{wf}, false); err != nil {
 		t.Fatalf("expected no error for nil/false flag, got: %v", err)
 	}
 }

--- a/internal/domain/workflow/schedule_roundtrip_test.go
+++ b/internal/domain/workflow/schedule_roundtrip_test.go
@@ -1,0 +1,78 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+func TestSchedule_RoundTrip_TimeoutMsPointerStates(t *testing.T) {
+	tm := int64(90000000)
+	tmZero := int64(0)
+
+	cases := []struct {
+		name          string
+		schedule      *spi.TransitionSchedule
+		wantInJSON    string // substring that MUST appear in marshalled JSON
+		wantNotInJSON string // substring that MUST NOT appear
+	}{
+		{
+			name:       "timeoutMs_non_nil_positive",
+			schedule:   &spi.TransitionSchedule{DelayMs: 86400000, TimeoutMs: &tm},
+			wantInJSON: `"timeoutMs":90000000`,
+		},
+		{
+			name:       "timeoutMs_non_nil_zero",
+			schedule:   &spi.TransitionSchedule{DelayMs: 86400000, TimeoutMs: &tmZero},
+			wantInJSON: `"timeoutMs":0`,
+		},
+		{
+			name:          "timeoutMs_nil",
+			schedule:      &spi.TransitionSchedule{DelayMs: 86400000},
+			wantNotInJSON: "timeoutMs",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := spi.TransitionDefinition{
+				Name:     "AutoClose",
+				Next:     "Closed",
+				Manual:   false,
+				Schedule: tc.schedule,
+			}
+			bs, err := json.Marshal(tr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.wantInJSON != "" && !strings.Contains(string(bs), tc.wantInJSON) {
+				t.Errorf("expected JSON to contain %q; got %s", tc.wantInJSON, bs)
+			}
+			if tc.wantNotInJSON != "" && strings.Contains(string(bs), tc.wantNotInJSON) {
+				t.Errorf("expected JSON NOT to contain %q; got %s", tc.wantNotInJSON, bs)
+			}
+
+			var back spi.TransitionDefinition
+			if err := json.Unmarshal(bs, &back); err != nil {
+				t.Fatal(err)
+			}
+			if back.Schedule == nil {
+				t.Fatal("Schedule lost on round-trip")
+			}
+			if back.Schedule.DelayMs != tc.schedule.DelayMs {
+				t.Errorf("DelayMs lost: got %d", back.Schedule.DelayMs)
+			}
+			// Pointer-state-preserving equality check.
+			gotPtr := back.Schedule.TimeoutMs
+			wantPtr := tc.schedule.TimeoutMs
+			if (gotPtr == nil) != (wantPtr == nil) {
+				t.Errorf("TimeoutMs pointer-presence mismatched: got %v, want %v", gotPtr, wantPtr)
+			}
+			if gotPtr != nil && wantPtr != nil && *gotPtr != *wantPtr {
+				t.Errorf("TimeoutMs value mismatched: got %d, want %d", *gotPtr, *wantPtr)
+			}
+		})
+	}
+}

--- a/internal/domain/workflow/validate.go
+++ b/internal/domain/workflow/validate.go
@@ -195,6 +195,12 @@ func validateWorkflowStructure(wf spi.WorkflowDefinition) error {
 					wf.Name, stateName, tr.Name, tr.Next)
 			}
 
+			if tr.Manual && tr.Schedule != nil {
+				return fmt.Errorf(
+					"workflow %q state %q transition %q: manual and scheduled are mutually exclusive",
+					wf.Name, stateName, tr.Name)
+			}
+
 			for _, p := range tr.Processors {
 				if p.Name == "" {
 					return fmt.Errorf("workflow %q state %q transition %q: empty processor name is not allowed",

--- a/internal/domain/workflow/validate.go
+++ b/internal/domain/workflow/validate.go
@@ -200,6 +200,11 @@ func validateWorkflowStructure(wf spi.WorkflowDefinition) error {
 					"workflow %q state %q transition %q: manual and scheduled are mutually exclusive",
 					wf.Name, stateName, tr.Name)
 			}
+			if tr.Schedule != nil && tr.Schedule.DelayMs <= 0 {
+				return fmt.Errorf(
+					"workflow %q state %q transition %q: schedule.delayMs must be > 0 (got %d)",
+					wf.Name, stateName, tr.Name, tr.Schedule.DelayMs)
+			}
 
 			for _, p := range tr.Processors {
 				if p.Name == "" {

--- a/internal/domain/workflow/validate.go
+++ b/internal/domain/workflow/validate.go
@@ -115,10 +115,12 @@ func validateImportRequest(workflows []spi.WorkflowDefinition) error {
 // The newer structural rules (state graph, name uniqueness,
 // ExecutionMode enum) deliberately do NOT run here — see
 // validateImportRequest for why.
-func validateWorkflows(workflows []spi.WorkflowDefinition) error {
+func validateWorkflows(workflows []spi.WorkflowDefinition, allowCycles bool) error {
 	for _, wf := range workflows {
-		if err := validateWorkflowLoops(wf); err != nil {
-			return fmt.Errorf("workflow %q: %w", wf.Name, err)
+		if !allowCycles {
+			if err := validateWorkflowLoops(wf); err != nil {
+				return fmt.Errorf("workflow %q: %w", wf.Name, err)
+			}
 		}
 		if err := validateProcessorFlags(wf); err != nil {
 			return err

--- a/internal/domain/workflow/validate_import_test.go
+++ b/internal/domain/workflow/validate_import_test.go
@@ -435,6 +435,58 @@ func TestValidator_ManualAndSchedule_Rejected(t *testing.T) {
 	}
 }
 
+// --- Schedule.DelayMs must be > 0 -------------------------------------------
+
+func TestValidator_DelayMsZero_Rejected(t *testing.T) {
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "test",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {
+				Transitions: []spi.TransitionDefinition{
+					{
+						Name:     "T1",
+						Next:     "S1",
+						Manual:   false,
+						Schedule: &spi.TransitionSchedule{DelayMs: 0},
+					},
+				},
+			},
+		},
+	}
+	err := validateImportRequest([]spi.WorkflowDefinition{wf})
+	if err == nil || !strings.Contains(err.Error(), "delayMs must be > 0") {
+		t.Errorf("expected delayMs error, got: %v", err)
+	}
+}
+
+func TestValidator_DelayMsNegative_Rejected(t *testing.T) {
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "test",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {
+				Transitions: []spi.TransitionDefinition{
+					{
+						Name:     "T1",
+						Next:     "S1",
+						Manual:   false,
+						Schedule: &spi.TransitionSchedule{DelayMs: -100},
+					},
+				},
+			},
+		},
+	}
+	err := validateImportRequest([]spi.WorkflowDefinition{wf})
+	if err == nil || !strings.Contains(err.Error(), "delayMs must be > 0") {
+		t.Errorf("expected delayMs error, got: %v", err)
+	}
+}
+
 // All four named modes must be accepted.
 func TestValidateImportRequest_AcceptsAllKnownExecutionModes(t *testing.T) {
 	for _, mode := range []string{

--- a/internal/domain/workflow/validate_import_test.go
+++ b/internal/domain/workflow/validate_import_test.go
@@ -487,6 +487,64 @@ func TestValidator_DelayMsNegative_Rejected(t *testing.T) {
 	}
 }
 
+// --- Schedule happy paths — regression guards for TimeoutMs pointer states ------
+//
+// These four shapes MUST validate successfully. Their primary value is as a
+// regression guard against the bogus rev 1/rev 2 TimeoutMs >= DelayMs rule
+// (removed in rev 3 as nonsensical under the late-tolerance semantic).
+// No validator changes are needed — the tests document an existing acceptance
+// contract and pin that contract against future regressions.
+//
+// Semantic notes:
+//
+//   - timeoutMs absent (nil) — "no-timeout" semantic: fire indefinitely late.
+//   - timeoutMs explicit zero (&0) — "strictest" semantic: drop if any
+//     lateness is observed.
+//   - timeoutMs < delayMs (e.g. delay 1000ms, timeout 500ms) — VALID under the
+//     late-tolerance semantic. TimeoutMs is not a maximum age of the armed
+//     timer; it is the maximum lateness of actual firing vs. scheduled time.
+//     A transition armed at t=0, scheduled to fire at t=1000ms, with a
+//     timeout of 500ms, will fire at t=1000ms and be dropped only if it
+//     fires after t=1500ms.
+//   - timeoutMs > delayMs — valid under the same semantic.
+
+func TestValidator_ScheduleHappyPaths(t *testing.T) {
+	tmZero := int64(0)
+	tmSmall := int64(500)
+	tmPositive := int64(5000)
+
+	cases := []struct {
+		name string
+		sch  *spi.TransitionSchedule
+	}{
+		{"timeoutMs_absent_nil", &spi.TransitionSchedule{DelayMs: 1000}},
+		{"timeoutMs_explicit_zero", &spi.TransitionSchedule{DelayMs: 1000, TimeoutMs: &tmZero}},
+		{"timeoutMs_less_than_delayMs", &spi.TransitionSchedule{DelayMs: 1000, TimeoutMs: &tmSmall}},
+		{"timeoutMs_greater_than_delayMs", &spi.TransitionSchedule{DelayMs: 1000, TimeoutMs: &tmPositive}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wf := spi.WorkflowDefinition{
+				Version:      "1",
+				Name:         "test",
+				InitialState: "S1",
+				Active:       true,
+				States: map[string]spi.StateDefinition{
+					"S1": {
+						Transitions: []spi.TransitionDefinition{
+							{Name: "T1", Next: "S1", Manual: false, Schedule: tc.sch},
+						},
+					},
+				},
+			}
+			if err := validateImportRequest([]spi.WorkflowDefinition{wf}); err != nil {
+				t.Errorf("expected acceptance for shape %q; got: %v", tc.name, err)
+			}
+		})
+	}
+}
+
 // All four named modes must be accepted.
 func TestValidateImportRequest_AcceptsAllKnownExecutionModes(t *testing.T) {
 	for _, mode := range []string{

--- a/internal/domain/workflow/validate_import_test.go
+++ b/internal/domain/workflow/validate_import_test.go
@@ -404,6 +404,37 @@ func TestValidateImportRequest_RejectsOverlongProcessorName(t *testing.T) {
 	}
 }
 
+// --- Manual + Schedule mutual exclusion -----------------------------------
+
+func TestValidator_ManualAndSchedule_Rejected(t *testing.T) {
+	tm := int64(1000)
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "test",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {
+				Transitions: []spi.TransitionDefinition{
+					{
+						Name:     "T1",
+						Next:     "S1",
+						Manual:   true,
+						Schedule: &spi.TransitionSchedule{DelayMs: 1000, TimeoutMs: &tm},
+					},
+				},
+			},
+		},
+	}
+	err := validateImportRequest([]spi.WorkflowDefinition{wf})
+	if err == nil {
+		t.Fatal("expected validation error for manual=true + schedule, got nil")
+	}
+	if !strings.Contains(err.Error(), "manual and scheduled are mutually exclusive") {
+		t.Errorf("error message missing expected substring; got: %v", err)
+	}
+}
+
 // All four named modes must be accepted.
 func TestValidateImportRequest_AcceptsAllKnownExecutionModes(t *testing.T) {
 	for _, mode := range []string{

--- a/internal/domain/workflow/validate_import_test.go
+++ b/internal/domain/workflow/validate_import_test.go
@@ -545,6 +545,93 @@ func TestValidator_ScheduleHappyPaths(t *testing.T) {
 	}
 }
 
+// --- allowCycles bypass behaviour ----------------------------------------
+
+// cyclicWorkflow builds S1 -automated, no criterion-> S2 -automated, no
+// criterion-> S1. validateWorkflowLoops rejects this by default.
+func cyclicWorkflow(t *testing.T) spi.WorkflowDefinition {
+	t.Helper()
+	return spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "cyclic",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{{Name: "to-S2", Next: "S2", Manual: false}}},
+			"S2": {Transitions: []spi.TransitionDefinition{{Name: "to-S1", Next: "S1", Manual: false}}},
+		},
+	}
+}
+
+func TestValidator_DefaultFalse_RejectsCycle(t *testing.T) {
+	wf := cyclicWorkflow(t)
+	if err := validateWorkflows([]spi.WorkflowDefinition{wf}, false); err == nil {
+		t.Fatal("expected cycle rejection at default allowCycles=false")
+	}
+}
+
+func TestValidator_AllowCyclesTrue_BypassesCycleCheck(t *testing.T) {
+	wf := cyclicWorkflow(t)
+	if err := validateWorkflows([]spi.WorkflowDefinition{wf}, true); err != nil {
+		t.Errorf("expected acceptance with allowCycles=true; got: %v", err)
+	}
+}
+
+func TestValidator_AllowCyclesTrue_DoesNotBypassScheduleRules(t *testing.T) {
+	tm := int64(1000)
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "cyclic_and_incoherent",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{
+				{Name: "to-S2", Next: "S2", Manual: true, Schedule: &spi.TransitionSchedule{DelayMs: 1000, TimeoutMs: &tm}},
+			}},
+			"S2": {Transitions: []spi.TransitionDefinition{
+				{Name: "to-S1", Next: "S1", Manual: false},
+			}},
+		},
+	}
+	// validateImportRequest catches the structural (manual+schedule) rule,
+	// regardless of allowCycles. Note this calls validateImportRequest, not
+	// validateWorkflows — the Schedule rules live in validateWorkflowStructure.
+	if err := validateImportRequest([]spi.WorkflowDefinition{wf}); err == nil {
+		t.Fatal("expected manual+schedule rejection even when cyclic")
+	} else if !strings.Contains(err.Error(), "manual and scheduled are mutually exclusive") {
+		t.Errorf("expected Schedule-rule error, got: %v", err)
+	}
+}
+
+func TestValidator_AllowCyclesTrue_PollingScheduledWorkflow_Accepted(t *testing.T) {
+	wf := spi.WorkflowDefinition{
+		Version:      "1",
+		Name:         "polling",
+		InitialState: "S1",
+		Active:       true,
+		States: map[string]spi.StateDefinition{
+			"S1": {Transitions: []spi.TransitionDefinition{
+				{Name: "to-S2", Next: "S2", Manual: false, Schedule: &spi.TransitionSchedule{DelayMs: 1000}},
+			}},
+			"S2": {Transitions: []spi.TransitionDefinition{
+				{Name: "to-S1", Next: "S1", Manual: false, Schedule: &spi.TransitionSchedule{DelayMs: 1000}},
+			}},
+		},
+	}
+	// Default (allowCycles=false) rejects (the scheduled-polling cycle).
+	if err := validateWorkflows([]spi.WorkflowDefinition{wf}, false); err == nil {
+		t.Fatal("expected cycle rejection on polling workflow at allowCycles=false")
+	}
+	// allowCycles=true accepts.
+	if err := validateWorkflows([]spi.WorkflowDefinition{wf}, true); err != nil {
+		t.Errorf("expected polling workflow to validate with allowCycles=true; got: %v", err)
+	}
+	// Structural validation (Schedule rules) also passes.
+	if err := validateImportRequest([]spi.WorkflowDefinition{wf}); err != nil {
+		t.Errorf("expected structural validation to pass on polling workflow; got: %v", err)
+	}
+}
+
 // All four named modes must be accepted.
 func TestValidateImportRequest_AcceptsAllKnownExecutionModes(t *testing.T) {
 	for _, mode := range []string{

--- a/internal/e2e/scheduled_transition_test.go
+++ b/internal/e2e/scheduled_transition_test.go
@@ -1,0 +1,88 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestE2E_ExplicitFireOfScheduledTransition_ReturnsTransitionNotFound exercises
+// the explicit-fire-of-a-scheduled-transition rejection path end-to-end through
+// the full HTTP stack (#259). The validator accepts the shape-coherent
+// scheduled transition (Schedule.DelayMs > 0, manual=false), cascade silently
+// skips it on entity creation (no other automated exit), and a client-issued
+// PUT against the transition by name returns 400 TRANSITION_NOT_FOUND with a
+// message containing "scheduled transitions are not yet implemented". The
+// entity stays in the source state.
+//
+// Mirrors the Disabled-transition precedent (TestEntityLifecycle_DisabledTransition):
+// the transition exists in config but is not currently dispatchable from the
+// caller's POV.
+func TestE2E_ExplicitFireOfScheduledTransition_ReturnsTransitionNotFound(t *testing.T) {
+	const model = "e2e-scheduled-explicit-fire"
+
+	// 1+2: Import model and workflow with a single scheduled, non-manual
+	// transition out of the initial state. setupModelWithWorkflow asserts
+	// 200 on workflow import — pins that the validator accepts shape-coherent
+	// scheduled transitions.
+	wf := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1", "name": "sched-explicit-wf", "initialState": "Open", "active": true,
+			"states": {
+				"Open": {"transitions": [{"name": "AutoClose", "next": "Closed", "manual": false, "schedule": {"delayMs": 1000}}]},
+				"Closed": {}
+			}
+		}]
+	}`
+	setupModelWithWorkflow(t, model, wf)
+
+	// 3: Create entity instance. Cascade silently skips the scheduled
+	// transition (no other automated exit), so the entity rests in Open.
+	entityID := createEntityE2E(t, model, 1, `{"name":"Test Order","amount":100,"status":"draft"}`)
+	if s := getEntityState(t, entityID); s != "Open" {
+		t.Fatalf("expected entity to rest in initial state Open (cascade skips scheduled); got %q", s)
+	}
+
+	// 4: Fire AutoClose by name. Expect 400 TRANSITION_NOT_FOUND with the
+	// message naming the rejection cause.
+	path := fmt.Sprintf("/api/entity/JSON/%s/AutoClose", entityID)
+	resp := doAuth(t, http.MethodPut, path, `{"name":"Test Order","amount":100,"status":"draft"}`)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 TRANSITION_NOT_FOUND firing scheduled transition; got %d: %s", resp.StatusCode, body)
+	}
+
+	// Error response is RFC 9457 problem+json with properties.errorCode
+	// (per common.WriteError) — same shape as TestGroupedStats_E2E_ValidationError.
+	var pd struct {
+		Status     int            `json:"status"`
+		Detail     string         `json:"detail"`
+		Title      string         `json:"title"`
+		Properties map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(body), &pd); err != nil {
+		t.Fatalf("decode problem detail: %v\nbody: %s", err, body)
+	}
+	if pd.Status != http.StatusBadRequest {
+		t.Errorf("ProblemDetail.status: got %d, want 400", pd.Status)
+	}
+	if code, _ := pd.Properties["errorCode"].(string); code != "TRANSITION_NOT_FOUND" {
+		t.Errorf("properties.errorCode: got %q, want TRANSITION_NOT_FOUND; body=%s", code, body)
+	}
+	// The "scheduled transitions are not yet implemented" substring may appear
+	// in detail, title, or another problem-detail field — assert against the
+	// raw body so we're robust to where common.WriteError surfaces the wrapped
+	// error string.
+	if !strings.Contains(body, "scheduled transitions are not yet implemented") {
+		t.Errorf("expected response body to contain rejection cause %q; got: %s",
+			"scheduled transitions are not yet implemented", body)
+	}
+
+	// 5: Entity must remain in the source state after rejection.
+	if s := getEntityState(t, entityID); s != "Open" {
+		t.Errorf("expected entity to remain in Open after rejected explicit-fire; got %q", s)
+	}
+}

--- a/plugins/memory/go.mod
+++ b/plugins/memory/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/memory
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a
+	github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b
 	github.com/google/uuid v1.6.0
 	github.com/tidwall/gjson v1.19.0
 )

--- a/plugins/memory/go.sum
+++ b/plugins/memory/go.sum
@@ -1,6 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a h1:TC8koQ/W5Ylk0IPQ0pCOajsKzftJkjPU3t4A3jmLuD4=
-github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b h1:VoC0mAecMXc1PHS8VP+Sel45mBNMrsLfKJTY4VzjhBg=
+github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/plugins/postgres/go.mod
+++ b/plugins/postgres/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/postgres
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a
+	github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa

--- a/plugins/postgres/go.sum
+++ b/plugins/postgres/go.sum
@@ -9,8 +9,8 @@ github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a h1:TC8koQ/W5Ylk0IPQ0pCOajsKzftJkjPU3t4A3jmLuD4=
-github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b h1:VoC0mAecMXc1PHS8VP+Sel45mBNMrsLfKJTY4VzjhBg=
+github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/plugins/sqlite/go.mod
+++ b/plugins/sqlite/go.mod
@@ -3,7 +3,7 @@ module github.com/cyoda-platform/cyoda-go/plugins/sqlite
 go 1.26.4
 
 require (
-	github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a
+	github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b
 	github.com/gofrs/flock v0.13.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/uuid v1.6.0

--- a/plugins/sqlite/go.sum
+++ b/plugins/sqlite/go.sum
@@ -1,6 +1,6 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a h1:TC8koQ/W5Ylk0IPQ0pCOajsKzftJkjPU3t4A3jmLuD4=
-github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615003314-ee4b5c35693a/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
+github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b h1:VoC0mAecMXc1PHS8VP+Sel45mBNMrsLfKJTY4VzjhBg=
+github.com/cyoda-platform/cyoda-go-spi v0.7.2-0.20260615212244-6e7ec98c210b/go.mod h1:zyjI4jQb4Jz3p52FXGqImxGZ3b81Nuxe+cfsIStK3EQ=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=


### PR DESCRIPTION
Closes #259.

## What this adds

Implements the scheduled-transition configuration shape and SPI per
the spec at `docs/superpowers/specs/2026-06-15-issue-259-scheduled-transition-shape-design.md` rev 3.

- New `TransitionScheduleDto` schema (api/openapi.yaml) + regenerated
  DTO.
- Optional `schedule` property on `TransitionDefinitionDto`.
- Two validator rules: `manual+schedule` mutually exclusive,
  `delayMs <= 0` rejected.
- Cascade silently skips `Schedule != nil` transitions (one-line
  extension to existing Disabled/Manual filter).
- Explicit-fire of a scheduled transition returns
  `400 TRANSITION_NOT_FOUND` with message
  "scheduled transitions are not yet implemented" (mirrors the
  Disabled precedent byte-for-byte).
- Request-level `allowCycles` escape hatch on the import body for
  polling-pattern scheduled workflows. Bypasses only
  `validateWorkflowLoops`; emits one `slog.Warn` per import call.
- New help-topic section `## SCHEDULED TRANSITIONS` in
  `cmd/cyoda/help/content/workflows.md`.
- Three new parity scenarios `wf-import/07..09` + their executable
  Go runners in `e2e/parity/externalapi/workflow_import_export.go`.
- E2E test for the explicit-fire reject.

## What this does NOT do

- No timer runtime — that's a follow-up (deferred beyond v0.8.0).
- No new `SMEventScheduledTransition*` events — also deferred.
- No per-workflow `AllowCycles` field — request-level only by
  design.

## SPI coordination

- Bundled SPI changes landed in cyoda-go-spi PR (merged): new
  `TransitionSchedule` type + `Schedule` field + deferred
  `ProcessorDefinition.Type` docstring follow-up.
- This PR bumps the cyoda-go-spi pseudo-version pin across all
  four go.mod files (root + plugins/memory|sqlite|postgres).
- No SPI tag cut — bundled into v0.8.0's end-of-milestone tag per
  `cyoda-go-spi/MAINTAINING.md`.

## TimeoutMs semantic

Per project lead's clarification:
- `scheduledTime = stateEntryTime + delayMs`
- `lateness = executionTime - scheduledTime`
- if `lateness > timeoutMs` → drop the task, transition NOT
  attempted

`TimeoutMs` is `*int64`. `nil` = no timeout (always eventually
fire), `&0` = strictest (drop on any lateness), `&N` = drop if
late > N ms. Pointer pattern matches precedent
`ProcessorConfig.StartNewTxOnDispatch *bool`. All three states
round-trip byte-equivalent.

## Verification

- `go vet ./...` clean.
- `go test -short ./...` green.
- `go test ./internal/e2e/...` green (Docker).
- `make test-all` green (all plugins).
- `go test -race ./...` clean (one-shot pre-PR sanity check).
- Parity scenarios 07..09 PASS on all three backends (memory, sqlite, postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
