### PR TITLE
feat: entity partial-update (PATCH / RFC 7386 merge patch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Cyoda-Go
 
-Lightweight, multi-node Go digital twin of the Cyoda platform.
-Goal: API and behavioral fidelity with Cyoda Cloud.
+Lightweight, multi-node Go implementation of the Cyoda platform.
+cyoda-go defines the API and integration contract; Cyoda Cloud aligns to it.
 
 ## Development Gates
 

--- a/api/generated.go
+++ b/api/generated.go
@@ -1522,6 +1522,24 @@ func (e UpdateCollectionParamsFormat) Valid() bool {
 	}
 }
 
+// Defines values for PatchSingleWithLoopbackParamsFormat.
+const (
+	PatchSingleWithLoopbackParamsFormatJSON PatchSingleWithLoopbackParamsFormat = "JSON"
+	PatchSingleWithLoopbackParamsFormatXML  PatchSingleWithLoopbackParamsFormat = "XML"
+)
+
+// Valid indicates whether the value is a known member of the PatchSingleWithLoopbackParamsFormat enum.
+func (e PatchSingleWithLoopbackParamsFormat) Valid() bool {
+	switch e {
+	case PatchSingleWithLoopbackParamsFormatJSON:
+		return true
+	case PatchSingleWithLoopbackParamsFormatXML:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for UpdateSingleWithLoopbackParamsFormat.
 const (
 	UpdateSingleWithLoopbackParamsFormatJSON UpdateSingleWithLoopbackParamsFormat = "JSON"
@@ -1534,6 +1552,24 @@ func (e UpdateSingleWithLoopbackParamsFormat) Valid() bool {
 	case UpdateSingleWithLoopbackParamsFormatJSON:
 		return true
 	case UpdateSingleWithLoopbackParamsFormatXML:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for PatchSingleParamsFormat.
+const (
+	PatchSingleParamsFormatJSON PatchSingleParamsFormat = "JSON"
+	PatchSingleParamsFormatXML  PatchSingleParamsFormat = "XML"
+)
+
+// Valid indicates whether the value is a known member of the PatchSingleParamsFormat enum.
+func (e PatchSingleParamsFormat) Valid() bool {
+	switch e {
+	case PatchSingleParamsFormatJSON:
+		return true
+	case PatchSingleParamsFormatXML:
 		return true
 	default:
 		return false
@@ -3439,6 +3475,21 @@ type UpdateCollectionParams struct {
 // UpdateCollectionParamsFormat defines parameters for UpdateCollection.
 type UpdateCollectionParamsFormat string
 
+// PatchSingleWithLoopbackApplicationJSONPatchPlusJSONBody defines parameters for PatchSingleWithLoopback.
+type PatchSingleWithLoopbackApplicationJSONPatchPlusJSONBody = []map[string]interface{}
+
+// PatchSingleWithLoopbackApplicationMergePatchPlusJSONBody defines parameters for PatchSingleWithLoopback.
+type PatchSingleWithLoopbackApplicationMergePatchPlusJSONBody = map[string]interface{}
+
+// PatchSingleWithLoopbackParams defines parameters for PatchSingleWithLoopback.
+type PatchSingleWithLoopbackParams struct {
+	// IfMatch transactionId from the last read, or "*" for unconditional. Absent returns 428.
+	IfMatch *string `json:"If-Match,omitempty"`
+}
+
+// PatchSingleWithLoopbackParamsFormat defines parameters for PatchSingleWithLoopback.
+type PatchSingleWithLoopbackParamsFormat string
+
 // UpdateSingleWithLoopbackJSONBody defines parameters for UpdateSingleWithLoopback.
 type UpdateSingleWithLoopbackJSONBody = map[string]interface{}
 
@@ -3467,6 +3518,21 @@ type UpdateSingleWithLoopbackParams struct {
 
 // UpdateSingleWithLoopbackParamsFormat defines parameters for UpdateSingleWithLoopback.
 type UpdateSingleWithLoopbackParamsFormat string
+
+// PatchSingleApplicationJSONPatchPlusJSONBody defines parameters for PatchSingle.
+type PatchSingleApplicationJSONPatchPlusJSONBody = []map[string]interface{}
+
+// PatchSingleApplicationMergePatchPlusJSONBody defines parameters for PatchSingle.
+type PatchSingleApplicationMergePatchPlusJSONBody = map[string]interface{}
+
+// PatchSingleParams defines parameters for PatchSingle.
+type PatchSingleParams struct {
+	// IfMatch transactionId from the last read, or "*" for unconditional. Absent returns 428.
+	IfMatch *string `json:"If-Match,omitempty"`
+}
+
+// PatchSingleParamsFormat defines parameters for PatchSingle.
+type PatchSingleParamsFormat string
 
 // UpdateSingleJSONBody defines parameters for UpdateSingle.
 type UpdateSingleJSONBody = map[string]interface{}
@@ -3688,8 +3754,20 @@ type CreateCollectionJSONRequestBody = CreateCollectionJSONBody
 // UpdateCollectionJSONRequestBody defines body for UpdateCollection for application/json ContentType.
 type UpdateCollectionJSONRequestBody = UpdateCollectionJSONBody
 
+// PatchSingleWithLoopbackApplicationJSONPatchPlusJSONRequestBody defines body for PatchSingleWithLoopback for application/json-patch+json ContentType.
+type PatchSingleWithLoopbackApplicationJSONPatchPlusJSONRequestBody = PatchSingleWithLoopbackApplicationJSONPatchPlusJSONBody
+
+// PatchSingleWithLoopbackApplicationMergePatchPlusJSONRequestBody defines body for PatchSingleWithLoopback for application/merge-patch+json ContentType.
+type PatchSingleWithLoopbackApplicationMergePatchPlusJSONRequestBody = PatchSingleWithLoopbackApplicationMergePatchPlusJSONBody
+
 // UpdateSingleWithLoopbackJSONRequestBody defines body for UpdateSingleWithLoopback for application/json ContentType.
 type UpdateSingleWithLoopbackJSONRequestBody = UpdateSingleWithLoopbackJSONBody
+
+// PatchSingleApplicationJSONPatchPlusJSONRequestBody defines body for PatchSingle for application/json-patch+json ContentType.
+type PatchSingleApplicationJSONPatchPlusJSONRequestBody = PatchSingleApplicationJSONPatchPlusJSONBody
+
+// PatchSingleApplicationMergePatchPlusJSONRequestBody defines body for PatchSingle for application/merge-patch+json ContentType.
+type PatchSingleApplicationMergePatchPlusJSONRequestBody = PatchSingleApplicationMergePatchPlusJSONBody
 
 // UpdateSingleJSONRequestBody defines body for UpdateSingle for application/json ContentType.
 type UpdateSingleJSONRequestBody = UpdateSingleJSONBody
@@ -4782,9 +4860,15 @@ type ServerInterface interface {
 	// Update Collection
 	// (PUT /entity/{format})
 	UpdateCollection(w http.ResponseWriter, r *http.Request, format UpdateCollectionParamsFormat, params UpdateCollectionParams)
+	// Patch Single with a loopback transition
+	// (PATCH /entity/{format}/{entityId})
+	PatchSingleWithLoopback(w http.ResponseWriter, r *http.Request, format PatchSingleWithLoopbackParamsFormat, entityId openapi_types.UUID, params PatchSingleWithLoopbackParams)
 	// Update Single with a loopback transition
 	// (PUT /entity/{format}/{entityId})
 	UpdateSingleWithLoopback(w http.ResponseWriter, r *http.Request, format UpdateSingleWithLoopbackParamsFormat, entityId openapi_types.UUID, params UpdateSingleWithLoopbackParams)
+	// Patch Single
+	// (PATCH /entity/{format}/{entityId}/{transition})
+	PatchSingle(w http.ResponseWriter, r *http.Request, format PatchSingleParamsFormat, entityId openapi_types.UUID, transition string, params PatchSingleParams)
 	// Update Single
 	// (PUT /entity/{format}/{entityId}/{transition})
 	UpdateSingle(w http.ResponseWriter, r *http.Request, format UpdateSingleParamsFormat, entityId openapi_types.UUID, transition string, params UpdateSingleParams)
@@ -6021,6 +6105,71 @@ func (siw *ServerInterfaceWrapper) UpdateCollection(w http.ResponseWriter, r *ht
 	handler.ServeHTTP(w, r)
 }
 
+// PatchSingleWithLoopback operation middleware
+func (siw *ServerInterfaceWrapper) PatchSingleWithLoopback(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "format" -------------
+	var format PatchSingleWithLoopbackParamsFormat
+
+	err = runtime.BindStyledParameterWithOptions("simple", "format", r.PathValue("format"), &format, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "format", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "entityId" -------------
+	var entityId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "entityId", r.PathValue("entityId"), &entityId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "entityId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PatchSingleWithLoopbackParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "If-Match", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "If-Match", valueList[0], &IfMatch, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "If-Match", Err: err})
+			return
+		}
+
+		params.IfMatch = &IfMatch
+
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PatchSingleWithLoopback(w, r, format, entityId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // UpdateSingleWithLoopback operation middleware
 func (siw *ServerInterfaceWrapper) UpdateSingleWithLoopback(w http.ResponseWriter, r *http.Request) {
 
@@ -6103,6 +6252,80 @@ func (siw *ServerInterfaceWrapper) UpdateSingleWithLoopback(w http.ResponseWrite
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateSingleWithLoopback(w, r, format, entityId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PatchSingle operation middleware
+func (siw *ServerInterfaceWrapper) PatchSingle(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "format" -------------
+	var format PatchSingleParamsFormat
+
+	err = runtime.BindStyledParameterWithOptions("simple", "format", r.PathValue("format"), &format, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "format", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "entityId" -------------
+	var entityId openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "entityId", r.PathValue("entityId"), &entityId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: "uuid"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "entityId", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "transition" -------------
+	var transition string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "transition", r.PathValue("transition"), &transition, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "transition", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PatchSingleParams
+
+	headers := r.Header
+
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch string
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "If-Match", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "If-Match", valueList[0], &IfMatch, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: false, Type: "string", Format: ""})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "If-Match", Err: err})
+			return
+		}
+
+		params.IfMatch = &IfMatch
+
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PatchSingle(w, r, format, entityId, transition, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -8058,7 +8281,9 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc(http.MethodGet+" "+options.BaseURL+"/entity/{entityName}/{modelVersion}", wrapper.GetAllEntities)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/entity/{format}", wrapper.CreateCollection)
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/entity/{format}", wrapper.UpdateCollection)
+	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/entity/{format}/{entityId}", wrapper.PatchSingleWithLoopback)
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/entity/{format}/{entityId}", wrapper.UpdateSingleWithLoopback)
+	m.HandleFunc(http.MethodPatch+" "+options.BaseURL+"/entity/{format}/{entityId}/{transition}", wrapper.PatchSingle)
 	m.HandleFunc(http.MethodPut+" "+options.BaseURL+"/entity/{format}/{entityId}/{transition}", wrapper.UpdateSingle)
 	m.HandleFunc(http.MethodPost+" "+options.BaseURL+"/entity/{format}/{entityName}/{modelVersion}", wrapper.Create)
 	m.HandleFunc(http.MethodDelete+" "+options.BaseURL+"/message", wrapper.DeleteMessages)

--- a/api/generated.go
+++ b/api/generated.go
@@ -3483,6 +3483,23 @@ type PatchSingleWithLoopbackApplicationMergePatchPlusJSONBody = map[string]inter
 
 // PatchSingleWithLoopbackParams defines parameters for PatchSingleWithLoopback.
 type PatchSingleWithLoopbackParams struct {
+	// TransactionTimeoutMillis Maximum time in milliseconds allowed for transaction completion.
+	// Operation will fail if it takes longer than this timeout.
+	// Accepted for Cyoda Cloud API parity. Behavior is
+	// storage-engine-plugin dependent — not every plugin honors this
+	// field; consult the runtime plugin's documentation for the
+	// supported behavior.
+	TransactionTimeoutMillis *int64 `form:"transactionTimeoutMillis,omitempty" json:"transactionTimeoutMillis,omitempty"`
+
+	// WaitForConsistencyAfter If true, waits for the consistency time to pass before responding.
+	// May increase response time but guarantees data consistency when
+	// returning, so that subsequent calls will see the updated data.
+	// Accepted for Cyoda Cloud API parity. Behavior is
+	// storage-engine-plugin dependent — not every plugin honors this
+	// field; consult the runtime plugin's documentation for the
+	// supported behavior.
+	WaitForConsistencyAfter *bool `form:"waitForConsistencyAfter,omitempty" json:"waitForConsistencyAfter,omitempty"`
+
 	// IfMatch transactionId from the last read, or "*" for unconditional. Absent returns 428.
 	IfMatch *string `json:"If-Match,omitempty"`
 }
@@ -3527,6 +3544,23 @@ type PatchSingleApplicationMergePatchPlusJSONBody = map[string]interface{}
 
 // PatchSingleParams defines parameters for PatchSingle.
 type PatchSingleParams struct {
+	// TransactionTimeoutMillis Maximum time in milliseconds allowed for transaction completion.
+	// Operation will fail if it takes longer than this timeout.
+	// Accepted for Cyoda Cloud API parity. Behavior is
+	// storage-engine-plugin dependent — not every plugin honors this
+	// field; consult the runtime plugin's documentation for the
+	// supported behavior.
+	TransactionTimeoutMillis *int64 `form:"transactionTimeoutMillis,omitempty" json:"transactionTimeoutMillis,omitempty"`
+
+	// WaitForConsistencyAfter If true, waits for the consistency time to pass before responding.
+	// May increase response time but guarantees data consistency when
+	// returning, so that subsequent calls will see the updated data.
+	// Accepted for Cyoda Cloud API parity. Behavior is
+	// storage-engine-plugin dependent — not every plugin honors this
+	// field; consult the runtime plugin's documentation for the
+	// supported behavior.
+	WaitForConsistencyAfter *bool `form:"waitForConsistencyAfter,omitempty" json:"waitForConsistencyAfter,omitempty"`
+
 	// IfMatch transactionId from the last read, or "*" for unconditional. Absent returns 428.
 	IfMatch *string `json:"If-Match,omitempty"`
 }
@@ -6138,6 +6172,32 @@ func (siw *ServerInterfaceWrapper) PatchSingleWithLoopback(w http.ResponseWriter
 	// Parameter object where we will unmarshal all parameters from the context
 	var params PatchSingleWithLoopbackParams
 
+	// ------------- Optional query parameter "transactionTimeoutMillis" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "transactionTimeoutMillis", r.URL.Query(), &params.TransactionTimeoutMillis, runtime.BindQueryParameterOptions{Type: "integer", Format: "int64"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "transactionTimeoutMillis"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "transactionTimeoutMillis", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "waitForConsistencyAfter" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "waitForConsistencyAfter", r.URL.Query(), &params.WaitForConsistencyAfter, runtime.BindQueryParameterOptions{Type: "boolean", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "waitForConsistencyAfter"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "waitForConsistencyAfter", Err: err})
+		}
+		return
+	}
+
 	headers := r.Header
 
 	// ------------- Optional header parameter "If-Match" -------------
@@ -6302,6 +6362,32 @@ func (siw *ServerInterfaceWrapper) PatchSingle(w http.ResponseWriter, r *http.Re
 
 	// Parameter object where we will unmarshal all parameters from the context
 	var params PatchSingleParams
+
+	// ------------- Optional query parameter "transactionTimeoutMillis" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "transactionTimeoutMillis", r.URL.Query(), &params.TransactionTimeoutMillis, runtime.BindQueryParameterOptions{Type: "integer", Format: "int64"})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "transactionTimeoutMillis"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "transactionTimeoutMillis", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "waitForConsistencyAfter" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "waitForConsistencyAfter", r.URL.Query(), &params.WaitForConsistencyAfter, runtime.BindQueryParameterOptions{Type: "boolean", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "waitForConsistencyAfter"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "waitForConsistencyAfter", Err: err})
+		}
+		return
+	}
 
 	headers := r.Header
 

--- a/api/grpc/events/types.go
+++ b/api/grpc/events/types.go
@@ -2,12 +2,10 @@
 
 package events
 
-import (
-	"encoding/json"
-	"fmt"
-	"reflect"
-	"time"
-)
+import "encoding/json"
+import "fmt"
+import "reflect"
+import "time"
 
 type BaseEventJson struct {
 	// Error details (if present).
@@ -2389,6 +2387,126 @@ func (j *EntityModelTransitionResponseJson) UnmarshalJSON(value []byte) error {
 	return nil
 }
 
+type EntityPatchPayloadJson struct {
+	// ID of the entity to patch.
+	EntityID string `json:"entityId" yaml:"entityId" mapstructure:"entityId"`
+
+	// transactionId from the last read, or "*" for unconditional. Empty is rejected
+	// as precondition-required.
+	IfMatch *string `json:"ifMatch,omitempty" yaml:"ifMatch,omitempty" mapstructure:"ifMatch,omitempty"`
+
+	// The patch document (RFC 7386 merge patch).
+	Patch interface{} `json:"patch" yaml:"patch" mapstructure:"patch"`
+
+	// Transition to apply, or omit for loopback.
+	Transition *string `json:"transition,omitempty" yaml:"transition,omitempty" mapstructure:"transition,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *EntityPatchPayloadJson) UnmarshalJSON(value []byte) error {
+	var raw map[string]interface{}
+	if err := decodeWithUseNumber(value, &raw); err != nil {
+		return err
+	}
+	if _, ok := raw["entityId"]; raw != nil && !ok {
+		return fmt.Errorf("field entityId in EntityPatchPayloadJson: required")
+	}
+	if _, ok := raw["patch"]; raw != nil && !ok {
+		return fmt.Errorf("field patch in EntityPatchPayloadJson: required")
+	}
+	type Plain EntityPatchPayloadJson
+	var plain Plain
+	if err := decodeWithUseNumber(value, &plain); err != nil {
+		return err
+	}
+	*j = EntityPatchPayloadJson(plain)
+	return nil
+}
+
+type EntityPatchRequestJson struct {
+	// Error details (if present).
+	Error *EntityPatchRequestJsonError `json:"error,omitempty" yaml:"error,omitempty" mapstructure:"error,omitempty"`
+
+	// Event ID.
+	ID string `json:"id" yaml:"id" mapstructure:"id"`
+
+	// PatchFormat corresponds to the JSON schema field "patchFormat".
+	PatchFormat PatchFormatJson `json:"patchFormat" yaml:"patchFormat" mapstructure:"patchFormat"`
+
+	// Data payload containing the entity id and patch.
+	Payload EntityPatchPayloadJson `json:"payload" yaml:"payload" mapstructure:"payload"`
+
+	// Flag indicates whether this message relates to some failure.
+	Success bool `json:"success" yaml:"success,omitempty" mapstructure:"success,omitempty"`
+
+	// Indicates the timeout of transaction for transactional save.
+	TransactionTimeoutMs *int `json:"transactionTimeoutMs,omitempty" yaml:"transactionTimeoutMs,omitempty" mapstructure:"transactionTimeoutMs,omitempty"`
+
+	// Warnings (if applicable).
+	Warnings []string `json:"warnings,omitempty" yaml:"warnings,omitempty" mapstructure:"warnings,omitempty"`
+}
+
+// Error details (if present).
+type EntityPatchRequestJsonError struct {
+	// Error code.
+	Code string `json:"code" yaml:"code" mapstructure:"code"`
+
+	// Error message.
+	Message string `json:"message" yaml:"message" mapstructure:"message"`
+
+	// Flag indicates whether this error is retryable (for example, whether cyoda
+	// should retry the calculation request).
+	Retryable *bool `json:"retryable,omitempty" yaml:"retryable,omitempty" mapstructure:"retryable,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *EntityPatchRequestJsonError) UnmarshalJSON(value []byte) error {
+	var raw map[string]interface{}
+	if err := decodeWithUseNumber(value, &raw); err != nil {
+		return err
+	}
+	if _, ok := raw["code"]; raw != nil && !ok {
+		return fmt.Errorf("field code in EntityPatchRequestJsonError: required")
+	}
+	if _, ok := raw["message"]; raw != nil && !ok {
+		return fmt.Errorf("field message in EntityPatchRequestJsonError: required")
+	}
+	type Plain EntityPatchRequestJsonError
+	var plain Plain
+	if err := decodeWithUseNumber(value, &plain); err != nil {
+		return err
+	}
+	*j = EntityPatchRequestJsonError(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *EntityPatchRequestJson) UnmarshalJSON(value []byte) error {
+	var raw map[string]interface{}
+	if err := decodeWithUseNumber(value, &raw); err != nil {
+		return err
+	}
+	if _, ok := raw["id"]; raw != nil && !ok {
+		return fmt.Errorf("field id in EntityPatchRequestJson: required")
+	}
+	if _, ok := raw["patchFormat"]; raw != nil && !ok {
+		return fmt.Errorf("field patchFormat in EntityPatchRequestJson: required")
+	}
+	if _, ok := raw["payload"]; raw != nil && !ok {
+		return fmt.Errorf("field payload in EntityPatchRequestJson: required")
+	}
+	type Plain EntityPatchRequestJson
+	var plain Plain
+	if err := decodeWithUseNumber(value, &plain); err != nil {
+		return err
+	}
+	if v, ok := raw["success"]; !ok || v == nil {
+		plain.Success = true
+	}
+	*j = EntityPatchRequestJson(plain)
+	return nil
+}
+
 type EntityProcessorCalculationRequestJson struct {
 	// Entity ID.
 	EntityID string `json:"entityId" yaml:"entityId" mapstructure:"entityId"`
@@ -3906,6 +4024,36 @@ func (j *ModelSpecJson) UnmarshalJSON(value []byte) error {
 		return err
 	}
 	*j = ModelSpecJson(plain)
+	return nil
+}
+
+type PatchFormatJson string
+
+const PatchFormatJsonJSONPATCH PatchFormatJson = "JSON_PATCH"
+const PatchFormatJsonMERGEPATCH PatchFormatJson = "MERGE_PATCH"
+
+var enumValues_PatchFormatJson = []interface{}{
+	"MERGE_PATCH",
+	"JSON_PATCH",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *PatchFormatJson) UnmarshalJSON(value []byte) error {
+	var v string
+	if err := json.Unmarshal(value, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_PatchFormatJson {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_PatchFormatJson, v)
+	}
+	*j = PatchFormatJson(v)
 	return nil
 }
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2494,6 +2494,113 @@ paths:
           $ref: '#/components/responses/Forbidden'
         default:
           $ref: '#/components/responses/InternalServerError'
+    patch:
+      tags:
+        - Entity Management
+      summary: Patch Single with a loopback transition
+      description: |
+        Partially updates a single entity (RFC 7386 JSON Merge Patch) with a
+        loopback transition. Send only the fields that change; an explicit null
+        deletes a key. The merged result is validated against the model schema
+        and cannot introduce a new field (unlike PUT). The dialect is selected
+        by Content-Type: application/merge-patch+json (RFC 7386, implemented) or
+        application/json-patch+json (RFC 6902, not implemented -> 501).
+
+        If-Match is required in some form: the transactionId from your last GET
+        of this entity (conditional; 412 if it has moved), or "*" to accept
+        last-writer-wins. Its absence returns 428.
+      operationId: patchSingleWithLoopback
+      parameters:
+        - name: format
+          in: path
+          description: Must be JSON (merge patch is JSON only)
+          required: true
+          schema:
+            type: string
+            enum:
+              - JSON
+              - XML
+        - name: entityId
+          in: path
+          description: The UUID of the entity to patch
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: If-Match
+          in: header
+          description: transactionId from the last read, or "*" for unconditional. Absent returns 428.
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              type: object
+              format: json
+            examples:
+              MergePatch:
+                summary: Change one field
+                value:
+                  year: "2025"
+          application/json-patch+json:
+            schema:
+              type: array
+              items:
+                type: object
+      responses:
+        "200":
+          description: Entity patched successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityTransactionResponse"
+        "400":
+          description: Bad request — invalid patch or validation failure
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "404":
+          description: Entity not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "409":
+          description: Conflict — concurrent writer committed during the patch (retryable)
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "412":
+          description: Precondition Failed — If-Match transactionId no longer matches
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "415":
+          description: Unsupported Media Type — non-JSON format or unrecognised Content-Type
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "428":
+          description: Precondition Required — If-Match absent; supply a transactionId or "*"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "501":
+          $ref: '#/components/responses/NotImplemented'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
+        default:
+          $ref: '#/components/responses/InternalServerError'
   /entity/{format}/{entityId}/{transition}:
     put:
       tags:
@@ -2675,6 +2782,123 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
+        default:
+          $ref: '#/components/responses/InternalServerError'
+    patch:
+      tags:
+        - Entity Management
+      summary: Patch Single
+      description: |
+        Partially updates a single entity (RFC 7386 JSON Merge Patch) with a
+        named transition. Send only the fields that change; an explicit null
+        deletes a key. The merged result is validated against the model schema
+        and cannot introduce a new field (unlike PUT). The dialect is selected
+        by Content-Type: application/merge-patch+json (RFC 7386, implemented) or
+        application/json-patch+json (RFC 6902, not implemented -> 501).
+
+        If-Match is required in some form: the transactionId from your last GET
+        of this entity (conditional; 412 if it has moved), or "*" to accept
+        last-writer-wins. Its absence returns 428.
+      operationId: patchSingle
+      parameters:
+        - name: format
+          in: path
+          description: Must be JSON (merge patch is JSON only)
+          required: true
+          schema:
+            type: string
+            enum:
+              - JSON
+              - XML
+        - name: entityId
+          in: path
+          description: The UUID of the entity to patch
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: transition
+          in: path
+          description: The transition state to apply to the entity (e.g., 'UPDATE',
+            'PUBLISH')
+          required: true
+          schema:
+            type: string
+            maxLength: 1024
+            minLength: 1
+          example: UPDATE
+        - name: If-Match
+          in: header
+          description: transactionId from the last read, or "*" for unconditional. Absent returns 428.
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              type: object
+              format: json
+            examples:
+              MergePatch:
+                summary: Change one field
+                value:
+                  year: "2025"
+          application/json-patch+json:
+            schema:
+              type: array
+              items:
+                type: object
+      responses:
+        "200":
+          description: Entity patched successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityTransactionResponse"
+        "400":
+          description: Bad request — invalid patch or validation failure
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "404":
+          description: Entity not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "409":
+          description: Conflict — concurrent writer committed during the patch (retryable)
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "412":
+          description: Precondition Failed — If-Match transactionId no longer matches
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "415":
+          description: Unsupported Media Type — non-JSON format or unrecognised Content-Type
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "428":
+          description: Precondition Required — If-Match absent; supply a transactionId or "*"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "501":
+          $ref: '#/components/responses/NotImplemented'
         "401":
           $ref: '#/components/responses/Unauthorized'
         "403":

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2533,6 +2533,36 @@ paths:
           required: false
           schema:
             type: string
+        - name: transactionTimeoutMillis
+          in: query
+          description: |
+            Maximum time in milliseconds allowed for transaction completion.
+            Operation will fail if it takes longer than this timeout.
+            Accepted for Cyoda Cloud API parity. Behavior is
+            storage-engine-plugin dependent — not every plugin honors this
+            field; consult the runtime plugin's documentation for the
+            supported behavior.
+          required: false
+          schema:
+            type: integer
+            format: int64
+            default: 10000
+          example: 30000
+        - name: waitForConsistencyAfter
+          in: query
+          description: |
+            If true, waits for the consistency time to pass before responding.
+            May increase response time but guarantees data consistency when
+            returning, so that subsequent calls will see the updated data.
+            Accepted for Cyoda Cloud API parity. Behavior is
+            storage-engine-plugin dependent — not every plugin honors this
+            field; consult the runtime plugin's documentation for the
+            supported behavior.
+          required: false
+          schema:
+            type: boolean
+            default: false
+          example: true
       requestBody:
         required: true
         content:
@@ -2837,6 +2867,36 @@ paths:
           required: false
           schema:
             type: string
+        - name: transactionTimeoutMillis
+          in: query
+          description: |
+            Maximum time in milliseconds allowed for transaction completion.
+            Operation will fail if it takes longer than this timeout.
+            Accepted for Cyoda Cloud API parity. Behavior is
+            storage-engine-plugin dependent — not every plugin honors this
+            field; consult the runtime plugin's documentation for the
+            supported behavior.
+          required: false
+          schema:
+            type: integer
+            format: int64
+            default: 10000
+          example: 30000
+        - name: waitForConsistencyAfter
+          in: query
+          description: |
+            If true, waits for the consistency time to pass before responding.
+            May increase response time but guarantees data consistency when
+            returning, so that subsequent calls will see the updated data.
+            Accepted for Cyoda Cloud API parity. Behavior is
+            storage-engine-plugin dependent — not every plugin honors this
+            field; consult the runtime plugin's documentation for the
+            supported behavior.
+          required: false
+          schema:
+            type: boolean
+            default: false
+          example: true
       requestBody:
         required: true
         content:

--- a/cmd/cyoda/help/content/crud.md
+++ b/cmd/cyoda/help/content/crud.md
@@ -248,7 +248,7 @@ Response: `200 OK`, `application/json`, `EntityTransactionResponse` array — on
 - `format` (path): `JSON` only — Merge Patch is JSON-only by RFC 7386; `XML` ⇒ `415 Unsupported Media Type`
 - `entityId` (path): UUID
 - `Content-Type` (header, required): `application/merge-patch+json` (RFC 7386 merge patch, implemented) or `application/json-patch+json` (RFC 6902, returns `501 Not Implemented`); any other value ⇒ `415 Unsupported Media Type`
-- `If-Match` (header, required in some form): see the three-state table below
+- `If-Match` (header, required in some form): see the three-state list below
 - `transactionTimeoutMillis` (query, optional): int64, default `10000` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.
 - `waitForConsistencyAfter` (query, optional): boolean, default `false` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.
 
@@ -276,7 +276,7 @@ Response: `200 OK`, same shape as the single-item PUT update.
 - `entityId` (path): UUID
 - `transition` (path): string — transition name defined in the model's workflow
 - `Content-Type` (header, required): same two-value table as the loopback form
-- `If-Match` (header, required in some form): same three-state table as the loopback form
+- `If-Match` (header, required in some form): same three-state list as the loopback form
 - `transactionTimeoutMillis` (query, optional): int64, default `10000` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.
 - `waitForConsistencyAfter` (query, optional): boolean, default `false` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.
 

--- a/cmd/cyoda/help/content/crud.md
+++ b/cmd/cyoda/help/content/crud.md
@@ -33,6 +33,8 @@ GET    /api/entity/{entityId}
 PUT    /api/entity/{format}/{entityId}
 PUT    /api/entity/{format}/{entityId}/{transition}
 PUT    /api/entity/{format}
+PATCH  /api/entity/{format}/{entityId}
+PATCH  /api/entity/{format}/{entityId}/{transition}
 DELETE /api/entity/{entityId}
 DELETE /api/entity/{entityName}/{modelVersion}
 GET    /api/entity/{entityName}/{modelVersion}
@@ -240,6 +242,61 @@ Response: `200 OK`, `application/json`, `EntityTransactionResponse` array — on
 ```
 
 `itemIndex` is the failing item's zero-based position within its chunk's request slice (per-chunk relative). When every item in a chunk fails its `ifMatch` precondition, the chunk still commits as a zero-write transaction — `entityIds` is empty, `failed[]` lists every item, and `transactionId` remains meaningful for audit correlation.
+
+**PATCH /api/entity/{format}/{entityId}** — Partial update of a single entity (loopback transition)
+
+- `format` (path): `JSON` only — Merge Patch is JSON-only by RFC 7386; `XML` ⇒ `415 Unsupported Media Type`
+- `entityId` (path): UUID
+- `Content-Type` (header, required): `application/merge-patch+json` (RFC 7386 merge patch, implemented) or `application/json-patch+json` (RFC 6902, returns `501 Not Implemented`); any other value ⇒ `415 Unsupported Media Type`
+- `If-Match` (header, required in some form): see the three-state table below
+- `transactionTimeoutMillis` (query, optional): int64, default `10000` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.
+- `waitForConsistencyAfter` (query, optional): boolean, default `false` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.
+
+Request body: a sparse JSON object (the patch document). The patch is applied to the **stored** entity payload using RFC 7386 merge semantics:
+
+- A key present in the patch with a non-null value overwrites the target key.
+- A key whose value is itself an object merges recursively.
+- A key present in the patch with an explicit `null` value deletes that key from the stored payload.
+- Arrays are replaced wholesale — there are no element-level operations.
+- The empty patch `{}` is a valid no-op merge: the data is unchanged, but the request still commits a new transaction and fires the loopback transition (consistent with PUT-with-empty-body).
+
+**If-Match precondition (required).** Unlike `PUT`, where omitting `If-Match` means unconditional replace, PATCH requires `If-Match` to be present in some form, because the merge is applied relative to a base the caller read; silently patching a stale base risks lost updates. The token is the `meta.transactionId` from the caller's last `GET` of this entity — the same field the existing `PUT` `If-Match` uses.
+
+Three states are accepted:
+
+- `If-Match: "<transactionId>"` — Conditional: the stored entity's `transactionId` must still match; returns `412 Precondition Failed` if it has moved since the caller's read.
+- `If-Match: *` — Unconditional opt-out: merge onto current state regardless of version (entity must exist); a concurrent-writer race can still surface as `409` (see below).
+- Absent — returns `428 Precondition Required`; the response body explains the two valid choices.
+
+Response: `200 OK`, same shape as the single-item PUT update.
+
+**PATCH /api/entity/{format}/{entityId}/{transition}** — Partial update of a single entity with a named transition
+
+- `format` (path): `JSON` only
+- `entityId` (path): UUID
+- `transition` (path): string — transition name defined in the model's workflow
+- `Content-Type` (header, required): same two-value table as the loopback form
+- `If-Match` (header, required in some form): same three-state table as the loopback form
+- `transactionTimeoutMillis` (query, optional): int64, default `10000` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.
+- `waitForConsistencyAfter` (query, optional): boolean, default `false` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.
+
+The merge patch is applied first; the named transition's processors then run on the merged state and may further mutate the entity. Response: `200 OK`, same shape as the loopback form.
+
+**Two behaviours to be aware of:**
+
+1. **Strict validation.** The merged result is validated strictly against the model schema — the model is never extended, regardless of its `ChangeLevel`. A PATCH cannot introduce a field that the schema does not already allow, even when the model is in an extend-permitting mode. To add a genuinely new field, use `PUT` (which may extend the schema), then PATCH thereafter.
+
+2. **Processors run after the merge.** Under a named transition, the transition's processors run on the merged entity state and may overwrite fields the patch set. The observable result of a patch with a named transition is not guaranteed to retain the patched values when the transition has mutating processors. This is the same ordering as `PUT` plus a named transition.
+
+**Partial-update error codes:**
+
+- `404 Not Found` — entity does not exist
+- `409 Conflict` (retryable) — a concurrent writer committed between the in-transaction base read and this save (read-set conflict at commit); may occur even with `If-Match: *`; caller may retry
+- `412 Precondition Failed` — `If-Match: "<transactionId>"` supplied and the stored `transactionId` differs; see `errors.ENTITY_MODIFIED`
+- `415 Unsupported Media Type` — `XML` format, or a `Content-Type` other than the two patch media types
+- `428 Precondition Required` — no `If-Match` header present
+- `501 Not Implemented` — `Content-Type: application/json-patch+json` (RFC 6902 is recognised but not yet implemented)
+- Standard `4xx` domain errors — the **merged result** fails strict schema validation (full domain detail + error code)
 
 **DELETE /api/entity/{entityId}** — Delete a single entity by UUID
 

--- a/cmd/cyoda/help/content/crud.md
+++ b/cmd/cyoda/help/content/crud.md
@@ -275,7 +275,7 @@ Response: `200 OK`, same shape as the single-item PUT update.
 - `format` (path): `JSON` only
 - `entityId` (path): UUID
 - `transition` (path): string — transition name defined in the model's workflow
-- `Content-Type` (header, required): same two-value table as the loopback form
+- `Content-Type` (header, required): same two-value list as the loopback form
 - `If-Match` (header, required in some form): same three-state list as the loopback form
 - `transactionTimeoutMillis` (query, optional): int64, default `10000` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.
 - `waitForConsistencyAfter` (query, optional): boolean, default `false` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.

--- a/cmd/cyoda/help/content/errors/PRECONDITION_REQUIRED.md
+++ b/cmd/cyoda/help/content/errors/PRECONDITION_REQUIRED.md
@@ -1,0 +1,42 @@
+---
+topic: errors.PRECONDITION_REQUIRED
+title: "PRECONDITION_REQUIRED — PATCH request missing required If-Match header"
+stability: stable
+see_also:
+  - errors
+  - errors.ENTITY_MODIFIED
+  - errors.BAD_REQUEST
+---
+
+# errors.PRECONDITION_REQUIRED
+
+## NAME
+
+PRECONDITION_REQUIRED — a PATCH request was submitted without an `If-Match` header, which is mandatory for patch operations.
+
+## SYNOPSIS
+
+HTTP: `428` `Precondition Required`. Retryable: `no`.
+
+## DESCRIPTION
+
+PATCH applies a merge patch to the entity's stored state rather than replacing it wholesale. Because the patch is applied relative to the current stored data, cyoda-go requires the caller to state a precondition explicitly via `If-Match`. Omitting the header entirely is rejected.
+
+This behaviour is specific to PATCH. A PUT without `If-Match` is treated as an unconditional replace and is accepted.
+
+Not retryable as-is — the same request without an `If-Match` header produces the same error.
+
+## RECOVERY
+
+Add an `If-Match` header to the PATCH request. Two modes are supported:
+
+- **Conditional patch** — supply the `transactionId` obtained from your most recent GET of the entity as the `If-Match` value. The patch is applied only if the entity has not changed since that read; a `412 ENTITY_MODIFIED` is returned if another writer has committed in the meantime.
+- **Unconditional patch (last-writer-wins)** — supply `If-Match: *` to explicitly accept that the patch will be applied to whatever the current stored state is, without a version check.
+
+Choose the conditional form when you need to detect concurrent modifications; choose `*` when you intentionally want last-writer-wins semantics and have already decided the patch is safe to apply regardless of concurrent changes.
+
+## SEE ALSO
+
+- errors
+- errors.ENTITY_MODIFIED
+- errors.BAD_REQUEST

--- a/cmd/cyoda/help/content/errors/UNSUPPORTED_MEDIA_TYPE.md
+++ b/cmd/cyoda/help/content/errors/UNSUPPORTED_MEDIA_TYPE.md
@@ -1,0 +1,40 @@
+---
+topic: errors.UNSUPPORTED_MEDIA_TYPE
+title: "UNSUPPORTED_MEDIA_TYPE — PATCH format or Content-Type not supported"
+stability: stable
+see_also:
+  - errors
+  - errors.NOT_IMPLEMENTED
+  - errors.BAD_REQUEST
+---
+
+# errors.UNSUPPORTED_MEDIA_TYPE
+
+## NAME
+
+UNSUPPORTED_MEDIA_TYPE — the PATCH request used a format or `Content-Type` that is not supported.
+
+## SYNOPSIS
+
+HTTP: `415` `Unsupported Media Type`. Retryable: `no`.
+
+## DESCRIPTION
+
+Returned by PATCH in two situations:
+
+- The `{format}` path segment is not `JSON`. Merge patch is JSON-only; other format values (e.g. `CSV`) are not accepted for PATCH requests.
+- The `Content-Type` header names a patch dialect that is not recognised. Only `application/merge-patch+json` (RFC 7386) is implemented.
+
+Note that `application/json-patch+json` (RFC 6902, JSON Patch) is a recognised dialect but is not implemented; requests using that content type receive `501 NOT_IMPLEMENTED`, not `415`.
+
+Not retryable as-is — the same request produces the same error until the format or content type is corrected.
+
+## RECOVERY
+
+Use `JSON` as the `{format}` path segment and set `Content-Type: application/merge-patch+json` in the request. Merge patch (RFC 7386) describes the delta as a JSON object whose keys are merged into the stored entity; keys present in the patch overwrite stored values, and keys explicitly set to `null` remove the field.
+
+## SEE ALSO
+
+- errors
+- errors.NOT_IMPLEMENTED
+- errors.BAD_REQUEST

--- a/docs/cloud-parity/README.md
+++ b/docs/cloud-parity/README.md
@@ -1,0 +1,22 @@
+# docs/cloud-parity — Cloud-facing implementation contracts
+
+cyoda-go **defines** the API and integration contract; Cyoda Cloud follows and
+mirrors it. This folder holds the Cloud-facing implementation specs — contracts
+written precisely enough for the Cyoda Cloud team to implement twin-alignment.
+
+There is no shared ticketing system across the two streams yet; this folder is
+the interim coordination surface. Each file in this folder describes a feature
+or behaviour that Cloud must implement to stay aligned with cyoda-go.
+
+## Relationship to cloud-divergences.md
+
+`../cyoda/cloud-divergences.md` is the **inverse vector**: fields cyoda-go
+*declares* in its OpenAPI spec but does not yet implement on the OSS server side.
+This folder is the opposite direction — behaviour cyoda-go *has implemented* that
+Cloud needs to adopt.
+
+## Contents
+
+| File | Covers |
+|---|---|
+| `entity-patch.md` | PATCH single-entity contract (RFC 7386 merge patch) |

--- a/docs/cloud-parity/entity-patch.md
+++ b/docs/cloud-parity/entity-patch.md
@@ -65,12 +65,11 @@ This is never referred to as "version".
 
 ### The 428 educational body
 
-The 428 response body must explain the two valid choices to the caller. Example:
+The 428 response body must explain the two valid choices to the caller. This is
+the message cyoda-go returns:
 
-> This entity was patched without stating which version you read.
-> Send `If-Match: <transactionId>` (the `transactionId` from your last GET of
-> this entity) to patch safely, or `If-Match: *` to explicitly accept
-> last-writer-wins.
+> missing If-Match: send `If-Match: <transactionId>` from your last GET of this
+> entity to patch safely, or `If-Match: *` to explicitly accept last-writer-wins
 
 The target audience is naive or LLM-generated clients that will not send
 `If-Match` unprompted. The body teaches the GET-first discipline.

--- a/docs/cloud-parity/entity-patch.md
+++ b/docs/cloud-parity/entity-patch.md
@@ -1,0 +1,224 @@
+# Entity PATCH contract — Cloud twin-alignment spec
+
+This document is the contract Cyoda Cloud implements to stay aligned with
+cyoda-go's entity partial-update (PATCH) feature. cyoda-go is the authoritative
+implementation; the behaviour described here is derived directly from its design
+spec and implemented code.
+
+## 1. Merge semantics — RFC 7386 (JSON Merge Patch)
+
+The request body is a **sparse JSON object** applied to the stored entity
+payload using the RFC 7386 `MergePatch` algorithm:
+
+- A key present in the patch with a **non-null value** overwrites that key in
+  the stored payload.
+- A key whose value is itself an **object** merges recursively.
+- A key present in the patch with an explicit **`null` value** deletes that key
+  from the stored payload.
+- **Arrays** are replaced wholesale — there are no element-level operations.
+- A **non-object** patch document (bare scalar, bare array) replaces the stored
+  payload entirely, per the RFC.
+- The **empty patch `{}`** is a valid no-op merge: the stored data is
+  unchanged, but the request still commits a new transaction and fires the
+  loopback or named transition. A patch that changes no data still advances
+  workflow state.
+
+The merge must operate on **number-preserving decoding** so that `int64` values
+larger than 2^53 survive a merge without `float64` coercion.
+
+### Strict validation
+
+The **merged result** is validated strictly against the model schema. PATCH
+**never** extends the model schema, regardless of the model's `ChangeLevel`
+setting. This is a deliberate divergence from PUT (which may extend the schema
+when `ChangeLevel` permits):
+
+**Hard limitation:** a PATCH can never introduce a field the model schema does
+not already allow — even when the model is in an extend-permitting `ChangeLevel`.
+To add a genuinely new field, callers must use PUT (which extends), then PATCH
+thereafter.
+
+Validation is applied to the merged result, not to the patch body alone. A
+`null`-deletion that removes a field the schema marks `required` fails
+validation; if the schema does not mark the field `required`, the deletion
+succeeds and the field is removed.
+
+### Merge-then-processor ordering
+
+When a named transition is supplied, **processors run after the merge** and may
+overwrite fields the patch set. The observable result of a PATCH with a
+mutating transition is not guaranteed to retain the patched values. This is
+identical to PUT-plus-transition.
+
+## 2. The `If-Match` precondition — three states
+
+`If-Match` is **required to be present in some form** on every PATCH request.
+The precondition token is the entity's **`transactionId`** — the `transactionId`
+from the caller's last read of this entity (stored in `_meta.transaction_id`).
+This is never referred to as "version".
+
+| `If-Match` value | Meaning | Outcome |
+|---|---|---|
+| `"<transactionId>"` | Conditional: the stored entity must still carry this transactionId as its merge base | **412 Precondition Failed** if the stored transactionId differs |
+| `*` | Unconditional opt-out: merge onto the current state, whatever it is | Proceeds (entity must exist); translated internally to a no-CAS save |
+| *absent* | — | **428 Precondition Required**; the error body is educational (see below) |
+
+### The 428 educational body
+
+The 428 response body must explain the two valid choices to the caller. Example:
+
+> This entity was patched without stating which version you read.
+> Send `If-Match: <transactionId>` (the `transactionId` from your last GET of
+> this entity) to patch safely, or `If-Match: *` to explicitly accept
+> last-writer-wins.
+
+The target audience is naive or LLM-generated clients that will not send
+`If-Match` unprompted. The body teaches the GET-first discipline.
+
+### `If-Match: *` mechanism
+
+`*` is **not** passed to the conditional-save comparison as the literal string
+`"*"`. Instead it is translated to an unconditional save (no CAS), with entity
+existence guaranteed by the in-transaction base read. `If-Match: *` means "save
+unconditionally, but the entity must exist."
+
+This is a deliberate divergence from PUT, where a missing `If-Match` means
+unconditional replace. PATCH treats a missing `If-Match` as 428; the divergence
+is justified by merge being base-relative.
+
+## 3. HTTP surface
+
+### Endpoints
+
+```
+PATCH /api/entity/{format}/{entityId}
+PATCH /api/entity/{format}/{entityId}/{transition}
+```
+
+The first form fires the loopback. The second form carries a named transition.
+Both are parallel to the existing PUT endpoints, which are unchanged.
+
+The same query parameters PUT accepts (`transactionTimeoutMillis`,
+`waitForConsistencyAfter`) apply unchanged. The response shape is the existing
+`EntityTransactionResponse`.
+
+### Format
+
+`{format}` **must be `JSON`**. Merge Patch is JSON-only by RFC 7386. Supplying
+`XML` returns **415 Unsupported Media Type**. The `{format}` segment is retained
+for structural symmetry with the PUT routes; only `JSON` is accepted for PATCH.
+
+### Patch dialect — `Content-Type`
+
+| `Content-Type` | Dialect | Behaviour |
+|---|---|---|
+| `application/merge-patch+json` | RFC 7386 JSON Merge Patch | Implemented |
+| `application/json-patch+json` | RFC 6902 JSON Patch | Scaffolded — returns **501 Not Implemented** |
+| anything else | — | **415 Unsupported Media Type** |
+
+### Error table
+
+| Code | Condition |
+|---|---|
+| 404 Not Found | Entity does not exist (including soft-deleted) |
+| 409 Conflict (retryable) | A concurrent writer committed between the in-transaction base read and this save (read-set conflict at commit). Possible even under `If-Match: *`; the caller may retry. |
+| 412 Precondition Failed | `If-Match: "<transactionId>"` supplied and the stored transactionId differs. Error code: `ENTITY_MODIFIED` ("entity has been modified since last read"). |
+| 415 Unsupported Media Type | `XML` format, or a `Content-Type` other than the two recognised patch media types |
+| 428 Precondition Required | No `If-Match` header present |
+| 501 Not Implemented | `Content-Type: application/json-patch+json` |
+| 4xx (domain) | The merged result fails strict model-schema validation; full domain detail plus error code |
+
+### 409 vs 412
+
+**412** is the *up-front* conditional rejection: the caller's `If-Match`
+transactionId no longer matches the stored one at the point of the conditional
+save. The stored entity moved before the merge began.
+
+**409** is the *commit-time* read-set conflict: the transaction manager detects
+that a concurrent writer touched the base entity after the in-transaction
+snapshot but before commit. 409 is retryable and can occur even under
+`If-Match: *`.
+
+### Error precedence
+
+Request-shape validation runs before resource-state checks, so entity existence
+is never leaked to a malformed or unconditional request:
+
+1. Media type / format resolution — unrecognised `Content-Type` or `XML` ⇒ **415**;
+   recognised-but-unimplemented `application/json-patch+json` ⇒ **501**
+2. `If-Match` presence — absent ⇒ **428**
+3. Entity lookup — not found or soft-deleted ⇒ **404**
+4. transactionId compare — mismatch ⇒ **412**
+5. Merge + strict schema validation — invalid merged result ⇒ **4xx domain**
+6. Commit — read-set conflict ⇒ **409** (only possible at this stage)
+
+Example: a request with `XML` format and no `If-Match` returns **415**, not 428.
+
+## 4. gRPC surface
+
+### CloudEvent type
+
+The `entityManage` unary RPC dispatches on the CloudEvent `type` string. The
+new type for entity patch is **`EntityPatchRequest`**.
+
+No `.proto` change is required. The type string is a new constant alongside the
+existing `EntityUpdateRequest`.
+
+### Payload fields
+
+```
+EntityPatchRequest {
+    entityId    string        // required
+    patch       bytes         // the merge-patch body (JSON)
+    transition  string        // optional; empty for loopback
+    ifMatch     string        // "<transactionId>" | "*"; required (absence → CLIENT_ERROR)
+    patchFormat PatchFormat   // enum; see below
+}
+```
+
+### `PatchFormat` enum
+
+| Value | Meaning |
+|---|---|
+| `MERGE_PATCH` | RFC 7386 JSON Merge Patch (implemented) |
+| `JSON_PATCH` | RFC 6902 JSON Patch (not implemented) |
+
+This is the gRPC mirror of the HTTP `Content-Type` dialect selector. The same
+501 / not-implemented behaviour applies when `JSON_PATCH` is supplied.
+
+### gRPC error representation — important
+
+Domain failures over gRPC are **not** surfaced as gRPC `status` codes. The
+`EntityManage` RPC always returns an `EntityTransactionResponse` envelope.
+On failure: `Success: false`, `Error.Code: "CLIENT_ERROR"`, and the real
+operational code inside the `Error.Message` string as `"<CODE>: detail"`.
+
+Examples of how PATCH-specific errors appear in the envelope:
+
+| Condition | `Error.Code` | `Error.Message` (prefix) |
+|---|---|---|
+| `patchFormat: JSON_PATCH` | `CLIENT_ERROR` | `NOT_IMPLEMENTED: ...` |
+| `ifMatch` absent or empty | `CLIENT_ERROR` | `PRECONDITION_REQUIRED: ...` |
+| transactionId mismatch | `CLIENT_ERROR` | `ENTITY_MODIFIED: ...` |
+| schema validation failure | `CLIENT_ERROR` | `VALIDATION_FAILED: ...` |
+
+This `CLIENT_ERROR` flattening is a **pre-existing limitation** of the gRPC
+envelope shared by all operations, not something specific to PATCH. The HTTP
+status codes are canonical; the gRPC envelope's representation is the current
+mirror. Surfacing distinct, machine-readable gRPC error identity per operation
+code is a tracked future gRPC-error improvement.
+
+### `ifMatch: "*"` on gRPC
+
+The same translation applies: `"*"` is mapped to an unconditional (no-CAS) save
+with entity-existence guaranteed by the in-transaction base read. It is **not**
+compared literally against the stored transactionId.
+
+## 5. Atomicity guarantee
+
+The base read, merge, validation, and conditional save all occur within a
+**single transaction**. Every storage backend re-validates the transaction's
+read-set at commit. If a concurrent writer touches the base entity after the
+in-transaction snapshot but before commit, the backend raises a conflict surfaced
+as the documented **409 Conflict** — not silent data corruption. This guarantee
+holds even under `If-Match: *`.

--- a/docs/cyoda/README.md
+++ b/docs/cyoda/README.md
@@ -1,9 +1,10 @@
 # docs/cyoda — Cyoda Cloud OpenAPI reference
 
-This directory is a **read-only reference** mirror of the Cyoda Cloud
-OpenAPI spec, used by cyoda-go for parity work. Nothing in this
-directory is served at runtime — cyoda-go's authoritative, embedded
-spec lives at `api/openapi.yaml` at the repo root.
+This directory holds a **reference snapshot** of the Cyoda Cloud
+OpenAPI spec, kept for comparison and diff work. The authoritative
+contract is `api/openapi.yaml` at the repo root — cyoda-go defines
+that spec and Cyoda Cloud aligns to it. Nothing in this directory is
+served at runtime.
 
 ## Layout
 

--- a/docs/cyoda/cloud-divergences.md
+++ b/docs/cyoda/cloud-divergences.md
@@ -5,8 +5,9 @@ to it. Most of the API surface matches one-for-one. This page tracks
 the **deliberate, known divergences** — fields cyoda-go declares in
 `api/openapi.yaml` but does not yet implement, behavior that
 intentionally differs, or enterprise-tier features that live only in
-the commercial backend. For features Cloud exposes that cyoda-go has
-not yet implemented, see [`../cloud-parity/`](../cloud-parity/).
+the commercial backend. For the inverse — contracts cyoda-go has
+defined that Cyoda Cloud implements to stay aligned — see
+[`../cloud-parity/`](../cloud-parity/).
 
 This is the canonical place for "I see this in the OpenAPI spec but
 cyoda-go silently ignores it" entries. Add new rows here whenever a

--- a/docs/cyoda/cloud-divergences.md
+++ b/docs/cyoda/cloud-divergences.md
@@ -1,10 +1,12 @@
 # Cloud divergences
 
-cyoda-go is the digital twin of Cyoda Cloud. Most of the API surface
-matches one-for-one. This page tracks the **deliberate, known
-divergences** — fields cyoda-go declares for spec parity but does not
-yet implement, behavior that intentionally differs, or
-enterprise-tier features that live only in the commercial backend.
+cyoda-go defines the API and integration contract; Cyoda Cloud aligns
+to it. Most of the API surface matches one-for-one. This page tracks
+the **deliberate, known divergences** — fields cyoda-go declares in
+`api/openapi.yaml` but does not yet implement, behavior that
+intentionally differs, or enterprise-tier features that live only in
+the commercial backend. For features Cloud exposes that cyoda-go has
+not yet implemented, see [`../cloud-parity/`](../cloud-parity/).
 
 This is the canonical place for "I see this in the OpenAPI spec but
 cyoda-go silently ignores it" entries. Add new rows here whenever a

--- a/docs/cyoda/schema/common/PatchFormat.json
+++ b/docs/cyoda/schema/common/PatchFormat.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyoda.com/cloud/event/common/PatchFormat.json",
+  "title": "PatchFormat",
+  "type": "string",
+  "enum": [
+    "MERGE_PATCH",
+    "JSON_PATCH"
+  ],
+  "description": "Patch dialect: MERGE_PATCH (RFC 7386, implemented) or JSON_PATCH (RFC 6902, not implemented)."
+}

--- a/docs/cyoda/schema/entity/EntityPatchPayload.json
+++ b/docs/cyoda/schema/entity/EntityPatchPayload.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyoda.com/cloud/event/entity/EntityPatchPayload.json",
+  "title": "EntityPatchPayload",
+  "type": "object",
+  "properties": {
+    "entityId": {
+      "type": "string",
+      "description": "ID of the entity to patch.",
+      "format": "uuid"
+    },
+    "patch": {
+      "type": "any",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode",
+      "description": "The patch document (RFC 7386 merge patch)."
+    },
+    "transition": {
+      "type": "string",
+      "description": "Transition to apply, or omit for loopback."
+    },
+    "ifMatch": {
+      "type": "string",
+      "description": "transactionId from the last read, or \"*\" for unconditional. Empty is rejected as precondition-required."
+    }
+  },
+  "required": [
+    "entityId",
+    "patch"
+  ]
+}

--- a/docs/cyoda/schema/entity/EntityPatchRequest.json
+++ b/docs/cyoda/schema/entity/EntityPatchRequest.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyoda.com/cloud/event/entity/EntityPatchRequest.json",
+  "title": "EntityPatchRequest",
+  "type": "object",
+  "extends": {
+    "$ref": "../common/BaseEvent.json"
+  },
+  "properties": {
+    "payload": {
+      "$ref": "./EntityPatchPayload.json",
+      "description": "Data payload containing the entity id and patch."
+    },
+    "patchFormat": {
+      "$ref": "../common/PatchFormat.json"
+    },
+    "transactionTimeoutMs": {
+      "type": "integer",
+      "existingJavaType": "java.lang.Long",
+      "description": "Indicates the timeout of transaction for transactional save."
+    }
+  },
+  "required": [
+    "patchFormat",
+    "payload"
+  ]
+}

--- a/docs/superpowers/plans/2026-06-24-entity-patch.md
+++ b/docs/superpowers/plans/2026-06-24-entity-patch.md
@@ -1,0 +1,1220 @@
+# Entity Partial-Update (PATCH / RFC 7386) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a single-entity PATCH (RFC 7386 JSON Merge Patch) capability over both the HTTP API and the gRPC layer, as an additive non-breaking feature for v0.8.2.
+
+**Architecture:** PATCH is implemented as a *merge hook* on the existing `UpdateEntity` flow — `UpdateEntity` is refactored into a shared `updateEntityCore` that accepts a merge transform (applied to the stored payload inside the transaction) and a strict-validation flag. A pure RFC 7386 merge function produces the new payload; everything downstream (validation, transition engine, If-Match CAS, commit) is reused unchanged. HTTP selects the dialect via `Content-Type`; gRPC mirrors it with a generated `patchFormat` enum on a new `EntityPatchRequest` CloudEvent type. RFC 6902 is scaffolded (returns 501 / NOT_IMPLEMENTED).
+
+**Tech Stack:** Go 1.26+, `log/slog`, oapi-codegen (HTTP from `api/openapi.yaml`), go-jsonschema (gRPC event types from `docs/cyoda/schema/`), testcontainers-go (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-06-24-entity-patch-design.md` (twice-reviewed). Issue #341; gRPC error follow-up #342.
+
+## Global Constraints
+
+- Go 1.26+; use `log/slog` only (never `log.Printf`/`fmt.Printf`).
+- Wrap errors: `fmt.Errorf("...: %w", err)`. Use `uuid.UUID` not `string` for UUIDs in new code (note: existing `UpdateEntityInput.EntityID` is `string` — match it at the service boundary).
+- TDD mandatory (Gate 1): failing test before implementation, every task.
+- E2E coverage for user-facing behaviour (Gate 2): `internal/e2e/`.
+- Security (Gate 3): never log tokens/secrets; every data path tenant-isolated; validate at boundaries; no stack traces/internals in responses.
+- **No issue IDs** in shipped artefacts (error text, response bodies, code comments, OpenAPI/help content). Issue IDs only in commits/PR/spec docs.
+- Precondition token is the entity **`transactionId`** (never call it "version" in any user-facing text).
+- Merge must preserve numbers (operate on `json.Number`-decoded values; never re-coerce through `float64`).
+- 4xx: full domain detail + error code. 5xx: generic message + ticket.
+- Frequent commits — one per task minimum; the fidelity-reframe is its **own** commit (Task 9).
+
+---
+
+### Task 1: RFC 7386 merge function (pure, number-preserving)
+
+**Files:**
+- Create: `internal/domain/entity/mergepatch.go`
+- Test: `internal/domain/entity/mergepatch_test.go`
+
+**Interfaces:**
+- Produces: `func mergeMergePatch(existing json.RawMessage, patch any) (any, error)` — decodes `existing` (number-preserving) and applies RFC 7386 merge of the already-parsed `patch` onto it, returning the merged value. `func applyMergePatch(target, patch any) any` — the recursive RFC 7386 §2 algorithm.
+- Consumes: `decodeJSONPreservingNumbers` (existing, `service.go:29`).
+
+- [ ] **Step 1: Write the failing test** (RFC 7386 Appendix A cases + null-delete, nested, array-replace, non-object, empty, number fidelity)
+
+```go
+package entity
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func mustParse(t *testing.T, s string) any {
+	t.Helper()
+	var v any
+	if err := decodeJSONPreservingNumbers([]byte(s), &v); err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return v
+}
+
+func TestApplyMergePatch_RFC7386_AppendixA(t *testing.T) {
+	cases := []struct{ name, target, patch, want string }{
+		{"replace-field", `{"a":"b"}`, `{"a":"c"}`, `{"a":"c"}`},
+		{"add-field", `{"a":"b"}`, `{"b":"c"}`, `{"a":"b","b":"c"}`},
+		{"delete-field", `{"a":"b"}`, `{"a":null}`, `{}`},
+		{"delete-one-of-two", `{"a":"b","b":"c"}`, `{"a":null}`, `{"b":"c"}`},
+		{"array-replaces", `{"a":["b"]}`, `{"a":"c"}`, `{"a":"c"}`},
+		{"scalar-replaces-array", `{"a":"c"}`, `{"a":["b"]}`, `{"a":["b"]}`},
+		{"nested-merge", `{"a":{"b":"c"}}`, `{"a":{"b":"d","c":null}}`, `{"a":{"b":"d"}}`},
+		{"array-wholesale", `{"a":[{"b":"c"}]}`, `{"a":[1]}`, `{"a":[1]}`},
+		{"non-object-patch-replaces", `{"a":"b"}`, `["c"]`, `["c"]`},
+		{"empty-patch-noop", `{"a":"b"}`, `{}`, `{"a":"b"}`},
+		{"null-creates-nothing", `{"a":"foo"}`, `null`, `null`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := mergeMergePatch(json.RawMessage(tc.target), mustParse(t, tc.patch))
+			if err != nil {
+				t.Fatalf("merge: %v", err)
+			}
+			gotBytes, _ := json.Marshal(got)
+			var gotN, wantN any
+			_ = decodeJSONPreservingNumbers(gotBytes, &gotN)
+			_ = decodeJSONPreservingNumbers([]byte(tc.want), &wantN)
+			if !reflect.DeepEqual(gotN, wantN) {
+				t.Errorf("got %s, want %s", gotBytes, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyMergePatch_NumberFidelity(t *testing.T) {
+	// int64 above 2^53 must survive without float64 coercion.
+	target := json.RawMessage(`{"big":1}`)
+	patch := mustParse(t, `{"big":9007199254740993}`)
+	got, err := mergeMergePatch(target, patch)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	b, _ := json.Marshal(got)
+	if string(b) != `{"big":9007199254740993}` {
+		t.Errorf("number fidelity lost: got %s", b)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/domain/entity/ -run TestApplyMergePatch -v`
+Expected: FAIL — `undefined: mergeMergePatch`.
+
+- [ ] **Step 3: Implement the merge**
+
+```go
+package entity
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// mergeMergePatch applies an RFC 7386 JSON Merge Patch (the already-parsed
+// patch) onto the stored entity data, returning the merged value. Both sides
+// are number-preserving (json.Number) so large integers survive the merge.
+func mergeMergePatch(existing json.RawMessage, patch any) (any, error) {
+	var target any
+	if len(existing) > 0 {
+		if err := decodeJSONPreservingNumbers(existing, &target); err != nil {
+			return nil, fmt.Errorf("failed to decode stored entity data: %w", err)
+		}
+	}
+	return applyMergePatch(target, patch), nil
+}
+
+// applyMergePatch is the RFC 7386 section 2 algorithm. When patch is not a
+// JSON object it replaces the target wholesale; otherwise each key is merged
+// recursively, and an explicit null deletes the key.
+func applyMergePatch(target, patch any) any {
+	patchObj, ok := patch.(map[string]any)
+	if !ok {
+		return patch
+	}
+	targetObj, ok := target.(map[string]any)
+	if !ok {
+		targetObj = map[string]any{}
+	}
+	for k, v := range patchObj {
+		if v == nil {
+			delete(targetObj, k)
+		} else {
+			targetObj[k] = applyMergePatch(targetObj[k], v)
+		}
+	}
+	return targetObj
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/domain/entity/ -run TestApplyMergePatch -v`
+Expected: PASS (both tests, all sub-cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/domain/entity/mergepatch.go internal/domain/entity/mergepatch_test.go
+git commit -m "feat(entity): RFC 7386 JSON merge patch function
+
+Pure, number-preserving merge for partial entity updates (#341)."
+```
+
+---
+
+### Task 2: New error codes (428, 415)
+
+**Files:**
+- Modify: `internal/common/error_codes.go` (the `const (...)` block)
+- Test: `internal/common/error_codes_test.go` (create if absent)
+
+**Interfaces:**
+- Produces: `common.ErrCodePreconditionRequired = "PRECONDITION_REQUIRED"`, `common.ErrCodeUnsupportedMediaType = "UNSUPPORTED_MEDIA_TYPE"`. (`ErrCodeNotImplemented` and `ErrCodeConflict` already exist.)
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package common
+
+import "testing"
+
+func TestPatchErrorCodes(t *testing.T) {
+	if ErrCodePreconditionRequired != "PRECONDITION_REQUIRED" {
+		t.Errorf("got %q", ErrCodePreconditionRequired)
+	}
+	if ErrCodeUnsupportedMediaType != "UNSUPPORTED_MEDIA_TYPE" {
+		t.Errorf("got %q", ErrCodeUnsupportedMediaType)
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/common/ -run TestPatchErrorCodes -v`
+Expected: FAIL — `undefined: ErrCodePreconditionRequired`.
+
+- [ ] **Step 3: Add the constants** to the `const` block in `internal/common/error_codes.go` (after `ErrCodeNotFound`):
+
+```go
+	ErrCodePreconditionRequired      = "PRECONDITION_REQUIRED"
+	ErrCodeUnsupportedMediaType      = "UNSUPPORTED_MEDIA_TYPE"
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/common/ -run TestPatchErrorCodes -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/common/error_codes.go internal/common/error_codes_test.go
+git commit -m "feat(common): PRECONDITION_REQUIRED and UNSUPPORTED_MEDIA_TYPE error codes (#341)"
+```
+
+---
+
+### Task 3: Service layer — `updateEntityCore` seam + `PatchEntity`
+
+**Files:**
+- Modify: `internal/domain/entity/service.go` (refactor `UpdateEntity` ~960; add `PatchEntity`, `PatchEntityInput`, `updateOptions`)
+- Modify: `internal/domain/entity/handler.go` (add `validateStrict`)
+- Test: `internal/domain/entity/patch_test.go` (create)
+
+**Interfaces:**
+- Consumes: `mergeMergePatch` (Task 1); `common.ErrCodePreconditionRequired`/`ErrCodeUnsupportedMediaType`/`ErrCodeNotImplemented` (Task 2); existing `validateOrExtend`, `classifyValidateOrExtendErr`, `enrichWithModelRef`, `validationErrorsToError`, `schema.Unmarshal`, `schema.Validate`, `errInternalSchema`.
+- Produces:
+  - `type PatchEntityInput struct { EntityID string; Patch json.RawMessage; PatchFormat string; Transition string; IfMatch string }`
+  - `func (h *Handler) PatchEntity(ctx context.Context, input PatchEntityInput) (*EntityTransactionResult, error)`
+  - `type updateOptions struct { merge func(existing json.RawMessage, incoming any) (any, error); strictValidate bool }`
+  - `func (h *Handler) validateStrict(desc *spi.ModelDescriptor, parsedData any) error`
+
+- [ ] **Step 1: Refactor `UpdateEntity` into `updateEntityCore` (pure refactor — existing tests must stay green).**
+
+In `service.go`, rename the existing `func (h *Handler) UpdateEntity(...)` body to `updateEntityCore` with an added `opts updateOptions` parameter, and add a thin wrapper. Add the `updateOptions` type near `UpdateEntityInput`:
+
+```go
+// updateOptions tunes the shared update flow. Zero value = plain replace (PUT).
+type updateOptions struct {
+	// merge, when non-nil, transforms the parsed request body against the
+	// existing entity's stored data inside the transaction, before validation
+	// (RFC 7386 for PATCH).
+	merge func(existing json.RawMessage, incoming any) (any, error)
+	// strictValidate forces validate-only — never extend the model schema (PATCH).
+	strictValidate bool
+}
+
+func (h *Handler) UpdateEntity(ctx context.Context, input UpdateEntityInput) (*EntityTransactionResult, error) {
+	return h.updateEntityCore(ctx, input, updateOptions{})
+}
+
+func (h *Handler) updateEntityCore(ctx context.Context, input UpdateEntityInput, opts updateOptions) (*EntityTransactionResult, error) {
+	// ... existing UpdateEntity body, with the two edits in Step 2 ...
+}
+```
+
+- [ ] **Step 2: Insert the merge hook and strict-validation branch.**
+
+Locate the model-descriptor load (the line `desc, err := modelStore.Get(txCtx, existing.Meta.ModelRef)` — the descriptor used by `validateOrExtend`), which sits between the `existing, err := entityStore.Get(...)` 404 check and the `h.validateOrExtend(txCtx, modelStore, desc, parsedData)` call (~`service.go:1015`). **Immediately before** the `validateOrExtend` call, insert the merge block, and replace the single `validateOrExtend` call with the strict/extend branch:
+
+```go
+	// PATCH: merge the sparse body onto the stored data before validation,
+	// inside this transaction so the merge base is the version being overwritten.
+	if opts.merge != nil {
+		merged, mErr := opts.merge(existing.Data, parsedData)
+		if mErr != nil {
+			h.txMgr.Rollback(txCtx, txID)
+			return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "invalid patch: "+mErr.Error())
+		}
+		parsedData = merged
+		bodyBytes, err = json.Marshal(parsedData)
+		if err != nil {
+			h.txMgr.Rollback(txCtx, txID)
+			return nil, common.Internal("failed to serialize merged entity", err)
+		}
+	}
+
+	// Validate the (possibly merged) result. PATCH validates strictly and never
+	// extends the model; PUT may extend per the model's ChangeLevel.
+	if opts.strictValidate {
+		if vErr := h.validateStrict(desc, parsedData); vErr != nil {
+			h.txMgr.Rollback(txCtx, txID)
+			return nil, classifyValidateOrExtendErr(vErr)
+		}
+	} else {
+		if vErr := h.validateOrExtend(txCtx, modelStore, desc, parsedData); vErr != nil {
+			h.txMgr.Rollback(txCtx, txID)
+			return nil, classifyValidateOrExtendErr(vErr)
+		}
+	}
+```
+
+(Remove the original standalone `if err := h.validateOrExtend(...)` block this replaces.)
+
+- [ ] **Step 3: Add `validateStrict` to `handler.go`** (mirrors `validateOrExtend`'s `ChangeLevel == ""` branch, never extends):
+
+```go
+// validateStrict validates parsedData against the model schema WITHOUT
+// extending it. PATCH uses this: a sparse delta must never widen the tenant's
+// model (a stray/typo'd key is rejected, not absorbed). Mirrors the
+// ChangeLevel=="" branch of validateOrExtend.
+func (h *Handler) validateStrict(desc *spi.ModelDescriptor, parsedData any) error {
+	modelNode, err := schema.Unmarshal(desc.Schema)
+	if err != nil {
+		return fmt.Errorf("%w: failed to unmarshal model schema: %w", errInternalSchema, err)
+	}
+	errs := schema.Validate(modelNode, parsedData)
+	if len(errs) > 0 {
+		return enrichWithModelRef(validationErrorsToError(errs), desc.Ref)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run the existing entity tests to confirm the refactor is green.**
+
+Run: `go test ./internal/domain/entity/ -v`
+Expected: PASS (all pre-existing tests; the refactor changed no behaviour for PUT).
+
+- [ ] **Step 5: Write the failing PatchEntity test** (`patch_test.go`).
+
+Use the package's existing entity-test setup helpers (mirror those used in the existing `service`/`handler` tests in this package — same factory/txMgr/engine wiring used by `UpdateEntity` tests). The test imports a small model, creates an entity, then patches it.
+
+```go
+package entity
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestPatchEntity_MergeAndStrictValidate(t *testing.T) {
+	h, ctx := newPatchTestHandler(t) // helper: see Step 6
+	id := createPersonEntity(t, h, ctx, map[string]any{"name": "Alice", "age": 30})
+	txid := getTxID(t, h, ctx, id)
+
+	// Patch only "age"; "name" must be preserved.
+	res, err := h.PatchEntity(ctx, PatchEntityInput{
+		EntityID:    id,
+		Patch:       []byte(`{"age":31}`),
+		PatchFormat: "MERGE_PATCH",
+		IfMatch:     txid,
+	})
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if len(res.EntityIDs) != 1 {
+		t.Fatalf("expected 1 entity id")
+	}
+	got := getEntityData(t, h, ctx, id)
+	if got["name"] != "Alice" || got["age"].(json.Number).String() != "31" {
+		t.Errorf("merge wrong: %#v", got)
+	}
+}
+
+func TestPatchEntity_JSONPatchNotImplemented(t *testing.T) {
+	h, ctx := newPatchTestHandler(t)
+	id := createPersonEntity(t, h, ctx, map[string]any{"name": "A"})
+	_, err := h.PatchEntity(ctx, PatchEntityInput{
+		EntityID: id, Patch: []byte(`[]`), PatchFormat: "JSON_PATCH", IfMatch: "*",
+	})
+	assertStatus(t, err, http.StatusNotImplemented)
+}
+
+func TestPatchEntity_StrictRejectsNewField(t *testing.T) {
+	h, ctx := newPatchTestHandler(t) // model is locked & strict (ChangeLevel "")
+	id := createPersonEntity(t, h, ctx, map[string]any{"name": "A"})
+	_, err := h.PatchEntity(ctx, PatchEntityInput{
+		EntityID: id, Patch: []byte(`{"newfield":"x"}`), PatchFormat: "MERGE_PATCH", IfMatch: "*",
+	})
+	assertStatus(t, err, http.StatusBadRequest)
+}
+
+func TestPatchEntity_StaleTokenIs412(t *testing.T) {
+	h, ctx := newPatchTestHandler(t)
+	id := createPersonEntity(t, h, ctx, map[string]any{"name": "A", "age": 1})
+	stale := getTxID(t, h, ctx, id)
+	// Advance the entity so the token goes stale.
+	if _, err := h.PatchEntity(ctx, PatchEntityInput{EntityID: id, Patch: []byte(`{"age":2}`), PatchFormat: "MERGE_PATCH", IfMatch: stale}); err != nil {
+		t.Fatalf("first patch: %v", err)
+	}
+	_, err := h.PatchEntity(ctx, PatchEntityInput{EntityID: id, Patch: []byte(`{"age":3}`), PatchFormat: "MERGE_PATCH", IfMatch: stale})
+	assertStatus(t, err, http.StatusPreconditionFailed)
+}
+
+func TestPatchEntity_StarIsUnconditional(t *testing.T) {
+	h, ctx := newPatchTestHandler(t)
+	id := createPersonEntity(t, h, ctx, map[string]any{"name": "A", "age": 1})
+	if _, err := h.PatchEntity(ctx, PatchEntityInput{EntityID: id, Patch: []byte(`{"age":2}`), PatchFormat: "MERGE_PATCH", IfMatch: "*"}); err != nil {
+		t.Fatalf("star patch should succeed unconditionally: %v", err)
+	}
+}
+```
+
+Add the small helpers (`newPatchTestHandler`, `createPersonEntity`, `getTxID`, `getEntityData`, `assertStatus`) at the bottom of `patch_test.go`, modelled on the existing entity-package test setup. `assertStatus`:
+
+```go
+func assertStatus(t *testing.T, err error, want int) {
+	t.Helper()
+	var appErr *common.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected AppError, got %v", err)
+	}
+	if appErr.Status != want {
+		t.Fatalf("status: got %d want %d (%s)", appErr.Status, want, appErr.Message)
+	}
+}
+```
+
+- [ ] **Step 6: Run to verify the new tests fail**
+
+Run: `go test ./internal/domain/entity/ -run TestPatchEntity -v`
+Expected: FAIL — `undefined: PatchEntity` / `PatchEntityInput`.
+
+- [ ] **Step 7: Implement `PatchEntity` + `PatchEntityInput`** in `service.go`:
+
+```go
+// PatchEntityInput holds parameters for a partial (RFC 7386) entity update.
+// IfMatch is required in some form (a transactionId, or "*" for unconditional);
+// its absence is rejected as 428 at the HTTP/gRPC edge, not here.
+type PatchEntityInput struct {
+	EntityID    string
+	Patch       json.RawMessage
+	PatchFormat string // "MERGE_PATCH" | "JSON_PATCH"
+	Transition  string
+	IfMatch     string
+}
+
+// PatchEntity applies a partial update. RFC 7386 merge patch is implemented;
+// RFC 6902 (JSON_PATCH) is scaffolded and returns 501.
+func (h *Handler) PatchEntity(ctx context.Context, input PatchEntityInput) (*EntityTransactionResult, error) {
+	switch input.PatchFormat {
+	case "MERGE_PATCH":
+		// handled below
+	case "JSON_PATCH":
+		return nil, common.Operational(http.StatusNotImplemented, common.ErrCodeNotImplemented,
+			"RFC 6902 JSON Patch is not implemented; use application/merge-patch+json")
+	default:
+		return nil, common.Operational(http.StatusUnsupportedMediaType, common.ErrCodeUnsupportedMediaType,
+			"unsupported patch format")
+	}
+
+	// "*" = unconditional: drop the CAS token. Existence is still guaranteed by
+	// the in-transaction Get inside updateEntityCore (404 if the entity is gone).
+	ifMatch := input.IfMatch
+	if ifMatch == "*" {
+		ifMatch = ""
+	}
+
+	return h.updateEntityCore(ctx, UpdateEntityInput{
+		EntityID:   input.EntityID,
+		Format:     "JSON",
+		Data:       input.Patch,
+		Transition: input.Transition,
+		IfMatch:    ifMatch,
+	}, updateOptions{
+		merge:          mergeMergePatch,
+		strictValidate: true,
+	})
+}
+```
+
+- [ ] **Step 8: Run to verify the new tests pass**
+
+Run: `go test ./internal/domain/entity/ -run TestPatchEntity -v`
+Expected: PASS.
+
+- [ ] **Step 9: Run the whole package (no regressions)**
+
+Run: `go test ./internal/domain/entity/ -v`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/domain/entity/service.go internal/domain/entity/handler.go internal/domain/entity/patch_test.go
+git commit -m "feat(entity): PatchEntity via shared updateEntityCore merge hook
+
+RFC 7386 merge applied inside the update transaction; strict validate-only
+(no schema extension); If-Match: * -> unconditional; JSON_PATCH -> 501 (#341)."
+```
+
+---
+
+### Task 4: HTTP PATCH endpoints (OpenAPI + handler)
+
+**Files:**
+- Modify: `api/openapi.yaml` (add two `patch:` operations)
+- Regenerate: `api/generated.go` (via oapi-codegen)
+- Modify: `internal/domain/entity/handler.go` (add `PatchSingleWithLoopback`, `PatchSingle`, shared `patch`, `patchFormatFromContentType`)
+- Test: `internal/domain/entity/handler_patch_test.go` (create)
+
+**Interfaces:**
+- Consumes: `h.PatchEntity` (Task 3); generated `genapi.PatchSingleParams{IfMatch *string}`, `genapi.PatchSingleParamsFormat`, etc. (after regen).
+- Produces: HTTP routes `PATCH /entity/{format}/{entityId}` and `PATCH /entity/{format}/{entityId}/{transition}`.
+
+- [ ] **Step 1: Add the two PATCH operations to `api/openapi.yaml`.**
+
+Under the existing `/entity/{format}/{entityId}:` path object (which currently has only `put:`), add a sibling `patch:` key. Mirror the PUT `updateSingleWithLoopback` parameters (format, entityId, If-Match header, the two query params) but with `operationId: patchSingleWithLoopback`, this requestBody, and these responses:
+
+```yaml
+    patch:
+      tags:
+        - Entity Management
+      summary: Patch Single with a loopback transition
+      description: |
+        Partially updates a single entity (RFC 7386 JSON Merge Patch) with a
+        loopback transition. Send only the fields that change; an explicit null
+        deletes a key. The merged result is validated against the model schema
+        and cannot introduce a new field (unlike PUT). The dialect is selected
+        by Content-Type: application/merge-patch+json (RFC 7386, implemented) or
+        application/json-patch+json (RFC 6902, not implemented -> 501).
+
+        If-Match is required in some form: the transactionId from your last GET
+        of this entity (conditional; 412 if it has moved), or "*" to accept
+        last-writer-wins. Its absence returns 428.
+      operationId: patchSingleWithLoopback
+      parameters:
+        - name: format
+          in: path
+          description: Must be JSON (merge patch is JSON only)
+          required: true
+          schema:
+            type: string
+            enum:
+              - JSON
+              - XML
+        - name: entityId
+          in: path
+          description: The UUID of the entity to patch
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: If-Match
+          in: header
+          description: transactionId from the last read, or "*" for unconditional. Absent returns 428.
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              type: object
+              format: json
+            examples:
+              MergePatch:
+                summary: Change one field
+                value:
+                  year: "2025"
+          application/json-patch+json:
+            schema:
+              type: array
+              items:
+                type: object
+      responses:
+        "200":
+          description: Entity patched successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EntityTransactionResponse"
+        "400":
+          description: Bad request — invalid patch or validation failure
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "404":
+          description: Entity not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "409":
+          description: Conflict — concurrent writer committed during the patch (retryable)
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "412":
+          description: Precondition Failed — If-Match transactionId no longer matches
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "415":
+          description: Unsupported Media Type — non-JSON format or unrecognised Content-Type
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "428":
+          description: Precondition Required — If-Match absent; supply a transactionId or "*"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "501":
+          $ref: '#/components/responses/NotImplemented'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
+        default:
+          $ref: '#/components/responses/InternalServerError'
+```
+
+Add the analogous `patch:` under `/entity/{format}/{entityId}/{transition}:` with `operationId: patchSingle`, the extra `transition` path parameter (copy it verbatim from the PUT `updateSingle` operation), and the identical requestBody/responses.
+
+- [ ] **Step 2: Regenerate the HTTP layer**
+
+Run: `cd api && go tool oapi-codegen --config=config.yaml openapi.yaml && cd ..`
+Expected: `api/generated.go` now declares `PatchSingleWithLoopback`/`PatchSingle` in `ServerInterface`, the `PatchSingleParams`/`PatchSingleWithLoopbackParams` structs (with `IfMatch *string`), the `PatchSingleParamsFormat` enum, and route registrations for `http.MethodPatch`.
+
+- [ ] **Step 3: Confirm it fails to compile** (entity.Handler does not yet implement the new interface methods)
+
+Run: `go build ./... 2>&1 | head`
+Expected: compile error — `*entity.Handler` does not implement `genapi.ServerInterface` (missing `PatchSingle`, `PatchSingleWithLoopback`).
+
+- [ ] **Step 4: Write the failing handler test** (`handler_patch_test.go`) — drive the handler via `httptest` for the edge codes (415/428/501) that don't need a full store:
+
+```go
+package entity
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+func TestPatch_XMLFormatIs415(t *testing.T) {
+	h, _ := newPatchTestHandler(t)
+	r := httptest.NewRequest(http.MethodPatch, "/entity/XML/"+sampleUUID, strings.NewReader(`{}`))
+	r.Header.Set("Content-Type", "application/merge-patch+json")
+	r.Header.Set("If-Match", "*")
+	w := httptest.NewRecorder()
+	h.PatchSingleWithLoopback(w, r, "XML", openapi_types.UUID(mustUUID(sampleUUID)), genapiPatchLoopbackParams("*"))
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestPatch_BadContentTypeIs415(t *testing.T) {
+	h, _ := newPatchTestHandler(t)
+	r := httptest.NewRequest(http.MethodPatch, "/entity/JSON/"+sampleUUID, strings.NewReader(`{}`))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.PatchSingleWithLoopback(w, r, "JSON", openapi_types.UUID(mustUUID(sampleUUID)), genapiPatchLoopbackParams("*"))
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestPatch_MissingIfMatchIs428(t *testing.T) {
+	h, _ := newPatchTestHandler(t)
+	r := httptest.NewRequest(http.MethodPatch, "/entity/JSON/"+sampleUUID, strings.NewReader(`{}`))
+	r.Header.Set("Content-Type", "application/merge-patch+json")
+	w := httptest.NewRecorder()
+	h.PatchSingleWithLoopback(w, r, "JSON", openapi_types.UUID(mustUUID(sampleUUID)), genapiPatchLoopbackParams(""))
+	if w.Code != http.StatusPreconditionRequired {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+```
+
+Add helpers `genapiPatchLoopbackParams(ifMatch string) genapi.PatchSingleWithLoopbackParams` (returns the struct with `IfMatch` nil when `ifMatch==""`, else `&ifMatch`), `mustUUID`, and a `sampleUUID` const, at the bottom of the file.
+
+- [ ] **Step 5: Run to verify it fails**
+
+Run: `go test ./internal/domain/entity/ -run TestPatch_ -v`
+Expected: FAIL — undefined `PatchSingleWithLoopback`.
+
+- [ ] **Step 6: Implement the handlers** in `handler.go` (add `mime` to imports):
+
+```go
+// PatchSingleWithLoopback handles PATCH /entity/{format}/{entityId} (loopback).
+func (h *Handler) PatchSingleWithLoopback(w http.ResponseWriter, r *http.Request, format genapi.PatchSingleWithLoopbackParamsFormat, entityId openapi_types.UUID, params genapi.PatchSingleWithLoopbackParams) {
+	h.patch(w, r, string(format), entityId, "", params.IfMatch)
+}
+
+// PatchSingle handles PATCH /entity/{format}/{entityId}/{transition}.
+func (h *Handler) PatchSingle(w http.ResponseWriter, r *http.Request, format genapi.PatchSingleParamsFormat, entityId openapi_types.UUID, transition string, params genapi.PatchSingleParams) {
+	h.patch(w, r, string(format), entityId, transition, params.IfMatch)
+}
+
+// patch is the shared PATCH implementation. Error precedence: media-type/format
+// (415) -> If-Match presence (428) -> service (404/412/409/501/4xx).
+func (h *Handler) patch(w http.ResponseWriter, r *http.Request, format string, entityId openapi_types.UUID, transition string, ifMatchHeader *string) {
+	if format != "JSON" {
+		common.WriteError(w, r, common.Operational(http.StatusUnsupportedMediaType, common.ErrCodeUnsupportedMediaType, "patch supports the JSON format only"))
+		return
+	}
+	patchFormat, ok := patchFormatFromContentType(r.Header.Get("Content-Type"))
+	if !ok {
+		common.WriteError(w, r, common.Operational(http.StatusUnsupportedMediaType, common.ErrCodeUnsupportedMediaType,
+			"unsupported Content-Type; use application/merge-patch+json or application/json-patch+json"))
+		return
+	}
+	if ifMatchHeader == nil {
+		common.WriteError(w, r, common.Operational(http.StatusPreconditionRequired, common.ErrCodePreconditionRequired,
+			"missing If-Match: send If-Match: <transactionId> from your last GET of this entity to patch safely, or If-Match: * to explicitly accept last-writer-wins"))
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxEntityBodySize)
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "failed to read body"))
+		return
+	}
+	result, err := h.PatchEntity(r.Context(), PatchEntityInput{
+		EntityID:    entityId.String(),
+		Patch:       bodyBytes,
+		PatchFormat: patchFormat,
+		Transition:  transition,
+		IfMatch:     *ifMatchHeader,
+	})
+	if err != nil {
+		common.WriteError(w, r, classifyError(err))
+		return
+	}
+	common.WriteJSON(w, http.StatusOK, map[string]any{
+		"transactionId": result.TransactionID,
+		"entityIds":     result.EntityIDs,
+	})
+}
+
+// patchFormatFromContentType maps the request Content-Type to a patch dialect.
+func patchFormatFromContentType(ct string) (string, bool) {
+	if ct == "" {
+		return "", false
+	}
+	mediaType, _, err := mime.ParseMediaType(ct)
+	if err != nil {
+		return "", false
+	}
+	switch mediaType {
+	case "application/merge-patch+json":
+		return "MERGE_PATCH", true
+	case "application/json-patch+json":
+		return "JSON_PATCH", true
+	default:
+		return "", false
+	}
+}
+```
+
+- [ ] **Step 7: Run handler tests + build**
+
+Run: `go test ./internal/domain/entity/ -run TestPatch_ -v && go build ./...`
+Expected: PASS and clean build.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/openapi.yaml api/generated.go internal/domain/entity/handler.go internal/domain/entity/handler_patch_test.go
+git commit -m "feat(api): HTTP PATCH entity endpoints (RFC 7386 merge patch)
+
+Dialect via Content-Type; JSON only (XML->415); If-Match three-state
+(token/412, *, absent->428); json-patch+json->501 (#341)."
+```
+
+---
+
+### Task 5: gRPC EntityPatchRequest
+
+**Files:**
+- Create: `docs/cyoda/schema/common/PatchFormat.json`, `docs/cyoda/schema/entity/EntityPatchPayload.json`, `docs/cyoda/schema/entity/EntityPatchRequest.json`
+- Modify: `scripts/generate-events.sh` (add PatchFormat.json to the explicit common list)
+- Regenerate: `api/grpc/events/types.go`
+- Modify: `internal/grpc/cloudevent_types.go` (add `EntityPatchRequest` const)
+- Modify: `internal/grpc/entity.go` (add `case EntityPatchRequest`; add `net/http` import)
+- Test: `internal/grpc/rpc_test.go` (add `TestRPC_EntityPatch*`)
+
+**Interfaces:**
+- Consumes: `s.entityHandler.PatchEntity` (Task 3); generated `events.EntityPatchRequestJson{ Payload EntityPatchPayloadJson; PatchFormat PatchFormatJson }`, `events.EntityPatchPayloadJson{ EntityID string; Patch interface{}; Transition *string; IfMatch string }`.
+
+- [ ] **Step 1: Author the schema files.**
+
+`docs/cyoda/schema/common/PatchFormat.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyoda.com/cloud/event/common/PatchFormat.json",
+  "title": "PatchFormat",
+  "type": "string",
+  "enum": [
+    "MERGE_PATCH",
+    "JSON_PATCH"
+  ],
+  "description": "Patch dialect: MERGE_PATCH (RFC 7386, implemented) or JSON_PATCH (RFC 6902, not implemented)."
+}
+```
+
+`docs/cyoda/schema/entity/EntityPatchPayload.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyoda.com/cloud/event/entity/EntityPatchPayload.json",
+  "title": "EntityPatchPayload",
+  "type": "object",
+  "properties": {
+    "entityId": {
+      "type": "string",
+      "description": "ID of the entity to patch.",
+      "format": "uuid"
+    },
+    "patch": {
+      "type": "any",
+      "existingJavaType": "com.fasterxml.jackson.databind.JsonNode",
+      "description": "The patch document (RFC 7386 merge patch)."
+    },
+    "transition": {
+      "type": "string",
+      "description": "Transition to apply, or omit for loopback."
+    },
+    "ifMatch": {
+      "type": "string",
+      "description": "transactionId from the last read, or \"*\" for unconditional. Empty is rejected as precondition-required."
+    }
+  },
+  "required": [
+    "entityId",
+    "patch"
+  ]
+}
+```
+
+`docs/cyoda/schema/entity/EntityPatchRequest.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cyoda.com/cloud/event/entity/EntityPatchRequest.json",
+  "title": "EntityPatchRequest",
+  "type": "object",
+  "extends": {
+    "$ref": "../common/BaseEvent.json"
+  },
+  "properties": {
+    "payload": {
+      "$ref": "./EntityPatchPayload.json",
+      "description": "Data payload containing the entity id and patch."
+    },
+    "patchFormat": {
+      "$ref": "../common/PatchFormat.json"
+    },
+    "transactionTimeoutMs": {
+      "type": "integer",
+      "existingJavaType": "java.lang.Long",
+      "description": "Indicates the timeout of transaction for transactional save."
+    }
+  },
+  "required": [
+    "patchFormat",
+    "payload"
+  ]
+}
+```
+
+- [ ] **Step 2: Add PatchFormat.json to the generator's explicit common list.**
+
+In `scripts/generate-events.sh`, in the `"$TOOL" ...` invocation, add this line alongside the other `common/*.json` entries (e.g. right after the `DataFormat.json` line):
+
+```bash
+  "$CLEAN_DIR"/common/PatchFormat.json \
+```
+
+(The `entity/*.json` glob already picks up the two new entity schemas.)
+
+- [ ] **Step 3: Regenerate event types.**
+
+Run: `./scripts/generate-events.sh`
+(If the tool is missing: `go install github.com/atombender/go-jsonschema@latest` first.)
+Expected: `api/grpc/events/types.go` now contains `EntityPatchRequestJson`, `EntityPatchPayloadJson`, and `PatchFormatJson` (with `MERGE_PATCH`/`JSON_PATCH` constants and an `UnmarshalJSON` validator).
+
+- [ ] **Step 4: Add the CloudEvent type constant** to `internal/grpc/cloudevent_types.go` (in the entity-management `const` block, after `EntityUpdateRequest`):
+
+```go
+	EntityPatchRequest            = "EntityPatchRequest"
+```
+
+- [ ] **Step 5: Write the failing gRPC test** (`rpc_test.go`), mirroring `TestRPC_EntityCreate`/`TestRPC_EntityTransition`:
+
+```go
+func TestRPC_EntityPatch(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "Alice", "age": 30})
+
+	createCE := makeCE(EntityCreateRequest, map[string]any{
+		"id": "c1", "dataFormat": "JSON",
+		"payload": map[string]any{"model": map[string]any{"name": "person", "version": 1}, "data": map[string]any{"name": "Alice", "age": 30}},
+	})
+	createResp, err := svc.EntityManage(ctx, createCE)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	entityID := parseResponsePayload(t, createResp)["transactionInfo"].(map[string]any)["entityIds"].([]any)[0].(string)
+
+	patchCE := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p1", "patchFormat": "MERGE_PATCH",
+		"payload": map[string]any{"entityId": entityID, "patch": map[string]any{"age": 31}, "ifMatch": "*"},
+	})
+	resp, err := svc.EntityManage(ctx, patchCE)
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	var typed events.EntityTransactionResponseJson
+	validateResponse(t, resp, &typed)
+	if !typed.Success {
+		t.Fatalf("expected success; got %#v", typed.Error)
+	}
+}
+
+func TestRPC_EntityPatch_MissingIfMatch428(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "A"})
+	createResp, _ := svc.EntityManage(ctx, makeCE(EntityCreateRequest, map[string]any{
+		"id": "c1", "dataFormat": "JSON",
+		"payload": map[string]any{"model": map[string]any{"name": "person", "version": 1}, "data": map[string]any{"name": "A"}},
+	}))
+	entityID := parseResponsePayload(t, createResp)["transactionInfo"].(map[string]any)["entityIds"].([]any)[0].(string)
+
+	patchCE := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p1", "patchFormat": "MERGE_PATCH",
+		"payload": map[string]any{"entityId": entityID, "patch": map[string]any{"name": "B"}, "ifMatch": ""},
+	})
+	resp, err := svc.EntityManage(ctx, patchCE)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	var typed events.EntityTransactionResponseJson
+	validateResponse(t, resp, &typed)
+	if typed.Success || typed.Error == nil {
+		t.Fatalf("expected failure envelope")
+	}
+	if !strings.Contains(typed.Error.Message, "PRECONDITION_REQUIRED") {
+		t.Errorf("expected PRECONDITION_REQUIRED in message, got %q", typed.Error.Message)
+	}
+}
+```
+
+- [ ] **Step 6: Run to verify it fails**
+
+Run: `go test ./internal/grpc/ -run TestRPC_EntityPatch -v`
+Expected: FAIL — no `case EntityPatchRequest` (dispatch returns an "unknown type" error).
+
+- [ ] **Step 7: Add the dispatch case** in `internal/grpc/entity.go` `EntityManage` (after the `EntityUpdateRequest` case; add `"net/http"` to imports):
+
+```go
+	case EntityPatchRequest:
+		dec := json.NewDecoder(bytes.NewReader(payload))
+		dec.UseNumber()
+		var req events.EntityPatchRequestJson
+		if err := dec.Decode(&req); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid payload: %v", err)
+		}
+		if req.Payload.IfMatch == "" {
+			return entityTransactionError(ctx, ce.Id, common.Operational(
+				http.StatusPreconditionRequired, common.ErrCodePreconditionRequired,
+				"missing ifMatch: provide the transactionId from your last read, or \"*\" to accept last-writer-wins"))
+		}
+		patchBytes, err := json.Marshal(req.Payload.Patch)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to marshal patch: %v", err)
+		}
+		transition := ""
+		if req.Payload.Transition != nil {
+			transition = *req.Payload.Transition
+		}
+		result, err := s.entityHandler.PatchEntity(ctx, entity.PatchEntityInput{
+			EntityID:    req.Payload.EntityID,
+			Patch:       patchBytes,
+			PatchFormat: string(req.PatchFormat),
+			Transition:  transition,
+			IfMatch:     req.Payload.IfMatch,
+		})
+		if err != nil {
+			slog.Error("operation failed", "pkg", "grpc", "rpc", "entityManage", "type", eventType, "ceId", ce.Id, "error", err.Error())
+			return entityTransactionError(ctx, ce.Id, err)
+		}
+		diag := common.GetDiagnostics(ctx)
+		resp := events.EntityTransactionResponseJson{
+			ID:        ce.Id,
+			Success:   true,
+			Warnings:  diag.GetWarnings(),
+			RequestID: ce.Id,
+			TransactionInfo: events.EntityTransactionInfoJson{EntityIds: result.EntityIDs},
+		}
+		if result.TransactionID != "" {
+			resp.TransactionInfo.TransactionID = &result.TransactionID
+		}
+		return NewCloudEvent(EntityTransactionResponse, resp)
+```
+
+- [ ] **Step 8: Run to verify it passes**
+
+Run: `go test ./internal/grpc/ -run TestRPC_EntityPatch -v && go build ./...`
+Expected: PASS and clean build.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add docs/cyoda/schema/common/PatchFormat.json docs/cyoda/schema/entity/EntityPatchPayload.json docs/cyoda/schema/entity/EntityPatchRequest.json scripts/generate-events.sh api/grpc/events/types.go internal/grpc/cloudevent_types.go internal/grpc/entity.go internal/grpc/rpc_test.go
+git commit -m "feat(grpc): EntityPatchRequest CloudEvent (RFC 7386 merge patch)
+
+New event type + generated patchFormat enum; dispatches to PatchEntity;
+empty ifMatch -> PRECONDITION_REQUIRED envelope (#341)."
+```
+
+---
+
+### Task 6: E2E coverage (HTTP through the full stack)
+
+**Files:**
+- Create: `internal/e2e/entity_patch_test.go`
+
+**Interfaces:**
+- Consumes: the e2e harness (`TestMain` PostgreSQL + httptest server, JWT auth) and existing helpers used by entity E2E tests in `internal/e2e/` (model import/lock, entity create, authed HTTP client). Mirror an existing `*_test.go` in that package for the exact helper names.
+
+- [ ] **Step 1: Write the failing E2E test** covering the contract surface. Use the package's existing authed-request helper (match its signature to a sibling test) — sketch:
+
+```go
+//go:build !short
+
+package e2e
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestE2E_EntityPatch_MergeAndPreconditions(t *testing.T) {
+	c := newE2EClient(t) // existing harness client
+	importLockModel(t, c, "person", "1", map[string]any{"name": "Alice", "age": 30})
+	id, txid := createEntity(t, c, "person", "1", map[string]any{"name": "Alice", "age": 30})
+
+	// Happy path: merge-patch one field with a valid token.
+	resp := c.patch(t, "/api/entity/JSON/"+id, "application/merge-patch+json", txid, `{"age":31}`)
+	if resp.status != http.StatusOK {
+		t.Fatalf("merge patch: got %d", resp.status)
+	}
+	got := getEntity(t, c, id)
+	if got["name"] != "Alice" || got["age"].(string) != "31" {
+		t.Errorf("merge wrong: %#v", got)
+	}
+
+	// XML format -> 415.
+	if r := c.patch(t, "/api/entity/XML/"+id, "application/merge-patch+json", "*", `{}`); r.status != http.StatusUnsupportedMediaType {
+		t.Errorf("XML: got %d", r.status)
+	}
+	// Wrong Content-Type -> 415.
+	if r := c.patch(t, "/api/entity/JSON/"+id, "application/json", "*", `{}`); r.status != http.StatusUnsupportedMediaType {
+		t.Errorf("bad CT: got %d", r.status)
+	}
+	// Missing If-Match -> 428.
+	if r := c.patchNoIfMatch(t, "/api/entity/JSON/"+id, "application/merge-patch+json", `{}`); r.status != http.StatusPreconditionRequired {
+		t.Errorf("no If-Match: got %d", r.status)
+	}
+	// json-patch+json -> 501.
+	if r := c.patch(t, "/api/entity/JSON/"+id, "application/json-patch+json", "*", `[]`); r.status != http.StatusNotImplemented {
+		t.Errorf("json-patch: got %d", r.status)
+	}
+	// Stale token -> 412.
+	if r := c.patch(t, "/api/entity/JSON/"+id, "application/merge-patch+json", txid, `{"age":99}`); r.status != http.StatusPreconditionFailed {
+		t.Errorf("stale token: got %d", r.status)
+	}
+}
+
+func TestE2E_EntityPatch_TransitionRunsAfterMerge(t *testing.T) {
+	// Patch sets a field AND names a transition whose processor overwrites it;
+	// assert the processor's value wins (merge-then-processor ordering).
+	// Use a model/workflow fixture with a mutating processor on the transition.
+	// ... mirror an existing workflow E2E fixture ...
+}
+```
+
+Provide the `c.patch` / `c.patchNoIfMatch` helpers in the test file (set method PATCH, `Content-Type`, optional `If-Match`, body), modelled on the harness's existing request helper. If the package lacks a fixture with a mutating processor, build the smallest one mirroring an existing workflow E2E test; if that proves out of proportion, assert ordering at the service level in Task 3 instead and `log`/comment the substitution here (do not silently drop it).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/e2e/ -run TestE2E_EntityPatch -v`
+Expected: FAIL (routes/behaviour exercised end-to-end; fails until Tasks 4 are wired into the running server — they are, so failures here are assertion-level until helpers compile).
+
+- [ ] **Step 3: Make it pass** — adjust helper names to the harness, fix any assertion mismatches. No production code should be needed beyond Tasks 1–5; if a gap surfaces, fix it under TDD in the owning task.
+
+- [ ] **Step 4: Run the full E2E + unit suite**
+
+Run: `go test ./... 2>&1 | tail -30`
+Expected: PASS (requires Docker for E2E).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/e2e/entity_patch_test.go
+git commit -m "test(e2e): entity PATCH through the full HTTP stack
+
+merge happy-path, 415/428/501/412, merge-then-transition ordering (#341)."
+```
+
+---
+
+### Task 7: Cloud-parity contract docs
+
+**Files:**
+- Create: `docs/cloud-parity/README.md`, `docs/cloud-parity/entity-patch.md`
+
+**Interfaces:** none (documentation).
+
+- [ ] **Step 1: Write `docs/cloud-parity/README.md`** — state the convention: cyoda-go leads the contract; this folder holds Cloud-facing implementation specs; no shared ticketing yet; cross-link `../cyoda/cloud-divergences.md` as the inverse vector (fields cyoda-go declares but does not yet implement). ~15 lines.
+
+- [ ] **Step 2: Write `docs/cloud-parity/entity-patch.md`** — the PATCH contract for Cloud to implement, derived from the spec §4–§8: RFC 7386 merge semantics; the three-state `If-Match` precondition (transactionId / `*` / absent→428) with the educational 428 body; HTTP surface (verbs, media types, JSON-only, error table incl. 409 vs 412 and precedence); gRPC surface (`EntityPatchRequest`, `patchFormat` enum, the `CLIENT_ERROR` envelope reality and the #342 caveat); strict validate-only (PATCH can never introduce a new field); merge-then-processor ordering. Frame explicitly as "the spec Cloud implements." No issue IDs in the prose body (the #342 reference belongs only in an internal note, not user-facing text — refer to it as "a tracked future gRPC-error improvement").
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/cloud-parity/
+git commit -m "docs(cloud-parity): entity PATCH contract for Cloud twin-alignment (#341)"
+```
+
+---
+
+### Task 8: Help topic (`crud.md`)
+
+**Files:**
+- Modify: `cmd/cyoda/help/content/crud.md`
+
+**Interfaces:** none (documentation).
+
+- [ ] **Step 1: Update the SYNOPSIS** — add to the endpoint list:
+
+```
+PATCH  /api/entity/{format}/{entityId}
+PATCH  /api/entity/{format}/{entityId}/{transition}
+```
+
+- [ ] **Step 2: Add a "Partial update (PATCH)" section** after the PUT update sections, covering: RFC 7386 merge semantics (send only changed fields; null deletes a key; arrays replace wholesale); JSON only; `Content-Type: application/merge-patch+json` (implemented) vs `application/json-patch+json` (501); the three-state `If-Match` (transactionId / `*` / absent→428) with the educational framing; the error table (404/409/412/415/428/501); and the two surprise behaviours called out in the spec — **strict validation** (a PATCH cannot introduce a new field, even in extend mode) and **processors run after the merge** (a named transition's processor may overwrite patched fields). Match the file's existing topic prose style. No issue IDs.
+
+- [ ] **Step 3: Verify the help topic renders** (front-matter intact, builds):
+
+Run: `go build ./cmd/cyoda && ./cyoda help crud | head -40` (or the package's help test if present: `go test ./cmd/cyoda/help/...`)
+Expected: topic includes the PATCH lines; no build/parse error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/cyoda/help/content/crud.md
+git commit -m "docs(help): document entity PATCH in the crud topic (#341)"
+```
+
+---
+
+### Task 9: Fidelity-direction reframe (own commit)
+
+**Files:**
+- Modify: `CLAUDE.md` (lines 3-4), `docs/cyoda/cloud-divergences.md` (intro), `docs/cyoda/README.md` (intro)
+
+**Interfaces:** none (documentation). This is a **separate commit** by design (both reviews flagged it as a governance change riding on a feature).
+
+- [ ] **Step 1: Reword the three "fidelity-to-Cloud" framings** to "cyoda-go defines the contract; Cloud aligns." Keep edits surgical:
+  - `CLAUDE.md:3-4`: reframe "digital twin … fidelity with Cyoda Cloud" to express that cyoda-go now leads the API/integration contract and Cloud follows, while still describing the project as a multi-node Go implementation of the Cyoda platform.
+  - `docs/cyoda/cloud-divergences.md:1-7`: reframe "cyoda-go is the digital twin of Cyoda Cloud" to note cyoda-go leads; this page still tracks deliberate divergences (declared-but-unimplemented), now framed as Cloud-alignment items. Cross-link `../cloud-parity/`.
+  - `docs/cyoda/README.md:2-6`: clarify the directory is a snapshot of Cloud's prior spec used as reference; with the direction reversed, Cloud aligns to cyoda-go's authoritative `api/openapi.yaml`.
+- [ ] **Step 2: Do NOT** blanket-reword the per-feature `"accepted for Cyoda Cloud parity"` notes (crud.md/workflows.md/errors) — those describe specific declared-but-unimplemented fields, a different sense of "parity". Leave them unless a specific note's who-implements-what is now wrong; reword only those case-by-case.
+- [ ] **Step 3: Verify nothing else references the old framing** in a way that now contradicts:
+
+Run: `grep -rn "digital twin\|fidelity with Cyoda" CLAUDE.md docs/ README.md`
+Expected: only intended, reworded occurrences remain.
+
+- [ ] **Step 4: Commit (separate from the feature)**
+
+```bash
+git add CLAUDE.md docs/cyoda/cloud-divergences.md docs/cyoda/README.md
+git commit -m "docs: reframe contract direction — cyoda-go leads, Cloud aligns (#341)"
+```
+
+---
+
+### Task 10: Full verification
+
+- [ ] **Step 1: Vet**
+
+Run: `go vet ./...`
+Expected: no findings.
+
+- [ ] **Step 2: Full test suite (unit + E2E, Docker required)**
+
+Run: `go test ./... -v 2>&1 | tail -40`
+Expected: all green.
+
+- [ ] **Step 3: Race detector (CI-parity scope), once, end-of-deliverable**
+
+Run: `make race`
+Expected: green. (Do not run per-step.)
+
+- [ ] **Step 4: Regenerated-artefact check** — confirm `api/generated.go` and `api/grpc/events/types.go` are committed and reflect the schema/spec edits (no uncommitted regen diff):
+
+Run: `git status --short && git diff --stat`
+Expected: clean working tree.
+
+---
+
+## Notes for the executor
+
+- **COMPATIBILITY.md** does not need a feature entry (it tracks SPI pins / chart / release). The release entry (CHANGELOG.md + `docs/release-notes/v0.8.2.md`) is added at release time, not in this plan.
+- **Tooling:** Task 5 needs `go-jsonschema` (`go install github.com/atombender/go-jsonschema@latest`). Task 4 uses `go tool oapi-codegen` (already a module tool).
+- **Plugin submodules:** this change is in the root module only; no `plugins/*` edits. Still run `go vet ./...` at the root.
+- **Atomicity/409:** the commit-time read-set-conflict → 409 path is covered by existing tx-manager tests across backends; Task 3's `TestPatchEntity_StaleTokenIs412` covers the conditional precondition deterministically. A deterministic concurrent-interleave 409 test is hard to write at the service boundary; if one is added, it must use two genuinely concurrent commits (not a sequential call) — otherwise omit it and rely on the tx-manager coverage rather than writing a no-op.

--- a/docs/superpowers/specs/2026-06-24-entity-patch-design.md
+++ b/docs/superpowers/specs/2026-06-24-entity-patch-design.md
@@ -1,0 +1,248 @@
+# Entity Partial-Update (PATCH / RFC 7386 Merge Patch) — Design
+
+- **Issue:** Cyoda/cyoda-go#341
+- **Target release:** v0.8.2 (additive, non-breaking)
+- **Status:** Approved design, pre-implementation
+- **Date:** 2026-06-24
+
+## 1. Motivation
+
+Many cyoda-go applications — frequently LLM-generated — incorrectly assume an
+entity update only needs the fields that changed. They call the update endpoint
+with a transition and either no body, an empty body, or a body containing only a
+few fields. The current update endpoints
+(`PUT /api/entity/{format}/{entityId}[/{transition}]`) have **wholesale-replace**
+semantics: `updated.Data` is set directly to the request body and the stored
+payload is loaded but never merged. Any field absent from the request is silently
+destroyed.
+
+There is no partial-update / patch capability today. This design adds one as a
+first-class, additive feature. Existing `PUT` replace semantics are **untouched**.
+
+## 2. Framing: cyoda-go leads the contract
+
+cyoda-go now **defines** the API/integration contract; Cyoda Cloud follows and
+mirrors it. This reverses the historical "digital twin with fidelity *to* Cloud"
+framing. Two consequences for this work:
+
+1. The patch contract is published in a Cloud-facing form precise enough for Cloud
+   to implement the twin-alignment — under a new `docs/cloud-parity/` folder.
+2. Fidelity-direction language across the repo is updated (surgically) to reflect
+   that cyoda-go defines the contract and Cloud aligns.
+
+There is no shared ticketing system across the two streams yet; `docs/cloud-parity/`
+is the coordination surface in the interim.
+
+## 3. Scope
+
+**In scope (this issue):** single-entity patch, across **both** the HTTP API and
+the gRPC layer.
+
+**Out of scope (deferred, mechanical follow-ups):**
+- Collection/batch patch (`PATCH /api/entity/{format}` + streaming gRPC variant).
+- XML patch (Merge Patch is JSON-only by RFC 7386).
+- RFC 6902 (JSON Patch) *implementation* — scaffolded only (see §6.2).
+
+## 4. Merge semantics — RFC 7386 (JSON Merge Patch)
+
+The request body is a sparse JSON object applied to the **stored** entity payload:
+
+- A key present in the patch with a non-null value **overwrites** the target key.
+- A key whose value is itself an object **merges recursively**.
+- A key present in the patch with an explicit `null` value **deletes** that key
+  from the target.
+- Arrays are **replaced wholesale** — there are no element-level operations.
+- A non-object patch document (e.g. a bare scalar or array) **replaces** the target
+  entirely, per the RFC.
+
+The implementation must be a faithful realisation of RFC 7386 (the recursive
+`MergePatch` algorithm), so Cloud has a *specification* to match, not an
+observed behaviour to reverse-engineer. The algorithm is small enough to implement
+directly; the RFC's appendix test cases become unit tests (§10).
+
+## 5. The "no stale premise" precondition model
+
+A merge is applied relative to a base. A caller computes the delta against some
+version it read earlier; if the stored entity has moved underneath it, merging the
+delta onto the *new* current state can encode a stale premise (the classic
+lost-update problem). PATCH is therefore inherently more dangerous than a full
+replace, and we make the *choice* explicit rather than letting callers blunder
+into a blind patch.
+
+`If-Match` is **required to be present in some form** on every PATCH. Three states:
+
+| `If-Match` value | Meaning | Outcome |
+| --- | --- | --- |
+| `"<version>"` | Conditional: the merge base must equal this version | **412 Precondition Failed** if the stored version has moved |
+| `*` | Unconditional opt-out: "I am not pinning a version; merge onto current" | Proceeds (entity must exist) |
+| *absent* | — | **428 Precondition Required**; the error body explains the two valid choices |
+
+`*` is the RFC 7232 wildcard ("any current representation"); folding the opt-out
+into the same field that carries the version means the two states can never
+contradict each other. 428 is RFC 6585, which exists precisely to "prevent the
+lost update problem" by forcing requests to be conditional.
+
+This is a **deliberate divergence from `PUT`**, where a missing `If-Match` means
+"unconditional replace." PATCH treats a missing `If-Match` as 428. The divergence
+is justified by patch being base-relative, and is documented as such.
+
+The version token reuses the existing optimistic-concurrency mechanism (the ETag /
+`transactionId`-based `If-Match` already implemented for `PUT`); no new concurrency
+primitive is introduced.
+
+## 6. HTTP contract
+
+### 6.1 Endpoints
+
+New verb, parallel to the existing `PUT` endpoints (which are unchanged):
+
+- `PATCH /api/entity/{format}/{entityId}` — loopback (no named transition)
+- `PATCH /api/entity/{format}/{entityId}/{transition}` — patch carrying a named transition
+
+Transition stays orthogonal to the patch body, exactly as with update today
+(loopback vs `ManualTransition`). The same query parameters the `PUT` endpoints
+accept (`transactionTimeoutMillis`, `waitForConsistencyAfter`) apply unchanged, and
+the response shape is the existing `EntityTransactionResponse`.
+
+### 6.2 Patch dialect via `Content-Type`
+
+| `Content-Type` | Dialect | Behaviour |
+| --- | --- | --- |
+| `application/merge-patch+json` | RFC 7386 | Implemented |
+| `application/json-patch+json` | RFC 6902 | Scaffolded — recognised and routed, returns **501 Not Implemented** |
+| anything else | — | **415 Unsupported Media Type** |
+
+### 6.3 Format
+
+`{format}` **must be `JSON`.** Merge Patch is JSON-only by RFC 7386; `XML` ⇒
+**415 Unsupported Media Type**. The `{format}` path segment is retained for
+structural symmetry with the `PUT` routes (and forward-compatibility), but only
+`JSON` is accepted.
+
+### 6.4 HTTP error model
+
+| Code | Condition |
+| --- | --- |
+| 404 Not Found | Entity does not exist |
+| 412 Precondition Failed | `If-Match: "<version>"` supplied and the stored version has moved |
+| 415 Unsupported Media Type | `XML` format, or a `Content-Type` other than the two patch media types |
+| 428 Precondition Required | No `If-Match` header present |
+| 501 Not Implemented | `Content-Type: application/json-patch+json` (RFC 6902 scaffold) |
+| 4xx (domain) | The **merged result** fails model-schema validation (full domain detail + error code) |
+
+**Precedence** (request-shape validation before resource state, so existence is
+never leaked to a malformed or unconditional request): media-type/format
+resolution first — unknown `Content-Type` or `XML` ⇒ 415; recognised-but-unimplemented
+`application/json-patch+json` ⇒ 501 — then `If-Match` presence (absent ⇒ 428),
+then entity lookup (404), then version compare (412), then merge + schema
+validation (4xx). So XML with no `If-Match` returns 415, not 428.
+
+4xx responses carry full domain detail per the project's error conventions; 5xx
+remain generic. No issue IDs appear in any shipped error text.
+
+## 7. gRPC contract (no proto change)
+
+The `entityManage` unary RPC dispatches on the CloudEvent `type` string, so no
+`.proto` change and no regeneration is required.
+
+- New CloudEvent type **`EntityPatchRequest`** (registered alongside
+  `EntityUpdateRequest` in `internal/grpc/cloudevent_types.go`), handled by a new
+  case in `EntityManage`.
+- New payload type `EntityPatchPayloadJson` in `api/grpc/events/types.go`:
+  `{ entityId, patch, transition?, ifMatch, patchFormat }`.
+- New Go string-enum `PatchFormatJson` following the existing `DataFormatJson`
+  pattern (generated-style constants, not a proto3 enum): `MERGE_PATCH`
+  (implemented) and `JSON_PATCH` (⇒ gRPC `UNIMPLEMENTED`). This is the gRPC mirror
+  of the HTTP media type.
+- `ifMatch` carries `"<version>"` / `"*"` / empty. Empty ⇒ the gRPC equivalent of
+  428 (a `FailedPrecondition`/precondition-required-style error consistent with how
+  the existing `ENTITY_MODIFIED` mapping is surfaced).
+
+The HTTP media type and the gRPC `patchFormat` enum are two idiomatic expressions
+of the same choice; the contract doc states the mapping explicitly so Cloud can
+mirror both layers.
+
+## 8. Service layer
+
+A new `PatchEntity(ctx, PatchEntityInput)` method in
+`internal/domain/entity/service.go`, parallel to `UpdateEntity`:
+
+```
+PatchEntityInput {
+    EntityID    string
+    Format      string        // must be "JSON"
+    Patch       json.RawMessage
+    PatchFormat string        // "MERGE_PATCH" | "JSON_PATCH"
+    Transition  string        // optional, empty for loopback
+    IfMatch     string        // "<version>" | "*"; required (absence handled at the edge as 428)
+}
+```
+
+Flow, executed **atomically within a single transaction**:
+
+1. Load the base entity (`existing.Data`).
+2. If `PatchFormat == JSON_PATCH` ⇒ return not-implemented (501 / `UNIMPLEMENTED`).
+3. Apply the RFC 7386 merge of `Patch` onto `existing.Data` ⇒ merged payload.
+4. Validate the **merged result** against the model schema (reusing
+   `validateOrExtend`); a `null`-deletion that removes a required field fails here.
+5. Funnel the merged payload into the **existing** loopback / named-transition +
+   `If-Match` machinery that `UpdateEntity` already uses — no new engine path.
+
+Because the read-of-base, merge, validation, and conditional save all occur within
+one transaction, the merged result is always derived from the exact version being
+overwritten — including under `If-Match: *` — so there is no read-merge-write race.
+
+Both the HTTP handler and the gRPC `EntityManage` case call `PatchEntity`, so there
+is a single code path, mirroring how `UpdateEntity` is shared today.
+
+## 9. Documentation deliverables
+
+1. **`docs/cloud-parity/` (new folder)**
+   - `README.md` stating the convention: cyoda-go leads the contract; this folder
+     holds Cloud-facing implementation specs; no shared ticketing yet. Cross-links
+     to `docs/cyoda/cloud-divergences.md` (the inverse vector: fields cyoda-go
+     declares but does not yet implement).
+   - `entity-patch.md` — the PATCH contract for Cloud to implement: merge
+     semantics (§4), precondition model (§5), HTTP + gRPC surfaces (§6–7), error
+     table. Framed explicitly as *the spec Cloud implements*.
+2. **`cmd/cyoda/help/content/crud.md`** — add PATCH to the SYNOPSIS and a
+   partial-update section (media types, `If-Match` three-state, error codes).
+3. **`api/openapi.yaml`** — new PATCH operations; add `415`/`428`/`501` to
+   `components/responses` (reuse the existing `412`).
+4. **Fidelity-direction reframe (surgical)** — reword the genuine "who-follows-whom"
+   framing to "cyoda-go defines the contract; Cloud aligns":
+   - `CLAUDE.md:3-4` (mission statement)
+   - `docs/cyoda/cloud-divergences.md:1-7` (intro)
+   - `docs/cyoda/README.md:2-6` (read-only mirror purpose)
+   The per-feature `"accepted for Cyoda Cloud parity"` notes in `crud.md`,
+   `workflows.md`, and the error topics describe specific declared-but-unimplemented
+   fields — a *different* sense of "parity". They are reworded case-by-case during
+   planning (who-implements-what), **not** by blanket find/replace.
+5. **Release note** — `docs/release-notes/v0.8.2.md` + `CHANGELOG.md` entry at
+   release time; issue #341 milestoned to v0.8.2 (the milestone is the changelog
+   source).
+
+## 10. Testing (TDD)
+
+RED-first throughout (project Gate 1).
+
+- **Merge function unit tests** — the RFC 7386 appendix test cases verbatim, plus
+  null-delete, nested-object merge, array-wholesale-replace, and non-object-patch
+  replacement.
+- **Service-level patch tests** — merged-result schema validation (incl.
+  required-field removal failure), the three `If-Match` states (version-match,
+  version-moved ⇒ 412, `*` ⇒ unconditional, absent ⇒ 428), JSON_PATCH ⇒
+  not-implemented, and transactional atomicity of read-merge-validate-save.
+- **E2E (HTTP stack)** — each media type, 404/412/415/428/501, and a
+  transition-carrying patch, through the full HTTP server (project Gate 2).
+- **gRPC E2E** — an `EntityPatchRequest` round-trip including the `patchFormat`
+  enum and the `ifMatch` states.
+
+## 11. Out-of-scope follow-ups (recorded, not built)
+
+- Collection/batch patch — reuses the per-item envelope the collection `PUT`
+  already has; the single-item merge/precondition/validation semantics are
+  identical, so it is a mechanical extension.
+- XML patch.
+- RFC 6902 implementation — the dialect is already selectable; only the algorithm
+  and its error/validation wiring remain.

--- a/docs/superpowers/specs/2026-06-24-entity-patch-design.md
+++ b/docs/superpowers/specs/2026-06-24-entity-patch-design.md
@@ -54,39 +54,61 @@ The request body is a sparse JSON object applied to the **stored** entity payloa
 - Arrays are **replaced wholesale** — there are no element-level operations.
 - A non-object patch document (e.g. a bare scalar or array) **replaces** the target
   entirely, per the RFC.
+- The empty patch `{}` is a valid **no-op merge**: the data is unchanged, but the
+  request is still a normal update — it commits a new transaction and fires the
+  loopback (or named transition). "A patch that changes no data still advances
+  workflow state" is intentional and consistent with PUT-with-empty-body today.
 
 The implementation must be a faithful realisation of RFC 7386 (the recursive
 `MergePatch` algorithm), so Cloud has a *specification* to match, not an
 observed behaviour to reverse-engineer. The algorithm is small enough to implement
-directly; the RFC's appendix test cases become unit tests (§10).
+directly; the RFC's appendix test cases become unit tests (§10). The merge must
+operate on number-preserving decoding (`json.Number`, as `decodeJSONPreservingNumbers`
+does for update) so large `int64` values survive a merge without `float64`
+coercion.
 
 ## 5. The "no stale premise" precondition model
 
 A merge is applied relative to a base. A caller computes the delta against some
-version it read earlier; if the stored entity has moved underneath it, merging the
+state it read earlier; if the stored entity has moved underneath it, merging the
 delta onto the *new* current state can encode a stale premise (the classic
 lost-update problem). PATCH is therefore inherently more dangerous than a full
 replace, and we make the *choice* explicit rather than letting callers blunder
 into a blind patch.
 
+**The precondition token is the entity's `transactionId`** — the `transactionId`
+of the caller's last read, exactly as the existing `PUT` `If-Match` uses (the
+backends' `CompareAndSave` compares the stored `_meta.transaction_id`, not
+`EntityMeta.Version`; the `crud.md` help already documents `If-Match` as the
+"transaction ID of last read"). The contract text says **transactionId**, never
+"version", to avoid pointing Cloud at the wrong field.
+
 `If-Match` is **required to be present in some form** on every PATCH. Three states:
 
 | `If-Match` value | Meaning | Outcome |
 | --- | --- | --- |
-| `"<version>"` | Conditional: the merge base must equal this version | **412 Precondition Failed** if the stored version has moved |
-| `*` | Unconditional opt-out: "I am not pinning a version; merge onto current" | Proceeds (entity must exist) |
+| `"<transactionId>"` | Conditional: the merge base must still be this transactionId | **412 Precondition Failed** if the stored transactionId differs |
+| `*` | Unconditional opt-out: "I am not pinning a transactionId; merge onto current" | Proceeds (entity must exist) |
 | *absent* | — | **428 Precondition Required**; the error body explains the two valid choices |
 
 `*` is the RFC 7232 wildcard ("any current representation"); folding the opt-out
-into the same field that carries the version means the two states can never
+into the same field that carries the token means the two states can never
 contradict each other. 428 is RFC 6585, which exists precisely to "prevent the
 lost update problem" by forcing requests to be conditional.
+
+**`*` translation (mechanism).** `*` is *not* passed down to `CompareAndSave` as
+the literal string `"*"` — that would be compared against the stored
+`transaction_id` and never match, yielding a spurious 412. Instead `*` is
+translated to **"no CAS"** (the empty-`IfMatch` path that `UpdateEntity` already
+takes for an unconditional save), with entity existence guaranteed by the in-transaction
+base `Get` (a missing entity is a 404 before any save). So `*` = "save
+unconditionally, but the entity must exist."
 
 This is a **deliberate divergence from `PUT`**, where a missing `If-Match` means
 "unconditional replace." PATCH treats a missing `If-Match` as 428. The divergence
 is justified by patch being base-relative, and is documented as such.
 
-The version token reuses the existing optimistic-concurrency mechanism (the ETag /
+The token reuses the existing optimistic-concurrency mechanism (the
 `transactionId`-based `If-Match` already implemented for `PUT`); no new concurrency
 primitive is introduced.
 
@@ -115,27 +137,37 @@ the response shape is the existing `EntityTransactionResponse`.
 ### 6.3 Format
 
 `{format}` **must be `JSON`.** Merge Patch is JSON-only by RFC 7386; `XML` ⇒
-**415 Unsupported Media Type**. The `{format}` path segment is retained for
-structural symmetry with the `PUT` routes (and forward-compatibility), but only
-`JSON` is accepted.
+**415 Unsupported Media Type**. The `{format}` path segment is **retained for
+structural symmetry with the `PUT` routes** (which carry it); only `JSON` is
+accepted, so the segment is effectively fixed for PATCH. (Decision: kept for
+symmetry over the format-less `GET /api/entity/{entityId}` shape.)
 
 ### 6.4 HTTP error model
 
 | Code | Condition |
 | --- | --- |
-| 404 Not Found | Entity does not exist |
-| 412 Precondition Failed | `If-Match: "<version>"` supplied and the stored version has moved |
+| 404 Not Found | Entity does not exist (covers soft-deleted — `Get` filters `NOT deleted`) |
+| 409 Conflict (retryable) | A concurrent writer committed between the in-tx base read and this save (read-set conflict at commit). Possible even under `If-Match: *`; caller may retry. |
+| 412 Precondition Failed | `If-Match: "<transactionId>"` supplied and the stored transactionId differs |
 | 415 Unsupported Media Type | `XML` format, or a `Content-Type` other than the two patch media types |
 | 428 Precondition Required | No `If-Match` header present |
 | 501 Not Implemented | `Content-Type: application/json-patch+json` (RFC 6902 scaffold) |
-| 4xx (domain) | The **merged result** fails model-schema validation (full domain detail + error code) |
+| 4xx (domain) | The **merged result** fails strict model-schema validation (full domain detail + error code) |
+
+**409 vs 412.** 412 is the *up-front* conditional rejection when the caller's
+`If-Match` transactionId no longer matches at `CompareAndSave`. 409 is the
+*commit-time* read-set conflict the transaction manager raises when a concurrent
+writer touches the base entity after our in-tx snapshot but before commit — the
+mechanism that makes the single-transaction guarantee (§8) hold even for
+`If-Match: *`. Both are legitimate, documented outcomes; 409 is retryable.
 
 **Precedence** (request-shape validation before resource state, so existence is
 never leaked to a malformed or unconditional request): media-type/format
 resolution first — unknown `Content-Type` or `XML` ⇒ 415; recognised-but-unimplemented
 `application/json-patch+json` ⇒ 501 — then `If-Match` presence (absent ⇒ 428),
-then entity lookup (404), then version compare (412), then merge + schema
-validation (4xx). So XML with no `If-Match` returns 415, not 428.
+then entity lookup (404), then transactionId compare (412), then merge + strict
+schema validation (4xx); 409 can only arise at commit. So XML with no `If-Match`
+returns 415, not 428.
 
 4xx responses carry full domain detail per the project's error conventions; 5xx
 remain generic. No issue IDs appear in any shipped error text.
@@ -143,20 +175,43 @@ remain generic. No issue IDs appear in any shipped error text.
 ## 7. gRPC contract (no proto change)
 
 The `entityManage` unary RPC dispatches on the CloudEvent `type` string, so no
-`.proto` change and no regeneration is required.
+`.proto` change and no regeneration of the gRPC stubs is required.
 
-- New CloudEvent type **`EntityPatchRequest`** (registered alongside
-  `EntityUpdateRequest` in `internal/grpc/cloudevent_types.go`), handled by a new
-  case in `EntityManage`.
-- New payload type `EntityPatchPayloadJson` in `api/grpc/events/types.go`:
-  `{ entityId, patch, transition?, ifMatch, patchFormat }`.
-- New Go string-enum `PatchFormatJson` following the existing `DataFormatJson`
-  pattern (generated-style constants, not a proto3 enum): `MERGE_PATCH`
-  (implemented) and `JSON_PATCH` (⇒ gRPC `UNIMPLEMENTED`). This is the gRPC mirror
-  of the HTTP media type.
-- `ifMatch` carries `"<version>"` / `"*"` / empty. Empty ⇒ the gRPC equivalent of
-  428 (a `FailedPrecondition`/precondition-required-style error consistent with how
-  the existing `ENTITY_MODIFIED` mapping is surfaced).
+- New CloudEvent type **`EntityPatchRequest`** — the type-*string* constant is
+  hand-written in `internal/grpc/cloudevent_types.go` (alongside
+  `EntityUpdateRequest`), handled by a new case in `EntityManage`.
+- New payload + enum types are **generated, not hand-edited**. `api/grpc/events/types.go`
+  is stamped `DO NOT EDIT` and produced by `scripts/generate-events.sh` from
+  JSON-schema sources under `docs/cyoda/schema/`. So `EntityPatchRequest`'s payload
+  (`{ entityId, patch, transition?, ifMatch, patchFormat }`) and the `PatchFormat`
+  enum are authored as **new schema files** (e.g.
+  `docs/cyoda/schema/entity/EntityPatchRequest.json` and a `PatchFormat.json`
+  mirroring `common/DataFormat.json`), and the generator is re-run. Editing
+  `types.go` directly would be reverted by the next `make generate`.
+- `PatchFormat` values: `MERGE_PATCH` (implemented) and `JSON_PATCH` (not
+  implemented). This is the gRPC mirror of the HTTP media type.
+
+**gRPC error representation (important — corrects an earlier draft).** Domain
+failures over gRPC are *not* surfaced as gRPC `status` codes. `EntityManage`
+returns an `EntityTransactionResponse` **envelope** with `Success: false` and an
+`Error` block, and `buildErrorFields` (`internal/grpc/errors.go`) collapses **all**
+operational errors to `Error.Code = "CLIENT_ERROR"`, carrying the real code only
+inside the message string (`"<CODE>: detail"`). Therefore:
+
+- `JSON_PATCH` ⇒ a `NOT_IMPLEMENTED` operational error, surfaced in the envelope as
+  `Success:false, Error.Code:"CLIENT_ERROR", Error.Message:"NOT_IMPLEMENTED: ..."`.
+- empty `ifMatch` ⇒ a `PRECONDITION_REQUIRED` operational error, surfaced the same
+  envelope way; `"<transactionId>"` mismatch ⇒ the existing precondition error;
+  `"*"` ⇒ unconditional (translated to no-CAS, as in §5).
+
+This per-code flattening is a **pre-existing limitation of the gRPC envelope**, not
+specific to PATCH. We keep it as-is for the non-breaking v0.8.2 release and document
+it precisely. Surfacing distinct, machine-readable gRPC error identity (per-code, or
+`codes.Unimplemented`/`codes.FailedPrecondition`) is a wire-contract change affecting
+every operation and is tracked as a separate future-release improvement
+(Cyoda/cyoda-go#342). Until then the Cloud-parity contract states the HTTP status
+codes as canonical and documents the gRPC envelope's `CLIENT_ERROR`-plus-message
+representation as the current mirror.
 
 The HTTP media type and the gRPC `patchFormat` enum are two idiomatic expressions
 of the same choice; the contract doc states the mapping explicitly so Cloud can
@@ -164,8 +219,21 @@ mirror both layers.
 
 ## 8. Service layer
 
-A new `PatchEntity(ctx, PatchEntityInput)` method in
-`internal/domain/entity/service.go`, parallel to `UpdateEntity`:
+### 8.1 The internal seam — a merge hook on the update flow, not a parallel method
+
+The entire `UpdateEntity` flow from "have the new payload" onward — open tx, `Get`
+base, validate, build `updated`, call the engine's `*WithIfMatch`, CAS, commit — is
+identical for patch. The *only* patch-specific work is: between the in-tx `Get` and
+the construction of `updated.Data`, apply the merge to `existing.Data`. So PATCH is
+implemented by **refactoring `UpdateEntity` to accept an optional transform hook**
+applied to the base payload inside the existing transaction, **not** by a parallel
+`PatchEntity` that re-implements (and would inevitably fork) the ~200-line
+tx/engine/CAS sequence. A naive "compute merged bytes, then call `UpdateEntity`"
+is explicitly rejected: it would read the base in a *different* transaction from the
+save and lose the atomicity guarantee below.
+
+The public entry point `PatchEntity(ctx, PatchEntityInput)` builds the merge hook
+and delegates into the shared flow:
 
 ```
 PatchEntityInput {
@@ -174,26 +242,55 @@ PatchEntityInput {
     Patch       json.RawMessage
     PatchFormat string        // "MERGE_PATCH" | "JSON_PATCH"
     Transition  string        // optional, empty for loopback
-    IfMatch     string        // "<version>" | "*"; required (absence handled at the edge as 428)
+    IfMatch     string        // "<transactionId>" | "*"; required (absence is 428 at the edge)
 }
 ```
 
-Flow, executed **atomically within a single transaction**:
+### 8.2 Flow, executed atomically within a single transaction
 
-1. Load the base entity (`existing.Data`).
-2. If `PatchFormat == JSON_PATCH` ⇒ return not-implemented (501 / `UNIMPLEMENTED`).
-3. Apply the RFC 7386 merge of `Patch` onto `existing.Data` ⇒ merged payload.
-4. Validate the **merged result** against the model schema (reusing
-   `validateOrExtend`); a `null`-deletion that removes a required field fails here.
-5. Funnel the merged payload into the **existing** loopback / named-transition +
-   `If-Match` machinery that `UpdateEntity` already uses — no new engine path.
+1. Tenant-scoped, in-transaction `Get` of the base entity (`existing.Data`). The
+   `Get` is tenant-scoped and filters soft-deleted, so a missing/soft-deleted base
+   is a 404 before any save — and the read is registered in the transaction's
+   read-set.
+2. If `PatchFormat == JSON_PATCH` ⇒ return not-implemented (HTTP 501; gRPC envelope
+   per §7).
+3. Apply the RFC 7386 merge of `Patch` onto `existing.Data` (number-preserving) ⇒
+   merged payload.
+4. **Strictly validate** the merged result against the model schema — *validate
+   only, never extend* (see §8.3). A `null`-deletion that removes a required field
+   fails here.
+5. Run the merged payload through the **existing** loopback / named-transition +
+   `If-Match` machinery (`LoopbackWithIfMatch` / `ManualTransitionWithIfMatch`) — no
+   new engine path. `If-Match: *` is translated to the no-CAS path (§5).
 
-Because the read-of-base, merge, validation, and conditional save all occur within
-one transaction, the merged result is always derived from the exact version being
-overwritten — including under `If-Match: *` — so there is no read-merge-write race.
+**Ordering under a named transition.** The merge is applied *first*; the transition's
+processors then run on the merged state and may further mutate the entity. So a
+processor can legitimately overwrite a field the patch set — the observable result
+of a patch is *not* guaranteed to retain the patched values when a transition with
+mutating processors is named. This is identical to PUT-plus-transition and is stated
+explicitly in the contract (it is more than "orthogonal").
 
-Both the HTTP handler and the gRPC `EntityManage` case call `PatchEntity`, so there
-is a single code path, mirroring how `UpdateEntity` is shared today.
+**Atomicity.** Because the base read, merge, validation, and conditional save all
+occur within one transaction, and every backend re-validates the transaction's
+read-set at commit (raising `spi.ErrConflict` ⇒ **409 retryable** if a concurrent
+writer touched the base after our snapshot), the merged result is always derived
+from the exact base being overwritten — *including under `If-Match: *`*. There is no
+read-merge-write race; the residual conflict surfaces as the documented 409 (§6.4),
+not silent corruption.
+
+### 8.3 Strict validation — deliberate divergence from PUT
+
+`UpdateEntity` uses `validateOrExtend`, which — when the model's `ChangeLevel`
+permits — *extends and writes* the model schema for previously-unseen fields. PATCH
+deliberately does **not** reuse the extend behaviour: it validates the merged result
+**strictly** (validate-only) regardless of `ChangeLevel`, so a stray/typo'd key in a
+sparse delta is rejected rather than silently widening the tenant's model. This is a
+considered divergence from PUT (which may extend), justified by partial deltas —
+especially LLM-generated ones, the §1 motivation — being the most likely source of
+accidental fields. The divergence is documented in the Cloud-parity contract.
+
+Both the HTTP handler and the gRPC `EntityManage` case reach the same shared flow via
+`PatchEntity`, mirroring how `UpdateEntity` is shared today.
 
 ## 9. Documentation deliverables
 
@@ -207,8 +304,11 @@ is a single code path, mirroring how `UpdateEntity` is shared today.
      table. Framed explicitly as *the spec Cloud implements*.
 2. **`cmd/cyoda/help/content/crud.md`** — add PATCH to the SYNOPSIS and a
    partial-update section (media types, `If-Match` three-state, error codes).
-3. **`api/openapi.yaml`** — new PATCH operations; add `415`/`428`/`501` to
-   `components/responses` (reuse the existing `412`).
+3. **`api/openapi.yaml`** — new PATCH operations (the generator already supports
+   `patch:` ops — see the existing OIDC patch operation). Add `409`/`415`/`428`/`501`
+   responses; reuse a `412`/`409` component if one exists, otherwise define them.
+   HTTP routes are regenerated via oapi-codegen and the handler is hand-written,
+   mirroring `UpdateSingle`.
 4. **Fidelity-direction reframe (surgical)** — reword the genuine "who-follows-whom"
    framing to "cyoda-go defines the contract; Cloud aligns":
    - `CLAUDE.md:3-4` (mission statement)
@@ -227,16 +327,24 @@ is a single code path, mirroring how `UpdateEntity` is shared today.
 RED-first throughout (project Gate 1).
 
 - **Merge function unit tests** — the RFC 7386 appendix test cases verbatim, plus
-  null-delete, nested-object merge, array-wholesale-replace, and non-object-patch
-  replacement.
-- **Service-level patch tests** — merged-result schema validation (incl.
-  required-field removal failure), the three `If-Match` states (version-match,
-  version-moved ⇒ 412, `*` ⇒ unconditional, absent ⇒ 428), JSON_PATCH ⇒
-  not-implemented, and transactional atomicity of read-merge-validate-save.
-- **E2E (HTTP stack)** — each media type, 404/412/415/428/501, and a
-  transition-carrying patch, through the full HTTP server (project Gate 2).
+  null-delete, nested-object merge, array-wholesale-replace, non-object-patch
+  replacement, empty-`{}` no-op, and a **number-fidelity** case asserting an
+  `int64 > 2^53` survives a merge without `float64` coercion.
+- **Service-level patch tests** — strict merged-result validation (incl.
+  required-field removal failure **and** a stray new field being *rejected*, not
+  schema-extended), the three `If-Match` states (transactionId-match,
+  transactionId-moved ⇒ 412, `*` ⇒ unconditional via no-CAS, absent ⇒ 428), and
+  JSON_PATCH ⇒ not-implemented.
+- **Atomicity test** — a *concurrent interleaved commit* (not a sequential call):
+  a second writer commits to the base between PATCH's in-tx base read and its save,
+  asserting the read-set conflict surfaces as 409 — including under `If-Match: *`.
+  A sequential call would be a no-op and must not be mistaken for an atomicity test.
+- **E2E (HTTP stack)** — each media type, 404/409/412/415/428/501, and a
+  transition-carrying patch (asserting merge-then-processor ordering), through the
+  full HTTP server (project Gate 2).
 - **gRPC E2E** — an `EntityPatchRequest` round-trip including the `patchFormat`
-  enum and the `ifMatch` states.
+  enum and the `ifMatch` states, asserting the **envelope** error representation
+  (`Success:false`, `Error.Code:"CLIENT_ERROR"`, code-in-message) per §7.
 
 ## 11. Out-of-scope follow-ups (recorded, not built)
 
@@ -245,4 +353,28 @@ RED-first throughout (project Gate 1).
   identical, so it is a mechanical extension.
 - XML patch.
 - RFC 6902 implementation — the dialect is already selectable; only the algorithm
-  and its error/validation wiring remain.
+  and its error/validation wiring remain. (Conscious bet: we ship a public 501 for
+  `application/json-patch+json` / `JSON_PATCH` ahead of demand, to nail the
+  selector shape now.)
+- **gRPC per-code error identity** — the envelope flattens all operational errors to
+  `CLIENT_ERROR` (§7); surfacing distinct gRPC error codes is tracked as
+  Cyoda/cyoda-go#342 for a future release.
+
+## 12. Design-review disposition
+
+This spec was revised after an independent fresh-context code review. Verified
+corrections folded in: the precondition token is `transactionId` (not "version");
+`If-Match: *` is translated to no-CAS + existence, never the literal `"*"`; the
+single-transaction guarantee's residual conflict is a documented **409**; gRPC
+errors use the existing `CLIENT_ERROR` envelope (not gRPC status codes); the gRPC
+payload/enum types are generated from `docs/cyoda/schema/`, not hand-edited;
+PatchEntity is a **merge hook on the shared update flow**, not a forked method;
+merge-then-transition ordering and empty-`{}` semantics are stated.
+
+Decisions taken on the review's open forks:
+- **gRPC error identity:** keep the `CLIENT_ERROR` envelope for v0.8.2 (non-breaking);
+  per-code identity deferred to #342.
+- **Patch validation:** **strict validate-only** — patch may not extend the model
+  schema (divergence from PUT, §8.3).
+- **Fidelity-direction reframe:** kept folded into this change (§9.4).
+- **`{format}` segment:** kept for PUT symmetry (§6.3).

--- a/docs/superpowers/specs/2026-06-24-entity-patch-design.md
+++ b/docs/superpowers/specs/2026-06-24-entity-patch-design.md
@@ -62,7 +62,7 @@ The request body is a sparse JSON object applied to the **stored** entity payloa
 The implementation must be a faithful realisation of RFC 7386 (the recursive
 `MergePatch` algorithm), so Cloud has a *specification* to match, not an
 observed behaviour to reverse-engineer. The algorithm is small enough to implement
-directly; the RFC's appendix test cases become unit tests (§10). The merge must
+directly; the RFC **Appendix A** test cases become unit tests (§10). The merge must
 operate on number-preserving decoding (`json.Number`, as `decodeJSONPreservingNumbers`
 does for update) so large `int64` values survive a merge without `float64`
 coercion.
@@ -96,6 +96,18 @@ into the same field that carries the token means the two states can never
 contradict each other. 428 is RFC 6585, which exists precisely to "prevent the
 lost update problem" by forcing requests to be conditional.
 
+**The 428 body must be educational, not a bare status.** The target audience is
+naive/LLM-generated clients that will not send `If-Match` and will reach for the
+quickest way to clear the error. To make that choice *informed* rather than a
+cargo-culted "add the magic header", the 428 response teaches the GET-first
+discipline, e.g.: *"This entity was patched without stating which version you read.
+Send `If-Match: <transactionId>` (the `transactionId` from your last GET of this
+entity) to patch safely, or `If-Match: *` to explicitly accept last-writer-wins."*
+This is a considered acceptance of the trade-off the reviewer raised: 428 still
+costs the naive client one failed attempt and some will hardcode `*`, but they do so
+*consciously*, which is the whole point of refusing a silent unconditional patch
+(§1 motivation: don't let apps build on a stale premise without noticing).
+
 **`*` translation (mechanism).** `*` is *not* passed down to `CompareAndSave` as
 the literal string `"*"` — that would be compared against the stored
 `transaction_id` and never match, yielding a spurious 412. Instead `*` is
@@ -118,11 +130,14 @@ primitive is introduced.
 
 New verb, parallel to the existing `PUT` endpoints (which are unchanged):
 
-- `PATCH /api/entity/{format}/{entityId}` — loopback (no named transition)
-- `PATCH /api/entity/{format}/{entityId}/{transition}` — patch carrying a named transition
+- `PATCH /api/entity/{format}/{entityId}` — loopback (no named transition), mirroring
+  `UpdateSingleWithLoopback` (`handler.go:864`)
+- `PATCH /api/entity/{format}/{entityId}/{transition}` — patch carrying a named
+  transition, mirroring `UpdateSingle` (`handler.go:897`)
 
-Transition stays orthogonal to the patch body, exactly as with update today
-(loopback vs `ManualTransition`). The same query parameters the `PUT` endpoints
+Both PUT handlers have PATCH counterparts; the plan wires *both*, not just the
+transition form. Transition stays orthogonal to the patch body, exactly as with
+update today (loopback vs `ManualTransition`). The same query parameters the `PUT` endpoints
 accept (`transactionTimeoutMillis`, `waitForConsistencyAfter`) apply unchanged, and
 the response shape is the existing `EntityTransactionResponse`.
 
@@ -148,7 +163,7 @@ symmetry over the format-less `GET /api/entity/{entityId}` shape.)
 | --- | --- |
 | 404 Not Found | Entity does not exist (covers soft-deleted — `Get` filters `NOT deleted`) |
 | 409 Conflict (retryable) | A concurrent writer committed between the in-tx base read and this save (read-set conflict at commit). Possible even under `If-Match: *`; caller may retry. |
-| 412 Precondition Failed | `If-Match: "<transactionId>"` supplied and the stored transactionId differs |
+| 412 Precondition Failed | `If-Match: "<transactionId>"` supplied and the stored transactionId differs. Reuses the existing `ErrCodeEntityModified` code/message ("entity has been modified since last read", `service.go:1122`) for consistency with PUT. |
 | 415 Unsupported Media Type | `XML` format, or a `Content-Type` other than the two patch media types |
 | 428 Precondition Required | No `If-Match` header present |
 | 501 Not Implemented | `Content-Type: application/json-patch+json` (RFC 6902 scaffold) |
@@ -257,8 +272,12 @@ PatchEntityInput {
 3. Apply the RFC 7386 merge of `Patch` onto `existing.Data` (number-preserving) ⇒
    merged payload.
 4. **Strictly validate** the merged result against the model schema — *validate
-   only, never extend* (see §8.3). A `null`-deletion that removes a required field
-   fails here.
+   only, never extend* (see §8.3). The validation input is the **merged result**,
+   not the request body (PUT validates the body directly; PATCH must re-derive the
+   parsed/validated form from the merge output). A `null`-deletion that removes a
+   field the schema marks `required` fails here; if the schema does not mark the
+   field `required`, the deletion succeeds and the field vanishes (RFC-correct) —
+   the guard is exactly as strong as the model's `required` set, no stronger.
 5. Run the merged payload through the **existing** loopback / named-transition +
    `If-Match` machinery (`LoopbackWithIfMatch` / `ManualTransitionWithIfMatch`) — no
    new engine path. `If-Match: *` is translated to the no-CAS path (§5).
@@ -287,7 +306,14 @@ deliberately does **not** reuse the extend behaviour: it validates the merged re
 sparse delta is rejected rather than silently widening the tenant's model. This is a
 considered divergence from PUT (which may extend), justified by partial deltas —
 especially LLM-generated ones, the §1 motivation — being the most likely source of
-accidental fields. The divergence is documented in the Cloud-parity contract.
+accidental fields.
+
+**Hard limitation, stated plainly (not buried as "catches typos"):** because PATCH
+never extends, **a PATCH can never introduce a field the model schema does not
+already allow — even when the model is in an extend-permitting `ChangeLevel`.** To
+add a genuinely new field, callers use PUT (which extends), then PATCH it thereafter.
+This limitation is documented as such in the Cloud-parity contract and in `crud.md`,
+so a caller who legitimately wants schema growth is not surprised by a rejection.
 
 Both the HTTP handler and the gRPC `EntityManage` case reach the same shared flow via
 `PatchEntity`, mirroring how `UpdateEntity` is shared today.
@@ -303,7 +329,11 @@ Both the HTTP handler and the gRPC `EntityManage` case reach the same shared flo
      semantics (§4), precondition model (§5), HTTP + gRPC surfaces (§6–7), error
      table. Framed explicitly as *the spec Cloud implements*.
 2. **`cmd/cyoda/help/content/crud.md`** — add PATCH to the SYNOPSIS and a
-   partial-update section (media types, `If-Match` three-state, error codes).
+   partial-update section (media types, `If-Match` three-state with the educational
+   428 framing, error codes). Must explicitly carry two behaviours callers will
+   otherwise discover by surprise: (a) **strict validation** — a PATCH cannot
+   introduce a new field even in extend mode (§8.3); (b) **processors run after the
+   merge** and may overwrite patched fields under a named transition (§8.2).
 3. **`api/openapi.yaml`** — new PATCH operations (the generator already supports
    `patch:` ops — see the existing OIDC patch operation). Add `409`/`415`/`428`/`501`
    responses; reuse a `412`/`409` component if one exists, otherwise define them.
@@ -318,6 +348,11 @@ Both the HTTP handler and the gRPC `EntityManage` case reach the same shared flo
    `workflows.md`, and the error topics describe specific declared-but-unimplemented
    fields — a *different* sense of "parity". They are reworded case-by-case during
    planning (who-implements-what), **not** by blanket find/replace.
+   **Reviewability:** two independent reviews flagged this reframe as a repo-governance
+   change riding on a feature PR. Decision (Paul): keep it folded into this work, but
+   land it as its **own clearly-separable commit** (the reframe + `docs/cloud-parity/`
+   convention), distinct from the feature commits, so a reviewer can assess the
+   directional statement on its own.
 5. **Release note** — `docs/release-notes/v0.8.2.md` + `CHANGELOG.md` entry at
    release time; issue #341 milestoned to v0.8.2 (the milestone is the changelog
    source).
@@ -361,6 +396,25 @@ RED-first throughout (project Gate 1).
   Cyoda/cyoda-go#342 for a future release.
 
 ## 12. Design-review disposition
+
+This spec survived **two** independent fresh-context code reviews. The second found
+**no blocking issues** and verified every load-bearing codebase claim against the
+source (atomicity/read-set commit validation on all three backends, the `*`→no-CAS
+translation, the gRPC `CLIENT_ERROR` envelope, the generated-vs-hand-written type
+split, the merge-hook seam at `service.go:1005–1015`, and number fidelity).
+
+Second-review refinements folded in: educational 428 body (§5); both PUT handlers
+mirrored (§6.1); 412 reuses `ErrCodeEntityModified` (§6.4); validation input is the
+merged result and the `required`-field guard is only as strong as the schema (§8.2);
+strict validation's hard limitation stated plainly — PATCH can never introduce a new
+field even in extend mode (§8.3); merge-then-processor ordering pinned by E2E and
+documented in `crud.md` (§8.2/§9/§10); RFC 7386 **Appendix A** cited (§4/§10); the
+fidelity reframe lands as its own separable commit (§9.4).
+
+Second-review dissents consciously **not** adopted (prior explicit decisions): the
+428 gate stays (Paul: keep, with the educational body above); the RFC 6902 501
+scaffold stays (explicitly requested selector shaping); the reframe stays folded
+(as a separable commit). The first review's revisions remain below.
 
 This spec was revised after an independent fresh-context code review. Verified
 corrections folded in: the precondition token is `transactionId` (not "version");

--- a/e2e/parity/client/http.go
+++ b/e2e/parity/client/http.go
@@ -1539,3 +1539,59 @@ func (c *Client) QueryGroupedStatsRaw(t *testing.T, modelName string, modelVersi
 	resp.Body.Close()
 	return resp.StatusCode, raw, nil
 }
+
+// PatchEntityRaw issues PATCH /api/entity/{format}/{entityId} (loopback) or
+// PATCH /api/entity/{format}/{entityId}/{transition} (named transition) and
+// returns the HTTP status, response body, and a transport error only. A
+// non-2xx status is returned without raising, so scenarios can assert
+// 200/400/404/412/415/428/501 directly.
+//
+// transition == "" selects the loopback path (no transition segment).
+// ifMatch == "" omits the If-Match header entirely (to exercise the 428 path).
+// format is the path format segment (normally "JSON"; pass "XML" to exercise
+// the 415 unsupported-format path).
+// contentType is sent verbatim as the Content-Type header (e.g.
+// "application/merge-patch+json").
+//
+// No 409 retry is performed — concurrency scenarios need to observe 409/412
+// directly. The request is issued once via the underlying http.Client, which
+// mirrors the pattern of all other *Raw methods in this file.
+func (c *Client) PatchEntityRaw(t *testing.T, entityID uuid.UUID, format, transition, contentType, ifMatch, body string) (int, []byte, error) {
+	t.Helper()
+
+	var path string
+	if transition == "" {
+		path = fmt.Sprintf("/api/entity/%s/%s", format, entityID.String())
+	} else {
+		path = fmt.Sprintf("/api/entity/%s/%s/%s", format, entityID.String(), transition)
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPatch, c.baseURL+path, strings.NewReader(body))
+	if err != nil {
+		return 0, nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	if ifMatch != "" {
+		req.Header.Set("If-Match", ifMatch)
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("transport: %w", err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	return resp.StatusCode, raw, nil
+}
+
+// PatchEntityMerge issues a merge-patch (application/merge-patch+json) PATCH
+// against /api/entity/JSON/{entityId}[/{transition}] and returns status+body.
+// Delegates to PatchEntityRaw with format="JSON" and the merge-patch
+// Content-Type so scenarios don't have to repeat the MIME string.
+func (c *Client) PatchEntityMerge(t *testing.T, entityID uuid.UUID, transition, ifMatch, body string) (int, []byte, error) {
+	t.Helper()
+	return c.PatchEntityRaw(t, entityID, "JSON", transition, "application/merge-patch+json", ifMatch, body)
+}

--- a/e2e/parity/entity_patch.go
+++ b/e2e/parity/entity_patch.go
@@ -636,12 +636,15 @@ func RunEntityPatchTypeMismatchIs400(t *testing.T, fixture BackendFixture) {
 			ErrorCode string `json:"errorCode"`
 		} `json:"properties"`
 	}
-	if jsonErr := json.Unmarshal(body, &problem); jsonErr == nil && problem.Properties.ErrorCode != "" {
-		code := problem.Properties.ErrorCode
-		if code != "INCOMPATIBLE_TYPE" && code != "VALIDATION_FAILED" && code != "BAD_REQUEST" {
-			t.Errorf("error body properties.errorCode = %q; want INCOMPATIBLE_TYPE, VALIDATION_FAILED, or BAD_REQUEST; body=%s",
-				code, body)
-		}
+	if err := json.Unmarshal(body, &problem); err != nil {
+		t.Fatalf("type-mismatch 400 body is not JSON: %v; body=%s", err, body)
+	}
+	switch problem.Properties.ErrorCode {
+	case "INCOMPATIBLE_TYPE", "VALIDATION_FAILED", "BAD_REQUEST":
+		// acceptable client validation codes
+	default:
+		t.Errorf("type-mismatch: properties.errorCode = %q; want INCOMPATIBLE_TYPE / VALIDATION_FAILED / BAD_REQUEST; body=%s",
+			problem.Properties.ErrorCode, body)
 	}
 }
 
@@ -710,9 +713,19 @@ func RunEntityPatchCrossTenantIsNotFound(t *testing.T, fixture BackendFixture) {
 		t.Fatalf("tenantA CreateEntity: %v", err)
 	}
 
-	// Tenant B mints a fresh identity and uses it to PATCH A's entity.
+	// Tenant B mints a fresh identity, imports the same model (so the 404
+	// can only be entity-level, not model-level), and attempts to PATCH A's entity.
 	tenantB := fixture.NewTenant(t)
 	cB := client.NewClient(fixture.BaseURL(), tenantB.Token)
+	if err := cB.ImportModel(t, modelName, modelVersion, `{"name":"x","amount":1,"status":"new"}`); err != nil {
+		t.Fatalf("tenantB ImportModel: %v", err)
+	}
+	if err := cB.LockModel(t, modelName, modelVersion); err != nil {
+		t.Fatalf("tenantB LockModel: %v", err)
+	}
+	if err := cB.ImportWorkflow(t, modelName, modelVersion, patchWorkflowJSON); err != nil {
+		t.Fatalf("tenantB ImportWorkflow: %v", err)
+	}
 	status, body, err := cB.PatchEntityMerge(t, idA, "", "*", `{"amount":999}`)
 	if err != nil {
 		t.Fatalf("tenantB PatchEntityMerge transport: %v", err)

--- a/e2e/parity/entity_patch.go
+++ b/e2e/parity/entity_patch.go
@@ -1,0 +1,806 @@
+package parity
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
+)
+
+// patchWorkflowJSON is a workflow with two states:
+//
+//	NONE --(init, auto)--> CREATED --(approve, manual)--> APPROVED
+//
+// The loopback PUT in setupPatchModel advances the token without firing
+// "approve". The manual "approve" transition is exercised by
+// RunEntityPatchWithTransition and used only there via PatchEntityMerge
+// with the transition path segment.
+const patchWorkflowJSON = `{
+	"importMode": "REPLACE",
+	"workflows": [{
+		"version": "1.1",
+		"name": "patch-wf",
+		"initialState": "NONE",
+		"active": true,
+		"states": {
+			"NONE": {
+				"transitions": [{"name": "init", "next": "CREATED", "manual": false}]
+			},
+			"CREATED": {
+				"transitions": [{"name": "approve", "next": "APPROVED", "manual": true}]
+			},
+			"APPROVED": {}
+		}
+	}]
+}`
+
+// setupPatchModel imports a model with fields {name:string, amount:int,
+// status:string}, locks it, and imports patchWorkflowJSON. Returns a
+// ready Client. modelName must be unique per scenario to avoid cross-test
+// collisions on the shared backend.
+func setupPatchModel(t *testing.T, fixture BackendFixture, modelName string) (cli *client.Client, tenantToken string) {
+	t.Helper()
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+	const modelVersion = 1
+	if err := c.ImportModel(t, modelName, modelVersion, `{"name":"x","amount":1,"status":"new"}`); err != nil {
+		t.Fatalf("setupPatchModel ImportModel %q: %v", modelName, err)
+	}
+	if err := c.LockModel(t, modelName, modelVersion); err != nil {
+		t.Fatalf("setupPatchModel LockModel %q: %v", modelName, err)
+	}
+	if err := c.ImportWorkflow(t, modelName, modelVersion, patchWorkflowJSON); err != nil {
+		t.Fatalf("setupPatchModel ImportWorkflow %q: %v", modelName, err)
+	}
+	return c, tenant.Token
+}
+
+// setupPatchModelCustomSample is like setupPatchModel but accepts an
+// arbitrary sample document. Used by scenarios that need a schema with a
+// nested object or an array field.
+func setupPatchModelCustomSample(t *testing.T, fixture BackendFixture, modelName, sampleDoc string) *client.Client {
+	t.Helper()
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+	const modelVersion = 1
+	if err := c.ImportModel(t, modelName, modelVersion, sampleDoc); err != nil {
+		t.Fatalf("setupPatchModelCustomSample ImportModel %q: %v", modelName, err)
+	}
+	if err := c.LockModel(t, modelName, modelVersion); err != nil {
+		t.Fatalf("setupPatchModelCustomSample LockModel %q: %v", modelName, err)
+	}
+	if err := c.ImportWorkflow(t, modelName, modelVersion, patchWorkflowJSON); err != nil {
+		t.Fatalf("setupPatchModelCustomSample ImportWorkflow %q: %v", modelName, err)
+	}
+	return c
+}
+
+// --- Normal-operation scenarios ---
+
+// RunEntityPatchMergePreservesFields verifies that a merge-patch
+// updates only the patched fields and leaves other fields intact.
+func RunEntityPatchMergePreservesFields(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	c, _ := setupPatchModel(t, fixture, "patch-merge-preserve")
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-merge-preserve", modelVersion, `{"name":"Alice","amount":30,"status":"draft"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	ent, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (pre-patch): %v", err)
+	}
+	txID := ent.Meta.TransactionID
+	if txID == "" {
+		t.Fatal("GetEntity: meta.transactionId is empty")
+	}
+
+	status, body, err := c.PatchEntityMerge(t, id, "", txID, `{"amount":31}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("PatchEntityMerge: status %d, want 200; body=%s", status, body)
+	}
+
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (post-patch): %v", err)
+	}
+	if got.Data["name"] != "Alice" {
+		t.Errorf("data.name = %v, want %q (preserved field mutated)", got.Data["name"], "Alice")
+	}
+	if got.Data["amount"] != float64(31) {
+		t.Errorf("data.amount = %v, want 31 (patched field not updated)", got.Data["amount"])
+	}
+}
+
+// RunEntityPatchNullDeletesKey verifies that a null value in the merge
+// patch removes the corresponding key from the stored document.
+func RunEntityPatchNullDeletesKey(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	c, _ := setupPatchModel(t, fixture, "patch-null-delete")
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-null-delete", modelVersion, `{"name":"Bob","amount":10,"status":"active"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	ent, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (pre-patch): %v", err)
+	}
+	txID := ent.Meta.TransactionID
+	if txID == "" {
+		t.Fatal("GetEntity: meta.transactionId is empty")
+	}
+
+	status, body, err := c.PatchEntityMerge(t, id, "", txID, `{"status":null}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("PatchEntityMerge: status %d, want 200; body=%s", status, body)
+	}
+
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (post-patch): %v", err)
+	}
+	if _, exists := got.Data["status"]; exists {
+		t.Errorf("data.status key still present after null-patch; want it deleted, got %v", got.Data["status"])
+	}
+	if got.Data["name"] != "Bob" {
+		t.Errorf("data.name = %v, want %q (sibling field mutated by null-patch)", got.Data["name"], "Bob")
+	}
+	if got.Data["amount"] != float64(10) {
+		t.Errorf("data.amount = %v, want 10 (sibling field mutated by null-patch)", got.Data["amount"])
+	}
+}
+
+// RunEntityPatchNestedMerge verifies RFC 7396 recursive merge: a nested
+// object patch preserves untouched keys and updates patched keys within
+// the locked schema. Only fields declared in the sample document (and
+// therefore in the locked schema) are used — adding new keys would
+// trigger strict schema validation rejection on a locked model.
+func RunEntityPatchNestedMerge(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	// Separate model with nested object in schema. Fields a, b, and c are
+	// all declared in the sample so they are known to the locked schema.
+	c := setupPatchModelCustomSample(t, fixture, "patch-nested-merge", `{"name":"x","meta":{"a":1,"b":2,"c":0}}`)
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-nested-merge", modelVersion, `{"name":"N","meta":{"a":1,"b":2,"c":0}}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	ent, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (pre-patch): %v", err)
+	}
+	txID := ent.Meta.TransactionID
+	if txID == "" {
+		t.Fatal("GetEntity: meta.transactionId is empty")
+	}
+
+	// Merge patch: preserve a (untouched), update b to 9, update c to 3.
+	// All three keys are in the locked schema so strict validation passes.
+	status, body, err := c.PatchEntityMerge(t, id, "", txID, `{"meta":{"b":9,"c":3}}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("PatchEntityMerge: status %d, want 200; body=%s", status, body)
+	}
+
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (post-patch): %v", err)
+	}
+	metaAny, ok := got.Data["meta"]
+	if !ok {
+		t.Fatal("data.meta key missing after nested patch")
+	}
+	meta, ok := metaAny.(map[string]any)
+	if !ok {
+		t.Fatalf("data.meta is %T, want map[string]any", metaAny)
+	}
+	if meta["a"] != float64(1) {
+		t.Errorf("data.meta.a = %v, want 1 (should be preserved — not in patch delta)", meta["a"])
+	}
+	if meta["b"] != float64(9) {
+		t.Errorf("data.meta.b = %v, want 9 (should be updated by patch)", meta["b"])
+	}
+	if meta["c"] != float64(3) {
+		t.Errorf("data.meta.c = %v, want 3 (should be updated by patch)", meta["c"])
+	}
+}
+
+// RunEntityPatchArrayWholesaleReplace verifies that an array field in a
+// merge patch replaces the stored array wholesale (RFC 7396 — arrays are
+// atomic values, not merged recursively).
+func RunEntityPatchArrayWholesaleReplace(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	c := setupPatchModelCustomSample(t, fixture, "patch-array-replace", `{"name":"x","tags":["a","b"]}`)
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-array-replace", modelVersion, `{"name":"T","tags":["a","b"]}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	ent, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (pre-patch): %v", err)
+	}
+	txID := ent.Meta.TransactionID
+	if txID == "" {
+		t.Fatal("GetEntity: meta.transactionId is empty")
+	}
+
+	status, body, err := c.PatchEntityMerge(t, id, "", txID, `{"tags":["z"]}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("PatchEntityMerge: status %d, want 200; body=%s", status, body)
+	}
+
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (post-patch): %v", err)
+	}
+	tagsAny, ok := got.Data["tags"]
+	if !ok {
+		t.Fatal("data.tags key missing after patch")
+	}
+	tags, ok := tagsAny.([]any)
+	if !ok {
+		t.Fatalf("data.tags is %T, want []any", tagsAny)
+	}
+	if len(tags) != 1 || tags[0] != "z" {
+		t.Errorf("data.tags = %v, want [\"z\"] (array should be wholesale-replaced)", tags)
+	}
+}
+
+// RunEntityPatchEmptyNoOp verifies that an empty merge patch ({}) commits
+// a new transaction (so the txId advances) but leaves the entity data
+// unchanged.
+func RunEntityPatchEmptyNoOp(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	c, _ := setupPatchModel(t, fixture, "patch-empty-noop")
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-empty-noop", modelVersion, `{"name":"C","amount":5,"status":"ok"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	ent, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (pre-patch): %v", err)
+	}
+	txID1 := ent.Meta.TransactionID
+	if txID1 == "" {
+		t.Fatal("GetEntity: meta.transactionId is empty (pre-patch)")
+	}
+
+	status, body, err := c.PatchEntityMerge(t, id, "", txID1, `{}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("PatchEntityMerge empty: status %d, want 200; body=%s", status, body)
+	}
+
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (post-patch): %v", err)
+	}
+	if got.Data["name"] != "C" {
+		t.Errorf("data.name = %v, want %q (empty patch mutated data)", got.Data["name"], "C")
+	}
+	if got.Data["amount"] != float64(5) {
+		t.Errorf("data.amount = %v, want 5 (empty patch mutated data)", got.Data["amount"])
+	}
+	// A new transaction must be committed even for an empty patch.
+	if got.Meta.TransactionID == txID1 {
+		t.Errorf("meta.transactionId unchanged after empty patch (want a new txId, got same %q)", txID1)
+	}
+}
+
+// RunEntityPatchNumberFidelity verifies that a large integer value
+// (greater than 2^53, which float64 cannot represent exactly) is stored
+// and returned faithfully. Assertion is done on the raw response body to
+// avoid float64 precision loss in the Go json.Decoder.
+//
+// The sample document uses 2^53+1 (9007199254740993) as the initial value
+// so the schema infers the LONG type family. A LONG field accepts a
+// subsequent LONG-valued patch without type rejection.
+func RunEntityPatchNumberFidelity(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	// Sample uses 2^53+1 so the classifier infers LONG, not INTEGER.
+	// The post-A.1 numeric classifier no longer widens LONG values into an
+	// INTEGER schema, so the sample and all patch values must be LONG-family.
+	const bigVal = "9007199254740993" // 2^53 + 1 — not representable as float64
+	c := setupPatchModelCustomSample(t, fixture, "patch-num-fidelity",
+		`{"name":"x","big":`+bigVal+`}`)
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-num-fidelity", modelVersion,
+		`{"name":"x","big":`+bigVal+`}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	ent, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (pre-patch): %v", err)
+	}
+	txID := ent.Meta.TransactionID
+	if txID == "" {
+		t.Fatal("GetEntity: meta.transactionId is empty")
+	}
+
+	// Patch with the same LONG-family value to exercise precision round-trip.
+	status, body, err := c.PatchEntityMerge(t, id, "", txID, `{"big":`+bigVal+`}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("PatchEntityMerge: status %d, want 200; body=%s", status, body)
+	}
+
+	// Use GetEntityBodyRaw so we can inspect the raw JSON text without
+	// float64 precision loss.
+	rawStatus, rawBody, err := c.GetEntityBodyRaw(t, id)
+	if err != nil {
+		t.Fatalf("GetEntityBodyRaw transport: %v", err)
+	}
+	if rawStatus != 200 {
+		t.Fatalf("GetEntityBodyRaw: status %d, want 200; body=%s", rawStatus, rawBody)
+	}
+	if !strings.Contains(string(rawBody), bigVal) {
+		t.Errorf("GetEntityBodyRaw body does not contain literal %q (big-integer precision lost); body=%s",
+			bigVal, rawBody)
+	}
+}
+
+// RunEntityPatchStarUnconditional verifies that If-Match: * bypasses the
+// CAS check and the patch lands unconditionally.
+func RunEntityPatchStarUnconditional(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	c, _ := setupPatchModel(t, fixture, "patch-star-unconditional")
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-star-unconditional", modelVersion, `{"name":"D","amount":0,"status":"x"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	status, body, err := c.PatchEntityMerge(t, id, "", "*", `{"amount":42}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("PatchEntityMerge star: status %d, want 200; body=%s", status, body)
+	}
+
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (post-patch): %v", err)
+	}
+	if got.Data["amount"] != float64(42) {
+		t.Errorf("data.amount = %v, want 42 (star unconditional patch did not land)", got.Data["amount"])
+	}
+}
+
+// RunEntityPatchWithTransition verifies that a PATCH with a named
+// transition fires the transition, changes state, and applies the merge
+// patch to the entity data.
+func RunEntityPatchWithTransition(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	c, _ := setupPatchModel(t, fixture, "patch-with-transition")
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-with-transition", modelVersion, `{"name":"E","amount":1,"status":"new"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	ent, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (post-create): %v", err)
+	}
+	if ent.Meta.State != "CREATED" {
+		t.Fatalf("expected state CREATED after init, got %s", ent.Meta.State)
+	}
+	txID := ent.Meta.TransactionID
+	if txID == "" {
+		t.Fatal("GetEntity: meta.transactionId is empty")
+	}
+
+	// Fire the "approve" manual transition via PATCH.
+	status, body, err := c.PatchEntityMerge(t, id, "approve", txID, `{"amount":75}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge (approve) transport: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("PatchEntityMerge (approve): status %d, want 200; body=%s", status, body)
+	}
+
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (post-transition): %v", err)
+	}
+	if got.Meta.State != "APPROVED" {
+		t.Errorf("meta.state = %q, want APPROVED after approve transition", got.Meta.State)
+	}
+	if got.Data["amount"] != float64(75) {
+		t.Errorf("data.amount = %v, want 75 (merge-patch not applied)", got.Data["amount"])
+	}
+}
+
+// --- Error scenarios ---
+
+// RunEntityPatchNotFound verifies that PATCHing a non-existent entity
+// returns 404.
+func RunEntityPatchNotFound(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	// Use any tenant so we have a valid auth token; the entity uuid is fresh/random.
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	// A randomly-minted UUID cannot exist in the backend.
+	bogusID := uuid.New()
+	status, body, err := c.PatchEntityMerge(t, bogusID, "", "*", `{"amount":1}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 404 {
+		t.Errorf("PatchEntityMerge (non-existent): status %d, want 404; body=%s", status, body)
+	}
+}
+
+// RunEntityPatchStaleTokenIs412 verifies that supplying a txId that has
+// been superseded by a subsequent update returns 412 Precondition Failed.
+func RunEntityPatchStaleTokenIs412(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	c, _ := setupPatchModel(t, fixture, "patch-stale-412")
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-stale-412", modelVersion, `{"name":"F","amount":1,"status":"new"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	ent, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (pre-advance): %v", err)
+	}
+	staleTxID := ent.Meta.TransactionID
+	if staleTxID == "" {
+		t.Fatal("GetEntity: meta.transactionId is empty")
+	}
+
+	// Advance the txId so staleTxID is now stale.
+	if err := c.UpdateEntityData(t, id, `{"name":"F","amount":2,"status":"new"}`); err != nil {
+		t.Fatalf("UpdateEntityData (advance): %v", err)
+	}
+
+	// PATCH with the stale token must fail.
+	status, body, err := c.PatchEntityMerge(t, id, "", staleTxID, `{"amount":5}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 412 {
+		t.Errorf("PatchEntityMerge (stale): status %d, want 412; body=%s", status, body)
+	}
+
+	// Confirm the stale patch did not land.
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (post-stale-attempt): %v", err)
+	}
+	if got.Data["amount"] != float64(2) {
+		t.Errorf("data.amount = %v, want 2 (stale patch must not land); got stale-patch value", got.Data["amount"])
+	}
+}
+
+// RunEntityPatchXMLFormatIs415 verifies that requesting a PATCH against
+// the XML format segment returns 415 Unsupported Media Type.
+func RunEntityPatchXMLFormatIs415(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	// Use any tenant so we have a valid auth token; we do not need a real entity.
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	bogusID := uuid.New()
+	// format="XML", contentType="application/merge-patch+json", ifMatch="*"
+	status, body, err := c.PatchEntityRaw(t, bogusID, "XML", "", "application/merge-patch+json", "*", `{"amount":1}`)
+	if err != nil {
+		t.Fatalf("PatchEntityRaw transport: %v", err)
+	}
+	if status != 415 {
+		t.Errorf("PatchEntityRaw (XML format): status %d, want 415; body=%s", status, body)
+	}
+}
+
+// RunEntityPatchWrongContentTypeIs415 verifies that sending
+// Content-Type: application/json (not merge-patch+json) returns 415.
+func RunEntityPatchWrongContentTypeIs415(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	bogusID := uuid.New()
+	// format="JSON", contentType="application/json" (wrong), ifMatch="*"
+	status, body, err := c.PatchEntityRaw(t, bogusID, "JSON", "", "application/json", "*", `{"amount":1}`)
+	if err != nil {
+		t.Fatalf("PatchEntityRaw transport: %v", err)
+	}
+	if status != 415 {
+		t.Errorf("PatchEntityRaw (wrong content-type): status %d, want 415; body=%s", status, body)
+	}
+}
+
+// RunEntityPatchMissingIfMatchIs428 verifies that omitting the If-Match
+// header returns 428 Precondition Required.
+func RunEntityPatchMissingIfMatchIs428(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	c, _ := setupPatchModel(t, fixture, "patch-missing-ifmatch")
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-missing-ifmatch", modelVersion, `{"name":"G","amount":1,"status":"new"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	// ifMatch="" omits the If-Match header entirely.
+	status, body, err := c.PatchEntityMerge(t, id, "", "", `{"amount":9}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 428 {
+		t.Errorf("PatchEntityMerge (no If-Match): status %d, want 428; body=%s", status, body)
+	}
+}
+
+// RunEntityPatchJSONPatchNotImplemented verifies that
+// application/json-patch+json returns 501 Not Implemented.
+func RunEntityPatchJSONPatchNotImplemented(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	c, _ := setupPatchModel(t, fixture, "patch-jsonpatch-501")
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-jsonpatch-501", modelVersion, `{"name":"H","amount":1,"status":"new"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	// application/json-patch+json (RFC 6902) is scaffolded but not implemented.
+	status, body, err := c.PatchEntityRaw(t, id, "JSON", "", "application/json-patch+json", "*", `[]`)
+	if err != nil {
+		t.Fatalf("PatchEntityRaw transport: %v", err)
+	}
+	if status != 501 {
+		t.Errorf("PatchEntityRaw (json-patch+json): status %d, want 501; body=%s", status, body)
+	}
+}
+
+// RunEntityPatchTypeMismatchIs400 verifies that a merge patch that would
+// produce an invalid typed field (e.g. string for an int field) returns
+// 400 with a client validation error.
+func RunEntityPatchTypeMismatchIs400(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	// The standard patch model has amount typed as INTEGER.
+	c, _ := setupPatchModel(t, fixture, "patch-type-mismatch")
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-type-mismatch", modelVersion, `{"name":"I","amount":1,"status":"new"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	ent, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (pre-patch): %v", err)
+	}
+	txID := ent.Meta.TransactionID
+	if txID == "" {
+		t.Fatal("GetEntity: meta.transactionId is empty")
+	}
+
+	// Patch "amount" with a string — violates the INTEGER schema field.
+	status, body, err := c.PatchEntityMerge(t, id, "", txID, `{"amount":"not-a-number"}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 400 {
+		t.Errorf("PatchEntityMerge (type mismatch): status %d, want 400; body=%s", status, body)
+	}
+	// The error body is an RFC 7807 Problem Details envelope. The canonical
+	// error code (INCOMPATIBLE_TYPE, VALIDATION_FAILED, or BAD_REQUEST) is
+	// nested under the "properties" map, not at the top level.
+	var problem struct {
+		Properties struct {
+			ErrorCode string `json:"errorCode"`
+		} `json:"properties"`
+	}
+	if jsonErr := json.Unmarshal(body, &problem); jsonErr == nil && problem.Properties.ErrorCode != "" {
+		code := problem.Properties.ErrorCode
+		if code != "INCOMPATIBLE_TYPE" && code != "VALIDATION_FAILED" && code != "BAD_REQUEST" {
+			t.Errorf("error body properties.errorCode = %q; want INCOMPATIBLE_TYPE, VALIDATION_FAILED, or BAD_REQUEST; body=%s",
+				code, body)
+		}
+	}
+}
+
+// RunEntityPatchStrictRejectsUnknownField verifies that on a locked model
+// a merge patch containing an unknown field returns 400 (strict schema
+// validation rejects extra fields).
+//
+// If the backend returns 200 instead — meaning the locked model does not
+// strictly reject unknown fields on PATCH — this test will FAIL. That
+// failure is intentional: it signals a behavioural discrepancy that the
+// controller must evaluate, and the assertion must not be silently
+// weakened.
+func RunEntityPatchStrictRejectsUnknownField(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	c, _ := setupPatchModel(t, fixture, "patch-strict-unknown")
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-strict-unknown", modelVersion, `{"name":"J","amount":1,"status":"new"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	ent, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (pre-patch): %v", err)
+	}
+	txID := ent.Meta.TransactionID
+	if txID == "" {
+		t.Fatal("GetEntity: meta.transactionId is empty")
+	}
+
+	// "bogusField" is not declared in the locked schema.
+	status, body, err := c.PatchEntityMerge(t, id, "", txID, `{"bogusField":"x"}`)
+	if err != nil {
+		t.Fatalf("PatchEntityMerge transport: %v", err)
+	}
+	if status != 400 {
+		t.Errorf("PatchEntityMerge (unknown field on locked model): status %d, want 400; body=%s", status, body)
+	}
+}
+
+// --- Cross-tenant isolation ---
+
+// RunEntityPatchCrossTenantIsNotFound verifies that tenant B cannot PATCH
+// an entity owned by tenant A — the PATCH must return 404 (B must not be
+// able to patch or even confirm the existence of A's entity).
+func RunEntityPatchCrossTenantIsNotFound(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+
+	// Tenant A creates an entity.
+	tenantA := fixture.NewTenant(t)
+	cA := client.NewClient(fixture.BaseURL(), tenantA.Token)
+	const modelName = "patch-cross-tenant"
+	const modelVersion = 1
+	if err := cA.ImportModel(t, modelName, modelVersion, `{"name":"x","amount":1,"status":"new"}`); err != nil {
+		t.Fatalf("tenantA ImportModel: %v", err)
+	}
+	if err := cA.LockModel(t, modelName, modelVersion); err != nil {
+		t.Fatalf("tenantA LockModel: %v", err)
+	}
+	if err := cA.ImportWorkflow(t, modelName, modelVersion, patchWorkflowJSON); err != nil {
+		t.Fatalf("tenantA ImportWorkflow: %v", err)
+	}
+	idA, err := cA.CreateEntity(t, modelName, modelVersion, `{"name":"K","amount":1,"status":"new"}`)
+	if err != nil {
+		t.Fatalf("tenantA CreateEntity: %v", err)
+	}
+
+	// Tenant B mints a fresh identity and uses it to PATCH A's entity.
+	tenantB := fixture.NewTenant(t)
+	cB := client.NewClient(fixture.BaseURL(), tenantB.Token)
+	status, body, err := cB.PatchEntityMerge(t, idA, "", "*", `{"amount":999}`)
+	if err != nil {
+		t.Fatalf("tenantB PatchEntityMerge transport: %v", err)
+	}
+	if status != 404 {
+		t.Errorf("cross-tenant PATCH: status %d, want 404 (tenant B must not access tenant A's entity); body=%s",
+			status, body)
+	}
+
+	// Verify the entity is still intact from tenant A's perspective.
+	got, err := cA.GetEntity(t, idA)
+	if err != nil {
+		t.Fatalf("tenantA GetEntity (after cross-tenant attempt): %v", err)
+	}
+	if got.Data["amount"] != float64(1) {
+		t.Errorf("entity mutated by cross-tenant PATCH: data.amount = %v, want 1", got.Data["amount"])
+	}
+}
+
+// --- Concurrency ---
+
+// RunEntityPatchConcurrentConflict fires two concurrent PATCHes against
+// the same entity using the same If-Match txId. Exactly one must succeed
+// (200) and the other must fail with 412 or 409. The final entity state
+// must reflect the value committed by the winner with no torn write.
+func RunEntityPatchConcurrentConflict(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	c, _ := setupPatchModel(t, fixture, "patch-concurrent-conflict")
+	const modelVersion = 1
+
+	id, err := c.CreateEntity(t, "patch-concurrent-conflict", modelVersion, `{"name":"L","amount":0,"status":"new"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	ent, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (pre-concurrent): %v", err)
+	}
+	sharedTxID := ent.Meta.TransactionID
+	if sharedTxID == "" {
+		t.Fatal("GetEntity: meta.transactionId is empty")
+	}
+
+	type result struct {
+		status int
+		body   []byte
+		which  int // 100 or 200
+	}
+	results := make([]result, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		st, b, _ := c.PatchEntityMerge(t, id, "", sharedTxID, `{"amount":100}`)
+		results[0] = result{status: st, body: b, which: 100}
+	}()
+	go func() {
+		defer wg.Done()
+		st, b, _ := c.PatchEntityMerge(t, id, "", sharedTxID, `{"amount":200}`)
+		results[1] = result{status: st, body: b, which: 200}
+	}()
+	wg.Wait()
+
+	// Exactly one 200; the other is 412 or 409.
+	var winner result
+	var successCount int
+	for _, r := range results {
+		if r.status == 200 {
+			successCount++
+			winner = r
+		} else if r.status != 412 && r.status != 409 {
+			t.Errorf("concurrent PATCH loser: status %d, want 412 or 409; body=%s", r.status, r.body)
+		}
+	}
+	if successCount != 1 {
+		t.Fatalf("concurrent PATCH: %d succeeded, want exactly 1; results=%v", successCount, results)
+	}
+
+	// Final entity must reflect exactly the winner's value.
+	got, err := c.GetEntity(t, id)
+	if err != nil {
+		t.Fatalf("GetEntity (post-concurrent): %v", err)
+	}
+	wantAmount := float64(winner.which)
+	if got.Data["amount"] != wantAmount {
+		t.Errorf("data.amount = %v, want %v (winner's value); torn write or wrong commit",
+			got.Data["amount"], wantAmount)
+	}
+}

--- a/e2e/parity/entity_patch.go
+++ b/e2e/parity/entity_patch.go
@@ -3,7 +3,6 @@ package parity
 import (
 	"encoding/json"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -745,75 +744,3 @@ func RunEntityPatchCrossTenantIsNotFound(t *testing.T, fixture BackendFixture) {
 	}
 }
 
-// --- Concurrency ---
-
-// RunEntityPatchConcurrentConflict fires two concurrent PATCHes against
-// the same entity using the same If-Match txId. Exactly one must succeed
-// (200) and the other must fail with 412 or 409. The final entity state
-// must reflect the value committed by the winner with no torn write.
-func RunEntityPatchConcurrentConflict(t *testing.T, fixture BackendFixture) {
-	t.Helper()
-	c, _ := setupPatchModel(t, fixture, "patch-concurrent-conflict")
-	const modelVersion = 1
-
-	id, err := c.CreateEntity(t, "patch-concurrent-conflict", modelVersion, `{"name":"L","amount":0,"status":"new"}`)
-	if err != nil {
-		t.Fatalf("CreateEntity: %v", err)
-	}
-
-	ent, err := c.GetEntity(t, id)
-	if err != nil {
-		t.Fatalf("GetEntity (pre-concurrent): %v", err)
-	}
-	sharedTxID := ent.Meta.TransactionID
-	if sharedTxID == "" {
-		t.Fatal("GetEntity: meta.transactionId is empty")
-	}
-
-	type result struct {
-		status int
-		body   []byte
-		which  int // 100 or 200
-	}
-	results := make([]result, 2)
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	go func() {
-		defer wg.Done()
-		st, b, _ := c.PatchEntityMerge(t, id, "", sharedTxID, `{"amount":100}`)
-		results[0] = result{status: st, body: b, which: 100}
-	}()
-	go func() {
-		defer wg.Done()
-		st, b, _ := c.PatchEntityMerge(t, id, "", sharedTxID, `{"amount":200}`)
-		results[1] = result{status: st, body: b, which: 200}
-	}()
-	wg.Wait()
-
-	// Exactly one 200; the other is 412 or 409.
-	var winner result
-	var successCount int
-	for _, r := range results {
-		if r.status == 200 {
-			successCount++
-			winner = r
-		} else if r.status != 412 && r.status != 409 {
-			t.Errorf("concurrent PATCH loser: status %d, want 412 or 409; body=%s", r.status, r.body)
-		}
-	}
-	if successCount != 1 {
-		t.Fatalf("concurrent PATCH: %d succeeded, want exactly 1; results=%v", successCount, results)
-	}
-
-	// Final entity must reflect exactly the winner's value.
-	got, err := c.GetEntity(t, id)
-	if err != nil {
-		t.Fatalf("GetEntity (post-concurrent): %v", err)
-	}
-	wantAmount := float64(winner.which)
-	if got.Data["amount"] != wantAmount {
-		t.Errorf("data.amount = %v, want %v (winner's value); torn write or wrong commit",
-			got.Data["amount"], wantAmount)
-	}
-}

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -266,8 +266,6 @@ var allTests = []NamedTest{
 	{"EntityPatchStrictRejectsUnknownField", RunEntityPatchStrictRejectsUnknownField},
 	// Cross-tenant isolation.
 	{"EntityPatchCrossTenantIsNotFound", RunEntityPatchCrossTenantIsNotFound},
-	// Concurrency.
-	{"EntityPatchConcurrentConflict", RunEntityPatchConcurrentConflict},
 
 	// Grouped statistics — cross-backend parity matrix (spec §7).
 	// Each scenario asserts an OBSERVABLE response: every backend

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -245,6 +245,30 @@ var allTests = []NamedTest{
 	// I-1: reactivateKeys=false cache-preservation (unit-level coverage; skipped at parity level).
 	{"OidcReactivate_KeysFalse_PreservesCache_Skip", RunOidcReactivate_KeysFalse_PreservesCache_Skip},
 
+	// Entity PATCH (RFC 7386 merge-patch) — cross-backend contract matrix.
+	// Normal operation.
+	{"EntityPatchMergePreservesFields", RunEntityPatchMergePreservesFields},
+	{"EntityPatchNullDeletesKey", RunEntityPatchNullDeletesKey},
+	{"EntityPatchNestedMerge", RunEntityPatchNestedMerge},
+	{"EntityPatchArrayWholesaleReplace", RunEntityPatchArrayWholesaleReplace},
+	{"EntityPatchEmptyNoOp", RunEntityPatchEmptyNoOp},
+	{"EntityPatchNumberFidelity", RunEntityPatchNumberFidelity},
+	{"EntityPatchStarUnconditional", RunEntityPatchStarUnconditional},
+	{"EntityPatchWithTransition", RunEntityPatchWithTransition},
+	// Error scenarios.
+	{"EntityPatchNotFound", RunEntityPatchNotFound},
+	{"EntityPatchStaleTokenIs412", RunEntityPatchStaleTokenIs412},
+	{"EntityPatchXMLFormatIs415", RunEntityPatchXMLFormatIs415},
+	{"EntityPatchWrongContentTypeIs415", RunEntityPatchWrongContentTypeIs415},
+	{"EntityPatchMissingIfMatchIs428", RunEntityPatchMissingIfMatchIs428},
+	{"EntityPatchJSONPatchNotImplemented", RunEntityPatchJSONPatchNotImplemented},
+	{"EntityPatchTypeMismatchIs400", RunEntityPatchTypeMismatchIs400},
+	{"EntityPatchStrictRejectsUnknownField", RunEntityPatchStrictRejectsUnknownField},
+	// Cross-tenant isolation.
+	{"EntityPatchCrossTenantIsNotFound", RunEntityPatchCrossTenantIsNotFound},
+	// Concurrency.
+	{"EntityPatchConcurrentConflict", RunEntityPatchConcurrentConflict},
+
 	// Grouped statistics — cross-backend parity matrix (spec §7).
 	// Each scenario asserts an OBSERVABLE response: every backend
 	// (memory / sqlite / postgres / out-of-tree plugins) must produce the

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -168,6 +168,22 @@ func (s *Server) UpdateSingle(w http.ResponseWriter, r *http.Request, format gen
 	s.Unimplemented.UpdateSingle(w, r, format, entityId, transition, params)
 }
 
+func (s *Server) PatchSingleWithLoopback(w http.ResponseWriter, r *http.Request, format genapi.PatchSingleWithLoopbackParamsFormat, entityId openapi_types.UUID, params genapi.PatchSingleWithLoopbackParams) {
+	if s.Entity != nil {
+		s.Entity.PatchSingleWithLoopback(w, r, format, entityId, params)
+		return
+	}
+	s.Unimplemented.PatchSingleWithLoopback(w, r, format, entityId, params)
+}
+
+func (s *Server) PatchSingle(w http.ResponseWriter, r *http.Request, format genapi.PatchSingleParamsFormat, entityId openapi_types.UUID, transition string, params genapi.PatchSingleParams) {
+	if s.Entity != nil {
+		s.Entity.PatchSingle(w, r, format, entityId, transition, params)
+		return
+	}
+	s.Unimplemented.PatchSingle(w, r, format, entityId, transition, params)
+}
+
 func (s *Server) Create(w http.ResponseWriter, r *http.Request, format genapi.CreateParamsFormat, entityName string, modelVersion int32, params genapi.CreateParams) {
 	if s.Entity != nil {
 		s.Entity.Create(w, r, format, entityName, modelVersion, params)

--- a/internal/api/unimplemented.go
+++ b/internal/api/unimplemented.go
@@ -115,6 +115,14 @@ func (u *Unimplemented) UpdateSingle(w http.ResponseWriter, r *http.Request, for
 	u.stub(w, r)
 }
 
+func (u *Unimplemented) PatchSingleWithLoopback(w http.ResponseWriter, r *http.Request, format genapi.PatchSingleWithLoopbackParamsFormat, entityId openapi_types.UUID, params genapi.PatchSingleWithLoopbackParams) {
+	u.stub(w, r)
+}
+
+func (u *Unimplemented) PatchSingle(w http.ResponseWriter, r *http.Request, format genapi.PatchSingleParamsFormat, entityId openapi_types.UUID, transition string, params genapi.PatchSingleParams) {
+	u.stub(w, r)
+}
+
 func (u *Unimplemented) Create(w http.ResponseWriter, r *http.Request, format genapi.CreateParamsFormat, entityName string, modelVersion int32, params genapi.CreateParams) {
 	u.stub(w, r)
 }

--- a/internal/common/error_codes.go
+++ b/internal/common/error_codes.go
@@ -40,6 +40,8 @@ const (
 	ErrCodeServerError               = "SERVER_ERROR"
 	ErrCodeNotImplemented            = "NOT_IMPLEMENTED"
 	ErrCodeNotFound                  = "NOT_FOUND"
+	ErrCodePreconditionRequired      = "PRECONDITION_REQUIRED"
+	ErrCodeUnsupportedMediaType      = "UNSUPPORTED_MEDIA_TYPE"
 )
 
 const (

--- a/internal/common/error_codes_test.go
+++ b/internal/common/error_codes_test.go
@@ -1,0 +1,12 @@
+package common
+
+import "testing"
+
+func TestPatchErrorCodes(t *testing.T) {
+	if ErrCodePreconditionRequired != "PRECONDITION_REQUIRED" {
+		t.Errorf("got %q", ErrCodePreconditionRequired)
+	}
+	if ErrCodeUnsupportedMediaType != "UNSUPPORTED_MEDIA_TYPE" {
+		t.Errorf("got %q", ErrCodeUnsupportedMediaType)
+	}
+}

--- a/internal/domain/entity/handler.go
+++ b/internal/domain/entity/handler.go
@@ -146,6 +146,22 @@ func (h *Handler) validateOrExtend(ctx context.Context, modelStore spi.ModelStor
 	return nil
 }
 
+// validateStrict validates parsedData against the model schema WITHOUT
+// extending it. PATCH uses this: a sparse delta must never widen the tenant's
+// model (a stray/typo'd key is rejected, not absorbed). Mirrors the
+// ChangeLevel=="" branch of validateOrExtend.
+func (h *Handler) validateStrict(desc *spi.ModelDescriptor, parsedData any) error {
+	modelNode, err := schema.Unmarshal(desc.Schema)
+	if err != nil {
+		return fmt.Errorf("%w: failed to unmarshal model schema: %w", errInternalSchema, err)
+	}
+	errs := schema.Validate(modelNode, parsedData)
+	if len(errs) > 0 {
+		return enrichWithModelRef(validationErrorsToError(errs), desc.Ref)
+	}
+	return nil
+}
+
 // ValidateWithRefresh runs strict schema validation with a bounded
 // refresh-on-stale safety net. One refresh attempt, only on unknown-
 // schema-element errors — the signal that our cached schema is behind

--- a/internal/domain/entity/handler.go
+++ b/internal/domain/entity/handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -941,4 +942,74 @@ func (h *Handler) UpdateSingle(w http.ResponseWriter, r *http.Request, format ge
 		"entityIds":     result.EntityIDs,
 	}
 	common.WriteJSON(w, http.StatusOK, resp)
+}
+
+// PatchSingleWithLoopback handles PATCH /entity/{format}/{entityId} (loopback).
+func (h *Handler) PatchSingleWithLoopback(w http.ResponseWriter, r *http.Request, format genapi.PatchSingleWithLoopbackParamsFormat, entityId openapi_types.UUID, params genapi.PatchSingleWithLoopbackParams) {
+	h.patch(w, r, string(format), entityId, "", params.IfMatch)
+}
+
+// PatchSingle handles PATCH /entity/{format}/{entityId}/{transition}.
+func (h *Handler) PatchSingle(w http.ResponseWriter, r *http.Request, format genapi.PatchSingleParamsFormat, entityId openapi_types.UUID, transition string, params genapi.PatchSingleParams) {
+	h.patch(w, r, string(format), entityId, transition, params.IfMatch)
+}
+
+// patch is the shared PATCH implementation. Error precedence: media-type/format
+// (415) -> If-Match presence (428) -> service (404/412/409/501/4xx).
+func (h *Handler) patch(w http.ResponseWriter, r *http.Request, format string, entityId openapi_types.UUID, transition string, ifMatchHeader *string) {
+	if format != "JSON" {
+		common.WriteError(w, r, common.Operational(http.StatusUnsupportedMediaType, common.ErrCodeUnsupportedMediaType, "patch supports the JSON format only"))
+		return
+	}
+	patchFormat, ok := patchFormatFromContentType(r.Header.Get("Content-Type"))
+	if !ok {
+		common.WriteError(w, r, common.Operational(http.StatusUnsupportedMediaType, common.ErrCodeUnsupportedMediaType,
+			"unsupported Content-Type; use application/merge-patch+json or application/json-patch+json"))
+		return
+	}
+	if ifMatchHeader == nil {
+		common.WriteError(w, r, common.Operational(http.StatusPreconditionRequired, common.ErrCodePreconditionRequired,
+			"missing If-Match: send If-Match: <transactionId> from your last GET of this entity to patch safely, or If-Match: * to explicitly accept last-writer-wins"))
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxEntityBodySize)
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "failed to read body"))
+		return
+	}
+	result, err := h.PatchEntity(r.Context(), PatchEntityInput{
+		EntityID:    entityId.String(),
+		Patch:       bodyBytes,
+		PatchFormat: patchFormat,
+		Transition:  transition,
+		IfMatch:     *ifMatchHeader,
+	})
+	if err != nil {
+		common.WriteError(w, r, classifyError(err))
+		return
+	}
+	common.WriteJSON(w, http.StatusOK, map[string]any{
+		"transactionId": result.TransactionID,
+		"entityIds":     result.EntityIDs,
+	})
+}
+
+// patchFormatFromContentType maps the request Content-Type to a patch dialect.
+func patchFormatFromContentType(ct string) (string, bool) {
+	if ct == "" {
+		return "", false
+	}
+	mediaType, _, err := mime.ParseMediaType(ct)
+	if err != nil {
+		return "", false
+	}
+	switch mediaType {
+	case "application/merge-patch+json":
+		return "MERGE_PATCH", true
+	case "application/json-patch+json":
+		return "JSON_PATCH", true
+	default:
+		return "", false
+	}
 }

--- a/internal/domain/entity/handler_patch_test.go
+++ b/internal/domain/entity/handler_patch_test.go
@@ -18,9 +18,10 @@ func TestPatch_XMLFormatIs415(t *testing.T) {
 	h, _ := newPatchTestHandler(t)
 	r := httptest.NewRequest(http.MethodPatch, "/entity/XML/"+sampleUUID, strings.NewReader(`{}`))
 	r.Header.Set("Content-Type", "application/merge-patch+json")
-	r.Header.Set("If-Match", "*")
 	w := httptest.NewRecorder()
-	h.PatchSingleWithLoopback(w, r, "XML", openapi_types.UUID(mustUUID(sampleUUID)), genapiPatchLoopbackParams("*"))
+	// IfMatch is intentionally nil (absent) to prove that the format/media-type
+	// 415 check fires BEFORE the If-Match presence 428 check.
+	h.PatchSingleWithLoopback(w, r, "XML", openapi_types.UUID(mustUUID(sampleUUID)), genapiPatchLoopbackParams(""))
 	if w.Code != http.StatusUnsupportedMediaType {
 		t.Fatalf("got %d", w.Code)
 	}

--- a/internal/domain/entity/handler_patch_test.go
+++ b/internal/domain/entity/handler_patch_test.go
@@ -1,0 +1,69 @@
+package entity
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	genapi "github.com/cyoda-platform/cyoda-go/api"
+)
+
+const sampleUUID = "1d1e1b10-1155-11f0-bcd5-ae468cd3ed16"
+
+func TestPatch_XMLFormatIs415(t *testing.T) {
+	h, _ := newPatchTestHandler(t)
+	r := httptest.NewRequest(http.MethodPatch, "/entity/XML/"+sampleUUID, strings.NewReader(`{}`))
+	r.Header.Set("Content-Type", "application/merge-patch+json")
+	r.Header.Set("If-Match", "*")
+	w := httptest.NewRecorder()
+	h.PatchSingleWithLoopback(w, r, "XML", openapi_types.UUID(mustUUID(sampleUUID)), genapiPatchLoopbackParams("*"))
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestPatch_BadContentTypeIs415(t *testing.T) {
+	h, _ := newPatchTestHandler(t)
+	r := httptest.NewRequest(http.MethodPatch, "/entity/JSON/"+sampleUUID, strings.NewReader(`{}`))
+	r.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.PatchSingleWithLoopback(w, r, "JSON", openapi_types.UUID(mustUUID(sampleUUID)), genapiPatchLoopbackParams("*"))
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+func TestPatch_MissingIfMatchIs428(t *testing.T) {
+	h, _ := newPatchTestHandler(t)
+	r := httptest.NewRequest(http.MethodPatch, "/entity/JSON/"+sampleUUID, strings.NewReader(`{}`))
+	r.Header.Set("Content-Type", "application/merge-patch+json")
+	w := httptest.NewRecorder()
+	h.PatchSingleWithLoopback(w, r, "JSON", openapi_types.UUID(mustUUID(sampleUUID)), genapiPatchLoopbackParams(""))
+	if w.Code != http.StatusPreconditionRequired {
+		t.Fatalf("got %d", w.Code)
+	}
+}
+
+// --- helpers ---
+
+// genapiPatchLoopbackParams returns PatchSingleWithLoopbackParams with IfMatch
+// set to &ifMatch when ifMatch is non-empty, or nil when empty.
+func genapiPatchLoopbackParams(ifMatch string) genapi.PatchSingleWithLoopbackParams {
+	if ifMatch == "" {
+		return genapi.PatchSingleWithLoopbackParams{IfMatch: nil}
+	}
+	return genapi.PatchSingleWithLoopbackParams{IfMatch: &ifMatch}
+}
+
+// mustUUID parses a UUID string and panics if invalid.
+func mustUUID(s string) uuid.UUID {
+	u, err := uuid.Parse(s)
+	if err != nil {
+		panic("invalid UUID: " + s)
+	}
+	return u
+}

--- a/internal/domain/entity/mergepatch.go
+++ b/internal/domain/entity/mergepatch.go
@@ -1,0 +1,41 @@
+package entity
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// mergeMergePatch applies an RFC 7386 JSON Merge Patch (the already-parsed
+// patch) onto the stored entity data, returning the merged value. Both sides
+// are number-preserving (json.Number) so large integers survive the merge.
+func mergeMergePatch(existing json.RawMessage, patch any) (any, error) {
+	var target any
+	if len(existing) > 0 {
+		if err := decodeJSONPreservingNumbers(existing, &target); err != nil {
+			return nil, fmt.Errorf("failed to decode stored entity data: %w", err)
+		}
+	}
+	return applyMergePatch(target, patch), nil
+}
+
+// applyMergePatch is the RFC 7386 section 2 algorithm. When patch is not a
+// JSON object it replaces the target wholesale; otherwise each key is merged
+// recursively, and an explicit null deletes the key.
+func applyMergePatch(target, patch any) any {
+	patchObj, ok := patch.(map[string]any)
+	if !ok {
+		return patch
+	}
+	targetObj, ok := target.(map[string]any)
+	if !ok {
+		targetObj = map[string]any{}
+	}
+	for k, v := range patchObj {
+		if v == nil {
+			delete(targetObj, k)
+		} else {
+			targetObj[k] = applyMergePatch(targetObj[k], v)
+		}
+	}
+	return targetObj
+}

--- a/internal/domain/entity/mergepatch.go
+++ b/internal/domain/entity/mergepatch.go
@@ -21,6 +21,9 @@ func mergeMergePatch(existing json.RawMessage, patch any) (any, error) {
 // applyMergePatch is the RFC 7386 section 2 algorithm. When patch is not a
 // JSON object it replaces the target wholesale; otherwise each key is merged
 // recursively, and an explicit null deletes the key.
+//
+// Mutates targetObj in place; safe because mergeMergePatch always passes a
+// freshly-decoded, decode-local map that is never aliased back into the store.
 func applyMergePatch(target, patch any) any {
 	patchObj, ok := patch.(map[string]any)
 	if !ok {

--- a/internal/domain/entity/mergepatch_test.go
+++ b/internal/domain/entity/mergepatch_test.go
@@ -1,0 +1,61 @@
+package entity
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func mustParse(t *testing.T, s string) any {
+	t.Helper()
+	var v any
+	if err := decodeJSONPreservingNumbers([]byte(s), &v); err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return v
+}
+
+func TestApplyMergePatch_RFC7386_AppendixA(t *testing.T) {
+	cases := []struct{ name, target, patch, want string }{
+		{"replace-field", `{"a":"b"}`, `{"a":"c"}`, `{"a":"c"}`},
+		{"add-field", `{"a":"b"}`, `{"b":"c"}`, `{"a":"b","b":"c"}`},
+		{"delete-field", `{"a":"b"}`, `{"a":null}`, `{}`},
+		{"delete-one-of-two", `{"a":"b","b":"c"}`, `{"a":null}`, `{"b":"c"}`},
+		{"array-replaces", `{"a":["b"]}`, `{"a":"c"}`, `{"a":"c"}`},
+		{"scalar-replaces-array", `{"a":"c"}`, `{"a":["b"]}`, `{"a":["b"]}`},
+		{"nested-merge", `{"a":{"b":"c"}}`, `{"a":{"b":"d","c":null}}`, `{"a":{"b":"d"}}`},
+		{"array-wholesale", `{"a":[{"b":"c"}]}`, `{"a":[1]}`, `{"a":[1]}`},
+		{"non-object-patch-replaces", `{"a":"b"}`, `["c"]`, `["c"]`},
+		{"empty-patch-noop", `{"a":"b"}`, `{}`, `{"a":"b"}`},
+		{"null-creates-nothing", `{"a":"foo"}`, `null`, `null`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := mergeMergePatch(json.RawMessage(tc.target), mustParse(t, tc.patch))
+			if err != nil {
+				t.Fatalf("merge: %v", err)
+			}
+			gotBytes, _ := json.Marshal(got)
+			var gotN, wantN any
+			_ = decodeJSONPreservingNumbers(gotBytes, &gotN)
+			_ = decodeJSONPreservingNumbers([]byte(tc.want), &wantN)
+			if !reflect.DeepEqual(gotN, wantN) {
+				t.Errorf("got %s, want %s", gotBytes, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyMergePatch_NumberFidelity(t *testing.T) {
+	// int64 above 2^53 must survive without float64 coercion.
+	target := json.RawMessage(`{"big":1}`)
+	patch := mustParse(t, `{"big":9007199254740993}`)
+	got, err := mergeMergePatch(target, patch)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	b, _ := json.Marshal(got)
+	if string(b) != `{"big":9007199254740993}` {
+		t.Errorf("number fidelity lost: got %s", b)
+	}
+}

--- a/internal/domain/entity/mergepatch_test.go
+++ b/internal/domain/entity/mergepatch_test.go
@@ -17,17 +17,17 @@ func mustParse(t *testing.T, s string) any {
 
 func TestApplyMergePatch_RFC7386_AppendixA(t *testing.T) {
 	cases := []struct{ name, target, patch, want string }{
-		{"replace-field", `{"a":"b"}`, `{"a":"c"}`, `{"a":"c"}`},
-		{"add-field", `{"a":"b"}`, `{"b":"c"}`, `{"a":"b","b":"c"}`},
-		{"delete-field", `{"a":"b"}`, `{"a":null}`, `{}`},
-		{"delete-one-of-two", `{"a":"b","b":"c"}`, `{"a":null}`, `{"b":"c"}`},
-		{"array-replaces", `{"a":["b"]}`, `{"a":"c"}`, `{"a":"c"}`},
-		{"scalar-replaces-array", `{"a":"c"}`, `{"a":["b"]}`, `{"a":["b"]}`},
-		{"nested-merge", `{"a":{"b":"c"}}`, `{"a":{"b":"d","c":null}}`, `{"a":{"b":"d"}}`},
-		{"array-wholesale", `{"a":[{"b":"c"}]}`, `{"a":[1]}`, `{"a":[1]}`},
-		{"non-object-patch-replaces", `{"a":"b"}`, `["c"]`, `["c"]`},
-		{"empty-patch-noop", `{"a":"b"}`, `{}`, `{"a":"b"}`},
-		{"null-creates-nothing", `{"a":"foo"}`, `null`, `null`},
+		{name: "replace-field", target: `{"a":"b"}`, patch: `{"a":"c"}`, want: `{"a":"c"}`},
+		{name: "add-field", target: `{"a":"b"}`, patch: `{"b":"c"}`, want: `{"a":"b","b":"c"}`},
+		{name: "delete-field", target: `{"a":"b"}`, patch: `{"a":null}`, want: `{}`},
+		{name: "delete-one-of-two", target: `{"a":"b","b":"c"}`, patch: `{"a":null}`, want: `{"b":"c"}`},
+		{name: "array-replaces", target: `{"a":["b"]}`, patch: `{"a":"c"}`, want: `{"a":"c"}`},
+		{name: "scalar-replaces-array", target: `{"a":"c"}`, patch: `{"a":["b"]}`, want: `{"a":["b"]}`},
+		{name: "nested-merge", target: `{"a":{"b":"c"}}`, patch: `{"a":{"b":"d","c":null}}`, want: `{"a":{"b":"d"}}`},
+		{name: "array-wholesale", target: `{"a":[{"b":"c"}]}`, patch: `{"a":[1]}`, want: `{"a":[1]}`},
+		{name: "non-object-patch-replaces", target: `{"a":"b"}`, patch: `["c"]`, want: `["c"]`},
+		{name: "empty-patch-noop", target: `{"a":"b"}`, patch: `{}`, want: `{"a":"b"}`},
+		{name: "null-creates-nothing", target: `{"a":"foo"}`, patch: `null`, want: `null`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -35,10 +35,17 @@ func TestApplyMergePatch_RFC7386_AppendixA(t *testing.T) {
 			if err != nil {
 				t.Fatalf("merge: %v", err)
 			}
-			gotBytes, _ := json.Marshal(got)
+			gotBytes, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("marshal got: %v", err)
+			}
 			var gotN, wantN any
-			_ = decodeJSONPreservingNumbers(gotBytes, &gotN)
-			_ = decodeJSONPreservingNumbers([]byte(tc.want), &wantN)
+			if err := decodeJSONPreservingNumbers(gotBytes, &gotN); err != nil {
+				t.Fatalf("decode got: %v", err)
+			}
+			if err := decodeJSONPreservingNumbers([]byte(tc.want), &wantN); err != nil {
+				t.Fatalf("decode want: %v", err)
+			}
 			if !reflect.DeepEqual(gotN, wantN) {
 				t.Errorf("got %s, want %s", gotBytes, tc.want)
 			}
@@ -54,7 +61,10 @@ func TestApplyMergePatch_NumberFidelity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("merge: %v", err)
 	}
-	b, _ := json.Marshal(got)
+	b, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal got: %v", err)
+	}
 	if string(b) != `{"big":9007199254740993}` {
 		t.Errorf("number fidelity lost: got %s", b)
 	}

--- a/internal/domain/entity/patch_test.go
+++ b/internal/domain/entity/patch_test.go
@@ -1,0 +1,194 @@
+package entity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/model/schema"
+	wfengine "github.com/cyoda-platform/cyoda-go/internal/domain/workflow"
+	"github.com/cyoda-platform/cyoda-go/plugins/memory"
+)
+
+func TestPatchEntity_MergeAndStrictValidate(t *testing.T) {
+	h, ctx := newPatchTestHandler(t)
+	id := createPersonEntity(t, h, ctx, map[string]any{"name": "Alice", "age": json.Number("30")})
+	txid := getTxID(t, h, ctx, id)
+
+	// Patch only "age"; "name" must be preserved.
+	res, err := h.PatchEntity(ctx, PatchEntityInput{
+		EntityID:    id,
+		Patch:       []byte(`{"age":31}`),
+		PatchFormat: "MERGE_PATCH",
+		IfMatch:     txid,
+	})
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if len(res.EntityIDs) != 1 {
+		t.Fatalf("expected 1 entity id")
+	}
+	got := getEntityData(t, h, ctx, id)
+	if got["name"] != "Alice" || got["age"].(json.Number).String() != "31" {
+		t.Errorf("merge wrong: %#v", got)
+	}
+}
+
+func TestPatchEntity_JSONPatchNotImplemented(t *testing.T) {
+	h, ctx := newPatchTestHandler(t)
+	id := createPersonEntity(t, h, ctx, map[string]any{"name": "A"})
+	_, err := h.PatchEntity(ctx, PatchEntityInput{
+		EntityID: id, Patch: []byte(`[]`), PatchFormat: "JSON_PATCH", IfMatch: "*",
+	})
+	assertStatus(t, err, http.StatusNotImplemented)
+}
+
+func TestPatchEntity_StrictRejectsNewField(t *testing.T) {
+	h, ctx := newPatchTestHandler(t) // model is locked & strict (ChangeLevel "")
+	id := createPersonEntity(t, h, ctx, map[string]any{"name": "A"})
+	_, err := h.PatchEntity(ctx, PatchEntityInput{
+		EntityID: id, Patch: []byte(`{"newfield":"x"}`), PatchFormat: "MERGE_PATCH", IfMatch: "*",
+	})
+	assertStatus(t, err, http.StatusBadRequest)
+}
+
+func TestPatchEntity_StaleTokenIs412(t *testing.T) {
+	h, ctx := newPatchTestHandler(t)
+	id := createPersonEntity(t, h, ctx, map[string]any{"name": "A", "age": json.Number("1")})
+	stale := getTxID(t, h, ctx, id)
+	// Advance the entity so the token goes stale.
+	if _, err := h.PatchEntity(ctx, PatchEntityInput{EntityID: id, Patch: []byte(`{"age":2}`), PatchFormat: "MERGE_PATCH", IfMatch: stale}); err != nil {
+		t.Fatalf("first patch: %v", err)
+	}
+	_, err := h.PatchEntity(ctx, PatchEntityInput{EntityID: id, Patch: []byte(`{"age":3}`), PatchFormat: "MERGE_PATCH", IfMatch: stale})
+	assertStatus(t, err, http.StatusPreconditionFailed)
+}
+
+func TestPatchEntity_StarIsUnconditional(t *testing.T) {
+	h, ctx := newPatchTestHandler(t)
+	id := createPersonEntity(t, h, ctx, map[string]any{"name": "A", "age": json.Number("1")})
+	if _, err := h.PatchEntity(ctx, PatchEntityInput{EntityID: id, Patch: []byte(`{"age":2}`), PatchFormat: "MERGE_PATCH", IfMatch: "*"}); err != nil {
+		t.Fatalf("star patch should succeed unconditionally: %v", err)
+	}
+}
+
+// --- helpers ---
+
+// newPatchTestHandler builds a Handler wired to a fresh in-memory store with a
+// real workflow engine, and a context carrying the test user. The model "Person/1"
+// has schema {name: String, age: Integer}, is locked, and has ChangeLevel == ""
+// (strict — never extends).
+func newPatchTestHandler(t *testing.T) (*Handler, context.Context) {
+	t.Helper()
+
+	factory := memory.NewStoreFactory()
+	ctx := spi.WithUserContext(context.Background(), &spi.UserContext{
+		UserID:   "patch-test-user",
+		UserName: "Patch Test",
+		Tenant:   spi.Tenant{ID: "patch-tenant", Name: "Patch"},
+		Roles:    []string{"user"},
+	})
+
+	txMgr, err := factory.TransactionManager(ctx)
+	if err != nil {
+		t.Fatalf("TransactionManager: %v", err)
+	}
+
+	engine := wfengine.NewEngine(factory, common.NewDefaultUUIDGenerator(), txMgr)
+	h := New(factory, txMgr, common.NewDefaultUUIDGenerator(), engine)
+
+	// Build a strict (ChangeLevel == "") schema for Person: {name: String, age: Integer}.
+	node := schema.NewObjectNode()
+	node.SetChild("name", schema.NewLeafNode(schema.String))
+	node.SetChild("age", schema.NewLeafNode(schema.Integer))
+	raw, mErr := schema.Marshal(node)
+	if mErr != nil {
+		t.Fatalf("schema.Marshal: %v", mErr)
+	}
+
+	modelStore, err := factory.ModelStore(ctx)
+	if err != nil {
+		t.Fatalf("ModelStore: %v", err)
+	}
+	if err := modelStore.Save(ctx, &spi.ModelDescriptor{
+		Ref:    spi.ModelRef{EntityName: "Person", ModelVersion: "1"},
+		State:  spi.ModelLocked,
+		Schema: raw,
+		// ChangeLevel == "" means strict-validate-only (never extends the schema).
+	}); err != nil {
+		t.Fatalf("ModelStore.Save: %v", err)
+	}
+
+	return h, ctx
+}
+
+// createPersonEntity creates a Person entity with the given data fields and
+// returns its entity ID.
+func createPersonEntity(t *testing.T, h *Handler, ctx context.Context, data map[string]any) string {
+	t.Helper()
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal entity data: %v", err)
+	}
+	res, err := h.CreateEntity(ctx, CreateEntityInput{
+		EntityName:   "Person",
+		ModelVersion: "1",
+		Format:       "JSON",
+		Data:         json.RawMessage(b),
+	})
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	if len(res.EntityIDs) != 1 {
+		t.Fatalf("expected 1 entity ID from CreateEntity, got %d", len(res.EntityIDs))
+	}
+	return res.EntityIDs[0]
+}
+
+// getTxID retrieves the current transactionId from the entity's meta.
+func getTxID(t *testing.T, h *Handler, ctx context.Context, entityID string) string {
+	t.Helper()
+	env, err := h.GetEntity(ctx, GetOneEntityInput{EntityID: entityID})
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	meta, ok := env.Meta["transactionId"]
+	if !ok {
+		t.Fatalf("entity meta has no transactionId: %#v", env.Meta)
+	}
+	txid, ok := meta.(string)
+	if !ok || txid == "" {
+		t.Fatalf("transactionId is not a non-empty string: %v", meta)
+	}
+	return txid
+}
+
+// getEntityData returns the data map from the entity, with json.Number for numerics.
+func getEntityData(t *testing.T, h *Handler, ctx context.Context, entityID string) map[string]any {
+	t.Helper()
+	env, err := h.GetEntity(ctx, GetOneEntityInput{EntityID: entityID})
+	if err != nil {
+		t.Fatalf("GetEntity: %v", err)
+	}
+	data, ok := env.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("entity data is not map[string]any: %T %#v", env.Data, env.Data)
+	}
+	return data
+}
+
+// assertStatus checks that err is a *common.AppError with the given HTTP status.
+func assertStatus(t *testing.T, err error, want int) {
+	t.Helper()
+	var appErr *common.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected AppError, got %v", err)
+	}
+	if appErr.Status != want {
+		t.Fatalf("status: got %d want %d (%s)", appErr.Status, want, appErr.Message)
+	}
+}

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -77,6 +77,27 @@ type UpdateEntityInput struct {
 	IfMatch    string // optional ETag for CAS
 }
 
+// updateOptions tunes the shared update flow. Zero value = plain replace (PUT).
+type updateOptions struct {
+	// merge, when non-nil, transforms the parsed request body against the
+	// existing entity's stored data inside the transaction, before validation
+	// (RFC 7386 for PATCH).
+	merge func(existing json.RawMessage, incoming any) (any, error)
+	// strictValidate forces validate-only — never extend the model schema (PATCH).
+	strictValidate bool
+}
+
+// PatchEntityInput holds parameters for a partial (RFC 7386) entity update.
+// IfMatch is required in some form (a transactionId, or "*" for unconditional);
+// its absence is rejected as 428 at the HTTP/gRPC edge, not here.
+type PatchEntityInput struct {
+	EntityID    string
+	Patch       json.RawMessage
+	PatchFormat string // "MERGE_PATCH" | "JSON_PATCH"
+	Transition  string
+	IfMatch     string
+}
+
 // DeleteAllResult holds the result of deleting all entities for a model.
 type DeleteAllResult struct {
 	TotalCount    int
@@ -958,6 +979,13 @@ func (h *Handler) CreateEntityCollection(ctx context.Context, items []Collection
 
 // UpdateEntity updates a single entity with an optional named transition or loopback.
 func (h *Handler) UpdateEntity(ctx context.Context, input UpdateEntityInput) (*EntityTransactionResult, error) {
+	return h.updateEntityCore(ctx, input, updateOptions{})
+}
+
+// updateEntityCore is the shared implementation for UpdateEntity and PatchEntity.
+// opts.merge, when non-nil, applies an RFC 7386 merge before validation.
+// opts.strictValidate forces validate-only (never extends the model schema).
+func (h *Handler) updateEntityCore(ctx context.Context, input UpdateEntityInput, opts updateOptions) (*EntityTransactionResult, error) {
 	modelStore, err := h.factory.ModelStore(ctx)
 	if err != nil {
 		return nil, common.Internal("failed to access model store", err)
@@ -1011,10 +1039,34 @@ func (h *Handler) UpdateEntity(ctx context.Context, input UpdateEntityInput) (*E
 		return nil, common.Internal("failed to load model for entity", err)
 	}
 
-	// Validate or extend model schema
-	if err := h.validateOrExtend(txCtx, modelStore, desc, parsedData); err != nil {
-		h.txMgr.Rollback(txCtx, txID)
-		return nil, classifyValidateOrExtendErr(err)
+	// PATCH: merge the sparse body onto the stored data before validation,
+	// inside this transaction so the merge base is the version being overwritten.
+	if opts.merge != nil {
+		merged, mErr := opts.merge(existing.Data, parsedData)
+		if mErr != nil {
+			h.txMgr.Rollback(txCtx, txID)
+			return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "invalid patch: "+mErr.Error())
+		}
+		parsedData = merged
+		bodyBytes, err = json.Marshal(parsedData)
+		if err != nil {
+			h.txMgr.Rollback(txCtx, txID)
+			return nil, common.Internal("failed to serialize merged entity", err)
+		}
+	}
+
+	// Validate the (possibly merged) result. PATCH validates strictly and never
+	// extends the model; PUT may extend per the model's ChangeLevel.
+	if opts.strictValidate {
+		if vErr := h.validateStrict(desc, parsedData); vErr != nil {
+			h.txMgr.Rollback(txCtx, txID)
+			return nil, classifyValidateOrExtendErr(vErr)
+		}
+	} else {
+		if vErr := h.validateOrExtend(txCtx, modelStore, desc, parsedData); vErr != nil {
+			h.txMgr.Rollback(txCtx, txID)
+			return nil, classifyValidateOrExtendErr(vErr)
+		}
 	}
 
 	now := time.Now()
@@ -1161,6 +1213,39 @@ func (h *Handler) UpdateEntity(ctx context.Context, input UpdateEntityInput) (*E
 		TransactionID: txID,
 		EntityIDs:     []string{input.EntityID},
 	}, nil
+}
+
+// PatchEntity applies a partial update. RFC 7386 merge patch is implemented;
+// RFC 6902 (JSON_PATCH) is scaffolded and returns 501.
+func (h *Handler) PatchEntity(ctx context.Context, input PatchEntityInput) (*EntityTransactionResult, error) {
+	switch input.PatchFormat {
+	case "MERGE_PATCH":
+		// handled below
+	case "JSON_PATCH":
+		return nil, common.Operational(http.StatusNotImplemented, common.ErrCodeNotImplemented,
+			"RFC 6902 JSON Patch is not implemented; use application/merge-patch+json")
+	default:
+		return nil, common.Operational(http.StatusUnsupportedMediaType, common.ErrCodeUnsupportedMediaType,
+			"unsupported patch format")
+	}
+
+	// "*" = unconditional: drop the CAS token. Existence is still guaranteed by
+	// the in-transaction Get inside updateEntityCore (404 if the entity is gone).
+	ifMatch := input.IfMatch
+	if ifMatch == "*" {
+		ifMatch = ""
+	}
+
+	return h.updateEntityCore(ctx, UpdateEntityInput{
+		EntityID:   input.EntityID,
+		Format:     "JSON",
+		Data:       input.Patch,
+		Transition: input.Transition,
+		IfMatch:    ifMatch,
+	}, updateOptions{
+		merge:          mergeMergePatch,
+		strictValidate: true,
+	})
 }
 
 // UpdateEntityCollection updates multiple entities in a single transaction

--- a/internal/e2e/entity_patch_test.go
+++ b/internal/e2e/entity_patch_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
@@ -312,5 +313,92 @@ func TestE2E_EntityPatch_MergeOrdering_WithProcessor(t *testing.T) {
 	}
 	if amt, _ := data["amount"].(float64); amt != 999 {
 		t.Errorf("processor must win: expected amount=999, got %v", data["amount"])
+	}
+}
+
+// TestE2E_EntityPatch_ConcurrentConflict fires two concurrent PATCHes
+// against the same entity using the same If-Match txId. Exactly one must
+// succeed (200) and the other must be rejected (409 or 412). The final
+// entity state must reflect the winner's value with no torn write.
+//
+// This test is isolated here (not in the shared cross-backend parity suite)
+// because goroutine-storm concurrency tests can tip an unrelated later
+// scenario over the parity HTTP client's timeout on the shared in-memory
+// store. Running it here exercises only the real PostgreSQL backend.
+func TestE2E_EntityPatch_ConcurrentConflict(t *testing.T) {
+	const model = "e2e-patch-concurrent"
+
+	setupModelWithWorkflow(t, model, `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "patch-concurrent-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE":    {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {}
+			}
+		}]
+	}`)
+
+	entityID, createTxID := createEntityE2EWithTxID(t, model, 1,
+		`{"name":"Race","amount":1,"status":"draft"}`)
+
+	type patchResult struct {
+		status int
+		amount int // 100 or 200 — which value this goroutine tried to set
+	}
+	results := [2]patchResult{}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		resp := patchEntity(t,
+			fmt.Sprintf("/api/entity/JSON/%s", entityID),
+			"application/merge-patch+json",
+			createTxID,
+			`{"amount":100}`,
+		)
+		readBody(t, resp)
+		results[0] = patchResult{status: resp.StatusCode, amount: 100}
+	}()
+	go func() {
+		defer wg.Done()
+		resp := patchEntity(t,
+			fmt.Sprintf("/api/entity/JSON/%s", entityID),
+			"application/merge-patch+json",
+			createTxID,
+			`{"amount":200}`,
+		)
+		readBody(t, resp)
+		results[1] = patchResult{status: resp.StatusCode, amount: 200}
+	}()
+	wg.Wait()
+
+	// Exactly one goroutine must have won (200); the other must have been
+	// rejected with 409 (Conflict) or 412 (Precondition Failed).
+	var winnerAmount int
+	var successCount int
+	for _, r := range results {
+		switch r.status {
+		case http.StatusOK:
+			successCount++
+			winnerAmount = r.amount
+		case http.StatusConflict, http.StatusPreconditionFailed:
+			// expected loser codes
+		default:
+			t.Errorf("concurrent PATCH goroutine (amount=%d): unexpected status %d; want 200, 409, or 412",
+				r.amount, r.status)
+		}
+	}
+	if successCount != 1 {
+		t.Fatalf("concurrent PATCH: %d goroutines succeeded, want exactly 1; results=%v", successCount, results)
+	}
+
+	// Final entity must reflect the winner's amount with no torn write.
+	data := getEntityData(t, entityID, "")
+	if amt, _ := data["amount"].(float64); int(amt) != winnerAmount {
+		t.Errorf("post-concurrent amount = %v, want %d (winner's value); torn write or wrong commit",
+			data["amount"], winnerAmount)
 	}
 }

--- a/internal/e2e/entity_patch_test.go
+++ b/internal/e2e/entity_patch_test.go
@@ -238,13 +238,15 @@ func TestE2E_EntityPatch_WithTransition(t *testing.T) {
 func TestE2E_EntityPatch_MergeOrdering_WithProcessor(t *testing.T) {
 	const model = "e2e-patch-order"
 
-	// Register an in-process processor that sets amount to 999 regardless of input.
+	// Register an in-process processor that records the incoming amount into
+	// seenAmount (proving what the merge produced) then overwrites amount to 999.
 	const procName = "patch-order-overwriter"
 	procSvc.RegisterProcessor(procName, func(ctx context.Context, entity *spi.Entity, proc spi.ProcessorDefinition) (*spi.Entity, error) {
 		var data map[string]any
 		if err := json.Unmarshal(entity.Data, &data); err != nil {
 			return nil, err
 		}
+		data["seenAmount"] = data["amount"] // snapshot what the processor received
 		data["amount"] = float64(999)
 		updated, err := json.Marshal(data)
 		if err != nil {
@@ -299,9 +301,14 @@ func TestE2E_EntityPatch_MergeOrdering_WithProcessor(t *testing.T) {
 	}
 
 	// Processor value wins over the merge value.
+	// seenAmount proves the processor received the MERGED value (75), not the
+	// pre-patch value (50) — i.e. the merge ran before the processor.
 	data := getEntityData(t, entityID, "")
 	if data["name"] != "Charlie" {
 		t.Errorf("name not preserved; got %v", data["name"])
+	}
+	if seen, _ := data["seenAmount"].(float64); seen != 75 {
+		t.Errorf("merge must run before processor: processor saw amount=%v, want 75 (the merged value)", data["seenAmount"])
 	}
 	if amt, _ := data["amount"].(float64); amt != 999 {
 		t.Errorf("processor must win: expected amount=999, got %v", data["amount"])

--- a/internal/e2e/entity_patch_test.go
+++ b/internal/e2e/entity_patch_test.go
@@ -1,0 +1,309 @@
+//go:build !short
+
+package e2e_test
+
+// TestE2E_EntityPatch_* tests cover the PATCH /api/entity/{format}/{entityId}
+// and PATCH /api/entity/{format}/{entityId}/{transition} endpoints through the
+// full HTTP stack (PostgreSQL + httptest.Server + JWT auth).
+//
+// Coverage:
+//   - Merge happy-path (field preserved, field changed).
+//   - Error preconditions: 415 (XML format), 415 (wrong Content-Type),
+//     428 (missing If-Match), 501 (json-patch+json), 412 (stale token).
+//   - PATCH with a named transition (state advance + merge).
+//   - Merge-then-transition ordering: PATCH sets a field; a SYNC processor on
+//     the transition overwrites it. Processor value must win (full E2E,
+//     TestE2E_EntityPatch_MergeOrdering_WithProcessor).
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// patchEntity issues an authenticated PATCH request to path with the given
+// Content-Type, If-Match (non-empty), and body. It returns the raw response.
+func patchEntity(t *testing.T, path, contentType, ifMatch, body string) *http.Response {
+	t.Helper()
+	token := getToken(t, "testclient", "testsecret")
+	req, err := e2eNewRequest(t, http.MethodPatch, serverURL+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("patchEntity newRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("If-Match", ifMatch)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("patchEntity do: %v", err)
+	}
+	return resp
+}
+
+// patchEntityNoIfMatch issues an authenticated PATCH request without the
+// If-Match header, used to exercise the 428 precondition-required path.
+func patchEntityNoIfMatch(t *testing.T, path, contentType, body string) *http.Response {
+	t.Helper()
+	token := getToken(t, "testclient", "testsecret")
+	req, err := e2eNewRequest(t, http.MethodPatch, serverURL+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("patchEntityNoIfMatch newRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", contentType)
+	// deliberately omit If-Match
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("patchEntityNoIfMatch do: %v", err)
+	}
+	return resp
+}
+
+// TestE2E_EntityPatch_MergeAndPreconditions exercises the PATCH
+// /api/entity/JSON/{entityId} loopback path through the full HTTP stack.
+//
+// Covered:
+//  1. Merge happy-path: patch one field, assert the other is preserved.
+//  2. XML format → 415.
+//  3. Wrong Content-Type (application/json) → 415.
+//  4. Missing If-Match → 428.
+//  5. application/json-patch+json → 501.
+//  6. Stale If-Match token → 412.
+func TestE2E_EntityPatch_MergeAndPreconditions(t *testing.T) {
+	const model = "e2e-patch-precond"
+
+	// Set up model+workflow; workflowSampleModel has {name, amount, status}.
+	setupModelWithWorkflow(t, model, `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "patch-precond-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE":    {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {}
+			}
+		}]
+	}`)
+
+	// Create an entity and capture the post-create transactionId.
+	entityID, createTxID := createEntityE2EWithTxID(t, model, 1,
+		`{"name":"Alice","amount":30,"status":"draft"}`)
+
+	// ── 1. Merge happy-path ───────────────────────────────────────────────
+	// createEntityE2EWithTxID returns the POST-response transactionId, which
+	// equals the If-Match token required by the next write.
+	resp := patchEntity(t,
+		fmt.Sprintf("/api/entity/JSON/%s", entityID),
+		"application/merge-patch+json",
+		createTxID,
+		`{"amount":31}`,
+	)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("merge happy-path: got %d; body: %s", resp.StatusCode, body)
+	}
+
+	// Verify merge: name preserved, amount changed.
+	// getEntityData uses json.Unmarshal, so numerics arrive as float64.
+	data := getEntityData(t, entityID, "")
+	if data["name"] != "Alice" {
+		t.Errorf("merge: name not preserved; got %v", data["name"])
+	}
+	if amt, _ := data["amount"].(float64); amt != 31 {
+		t.Errorf("merge: amount not updated; got %v (type %T)", data["amount"], data["amount"])
+	}
+
+	// ── 2. XML format → 415 ──────────────────────────────────────────────
+	r415xml := patchEntity(t,
+		fmt.Sprintf("/api/entity/XML/%s", entityID),
+		"application/merge-patch+json",
+		"*",
+		`{}`,
+	)
+	readBody(t, r415xml)
+	if r415xml.StatusCode != http.StatusUnsupportedMediaType {
+		t.Errorf("XML format: expected 415, got %d", r415xml.StatusCode)
+	}
+
+	// ── 3. Wrong Content-Type → 415 ──────────────────────────────────────
+	r415ct := patchEntity(t,
+		fmt.Sprintf("/api/entity/JSON/%s", entityID),
+		"application/json",
+		"*",
+		`{}`,
+	)
+	readBody(t, r415ct)
+	if r415ct.StatusCode != http.StatusUnsupportedMediaType {
+		t.Errorf("wrong Content-Type: expected 415, got %d", r415ct.StatusCode)
+	}
+
+	// ── 4. Missing If-Match → 428 ─────────────────────────────────────────
+	r428 := patchEntityNoIfMatch(t,
+		fmt.Sprintf("/api/entity/JSON/%s", entityID),
+		"application/merge-patch+json",
+		`{}`,
+	)
+	readBody(t, r428)
+	if r428.StatusCode != http.StatusPreconditionRequired {
+		t.Errorf("missing If-Match: expected 428, got %d", r428.StatusCode)
+	}
+
+	// ── 5. application/json-patch+json → 501 ─────────────────────────────
+	r501 := patchEntity(t,
+		fmt.Sprintf("/api/entity/JSON/%s", entityID),
+		"application/json-patch+json",
+		"*",
+		`[]`,
+	)
+	readBody(t, r501)
+	if r501.StatusCode != http.StatusNotImplemented {
+		t.Errorf("json-patch+json: expected 501, got %d", r501.StatusCode)
+	}
+
+	// ── 6. Stale If-Match token → 412 ─────────────────────────────────────
+	// createTxID is now stale (the happy-path patch above advanced the entity).
+	r412 := patchEntity(t,
+		fmt.Sprintf("/api/entity/JSON/%s", entityID),
+		"application/merge-patch+json",
+		createTxID,
+		`{"amount":99}`,
+	)
+	body412 := readBody(t, r412)
+	if r412.StatusCode != http.StatusPreconditionFailed {
+		t.Errorf("stale If-Match: expected 412, got %d; body: %s", r412.StatusCode, body412)
+	}
+}
+
+// TestE2E_EntityPatch_WithTransition patches an entity AND names a manual
+// transition through the PATCH /api/entity/JSON/{entityId}/{transition} route.
+// The test verifies that the transition fires (state advances) and the merge
+// is applied correctly.
+func TestE2E_EntityPatch_WithTransition(t *testing.T) {
+	const model = "e2e-patch-transition"
+
+	setupModelWithWorkflow(t, model, `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "patch-trans-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE":    {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {"transitions": [{"name": "approve", "next": "APPROVED", "manual": true}]},
+				"APPROVED": {}
+			}
+		}]
+	}`)
+
+	entityID, createTxID := createEntityE2EWithTxID(t, model, 1,
+		`{"name":"Bob","amount":50,"status":"draft"}`)
+
+	if s := getEntityState(t, entityID); s != "CREATED" {
+		t.Fatalf("pre-patch state: expected CREATED, got %s", s)
+	}
+
+	// PATCH with the "approve" transition — should advance the state and merge
+	// the delta ({amount:75}) onto the stored data.
+	resp := patchEntity(t,
+		fmt.Sprintf("/api/entity/JSON/%s/approve", entityID),
+		"application/merge-patch+json",
+		createTxID,
+		`{"amount":75}`,
+	)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PATCH with transition: got %d; body: %s", resp.StatusCode, body)
+	}
+
+	// State advanced.
+	if s := getEntityState(t, entityID); s != "APPROVED" {
+		t.Errorf("post-patch state: expected APPROVED, got %s", s)
+	}
+	// Merge applied: name preserved, amount updated.
+	data := getEntityData(t, entityID, "")
+	if data["name"] != "Bob" {
+		t.Errorf("PATCH+transition: name not preserved; got %v", data["name"])
+	}
+	if amt, _ := data["amount"].(float64); amt != 75 {
+		t.Errorf("PATCH+transition: amount not updated to 75; got %v", data["amount"])
+	}
+}
+
+// TestE2E_EntityPatch_MergeOrdering_WithProcessor asserts the merge-then-processor
+// ordering invariant end-to-end: a PATCH that sets amount=75 and names a
+// transition whose SYNC processor overwrites amount=999 — the processor's value
+// must win (merge runs first, processors run after inside updateEntityCore).
+func TestE2E_EntityPatch_MergeOrdering_WithProcessor(t *testing.T) {
+	const model = "e2e-patch-order"
+
+	// Register an in-process processor that sets amount to 999 regardless of input.
+	const procName = "patch-order-overwriter"
+	procSvc.RegisterProcessor(procName, func(ctx context.Context, entity *spi.Entity, proc spi.ProcessorDefinition) (*spi.Entity, error) {
+		var data map[string]any
+		if err := json.Unmarshal(entity.Data, &data); err != nil {
+			return nil, err
+		}
+		data["amount"] = float64(999)
+		updated, err := json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
+		return &spi.Entity{Meta: entity.Meta, Data: updated}, nil
+	})
+	defer procSvc.Reset()
+
+	// Workflow: NONE -init-> CREATED -approve-> APPROVED, with a SYNC processor
+	// on the approve transition that overwrites amount.
+	wf := fmt.Sprintf(`{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "patch-order-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE":    {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {"transitions": [{"name": "approve", "next": "APPROVED", "manual": true,
+					"processors": [{"type": "calculator", "name": "%s",
+						"executionMode": "SYNC",
+						"config": {"attachEntity": true, "calculationNodesTags": ""}}]
+				}]},
+				"APPROVED": {}
+			}
+		}]
+	}`, procName)
+	setupModelWithWorkflow(t, model, wf)
+
+	entityID, createTxID := createEntityE2EWithTxID(t, model, 1,
+		`{"name":"Charlie","amount":50,"status":"draft"}`)
+
+	if s := getEntityState(t, entityID); s != "CREATED" {
+		t.Fatalf("pre-patch state: expected CREATED, got %s", s)
+	}
+
+	// PATCH: set amount=75 (merge) + name the approve transition (processor sets amount=999).
+	// Post-condition: processor wins → amount must be 999, not 75.
+	resp := patchEntity(t,
+		fmt.Sprintf("/api/entity/JSON/%s/approve", entityID),
+		"application/merge-patch+json",
+		createTxID,
+		`{"amount":75}`,
+	)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PATCH with processor: got %d; body: %s", resp.StatusCode, body)
+	}
+
+	// State advanced.
+	if s := getEntityState(t, entityID); s != "APPROVED" {
+		t.Errorf("post-patch state: expected APPROVED, got %s", s)
+	}
+
+	// Processor value wins over the merge value.
+	data := getEntityData(t, entityID, "")
+	if data["name"] != "Charlie" {
+		t.Errorf("name not preserved; got %v", data["name"])
+	}
+	if amt, _ := data["amount"].(float64); amt != 999 {
+		t.Errorf("processor must win: expected amount=999, got %v", data["amount"])
+	}
+}

--- a/internal/grpc/cloudevent_types.go
+++ b/internal/grpc/cloudevent_types.go
@@ -31,6 +31,7 @@ const (
 	EntityDeleteAllResponse       = "EntityDeleteAllResponse"
 	EntityTransitionRequest       = "EntityTransitionRequest"
 	EntityTransitionResponse      = "EntityTransitionResponse"
+	EntityPatchRequest            = "EntityPatchRequest"
 )
 
 // Model management types.

--- a/internal/grpc/entity.go
+++ b/internal/grpc/entity.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -117,6 +118,51 @@ func (s *CloudEventsServiceImpl) EntityManage(ctx context.Context, ce *cepb.Clou
 			TransactionInfo: events.EntityTransactionInfoJson{
 				EntityIds: result.EntityIDs,
 			},
+		}
+		if result.TransactionID != "" {
+			resp.TransactionInfo.TransactionID = &result.TransactionID
+		}
+		slog.Debug("CloudEvent response", "pkg", "grpc", "rpc", "entityManage", "type", EntityTransactionResponse, "ceId", ce.Id, "success", true)
+		return NewCloudEvent(EntityTransactionResponse, resp)
+
+	case EntityPatchRequest:
+		dec := json.NewDecoder(bytes.NewReader(payload))
+		dec.UseNumber()
+		var req events.EntityPatchRequestJson
+		if err := dec.Decode(&req); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid payload: %v", err)
+		}
+		if req.Payload.IfMatch == nil || *req.Payload.IfMatch == "" {
+			return entityTransactionError(ctx, ce.Id, common.Operational(
+				http.StatusPreconditionRequired, common.ErrCodePreconditionRequired,
+				"missing ifMatch: provide the transactionId from your last read, or \"*\" to accept last-writer-wins"))
+		}
+		patchBytes, err := json.Marshal(req.Payload.Patch)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to marshal patch: %v", err)
+		}
+		transition := ""
+		if req.Payload.Transition != nil {
+			transition = *req.Payload.Transition
+		}
+		result, err := s.entityHandler.PatchEntity(ctx, entity.PatchEntityInput{
+			EntityID:    req.Payload.EntityID,
+			Patch:       patchBytes,
+			PatchFormat: string(req.PatchFormat),
+			Transition:  transition,
+			IfMatch:     *req.Payload.IfMatch,
+		})
+		if err != nil {
+			slog.Error("operation failed", "pkg", "grpc", "rpc", "entityManage", "type", eventType, "ceId", ce.Id, "error", err.Error())
+			return entityTransactionError(ctx, ce.Id, err)
+		}
+		diag := common.GetDiagnostics(ctx)
+		resp := events.EntityTransactionResponseJson{
+			ID:              ce.Id,
+			Success:         true,
+			Warnings:        diag.GetWarnings(),
+			RequestID:       ce.Id,
+			TransactionInfo: events.EntityTransactionInfoJson{EntityIds: result.EntityIDs},
 		}
 		if result.TransactionID != "" {
 			resp.TransactionInfo.TransactionID = &result.TransactionID

--- a/internal/grpc/rpc_test.go
+++ b/internal/grpc/rpc_test.go
@@ -1093,6 +1093,12 @@ func TestRPC_EntityPatch(t *testing.T) {
 	if !typed.Success {
 		t.Fatalf("expected success; got %#v", typed.Error)
 	}
+	if typed.RequestID == "" {
+		t.Error("missing requestId")
+	}
+	if len(typed.TransactionInfo.EntityIds) == 0 {
+		t.Error("expected at least one entityId in response")
+	}
 }
 
 func TestRPC_EntityPatch_MissingIfMatch428(t *testing.T) {
@@ -1119,6 +1125,24 @@ func TestRPC_EntityPatch_MissingIfMatch428(t *testing.T) {
 	}
 	if !strings.Contains(typed.Error.Message, "PRECONDITION_REQUIRED") {
 		t.Errorf("expected PRECONDITION_REQUIRED in message, got %q", typed.Error.Message)
+	}
+
+	// Also cover the absent-ifMatch branch (*string == nil): omit the ifMatch key entirely.
+	patchCENoKey := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p2", "patchFormat": "MERGE_PATCH",
+		"payload": map[string]any{"entityId": entityID, "patch": map[string]any{"name": "C"}},
+	})
+	resp2, err := svc.EntityManage(ctx, patchCENoKey)
+	if err != nil {
+		t.Fatalf("unexpected transport error (absent ifMatch): %v", err)
+	}
+	var typed2 events.EntityTransactionResponseJson
+	validateResponse(t, resp2, &typed2)
+	if typed2.Success || typed2.Error == nil {
+		t.Fatalf("expected failure envelope for absent ifMatch")
+	}
+	if !strings.Contains(typed2.Error.Message, "PRECONDITION_REQUIRED") {
+		t.Errorf("expected PRECONDITION_REQUIRED in message for absent ifMatch, got %q", typed2.Error.Message)
 	}
 }
 

--- a/internal/grpc/rpc_test.go
+++ b/internal/grpc/rpc_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/grpc/metadata"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
@@ -1143,6 +1144,232 @@ func TestRPC_EntityPatch_MissingIfMatch428(t *testing.T) {
 	}
 	if !strings.Contains(typed2.Error.Message, "PRECONDITION_REQUIRED") {
 		t.Errorf("expected PRECONDITION_REQUIRED in message for absent ifMatch, got %q", typed2.Error.Message)
+	}
+}
+
+func TestRPC_EntityPatch_JSONPatchNotImplemented(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "A", "amount": 1})
+
+	createResp, err := svc.EntityManage(ctx, makeCE(EntityCreateRequest, map[string]any{
+		"id": "c1", "dataFormat": "JSON",
+		"payload": map[string]any{"model": map[string]any{"name": "person", "version": 1}, "data": map[string]any{"name": "A", "amount": 1}},
+	}))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	entityID := parseResponsePayload(t, createResp)["transactionInfo"].(map[string]any)["entityIds"].([]any)[0].(string)
+
+	patchCE := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p1", "patchFormat": "JSON_PATCH",
+		"payload": map[string]any{"entityId": entityID, "patch": []any{}, "ifMatch": "*"},
+	})
+	resp, err := svc.EntityManage(ctx, patchCE)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	var typed events.EntityTransactionResponseJson
+	validateResponse(t, resp, &typed)
+	if typed.Success || typed.Error == nil {
+		t.Fatalf("expected failure envelope")
+	}
+	if !strings.Contains(typed.Error.Message, "NOT_IMPLEMENTED") {
+		t.Errorf("expected NOT_IMPLEMENTED in message, got %q", typed.Error.Message)
+	}
+}
+
+func TestRPC_EntityPatch_StaleTokenIs412(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "A", "amount": 1})
+
+	createResp, err := svc.EntityManage(ctx, makeCE(EntityCreateRequest, map[string]any{
+		"id": "c1", "dataFormat": "JSON",
+		"payload": map[string]any{"model": map[string]any{"name": "person", "version": 1}, "data": map[string]any{"name": "A", "amount": 1}},
+	}))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	createPayload := parseResponsePayload(t, createResp)
+	txInfo := createPayload["transactionInfo"].(map[string]any)
+	entityID := txInfo["entityIds"].([]any)[0].(string)
+	createTxID := txInfo["transactionId"].(string)
+
+	// First patch with the create txId — should succeed and advance the entity.
+	firstPatchCE := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p1", "patchFormat": "MERGE_PATCH",
+		"payload": map[string]any{"entityId": entityID, "patch": map[string]any{"amount": 31}, "ifMatch": createTxID},
+	})
+	firstResp, err := svc.EntityManage(ctx, firstPatchCE)
+	if err != nil {
+		t.Fatalf("first patch transport error: %v", err)
+	}
+	var firstTyped events.EntityTransactionResponseJson
+	validateResponse(t, firstResp, &firstTyped)
+	if !firstTyped.Success {
+		t.Fatalf("expected first patch to succeed; got %#v", firstTyped.Error)
+	}
+
+	// Second patch with the same now-stale createTxID — should fail with ENTITY_MODIFIED.
+	stalePatchCE := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p2", "patchFormat": "MERGE_PATCH",
+		"payload": map[string]any{"entityId": entityID, "patch": map[string]any{"amount": 99}, "ifMatch": createTxID},
+	})
+	staleResp, err := svc.EntityManage(ctx, stalePatchCE)
+	if err != nil {
+		t.Fatalf("stale patch transport error: %v", err)
+	}
+	var staleTyped events.EntityTransactionResponseJson
+	validateResponse(t, staleResp, &staleTyped)
+	if staleTyped.Success || staleTyped.Error == nil {
+		t.Fatalf("expected failure envelope for stale token")
+	}
+	if !strings.Contains(staleTyped.Error.Message, "ENTITY_MODIFIED") {
+		t.Errorf("expected ENTITY_MODIFIED in message, got %q", staleTyped.Error.Message)
+	}
+}
+
+func TestRPC_EntityPatch_StarUnconditional(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "A", "amount": 1})
+
+	createResp, err := svc.EntityManage(ctx, makeCE(EntityCreateRequest, map[string]any{
+		"id": "c1", "dataFormat": "JSON",
+		"payload": map[string]any{"model": map[string]any{"name": "person", "version": 1}, "data": map[string]any{"name": "A", "amount": 1}},
+	}))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	entityID := parseResponsePayload(t, createResp)["transactionInfo"].(map[string]any)["entityIds"].([]any)[0].(string)
+
+	patchCE := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p1", "patchFormat": "MERGE_PATCH",
+		"payload": map[string]any{"entityId": entityID, "patch": map[string]any{"amount": 42}, "ifMatch": "*"},
+	})
+	resp, err := svc.EntityManage(ctx, patchCE)
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	var typed events.EntityTransactionResponseJson
+	validateResponse(t, resp, &typed)
+	if !typed.Success {
+		t.Fatalf("expected success; got %#v", typed.Error)
+	}
+
+	// Read back and verify the field was applied.
+	envelope, err := svc.entityHandler.GetEntity(ctx, entity.GetOneEntityInput{EntityID: entityID})
+	if err != nil {
+		t.Fatalf("get entity: %v", err)
+	}
+	dataBytes, err := json.Marshal(envelope.Data)
+	if err != nil {
+		t.Fatalf("marshal entity data: %v", err)
+	}
+	var dataMap map[string]any
+	if err := json.Unmarshal(dataBytes, &dataMap); err != nil {
+		t.Fatalf("unmarshal entity data: %v", err)
+	}
+	// json.Unmarshal decodes numbers as float64 by default.
+	if dataMap["amount"] != float64(42) {
+		t.Errorf("expected amount=42, got %v", dataMap["amount"])
+	}
+}
+
+func TestRPC_EntityPatch_NotFound(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+
+	missingID := uuid.NewString()
+	patchCE := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p1", "patchFormat": "MERGE_PATCH",
+		"payload": map[string]any{"entityId": missingID, "patch": map[string]any{"name": "X"}, "ifMatch": "*"},
+	})
+	resp, err := svc.EntityManage(ctx, patchCE)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	var typed events.EntityTransactionResponseJson
+	validateResponse(t, resp, &typed)
+	if typed.Success || typed.Error == nil {
+		t.Fatalf("expected failure envelope")
+	}
+	if !strings.Contains(typed.Error.Message, "ENTITY_NOT_FOUND") {
+		t.Errorf("expected ENTITY_NOT_FOUND in message, got %q", typed.Error.Message)
+	}
+}
+
+func TestRPC_EntityPatch_TypeMismatchIs400(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "A", "amount": 1})
+
+	createResp, err := svc.EntityManage(ctx, makeCE(EntityCreateRequest, map[string]any{
+		"id": "c1", "dataFormat": "JSON",
+		"payload": map[string]any{"model": map[string]any{"name": "person", "version": 1}, "data": map[string]any{"name": "A", "amount": 1}},
+	}))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	entityID := parseResponsePayload(t, createResp)["transactionInfo"].(map[string]any)["entityIds"].([]any)[0].(string)
+
+	patchCE := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p1", "patchFormat": "MERGE_PATCH",
+		"payload": map[string]any{"entityId": entityID, "patch": map[string]any{"amount": "not-a-number"}, "ifMatch": "*"},
+	})
+	resp, err := svc.EntityManage(ctx, patchCE)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	var typed events.EntityTransactionResponseJson
+	validateResponse(t, resp, &typed)
+	if typed.Success || typed.Error == nil {
+		t.Fatalf("expected failure envelope")
+	}
+	msg := typed.Error.Message
+	if !strings.Contains(msg, "INCOMPATIBLE_TYPE") && !strings.Contains(msg, "VALIDATION_FAILED") && !strings.Contains(msg, "BAD_REQUEST") {
+		t.Errorf("expected INCOMPATIBLE_TYPE, VALIDATION_FAILED, or BAD_REQUEST in message, got %q", msg)
+	}
+}
+
+func TestRPC_EntityPatch_WithTransition(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "Alice"})
+
+	createResp, err := svc.EntityManage(ctx, makeCE(EntityCreateRequest, map[string]any{
+		"id": "c1", "dataFormat": "JSON",
+		"payload": map[string]any{"model": map[string]any{"name": "person", "version": 1}, "data": map[string]any{"name": "Alice"}},
+	}))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	entityID := parseResponsePayload(t, createResp)["transactionInfo"].(map[string]any)["entityIds"].([]any)[0].(string)
+
+	patchCE := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p1", "patchFormat": "MERGE_PATCH",
+		"payload": map[string]any{"entityId": entityID, "patch": map[string]any{"name": "Renamed"}, "ifMatch": "*", "transition": "UPDATE"},
+	})
+	resp, err := svc.EntityManage(ctx, patchCE)
+	if err != nil {
+		t.Fatalf("patch with transition: %v", err)
+	}
+	var typed events.EntityTransactionResponseJson
+	validateResponse(t, resp, &typed)
+	if !typed.Success {
+		t.Fatalf("expected success; got %#v", typed.Error)
+	}
+
+	// Read back and verify the field was applied.
+	envelope, err := svc.entityHandler.GetEntity(ctx, entity.GetOneEntityInput{EntityID: entityID})
+	if err != nil {
+		t.Fatalf("get entity: %v", err)
+	}
+	dataBytes, err := json.Marshal(envelope.Data)
+	if err != nil {
+		t.Fatalf("marshal entity data: %v", err)
+	}
+	var dataMap map[string]any
+	if err := json.Unmarshal(dataBytes, &dataMap); err != nil {
+		t.Fatalf("unmarshal entity data: %v", err)
+	}
+	if dataMap["name"] != "Renamed" {
+		t.Errorf("expected name=Renamed, got %v", dataMap["name"])
 	}
 }
 

--- a/internal/grpc/rpc_test.go
+++ b/internal/grpc/rpc_test.go
@@ -1066,6 +1066,62 @@ func TestRPC_SnapshotSearch_Error_SchemaValid(t *testing.T) {
 	}
 }
 
+func TestRPC_EntityPatch(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "Alice", "age": 30})
+
+	createCE := makeCE(EntityCreateRequest, map[string]any{
+		"id": "c1", "dataFormat": "JSON",
+		"payload": map[string]any{"model": map[string]any{"name": "person", "version": 1}, "data": map[string]any{"name": "Alice", "age": 30}},
+	})
+	createResp, err := svc.EntityManage(ctx, createCE)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	entityID := parseResponsePayload(t, createResp)["transactionInfo"].(map[string]any)["entityIds"].([]any)[0].(string)
+
+	patchCE := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p1", "patchFormat": "MERGE_PATCH",
+		"payload": map[string]any{"entityId": entityID, "patch": map[string]any{"age": 31}, "ifMatch": "*"},
+	})
+	resp, err := svc.EntityManage(ctx, patchCE)
+	if err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	var typed events.EntityTransactionResponseJson
+	validateResponse(t, resp, &typed)
+	if !typed.Success {
+		t.Fatalf("expected success; got %#v", typed.Error)
+	}
+}
+
+func TestRPC_EntityPatch_MissingIfMatch428(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "person", "1", map[string]any{"name": "A"})
+	createResp, _ := svc.EntityManage(ctx, makeCE(EntityCreateRequest, map[string]any{
+		"id": "c1", "dataFormat": "JSON",
+		"payload": map[string]any{"model": map[string]any{"name": "person", "version": 1}, "data": map[string]any{"name": "A"}},
+	}))
+	entityID := parseResponsePayload(t, createResp)["transactionInfo"].(map[string]any)["entityIds"].([]any)[0].(string)
+
+	patchCE := makeCE(EntityPatchRequest, map[string]any{
+		"id": "p1", "patchFormat": "MERGE_PATCH",
+		"payload": map[string]any{"entityId": entityID, "patch": map[string]any{"name": "B"}, "ifMatch": ""},
+	})
+	resp, err := svc.EntityManage(ctx, patchCE)
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	var typed events.EntityTransactionResponseJson
+	validateResponse(t, resp, &typed)
+	if typed.Success || typed.Error == nil {
+		t.Fatalf("expected failure envelope")
+	}
+	if !strings.Contains(typed.Error.Message, "PRECONDITION_REQUIRED") {
+		t.Errorf("expected PRECONDITION_REQUIRED in message, got %q", typed.Error.Message)
+	}
+}
+
 // --- mock stream implementations ---
 
 // mockManageStream implements CloudEventsService_EntityManageCollectionServer.

--- a/scripts/generate-events.sh
+++ b/scripts/generate-events.sh
@@ -84,6 +84,7 @@ mkdir -p "$(dirname "$OUT")"
   "$CLEAN_DIR"/common/DataPayload.json \
   "$CLEAN_DIR"/common/ModelInfo.json \
   "$CLEAN_DIR"/common/DataFormat.json \
+  "$CLEAN_DIR"/common/PatchFormat.json \
   "$CLEAN_DIR"/common/ModelConverterType.json \
   "$CLEAN_DIR"/common/EntityChangeMeta.json \
   "$CLEAN_DIR"/common/statemachine/WorkflowInfo.json \


### PR DESCRIPTION
## Summary

Adds a first-class **single-entity PATCH (RFC 7386 JSON Merge Patch)** capability across the HTTP API and the gRPC layer — additive and non-breaking. Existing `PUT` replace semantics are untouched. RFC 6902 (JSON Patch) is scaffolded and returns `501 NOT_IMPLEMENTED`.

This addresses the common (often LLM-generated) misuse where apps call the update endpoint with only a few fields and silently destroy the rest. Callers can now send only what changed, merged against the stored entity.

cyoda-go now **leads** the API/integration contract; Cyoda Cloud aligns to it. The Cloud-facing contract ships under a new `docs/cloud-parity/` folder, and the fidelity-direction language is reframed accordingly (in its own commit).

## What's included
- **Merge semantics:** RFC 7386 — sparse object; `null` deletes a key; nested objects merge recursively; arrays replace wholesale; empty `{}` is a no-op that still advances workflow state. Number fidelity preserved (no `float64` coercion).
- **HTTP:** `PATCH /api/entity/{format}/{entityId}[/{transition}]`; JSON only (XML → 415); dialect via `Content-Type` (`application/merge-patch+json` implemented; `application/json-patch+json` → 501).
- **gRPC:** new `EntityPatchRequest` CloudEvent type + generated `patchFormat` enum (no proto change).
- **No-stale-premise precondition:** `If-Match` required in some form — a `transactionId` (conditional; 412 if it moved), `*` (explicit unconditional opt-out), or **absent → 428** with an educational body. `409` documented for the commit-time read-set conflict (retryable, possible even under `*`).
- **Strict validate-only:** a PATCH validates the merged result strictly and **cannot introduce a new field** even in extend-permitting mode — a deliberate divergence from PUT (and a net security improvement). Implemented as a merge hook on the existing `UpdateEntity` transaction (read → merge → validate → save, atomic).
- **Docs:** `docs/cloud-parity/{README,entity-patch}.md`, `crud.md` PATCH section, two new `errors/*.md` topics (428/415), OpenAPI operations, fidelity-direction reframe.

## How it was built & verified
- TDD throughout (twice-reviewed design spec under `docs/superpowers/specs/`, 10-task plan, subagent-driven execution with a per-task review gate).
- `go vet`, `go build`, full `go test ./...` (unit + E2E across the in-process HTTP stack + all three parity backends: memory/postgres/sqlite), and `make race` — all green.
- Final whole-branch review: ready to merge (0 critical / 0 important).
- Security audit (security-auditor): tenant isolation/IDOR, HTTP+gRPC auth, and error-sanitisation all verified clean for the feature.

## Issues
- Closes #341 (the feature; milestone v0.8.2). Note: this PR targets `release/v0.8.2`, so #341 closes when v0.8.2 merges to `main`.
- Related (tracked, not closed here): #342 (per-code gRPC error identity — current envelope flattens to `CLIENT_ERROR`), #343 (pre-existing deep-nesting JSON decode DoS on all entity-write endpoints, surfaced during the audit; not introduced by this change).

## Out of scope (deferred)
Collection/batch patch; XML patch; RFC 6902 implementation (selector scaffolded, returns 501).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
