### PR TITLE
docs(versioning): adopt 0.x patch-for-features convention; decouple SPI version from binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to Cyoda-Go are documented here. The project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions and [Semantic Versioning](https://semver.org/) — pre-1.0, so minor bumps may include breaking changes (see [README — Versioning](./README.md#versioning)).
+All notable changes to Cyoda-Go are documented here. The project follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions and [Semantic Versioning](https://semver.org/) — pre-1.0, where the minor component signals a breaking change and new features ship in patches (see [README — Versioning](./README.md#versioning)).
 
 ## [Unreleased]
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -42,6 +42,12 @@ Coordinated-release procedure documented in [`MAINTAINING.md`](./MAINTAINING.md)
 
 † The in-tree plugin submodules pin `spi v0.6.1` rather than `v0.7.0` because they don't use `StartNewTxOnDispatch`. SPI is strictly additive — `v0.7.0` is fully backward-compatible with `v0.6.1` consumers.
 
+### Independent version axes
+
+`cyoda-go` and `cyoda-go-spi` version **independently**. The binary pins the SPI version it needs and never skips or burns a version number to mirror the SPI's — this matrix is the source of truth for which binary pins which SPI, not a shared digit. `cyoda-go-spi` follows the same convention as everything else ([README — Versioning](./README.md#versioning)): a **patch** for additive interface surface, a **minor** only for a breaking interface change. Because the SPI has been strictly additive throughout `v0.5.0…v0.8.1`, its minor moves rarely while the binary iterates freely.
+
+Two repo-internal rules still hold and must not be confused with a binary↔SPI coupling: **pin-sync** (root + every `plugins/*/go.mod` agree on one SPI version, CI-gated by `make check-spi-pin-sync`) and **plugin-tag-equals-umbrella** (plugin submodule tags match the `cyoda-go` tag). Both are release hygiene *within* this repo; neither ties the binary's version number to the SPI's.
+
 ### Out-of-tree plugin authors
 
 A plugin pinned to **`cyoda-go-spi v<X.Y.Z>`** is compatible with any **`cyoda-go v<A.B.C>`** whose root `go.mod` pins the same `v<X.Y>.*` series or any *later* `v<X+1.0.0>` series that hasn't broken the interfaces the plugin uses.
@@ -59,10 +65,13 @@ commit and was fetched through `proxy.golang.org`, which **permanently** binds a
 version to the first commit it serves. A Go module version cannot be re-cut once
 the proxy/checksum-database has seen it, so `v0.8.0` is abandoned and
 **`cyoda-go-spi v0.8.1`** is the canonical, complete v0.8.x SPI release — it
-resolves cleanly through the public proxy with no `GOPRIVATE` workaround. To keep
-the binary aligned with the SPI it pins, `cyoda-go` skips `v0.8.0` as well and
-ships **`v0.8.1`**. See [`MAINTAINING.md`](./MAINTAINING.md): a module version is
-tagged exactly once, at the final commit, and never re-cut.
+resolves cleanly through the public proxy with no `GOPRIVATE` workaround. At the
+time, `cyoda-go` also skipped `v0.8.0` to keep its number aligned with the SPI's
+and shipped **`v0.8.1`**. That number-matching is **no longer policy** — the
+binary and SPI now version independently (see [Independent version axes](#independent-version-axes)),
+so a future poisoned SPI tag would not force the binary to skip a number. See
+[`MAINTAINING.md`](./MAINTAINING.md): a module version is tagged exactly once, at
+the final commit, and never re-cut.
 
 ### Optional capability interfaces (grouped-stats)
 

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -92,12 +92,29 @@ fires `release.yml`, which builds artifacts, signs, and publishes.
 
 ### Versioning
 
-Semver with a leading `v`: `v0.6.0`, `v1.2.3`. Pre-v1 allows
-breaking changes between minor versions. New version must be
-**strictly greater** than the previous tag — Go module tags are
-write-once-per-value on the proxy (`proxy.golang.org` caches the
-SHA of every tag it serves), so you cannot retag or reuse a
+Semver with a leading `v`: `v0.6.0`, `v1.2.3`. Pre-v1, the **minor
+component is the breaking-change signal**: bump `0.MINOR.0` for a
+backward-incompatible change to that module's public contract, and
+`0.x.PATCH` for any backward-compatible change — **including new
+features**. Additive API parameters, new endpoints, new optional SPI
+fields, and bug fixes all ship as patches. The discipline this rests
+on: **a breaking change never ships in a patch.** (This is the
+"leftmost non-zero component is the de-facto major" convention; see
+[`README.md`](README.md#versioning) for the consumer-facing statement.)
+
+New version must be **strictly greater** than the previous tag — Go
+module tags are write-once-per-value on the proxy (`proxy.golang.org`
+caches the SHA of every tag it serves), so you cannot retag or reuse a
 version number, even on repos with no production consumers.
+
+**Each module versions on its own axis.** `cyoda-go-spi`, the
+`cyoda-go` binary, the in-tree plugins, and the Helm chart are **not**
+required to share a version number, and the binary must **never** skip
+or burn a version number merely to mirror the SPI's (as `v0.8.0` was
+once skipped — see [`COMPATIBILITY.md`](COMPATIBILITY.md)). The binary
+pins whatever SPI version it needs and versions independently; their
+compatible combinations are recorded in the compatibility matrix, not
+encoded in a shared digit.
 
 "Greenfield" means we promise nothing about backward compatibility
 between versions yet. It does **not** mean we can reset version
@@ -364,6 +381,19 @@ This rule is in addition to the existing **plugin-version lockstep**
 rule (plugin submodule tags use the same version as the umbrella).
 The two rules together ensure that consumers see consistent
 SPI-and-plugin pinning at every umbrella tag.
+
+**These two rules are repo-internal hygiene, not a binary↔SPI version
+coupling.** "Pin-sync" means every `go.mod` *in this repo* agrees on one
+SPI version; "plugin-version lockstep" means the plugin *tags* match the
+umbrella *tag*. Neither ties the `cyoda-go` version number to the
+`cyoda-go-spi` version number — those move independently (see the
+"Versioning" section above). `cyoda-go-spi` versions on its **own** axis
+under the same convention as everything else: a **patch** for additive
+interface surface (which is what every SPI release `v0.5.0…v0.8.1`
+actually was), a **minor** only for a breaking interface change. So the
+SPI minor stays put across many binary releases; pick the next SPI
+version by whether the SPI *interface* broke, never to match the
+binary's number.
 
 **The SPI pin is maintainer-owned, not Dependabot-owned.** During a milestone
 the root and plugin `go.mod` files pin a pseudo-version of `cyoda-go-spi`

--- a/README.md
+++ b/README.md
@@ -186,7 +186,16 @@ Sibling repositories under [github.com/cyoda](https://github.com/cyoda) that com
 
 ## Versioning
 
-cyoda-go is **pre-1.0**. Minor bumps may break wire format, configuration, or operational surface; patch bumps do not. See [`CHANGELOG.md`](CHANGELOG.md) for breaking changes and [`MAINTAINING.md`](MAINTAINING.md#maintenance-of-older-release-lines) for the policy on older release lines.
+The Cyoda-Go ecosystem follows Semantic Versioning with a leading `v`, under the pre-1.0 convention where **the minor component is the breaking-change signal**:
+
+- **`0.MINOR.0`** — a backward-*incompatible* change to that module's public contract (the HTTP/wire API for the `cyoda-go` binary; the Go interface surface for `cyoda-go-spi`).
+- **`0.x.PATCH`** — any backward-*compatible* change, **including new features**: additive API parameters, new endpoints, new optional SPI fields, and bug fixes all ship as patches.
+
+This is the "leftmost non-zero component is the de-facto major" convention (as used by Cargo and npm's `^0.x` ranges). It keeps the minor counter meaningful — a minor bump means "something under you may have broken" — rather than a feature odometer. The discipline it rests on: **a breaking change never ships in a patch.**
+
+**Each module versions on its own axis.** `cyoda-go-spi`, the `cyoda-go` binary, the in-tree plugins, and the Helm chart are **not** required to share a version number. Because the SPI surface is strictly additive today, its minor stays put while the binary iterates — a new SPI release is a *patch* unless it breaks an interface. The compatible combinations are recorded in [`COMPATIBILITY.md`](COMPATIBILITY.md); that matrix, not a shared digit, is the source of truth for what works with what.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for breaking changes and [`MAINTAINING.md`](MAINTAINING.md#maintenance-of-older-release-lines) for the policy on older release lines.
 
 ## License
 


### PR DESCRIPTION
## What

Codifies the project's pre-1.0 versioning convention and decouples the `cyoda-go-spi` version number from the `cyoda-go` binary version number. Docs-only.

## Why

Two questions surfaced while milestoning the search-sorting work (#37, #347):

1. **At this stage, strict semver (feature = minor) would race the minor counter to 0.38.0 fast.** Pre-1.0, semver explicitly grants latitude; the widely-adopted "leftmost non-zero component is the de-facto major" convention (Cargo, npm `^0.x`) keeps the minor as a *breaking-change* signal and ships features as patches. We were already leaning this way — MAINTAINING/CHANGELOG said "minor bumps may include breaking changes" — but it wasn't stated as the positive rule, leaving the patch-for-features question open.

2. **The SPI version had been de-facto locked to the binary's number** (v0.6↔v0.6, v0.7↔v0.7, v0.8.1↔v0.8.1), to the point the binary *skipped v0.8.0 entirely* just to match the SPI's number. Yet every SPI release v0.5.0…v0.8.1 was strictly additive — i.e. non-breaking — so under the patch-for-features rule none of those should have been minors. Making SPI management consistent with the rest means versioning it independently.

## Changes

- **README.md** — *Versioning* rewritten as the explicit convention: `0.MINOR.0` = breaking, `0.x.PATCH` = backward-compatible incl. features; each module versions on its own axis.
- **MAINTAINING.md** — same rule in the maintainer *Versioning* section; new "each module versions on its own axis / never skip a number to mirror SPI" note; clarifier in *Bumping cyoda-go-spi* that pin-sync and plugin-tag-equals-umbrella are repo-internal hygiene, **not** a binary↔SPI coupling, and that SPI bumps patch-for-additive / minor-only-on-break.
- **COMPATIBILITY.md** — new *Independent version axes* subsection; the "Why there is no v0.8.0" precedent reframed — binary number-matching SPI is **no longer policy**.
- **CHANGELOG.md** — header wording sharpened.

## Rules kept (deliberately, to avoid over-dropping)

- **pin-sync** — root + every `plugins/*/go.mod` agree on one SPI version (CI-gated by `make check-spi-pin-sync`).
- **plugin-tag-equals-umbrella** — plugin submodule tags match the `cyoda-go` tag.

Both are internal release hygiene, now explicitly distinguished from the dropped binary↔SPI number coupling.

## Notes

- Docs-only; no code, no tests affected. Touches README/MAINTAINING/COMPATIBILITY/CHANGELOG together per the documentation-hygiene gate.
- Targets `release/v0.8.2`, the active milestone branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
