### PR TITLE
chore(help): use sort.Strings, drop hand-rolled insertion sort

### DIFF
--- a/cmd/cyoda/help/actions.go
+++ b/cmd/cyoda/help/actions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -64,12 +65,7 @@ func actionsFor(topic string) []string {
 	for k := range m {
 		out = append(out, k)
 	}
-	// insertion sort for deterministic output without importing sort
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1] > out[j]; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
+	sort.Strings(out)
 	return out
 }
 
@@ -80,12 +76,7 @@ func topicsWithActions() []string {
 	for k := range actionRegistry {
 		out = append(out, k)
 	}
-	// insertion sort for deterministic output without importing sort
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1] > out[j]; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
+	sort.Strings(out)
 	return out
 }
 


### PR DESCRIPTION
## Summary

Replace two near-identical hand-rolled insertion sorts in `cmd/cyoda/help/actions.go` with the standard-library `sort.Strings`.

## Rationale

The original comments on both loops say `// insertion sort for deterministic output without importing sort`. That rationale is stale:

- 6 sibling files in the same `cmd/cyoda/help` package already import `sort` (`cloudevents.go`, `command.go`, `help.go`, `openapi_tags.go`, plus tests). The package as a whole has `sort` available; this file was the outlier.
- Hand-rolled sort is harder to audit at a glance than the standard-library call.
- Both loops were identical except for the slice they operate on.

## Diff

```diff
+	"sort"
...
-	// insertion sort for deterministic output without importing sort
-	for i := 1; i < len(out); i++ {
-		for j := i; j > 0 && out[j-1] > out[j]; j-- {
-			out[j-1], out[j] = out[j], out[j-1]
-		}
-	}
+	sort.Strings(out)
```

Applied at both `actionsFor` and `topicsWithActions`. Net diff: +3 / -12.

## Provenance

Surfaced during code review of PR #319 (workflow schema version contract) but kept out of that PR for scope discipline — landed here as a focused cleanup. Both sort loops have been there since the original help subsystem feature (PR #89, commit `60c6cc2`).

## Test Plan

- [x] `go test ./cmd/cyoda/help/ -short -count=1` — green (existing help-subsystem tests cover sort ordering via discovery output)
- [x] `go test -short ./...` — no regressions
- [x] `go vet ./cmd/cyoda/help/...` — clean
- [x] `gofmt -d cmd/cyoda/help/actions.go` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)