### PR TITLE
chore: self-injecting skill gates (test-coverage + independent design review)

### DIFF
--- a/.claude/hooks/inject-skill-gates.sh
+++ b/.claude/hooks/inject-skill-gates.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# PreToolUse(Skill): inject cyoda-go's per-skill gates when a planning skill runs.
+# Compact, project-specific directives the generic superpowers skills don't carry.
+# No-op (tool proceeds) for any other skill or on any error.
+set -euo pipefail
+skill=$(cat | jq -r '.tool_input.skill // ""')
+case "$skill" in
+  superpowers:brainstorming) f=gate-brainstorming.md ;;
+  superpowers:writing-plans) f=gate-writing-plans.md ;;
+  *) exit 0 ;;
+esac
+ctx=$(cat "${CLAUDE_PROJECT_DIR}/.claude/rules/$f" 2>/dev/null) || exit 0
+jq -n --arg c "$ctx" '{hookSpecificOutput:{hookEventName:"PreToolUse",additionalContext:$c,permissionDecision:"allow"}}'

--- a/.claude/rules/gate-brainstorming.md
+++ b/.claude/rules/gate-brainstorming.md
@@ -1,0 +1,4 @@
+cyoda-go gates for this design (additional to the skill):
+
+- After the design is agreed, before writing the spec, dispatch a fresh-context subagent to review it independently; don't bias it; iterate on findings.
+- For any API/gRPC change the spec must include an error/status-code table per endpoint and a coverage matrix (scenario × layer: unit / running-backend e2e / cross-backend parity / gRPC). See `.claude/rules/test-coverage.md`.

--- a/.claude/rules/gate-writing-plans.md
+++ b/.claude/rules/gate-writing-plans.md
@@ -1,0 +1,4 @@
+cyoda-go gates for this plan (additional to the skill):
+
+- Carry the spec's coverage matrix forward gap-free: every endpoint × status/error code → a running-backend test; backend-agnostic behavior → a cross-backend parity scenario; cover HTTP and gRPC; concurrency tests isolated, not in parity. See `.claude/rules/test-coverage.md`.
+- Every new error code → a task adding `errors/<CODE>.md` (TestErrCode_Parity enforces it). Add the Gate-4 doc tasks the change needs (help topic, README, COMPATIBILITY, CHANGELOG).

--- a/.claude/rules/test-coverage.md
+++ b/.claude/rules/test-coverage.md
@@ -1,0 +1,10 @@
+# Test coverage — API/gRPC features
+
+Full coverage = happy path AND every documented status/error code, on a running backend.
+
+- HTTP: one test per endpoint × status/error code in `internal/e2e` (real Postgres).
+- gRPC: one test per error class in `internal/grpc` (assert the envelope: `Success`, `Error.Code`).
+- Backend-agnostic behavior: a cross-backend parity scenario in `e2e/parity` (memory/sqlite/postgres + commercial); register it in `registry.go`.
+- HTTP and gRPC are separate entry points — cover both.
+- Concurrency/race: isolated single-backend e2e, never the shared parity suite. Assert consistency (one winner, loser 409/412, no torn write), not a precise interleave.
+- The spec's error table is the checklist; a missing cell blocks merge unless waived with a one-line reason.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/inject-skill-gates.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,11 @@ add or update E2E tests in `internal/e2e/` to cover the change through the full 
 E2E tests are self-contained: `TestMain` starts a PostgreSQL container via testcontainers-go
 and an in-process `httptest.Server` with JWT auth — no external instance needed.
 Just run `go test ./internal/e2e/... -v` (requires Docker running).
+For API/gRPC features the bar is **full coverage** — happy path AND every documented
+status/error code on a running backend, plus a cross-backend parity scenario for
+backend-agnostic behavior. See `.claude/rules/test-coverage.md` (the spec's error table is
+the checklist). `superpowers:brainstorming` and `superpowers:writing-plans` auto-inject these
+gates via a `PreToolUse` hook (`.claude/hooks/inject-skill-gates.sh`).
 
 ### Gate 3: Security by default
 Never log credentials, tokens, secrets, or signing keys at any level.


### PR DESCRIPTION
## Why

The generic `superpowers:` skills (brainstorming, writing-plans) don't know cyoda-go's invariants, so they get silently skipped. This recently bit us twice: a feature shipped without full test-coverage (only happy-path + a few error codes, no cross-backend parity) until it was caught by eye, and a plan that added error codes without the `errors/<CODE>.md` help topics `TestErrCode_Parity` requires. The fresh-context **independent design review** after brainstorming — which materially improved a recent design — also isn't in the skill.

A passive rule file relies on CLAUDE.md salience. This makes the directives **inject themselves at the moment of use**.

## What

- **`.claude/hooks/inject-skill-gates.sh`** + **`.claude/settings.json`** — a `PreToolUse` hook on the `Skill` tool. When `superpowers:brainstorming` or `superpowers:writing-plans` is invoked it injects the matching gate as `additionalContext`; for any other skill it is a zero-output no-op (tool proceeds). Committed to project settings so the whole team gets it.
- **`.claude/rules/gate-brainstorming.md`** — fresh-context independent design review before writing the spec; spec must carry an error/status-code table + coverage matrix.
- **`.claude/rules/gate-writing-plans.md`** — carry the coverage matrix forward gap-free; every new error code gets a help topic; Gate-4 doc tasks.
- **`.claude/rules/test-coverage.md`** — the coverage standard (full API/gRPC happy + every error code on a running backend; cross-backend parity; concurrency tests isolated, not in the shared parity suite).
- **CLAUDE.md Gate 2** — tightened to "full coverage" and points at the rule + hook.

Instructions are deliberately compact (tokens land at the right moment, not buried in prose).

## Verification

Hook unit-tested: brainstorming → injects the fresh-review + coverage gate; writing-plans → injects the coverage gate; any other skill → no-op; `settings.json` is valid JSON. The skill-name field (`.tool_input.skill`) matches the Skill tool's parameter; if it ever changes the hook simply no-ops (safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
