### PR TITLE
fix(ci): use client-id for Homebrew tap App token (app-id deprecated)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,12 @@ jobs:
         id: homebrew-tap-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.HOMEBREW_TAP_APP_ID }}
+          # actions/create-github-app-token deprecated `app-id` in favour of
+          # `client-id` (the App's Client ID, e.g. Iv23..., NOT the numeric App
+          # ID). Requires the repo Actions variable HOMEBREW_TAP_CLIENT_ID to be
+          # set to the tap App's Client ID. The old numeric HOMEBREW_TAP_APP_ID
+          # variable is now unused and can be removed.
+          client-id: ${{ vars.HOMEBREW_TAP_CLIENT_ID }}
           private-key: ${{ secrets.HOMEBREW_TAP_APP_KEY }}
           owner: cyoda
           repositories: homebrew-cyoda-go


### PR DESCRIPTION
Clears the deprecation warning from the v0.8.1 release: `actions/create-github-app-token@v3` deprecated `app-id` in favour of `client-id`.

## ⚠️ Prerequisite before merging
`client-id` needs the App's **Client ID** (e.g. `Iv23…`), which is a *different* value than the numeric App ID. **Add a repo Actions variable `HOMEBREW_TAP_CLIENT_ID`** = the tap App's Client ID (GitHub App settings → Client ID) **before merging**. Without it, the next release's Homebrew-tap push fails on an empty token.

After merge, the old `HOMEBREW_TAP_APP_ID` variable is unused and can be deleted.

No effect on the already-published v0.8.1 — this only matters for the next release cycle.