### PR TITLE
fix(test): unbuffered FaultInjectingKV pause channel (fix intermittent race deadlock)

### DIFF
--- a/internal/auth/oidc/fault_kv_test.go
+++ b/internal/auth/oidc/fault_kv_test.go
@@ -39,11 +39,17 @@ func NewFaultInjectingKV(inner spi.KeyValueStore) *FaultInjectingKV {
 //
 // When the corresponding operation completes, the wrapper sends on the returned
 // channel (signalling the test "op is done") and then blocks reading from the
-// same channel (waiting for the test to send "you may continue"). The channel
-// is buffered with capacity 1 so the test can send without blocking if it
-// resumes immediately.
+// same channel (waiting for the test to send "you may continue").
+//
+// The channel is UNBUFFERED so both handshakes are true rendezvous. A buffered
+// channel is unsafe here: maybeWait sends then immediately receives on the same
+// channel, so with a buffer the worker goroutine can consume its own signal back
+// before the test receives it — leaving the test's receive blocked forever (an
+// intermittent deadlock under randomized scheduling). An unbuffered send cannot
+// complete without a distinct receiver, so the worker can never satisfy its own
+// wait.
 func (k *FaultInjectingKV) PauseAt(opName string) chan struct{} {
-	ch := make(chan struct{}, 1)
+	ch := make(chan struct{})
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	k.pauseAfter[opName] = ch


### PR DESCRIPTION
## Problem

`make race` on `release/v0.8.0` intermittently times out (CI run 28045729352): `TestFaultInjectingKV_PauseAtPut` hangs for the full 15m. The same job passes on most runs and locally — a scheduling-dependent deadlock surfaced by the race detector, not a regression.

## Root cause

`FaultInjectingKV.PauseAt` (`internal/auth/oidc/fault_kv_test.go`, introduced in #284) returns a **buffered cap-1** channel used for a two-way handshake. `maybeWait` does `ch <- struct{}{}` immediately followed by `<-ch` on that same channel. If the worker goroutine reaches its own `<-ch` before the test's `<-ch` runs, it **consumes its own signal** back, returns, and the test's receive then blocks forever. The common case works only because the test is usually already parked on `<-ch` when the worker sends (Go hands off directly to a waiting receiver); under the race detector's randomized scheduling that ordering isn't guaranteed.

## Fix

Make the handshake channel **unbuffered**. An unbuffered send cannot complete without a distinct receiver, so the worker can never satisfy its own wait — each handshake becomes a true rendezvous. One-line change plus an explanatory comment. No production code touched (test helper only).

## Verification

- `go test -race -run TestFaultInjectingKV -count=500 ./internal/auth/oidc/` — clean.
- `go test -race ./internal/auth/oidc/` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)