### PR TITLE
chore(release): forward-port cyoda-platform → cyoda org-rename fix

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -99,7 +99,7 @@ jobs:
           for a in artifacts:
               name = a.get('name', '')
               # Match ghcr.io/cyoda-platform/cyoda:TAG — take TAG.
-              if ':' in name and 'cyoda-platform/cyoda' in name:
+              if ':' in name and 'cyoda/cyoda' in name:
                   cyoda_tags.add(name.rsplit(':', 1)[1])
 
           print(f"cyoda image tags produced on v0.0.0 snapshot: {sorted(cyoda_tags)}")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           app-id: ${{ vars.HOMEBREW_TAP_APP_ID }}
           private-key: ${{ secrets.HOMEBREW_TAP_APP_KEY }}
-          owner: cyoda-platform
+          owner: cyoda
           repositories: homebrew-cyoda-go
 
       - uses: goreleaser/goreleaser-action@v7
@@ -108,7 +108,7 @@ jobs:
         id: image-ref
         run: |
           version="${GITHUB_REF_NAME#v}"
-          echo "ref=ghcr.io/cyoda-platform/cyoda:${version}" >> "$GITHUB_OUTPUT"
+          echo "ref=ghcr.io/cyoda/cyoda:${version}" >> "$GITHUB_OUTPUT"
 
       - name: Scan release image (Trivy)
         # Pin to >= v0.35.0; earlier versions are covered by

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,7 +48,7 @@ nfpms:
   - id: cyoda
     package_name: cyoda
     vendor: Cyoda Platform
-    homepage: https://github.com/cyoda-platform/cyoda-go
+    homepage: https://github.com/cyoda/cyoda-go
     maintainer: Cyoda Platform <noreply@cyoda.com>
     description: Lightweight Go EDBMS — digital twin of the Cyoda platform.
     license: Apache-2.0
@@ -72,10 +72,10 @@ brews:
     # filter.
     skip_upload: auto
     repository:
-      owner: cyoda-platform
+      owner: cyoda
       name: homebrew-cyoda-go
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    homepage: https://github.com/cyoda-platform/cyoda-go
+    homepage: https://github.com/cyoda/cyoda-go
     description: Lightweight Go EDBMS — digital twin of the Cyoda platform
     license: Apache-2.0
     commit_author:
@@ -113,7 +113,7 @@ checksum:
 dockers_v2:
   - id: cyoda
     images:
-      - ghcr.io/cyoda-platform/cyoda
+      - ghcr.io/cyoda/cyoda
     tags:
       - "{{ .Version }}"
     platforms:
@@ -121,7 +121,7 @@ dockers_v2:
       - linux/arm64
     dockerfile: deploy/docker/Dockerfile
     labels:
-      org.opencontainers.image.source: https://github.com/cyoda-platform/cyoda-go
+      org.opencontainers.image.source: https://github.com/cyoda/cyoda-go
       org.opencontainers.image.version: "{{ .Version }}"
       org.opencontainers.image.revision: "{{ .Commit }}"
       org.opencontainers.image.created: "{{ .Date }}"
@@ -129,7 +129,7 @@ dockers_v2:
 
   - id: cyoda-latest
     images:
-      - ghcr.io/cyoda-platform/cyoda
+      - ghcr.io/cyoda/cyoda
     tags:
       - latest
     # `:latest` tracks stable releases only — skip for prereleases.
@@ -141,7 +141,7 @@ dockers_v2:
       - linux/arm64
     dockerfile: deploy/docker/Dockerfile
     labels:
-      org.opencontainers.image.source: https://github.com/cyoda-platform/cyoda-go
+      org.opencontainers.image.source: https://github.com/cyoda/cyoda-go
       org.opencontainers.image.version: "{{ .Version }}"
       org.opencontainers.image.revision: "{{ .Commit }}"
       org.opencontainers.image.created: "{{ .Date }}"


### PR DESCRIPTION
## Summary

The `cyoda-platform` GitHub org was renamed to `cyoda`. The v0.7 release pipeline hard-coded the old org name in `.goreleaser.yaml`, `.github/workflows/release.yml`, and `.github/workflows/release-smoke.yml`.

This was discovered during the v0.7.2/v0.7.3 release-cutting attempts when GHCR push and Homebrew-tap-token both failed with `denied: not_found: owner not found`. Fixed on `release/v0.7.x` and shipped as **v0.7.4**.

This PR forward-ports the same surgical fix to `release/v0.8.0` so v0.8.0 (and subsequent v0.8.x patches) can tag without the same plumbing breakage.

## What changed

| File | Sites |
|---|---|
| `.goreleaser.yaml` | 7 — GHCR image targets (cyoda image + cyoda-latest), Homebrew tap owner, formula homepages, OCI `org.opencontainers.image.source` labels. |
| `.github/workflows/release.yml` | 2 — Trivy scan image-ref, Homebrew app-token owner. |
| `.github/workflows/release-smoke.yml` | 1 — image-name match pattern that detects published cyoda images. |

Diff stat: `+10 / -10` across 3 files.

## What was deliberately NOT changed

- `.github/workflows/release.yml` lines 44–45 (`github.com/cyoda-platform/cyoda-go` module path in `go list -m` and `release-preflight --org`). The Go module identifier is **immutable** once published and is independent of the GitHub URL — modifying it would break every downstream consumer.
- Stale comments referencing the old org in `release.yml` line 28 / 105 and `release-smoke.yml` line 101 — harmless documentation drift, not load-bearing.

## Test plan

- [x] `grep -c cyoda-platform .goreleaser.yaml` → `0` (was 7)
- [x] `grep -n cyoda-platform .github/workflows/release.yml` → only Go-module-path lines + comments remain
- [x] Pipeline already proven working on `release/v0.7.x` → v0.7.4 published with all 34 signed artifacts.

## Forward-port chain

- ✅ `release/v0.7.x` — shipped as v0.7.4
- ⏳ `release/v0.8.0` — this PR
- ⏳ `main` — follow-up PR; will be cherry-picked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)