### PR TITLE
fix: canonicalize point-in-time read semantics (inclusive <=, no rounding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ## [Unreleased]
 
+### Fixed
+
+- Point-in-time ("as at T") reads now apply one canonical rule across all
+  storage engines and read paths: inclusive of the requested instant (`<=`),
+  compared at native precision, with no millisecond round-up. Previously the
+  memory engine and the SQL `GetAsAt`/`GetAllAsAt` paths rounded the requested
+  time up to the next millisecond (over-including later same-millisecond
+  versions), and sqlite used a strict `<` bound — so different backends, and
+  different read paths within one backend, could disagree at sub-millisecond
+  boundaries. ([#349](https://github.com/Cyoda-platform/cyoda-go/issues/349))
+
 ## [0.8.1] — 2026-06-23
 
 > No `v0.8.0` release. The `cyoda-go-spi v0.8.0` tag was poisoned by a premature

--- a/cmd/cyoda/help/content/analytics.md
+++ b/cmd/cyoda/help/content/analytics.md
@@ -239,6 +239,9 @@ Condition pushdown by category:
 
 Data is fetched in pages (default page size: 1000). Point-in-time is derived from the `POINT_TIME` condition or defaults to the current consistency time.
 
+Point-in-time search uses the canonical inclusive (`<=`, no rounding) bound —
+see `cyoda help crud` ("Point-in-time semantics").
+
 **Views (view.*):**
 
 - `view.getViews` — get all views the user can read; payload: userId string; returns stream of `TrinoViewDto`

--- a/cmd/cyoda/help/content/crud.md
+++ b/cmd/cyoda/help/content/crud.md
@@ -550,6 +550,21 @@ Error codes (response carries RFC 9457 problem+json with `properties.errorCode` 
 - `NOT_IMPLEMENTED_BY_BACKEND` — `501` — backend implements neither `Iterable` nor `GroupedAggregator`
 - Standard `401` (missing/invalid Bearer), `403` (authenticated but not authorized), `413` (body exceeds 10 MiB), `500` (internal/driver error with ticket UUID; full detail logged server-side) apply as elsewhere.
 
+## POINT-IN-TIME SEMANTICS
+
+A `pointInTime` read returns entity state **as at exactly that instant,
+inclusive**: a version whose write timestamp equals `pointInTime` is included
+(`<=`), and no rounding is applied to the requested time. The bound is compared
+against stored version timestamps at the storage engine's native precision.
+
+Behaviour is identical across every read path — single-entity read, list,
+search, grouped statistics, change history, and available transitions — and
+across storage backends. Because backends store timestamps at different
+precisions (down to milliseconds on some deployments), cross-backend results are
+guaranteed to agree at **millisecond granularity**; finer-grained ordering
+within a single millisecond is backend-defined. Timestamps are accepted and
+emitted as RFC 3339 with full fractional precision.
+
 ## ENTITY ENVELOPE
 
 All entity read operations return entities in the standard envelope:

--- a/cmd/cyoda/help/content/search.md
+++ b/cmd/cyoda/help/content/search.md
@@ -174,7 +174,9 @@ The function is dispatched as `EntityCriteriaCalculationRequest` to the matching
 
 - `entityName` (path): string
 - `modelVersion` (path): int32
-- `pointInTime` (query, optional): RFC 3339 date-time — search against entity state at this instant
+- `pointInTime` (query, optional): RFC 3339 date-time — search against entity state at this instant.
+  Point-in-time search uses the canonical inclusive (`<=`, no rounding) bound —
+  see `cyoda help crud` ("Point-in-time semantics").
 - `limit` (query, optional): string-encoded integer, clamped to maximum 10000; default 1000
 
 Request body: `Condition` JSON document.

--- a/docs/superpowers/plans/2026-06-27-pit-semantics-canonicalization.md
+++ b/docs/superpowers/plans/2026-06-27-pit-semantics-canonicalization.md
@@ -1,0 +1,928 @@
+# PIT Semantics Canonicalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make point-in-time ("as at T") reads use one canonical rule — inclusive `<=`, native stored precision, no millisecond round-up — uniformly across the memory, sqlite, and postgres storage engines and every PIT read path.
+
+**Architecture:** Remove the 7 `Truncate(time.Millisecond).Add(time.Millisecond)` round-up call sites and flip sqlite `GetAsAt`/`GetAllAsAt` from strict `<` to inclusive `<=`. Every other PIT path is already raw inclusive `<=` and becomes consistent automatically. Drive each engine fix with per-engine white-box boundary tests (deterministic sub-millisecond timestamps); lock cross-engine convergence with an exact-T inclusivity scenario in the shared parity suite (runs against the commercial backend too); add an isolated sqlite test for async select/re-fetch self-consistency; document the contract.
+
+**Tech Stack:** Go 1.26+, three in-tree plugin modules (`plugins/{memory,sqlite,postgres}`, each its own `go.mod`), `e2e/parity` shared scenario registry (root module), PostgreSQL via testcontainers-go (Docker required), sqlite via `modernc.org/sqlite`.
+
+## Global Constraints
+
+- **Canonical PIT rule:** inclusive `<=`, compared at the engine's native stored precision (memory ns, sqlite/postgres µs, commercial ms), **no rounding**. Cross-engine behavioural fidelity is guaranteed only to millisecond granularity.
+- **No new error codes, no SPI change, no schema migration, no env vars, no public Go interface change.** (TestErrCode_Parity, COMPATIBILITY.md, chart, SPI pin all untouched.)
+- **Commercial (Cassandra) backend is already canonical** — no change in this work; the new parity scenario verifies convergence on its next dependency bump.
+- **Logging/secrets:** none touched; standard `log/slog` only.
+- **TDD mandatory:** every change is driven by a failing test first (`.claude/rules/tdd.md`).
+- **Plugin submodules need explicit test runs** — `go test ./...` from root skips `plugins/*`; run each plugin's tests in its own module directory.
+- **Commit messages** end with the `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` trailer. Do not put issue numbers in code/comments/test names; `#349` belongs only in commit messages and the PR body.
+- **Spec:** `docs/superpowers/specs/2026-06-27-pit-semantics-canonicalization-design.md`.
+
+---
+
+### Task 1: Memory engine — remove round-up (GetAsAt / GetAllAsAt / Iterate-PIT)
+
+**Files:**
+- Modify: `plugins/memory/clock.go` (add `NewTestClockAt` constructor)
+- Modify: `plugins/memory/entity_store.go` (remove round-up at `GetAsAt` ~line 324, `GetAllAsAt` ~line 420)
+- Modify: `plugins/memory/grouped_stats.go` (remove round-up in `buildSnapshot` ~line 90)
+- Test: `plugins/memory/pit_boundary_test.go` (new)
+
+**Interfaces:**
+- Consumes: `memory.NewStoreFactory(memory.WithClock(c))`, `memory.Clock`, `store.Save/GetAsAt/GetAllAsAt`, `store.(spi.Iterable).Iterate`, existing test helper `ctxWithTenant(spi.TenantID)` (in `plugins/memory/entity_store_test.go:13`).
+- Produces: `memory.NewTestClockAt(t time.Time) *memory.TestClock` — a `TestClock` whose virtual time starts at exactly `t` (used by tests that need a millisecond-aligned base).
+
+- [ ] **Step 1: Add the `NewTestClockAt` constructor**
+
+In `plugins/memory/clock.go`, after `NewTestClock`:
+
+```go
+// NewTestClockAt returns a TestClock whose virtual time starts at t.
+// Tests that need a millisecond-aligned base (so sub-millisecond Advance
+// steps land in a known millisecond) use this instead of NewTestClock.
+func NewTestClockAt(t time.Time) *TestClock {
+	return &TestClock{now: t}
+}
+```
+
+- [ ] **Step 2: Write the failing boundary tests**
+
+Create `plugins/memory/pit_boundary_test.go`:
+
+```go
+package memory_test
+
+import (
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/memory"
+)
+
+// msBase is a millisecond-aligned instant (nanoseconds == 0) so that a
+// sub-millisecond Advance keeps both versions inside the same millisecond.
+var msBase = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// twoVersionsSameMillisecond saves v1 at msBase and v2 300µs later (same
+// millisecond) and returns the store. The buggy round-up rounds msBase up to
+// the next millisecond, so a query "as at msBase" wrongly includes v2.
+func twoVersionsSameMillisecond(t *testing.T) (spi.EntityStore, interface{ Now() time.Time }) {
+	t.Helper()
+	clock := memory.NewTestClockAt(msBase)
+	factory := memory.NewStoreFactory(memory.WithClock(clock))
+	ctx := ctxWithTenant("tenant-pit")
+	store, _ := factory.EntityStore(ctx)
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	e := &spi.Entity{
+		Meta: spi.EntityMeta{ID: "e-pit", TenantID: "tenant-pit", ModelRef: ref, State: "NEW"},
+		Data: []byte(`{"v":1}`),
+	}
+	if _, err := store.Save(ctx, e); err != nil {
+		t.Fatalf("Save v1: %v", err)
+	}
+	clock.Advance(300 * time.Microsecond)
+	e.Data = []byte(`{"v":2}`)
+	if _, err := store.Save(ctx, e); err != nil {
+		t.Fatalf("Save v2: %v", err)
+	}
+	return store, clock
+}
+
+func TestMemoryPIT_GetAsAt_InclusiveNoRoundUp(t *testing.T) {
+	store, _ := twoVersionsSameMillisecond(t)
+	ctx := ctxWithTenant("tenant-pit")
+
+	got, err := store.GetAsAt(ctx, "e-pit", msBase)
+	if err != nil {
+		t.Fatalf("GetAsAt(msBase): %v", err)
+	}
+	if string(got.Data) != `{"v":1}` {
+		t.Errorf("GetAsAt(msBase) = %s, want {\"v\":1} (round-up over-included the same-ms v2)", got.Data)
+	}
+}
+
+func TestMemoryPIT_GetAllAsAt_InclusiveNoRoundUp(t *testing.T) {
+	store, _ := twoVersionsSameMillisecond(t)
+	ctx := ctxWithTenant("tenant-pit")
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	got, err := store.GetAllAsAt(ctx, ref, msBase)
+	if err != nil {
+		t.Fatalf("GetAllAsAt(msBase): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("GetAllAsAt(msBase) returned %d entities, want 1", len(got))
+	}
+	if string(got[0].Data) != `{"v":1}` {
+		t.Errorf("GetAllAsAt(msBase) data = %s, want {\"v\":1}", got[0].Data)
+	}
+}
+
+func TestMemoryPIT_Iterate_InclusiveNoRoundUp(t *testing.T) {
+	store, _ := twoVersionsSameMillisecond(t)
+	ctx := ctxWithTenant("tenant-pit")
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	it := store.(spi.Iterable)
+	pit := msBase
+	iter, err := it.Iterate(ctx, ref, spi.Filter{}, spi.IterateOptions{PointInTime: &pit})
+	if err != nil {
+		t.Fatalf("Iterate(msBase): %v", err)
+	}
+	defer iter.Close()
+
+	var data string
+	var seen int
+	for iter.Next() {
+		seen++
+		data = string(iter.Entity().Data)
+	}
+	if err := iter.Err(); err != nil {
+		t.Fatalf("iter err: %v", err)
+	}
+	if seen != 1 || data != `{"v":1}` {
+		t.Errorf("Iterate(msBase) saw %d entities (data=%s), want 1 with {\"v\":1}", seen, data)
+	}
+}
+```
+
+- [ ] **Step 3: Run the tests and confirm they FAIL**
+
+Run: `cd plugins/memory && go test ./... -run TestMemoryPIT -v`
+Expected: all three FAIL — `GetAsAt(msBase) = {"v":2}` etc. (the round-up over-includes the same-millisecond v2).
+
+- [ ] **Step 4: Remove the three round-up call sites**
+
+In `plugins/memory/entity_store.go`, in `GetAsAt`, delete the round-up and its comment:
+
+```go
+	// (deleted) Round asAt up to the next millisecond boundary...
+	// asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
+```
+
+i.e. remove the lines:
+
+```go
+	// Round asAt up to the next millisecond boundary. Clients work at
+	// millisecond precision but submitTime has microsecond/nanosecond
+	// precision. A query for "302ms" should include "302.306ms".
+	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
+```
+
+In the same file, in `GetAllAsAt`, remove:
+
+```go
+	// Round asAt up to the next millisecond boundary (same as GetAsAt).
+	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
+```
+
+In `plugins/memory/grouped_stats.go`, in `buildSnapshot`'s PIT branch, replace:
+
+```go
+		// Round up to next millisecond boundary, matching GetAllAsAt.
+		asAt := pit.Truncate(time.Millisecond).Add(time.Millisecond)
+		var snapshot []*spi.Entity
+		func() {
+			s.factory.entityMu.RLock()
+			defer s.factory.entityMu.RUnlock()
+			snapshot = s.getAllSnapshotPointersUnlocked(model, asAt)
+		}()
+		return snapshot, nil
+```
+
+with (bind the raw instant, no rounding):
+
+```go
+		var snapshot []*spi.Entity
+		func() {
+			s.factory.entityMu.RLock()
+			defer s.factory.entityMu.RUnlock()
+			snapshot = s.getAllSnapshotPointersUnlocked(model, *pit)
+		}()
+		return snapshot, nil
+```
+
+If `time` is now unused in `grouped_stats.go`, remove it from the imports.
+
+- [ ] **Step 5: Run the boundary tests and confirm they PASS**
+
+Run: `cd plugins/memory && go test ./... -run TestMemoryPIT -v`
+Expected: all three PASS.
+
+- [ ] **Step 6: Run the full memory suite and confirm no regression**
+
+Run: `cd plugins/memory && go test ./... -v`
+Expected: PASS, including the existing `TestGetAllAsAt`, `TestSoftDeleteAsAtBeforeDeletion`, `TestGetAllAsAtWithDelete`, grouped-stats and conformance tests (they use multi-millisecond gaps, so they stay green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add plugins/memory/clock.go plugins/memory/entity_store.go plugins/memory/grouped_stats.go plugins/memory/pit_boundary_test.go
+git commit -m "fix(memory): inclusive PIT bound, drop millisecond round-up
+
+GetAsAt/GetAllAsAt/Iterate-PIT now compare against the raw requested
+instant (inclusive <=) at native precision instead of rounding up to the
+next millisecond, which over-included same-millisecond later versions.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Sqlite engine — remove round-up AND flip strict `<` to `<=`
+
+**Files:**
+- Modify: `plugins/sqlite/clock.go` (add `NewTestClockAt` constructor)
+- Modify: `plugins/sqlite/entity_store.go` (`GetAsAt` ~lines 414/434, `GetAllAsAt` ~lines 549/559)
+- Test: `plugins/sqlite/pit_boundary_test.go` (new)
+
+**Interfaces:**
+- Consumes: `sqlite.NewStoreFactoryForTest(ctx, dbPath, opts...)`, `sqlite.WithClock`, existing helper `testCtx(tenantID string)` (`plugins/sqlite/searcher_test.go:13`).
+- Produces: `sqlite.NewTestClockAt(t time.Time) *sqlite.TestClock`.
+
+**Why one test, two coupled changes:** On current sqlite, `as-at msBase` rounds up to `msBase+1ms` then does `submit_time < msBase+1ms`, returning the latest version in that window — the same-ms v2 (over-inclusion). Removing the round-up alone changes the predicate to `submit_time < msBase`, which now *excludes* the v1 written at exactly `msBase` (strict `<`), yielding `ENTITY_NOT_FOUND`. Only removing the round-up **and** flipping `<`→`<=` returns v1. The single assertion "GetAsAt(msBase) == v1" is therefore RED on current code (returns v2) and requires both edits to go green.
+
+- [ ] **Step 1: Add the `NewTestClockAt` constructor**
+
+In `plugins/sqlite/clock.go`, after `NewTestClock`:
+
+```go
+// NewTestClockAt returns a TestClock whose virtual time starts at t.
+func NewTestClockAt(t time.Time) *TestClock {
+	return &TestClock{now: t}
+}
+```
+
+- [ ] **Step 2: Write the failing boundary tests**
+
+Create `plugins/sqlite/pit_boundary_test.go`:
+
+```go
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/sqlite"
+)
+
+var pitBase = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// pitTwoVersions saves v1 at pitBase and v2 300µs later (same millisecond),
+// driven by a deterministic TestClock.
+func pitTwoVersions(t *testing.T) (*sqlite.StoreFactory, context.Context) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "pit.db")
+	clock := sqlite.NewTestClockAt(pitBase)
+	factory, err := sqlite.NewStoreFactoryForTest(context.Background(), dbPath, sqlite.WithClock(clock))
+	if err != nil {
+		t.Fatalf("create factory: %v", err)
+	}
+	t.Cleanup(func() { factory.Close() })
+
+	ctx := testCtx("tenant-1")
+	store, _ := factory.EntityStore(ctx)
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+
+	e := &spi.Entity{
+		Meta: spi.EntityMeta{ID: "e-pit", ModelRef: ref, State: "NEW"},
+		Data: []byte(`{"v":1}`),
+	}
+	if _, err := store.Save(ctx, e); err != nil {
+		t.Fatalf("Save v1: %v", err)
+	}
+	clock.Advance(300 * time.Microsecond)
+	e.Data = []byte(`{"v":2}`)
+	if _, err := store.Save(ctx, e); err != nil {
+		t.Fatalf("Save v2: %v", err)
+	}
+	return factory, ctx
+}
+
+func TestSqlitePIT_GetAsAt_InclusiveExactT(t *testing.T) {
+	factory, ctx := pitTwoVersions(t)
+	store, _ := factory.EntityStore(ctx)
+
+	got, err := store.GetAsAt(ctx, "e-pit", pitBase)
+	if err != nil {
+		t.Fatalf("GetAsAt(pitBase): %v", err)
+	}
+	if string(got.Data) != `{"v":1}` {
+		t.Errorf("GetAsAt(pitBase) = %s, want {\"v\":1} (inclusive of exactly T, no round-up)", got.Data)
+	}
+}
+
+func TestSqlitePIT_GetAllAsAt_InclusiveExactT(t *testing.T) {
+	factory, ctx := pitTwoVersions(t)
+	store, _ := factory.EntityStore(ctx)
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+
+	got, err := store.GetAllAsAt(ctx, ref, pitBase)
+	if err != nil {
+		t.Fatalf("GetAllAsAt(pitBase): %v", err)
+	}
+	if len(got) != 1 || string(got[0].Data) != `{"v":1}` {
+		t.Errorf("GetAllAsAt(pitBase) = %v entities, want 1 with {\"v\":1}", len(got))
+	}
+}
+```
+
+- [ ] **Step 3: Run the tests and confirm they FAIL**
+
+Run: `cd plugins/sqlite && go test ./... -run TestSqlitePIT -v`
+Expected: FAIL — `GetAsAt(pitBase) = {"v":2}` (round-up over-includes the same-ms v2).
+
+- [ ] **Step 4: Remove the round-up and flip the predicate — `GetAsAt`**
+
+In `plugins/sqlite/entity_store.go`, `GetAsAt`: remove
+
+```go
+	// Round asAt up to the next millisecond boundary. Clients work at
+	// millisecond precision but submitTime has microsecond precision.
+	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
+```
+
+and in the SQL change `submit_time < ?` to `submit_time <= ?`:
+
+```go
+	     WHERE tenant_id = ? AND entity_id = ? AND submit_time <= ?
+```
+
+- [ ] **Step 5: Remove the round-up and flip the predicate — `GetAllAsAt`**
+
+In the same file, `GetAllAsAt`: remove
+
+```go
+	// Round asAt up to the next millisecond boundary.
+	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
+```
+
+and change `submit_time < ?` to `submit_time <= ?`:
+
+```go
+	     WHERE tenant_id = ? AND model_name = ? AND model_version = ? AND submit_time <= ?
+```
+
+- [ ] **Step 6: Run the boundary tests and confirm they PASS**
+
+Run: `cd plugins/sqlite && go test ./... -run TestSqlitePIT -v`
+Expected: PASS. (Intermediate check, optional: with only the round-up removed but the predicate still `<`, these FAIL with `ErrNotFound` — confirming the strict `<` was masked by the round-up. Both edits are required.)
+
+- [ ] **Step 7: Run the full sqlite suite and confirm no regression**
+
+Run: `cd plugins/sqlite && go test ./... -v`
+Expected: PASS (searcher PIT, grouped-stats, conformance, crash/stress all green).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add plugins/sqlite/clock.go plugins/sqlite/entity_store.go plugins/sqlite/pit_boundary_test.go
+git commit -m "fix(sqlite): inclusive PIT bound for GetAsAt/GetAllAsAt
+
+Drop the millisecond round-up and flip submit_time '<' to '<=' so as-at
+reads are inclusive of exactly the requested instant at microsecond
+precision. The round-up had masked the strict '<'; both are corrected
+together. Adds the first GetAsAt/GetAllAsAt tests for sqlite.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Postgres engine — remove round-up (GetAsAt / GetAllAsAt)
+
+**Files:**
+- Modify: `plugins/postgres/entity_store.go` (`GetAsAt` ~line 183, `GetAllAsAt` ~line 242)
+- Test: `plugins/postgres/pit_boundary_test.go` (new)
+
+**Interfaces:**
+- Consumes: existing test helpers `setupEntityTest(t) *postgres.StoreFactory` (`plugins/postgres/entity_store_test.go:31`), `makeEntity(id string) *spi.Entity` (`:42`), `ctxWithTenant(...)`, and `factory.Pool() *pgxpool.Pool` (`plugins/postgres/store_factory.go:86`). Postgres has **no** injectable clock (it writes `valid_time = CURRENT_TIMESTAMP`), so the test hand-places `valid_time` via `pool.Exec(UPDATE ...)` after `Save`.
+- Produces: nothing consumed downstream.
+
+**Determinism note:** `Save` writes two real version rows (correct docs + `entities` row); the test then rewrites their `valid_time`/`transaction_time` to two explicit same-millisecond instants. `transaction_time` is set to a past date so the `transaction_time <= CURRENT_TIMESTAMP` filter still passes. Postgres `GetAsAt`/`GetAllAsAt` are already `<=`; the only defect is the round-up.
+
+- [ ] **Step 1: Write the failing boundary tests**
+
+Create `plugins/postgres/pit_boundary_test.go`:
+
+```go
+package postgres_test
+
+import (
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+const (
+	pitTenant = "entity-tenant"
+	pitBaseTS = "2026-01-01 00:00:00+00"        // millisecond-aligned
+	pitNextTS = "2026-01-01 00:00:00.000300+00" // +300µs, same millisecond
+)
+
+func pitParseBase(t *testing.T) time.Time {
+	t.Helper()
+	bt, err := time.Parse(time.RFC3339Nano, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+	return bt
+}
+
+// pitSetup saves v1 then v2 on one entity, then forces deterministic,
+// same-millisecond valid_times (v1 at pitBaseTS, v2 300µs later).
+func pitSetup(t *testing.T) (*spi.Entity, spi.EntityStore, func() time.Time) {
+	t.Helper()
+	factory := setupEntityTest(t)
+	ctx := ctxWithTenant(pitTenant)
+	store, _ := factory.EntityStore(ctx)
+	pool := factory.Pool()
+
+	ent := makeEntity("ent-pit")
+	ent.Data = []byte(`{"value":"v1"}`)
+	if _, err := store.Save(ctx, ent); err != nil {
+		t.Fatalf("Save v1: %v", err)
+	}
+	ent.Data = []byte(`{"value":"v2"}`)
+	if _, err := store.Save(ctx, ent); err != nil {
+		t.Fatalf("Save v2: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx,
+		`UPDATE entity_versions SET valid_time=$1, transaction_time=$1
+		 WHERE tenant_id=$2 AND entity_id=$3 AND version=1`,
+		pitBaseTS, pitTenant, "ent-pit"); err != nil {
+		t.Fatalf("update v1 valid_time: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE entity_versions SET valid_time=$1, transaction_time=$1
+		 WHERE tenant_id=$2 AND entity_id=$3 AND version=2`,
+		pitNextTS, pitTenant, "ent-pit"); err != nil {
+		t.Fatalf("update v2 valid_time: %v", err)
+	}
+	return ent, store, func() time.Time { return pitParseBase(t) }
+}
+
+func TestPostgresPIT_GetAsAt_InclusiveNoRoundUp(t *testing.T) {
+	_, store, base := pitSetup(t)
+	ctx := ctxWithTenant(pitTenant)
+
+	got, err := store.GetAsAt(ctx, "ent-pit", base())
+	if err != nil {
+		t.Fatalf("GetAsAt(base): %v", err)
+	}
+	if string(got.Data) != `{"value":"v1"}` {
+		t.Errorf("GetAsAt(base) = %s, want v1 (round-up over-included same-ms v2)", got.Data)
+	}
+}
+
+func TestPostgresPIT_GetAllAsAt_InclusiveNoRoundUp(t *testing.T) {
+	_, store, base := pitSetup(t)
+	ctx := ctxWithTenant(pitTenant)
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	got, err := store.GetAllAsAt(ctx, ref, base())
+	if err != nil {
+		t.Fatalf("GetAllAsAt(base): %v", err)
+	}
+	if len(got) != 1 || string(got[0].Data) != `{"value":"v1"}` {
+		t.Errorf("GetAllAsAt(base) = %d entities, want 1 with v1", len(got))
+	}
+}
+```
+
+(If `makeEntity` uses a model name other than `Order`/version `1`, set `ref` to match it — check `plugins/postgres/entity_store_test.go:42`.)
+
+- [ ] **Step 2: Run the tests and confirm they FAIL**
+
+Run: `cd plugins/postgres && go test ./... -run TestPostgresPIT -v`
+Expected: FAIL — `GetAsAt(base) = {"value":"v2"}` (round-up over-includes the same-ms v2). (Docker must be running for the testcontainer.)
+
+- [ ] **Step 3: Remove the two round-up call sites**
+
+In `plugins/postgres/entity_store.go`, `GetAsAt`, remove:
+
+```go
+	// Round up to the next millisecond boundary (matching memory implementation).
+	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
+```
+
+In `GetAllAsAt`, remove:
+
+```go
+	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
+```
+
+If `time` becomes unused in the file, remove it from imports (it is still used elsewhere — verify with the compiler).
+
+- [ ] **Step 4: Run the boundary tests and confirm they PASS**
+
+Run: `cd plugins/postgres && go test ./... -run TestPostgresPIT -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full postgres suite and confirm no regression**
+
+Run: `cd plugins/postgres && go test ./... -v`
+Expected: PASS (existing `TestEntityStore_GetAsAt`, `TestEntityStore_GetAllAsAt`, grouped-stats, conformance all green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/postgres/entity_store.go plugins/postgres/pit_boundary_test.go
+git commit -m "fix(postgres): inclusive PIT bound, drop millisecond round-up
+
+GetAsAt/GetAllAsAt bind the raw requested instant (already <=) instead of
+rounding up to the next millisecond, which over-included same-millisecond
+later versions.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Cross-backend parity — exact-T inclusivity scenario
+
+**Files:**
+- Create: `e2e/parity/pit_boundary.go`
+- Modify: `e2e/parity/registry.go` (register the new scenario)
+- Test: runs via existing per-backend wrappers (`e2e/parity/{memory,sqlite,postgres}` + commercial on its next dep bump)
+
+**Interfaces:**
+- Consumes: `parity.BackendFixture`, the in-process driver `driver.NewInProcess(t, fixture)` with `CreateModelFromSample`, `LockModel`, `CreateEntity`, `UpdateEntityData`, `GetEntityChanges(id) ([]parityclient.EntityChangeMeta, error)`, `GetEntityAt(id, t) (parityclient.EntityResult, error)`. `EntityChangeMeta.TimeOfChange time.Time`; `EntityResult.Data map[string]any`. (See `e2e/parity/externalapi/point_in_time.go` for the established pattern.)
+- Produces: `RunPITBoundaryExactT(t *testing.T, fixture parity.BackendFixture)` registered as scenario `"PITBoundaryExactT"`.
+
+**What it guards:** For each version written at its own reported `TimeOfChange` Tᵢ, `GetEntityAt(Tᵢ)` returns that version's data — inclusive of exactly T, at millisecond granularity (the floor every backend, including the commercial ms-precision one, can honour). This is RED on pre-fix sqlite (strict `<` returns the previous version) and green on every backend after Tasks 1–3.
+
+- [ ] **Step 1: Write the scenario**
+
+Create `e2e/parity/pit_boundary.go`:
+
+```go
+package parity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/externalapi/driver"
+)
+
+// RunPITBoundaryExactT asserts exact-T inclusivity: querying as-at a version's
+// own reported timestamp returns that version, uniformly across backends. It is
+// the cross-engine guard for the canonical inclusive `<=` PIT rule. Sub-ms
+// over-inclusion is covered by per-engine white-box tests, not here, because
+// the commercial backend stores at millisecond precision.
+func RunPITBoundaryExactT(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	d := driver.NewInProcess(t, fixture)
+
+	if err := d.CreateModelFromSample("pitb", 1, `{"k":1}`); err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+	if err := d.LockModel("pitb", 1); err != nil {
+		t.Fatalf("lock model: %v", err)
+	}
+
+	id, err := d.CreateEntity("pitb", 1, `{"k":1}`)
+	if err != nil {
+		t.Fatalf("create entity: %v", err)
+	}
+	t1 := latestChangeTime(t, d, fmtID(id))
+
+	if err := d.UpdateEntityData(id, `{"k":2}`); err != nil {
+		t.Fatalf("update k=2: %v", err)
+	}
+	t2 := latestChangeTime(t, d, fmtID(id))
+
+	if err := d.UpdateEntityData(id, `{"k":3}`); err != nil {
+		t.Fatalf("update k=3: %v", err)
+	}
+	t3 := latestChangeTime(t, d, fmtID(id))
+
+	// As-at exactly each version's write time returns that version.
+	assertKAt(t, d, id, t1, 1)
+	assertKAt(t, d, id, t2, 2)
+	assertKAt(t, d, id, t3, 3)
+}
+```
+
+Add the helpers in the same file:
+
+```go
+// latestChangeTime returns the most recent TimeOfChange for the entity — the
+// timestamp of the version just written.
+func latestChangeTime(t *testing.T, d *driver.Driver, id uuidLike) time.Time {
+	t.Helper()
+	changes, err := d.GetEntityChanges(id.UUID())
+	if err != nil {
+		t.Fatalf("GetEntityChanges: %v", err)
+	}
+	if len(changes) == 0 {
+		t.Fatal("GetEntityChanges returned no entries")
+	}
+	latest := changes[0].TimeOfChange
+	for _, c := range changes[1:] {
+		if c.TimeOfChange.After(latest) {
+			latest = c.TimeOfChange
+		}
+	}
+	return latest
+}
+
+func assertKAt(t *testing.T, d *driver.Driver, id uuidLike, at time.Time, wantK float64) {
+	t.Helper()
+	got, err := d.GetEntityAt(id.UUID(), at)
+	if err != nil {
+		t.Fatalf("GetEntityAt(%s): %v", at.Format(time.RFC3339Nano), err)
+	}
+	if got.Data["k"] != wantK {
+		t.Errorf("GetEntityAt(%s) k=%v, want %v (exact-T inclusivity violated)",
+			at.Format(time.RFC3339Nano), got.Data["k"], wantK)
+	}
+}
+```
+
+**Note for the implementer:** the `id` returned by `CreateEntity` is a `uuid.UUID`. The pseudo-types `uuidLike`/`fmtID`/`uuid.UUID()` above are placeholders for "pass the `uuid.UUID` straight through" — write the real signatures using `github.com/google/uuid`: `latestChangeTime(t, d, id uuid.UUID) time.Time` and `assertKAt(t, d, id uuid.UUID, ...)`, calling `d.GetEntityChanges(id)` / `d.GetEntityAt(id, at)` directly. Drop the `fmtID`/`uuidLike` indirection — it only exists here to flag the type. Confirm against `driver.go:108,308,334`.
+
+- [ ] **Step 2: Register the scenario**
+
+In `e2e/parity/registry.go`, add to the `allTests` slice, next to the existing bi-temporal entries (`TemporalPointInTimeRetrieval`):
+
+```go
+	{"PITBoundaryExactT", RunPITBoundaryExactT},
+```
+
+Update the running "Total parity scenarios" comment count at the top of the file (+1).
+
+- [ ] **Step 3: Run the scenario on memory and sqlite (fast, no Docker)**
+
+Run: `go test ./e2e/parity/memory/... -run 'PITBoundaryExactT' -v`
+Run: `go test ./e2e/parity/sqlite/... -run 'PITBoundaryExactT' -v`
+Expected: PASS. (To prove the guard bites, temporarily `git stash` Task 2's sqlite fix and re-run the sqlite parity — it FAILs with `k=1` at t2/t3 — then `git stash pop`.)
+
+- [ ] **Step 4: Run the scenario on postgres (Docker)**
+
+Run: `go test ./e2e/parity/postgres/... -run 'PITBoundaryExactT' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/parity/pit_boundary.go e2e/parity/registry.go
+git commit -m "test(parity): exact-T PIT inclusivity across backends
+
+New cross-backend scenario asserting as-at a version's own reported
+timestamp returns that version (inclusive <=, millisecond floor). Runs
+against memory/sqlite/postgres and the commercial backend; would fail on
+the pre-fix sqlite strict-< path.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Isolated sqlite test — async select / re-fetch self-consistency
+
+**Files:**
+- Test: `plugins/sqlite/pit_consistency_test.go` (new)
+
+**Interfaces:**
+- Consumes: `sqlite.NewStoreFactoryForTest` + `WithClock`, `sqlite.NewTestClockAt` (Task 2), `testCtx`, `store.(spi.Searcher).Search`, `store.GetAsAt`.
+- Produces: nothing.
+
+**What it reproduces:** Async search selects IDs via `Search` (raw `<=` PIT) and re-fetches via `GetAsAt` (pre-fix: rounded + strict `<`). At a same-millisecond boundary the select side matched one version while the re-fetch resolved a different one. After Tasks 1–2 both bind raw `<=`, so they agree. This is an isolated single-backend consistency test (not a parity scenario, per `.claude/rules/test-coverage.md`), and sqlite is the only backend where it is RED pre-fix (postgres has no sync `Searcher` until later predicate-pushdown work).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `plugins/sqlite/pit_consistency_test.go`:
+
+```go
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/sqlite"
+)
+
+// At a same-millisecond boundary, the version selected by Search (raw <=)
+// must be the same version GetAsAt re-fetches. Pre-fix, Search matched v1
+// (city=Berlin) at pitBase while rounded GetAsAt resolved v2 (city=Munich).
+func TestSqlitePIT_SearchSelectMatchesGetAsAtRefetch(t *testing.T) {
+	dir := t.TempDir()
+	clock := sqlite.NewTestClockAt(pitBase) // pitBase from pit_boundary_test.go
+	factory, err := sqlite.NewStoreFactoryForTest(
+		context.Background(), filepath.Join(dir, "c.db"), sqlite.WithClock(clock))
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	t.Cleanup(func() { factory.Close() })
+
+	ctx := testCtx("tenant-1")
+	store, _ := factory.EntityStore(ctx)
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+
+	e := &spi.Entity{
+		Meta: spi.EntityMeta{ID: "e-c", ModelRef: ref, State: "NEW"},
+		Data: []byte(`{"city":"Berlin"}`),
+	}
+	if _, err := store.Save(ctx, e); err != nil { // v1 @ pitBase
+		t.Fatalf("save v1: %v", err)
+	}
+	clock.Advance(300 * time.Microsecond)
+	e.Data = []byte(`{"city":"Munich"}`)
+	if _, err := store.Save(ctx, e); err != nil { // v2 @ pitBase+300µs
+		t.Fatalf("save v2: %v", err)
+	}
+
+	pit := pitBase
+	searcher := store.(spi.Searcher)
+	results, err := searcher.Search(ctx,
+		spi.Filter{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Berlin"},
+		spi.SearchOptions{ModelName: "person", ModelVersion: "1", PointInTime: &pit})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Search(city=Berlin, as-at pitBase) returned %d, want 1", len(results))
+	}
+
+	// Re-fetch the selected entity at the same instant: must agree (Berlin).
+	got, err := store.GetAsAt(ctx, "e-c", pit)
+	if err != nil {
+		t.Fatalf("GetAsAt re-fetch: %v", err)
+	}
+	if string(got.Data) != `{"city":"Berlin"}` {
+		t.Errorf("re-fetch = %s, want {\"city\":\"Berlin\"} (select/re-fetch disagree at boundary)", got.Data)
+	}
+}
+```
+
+(Confirm `spi.Searcher.Search` returns a slice whose `len` is the match count, matching `searcher_test.go`'s usage; if it returns `[]spi.Entity`/IDs, adjust the `len(results)` check accordingly — the assertion that matters is the `GetAsAt` re-fetch returning Berlin.)
+
+- [ ] **Step 2: Run and confirm it FAILS on pre-fix code**
+
+To see it RED, you must run it against the unfixed `GetAsAt`. If Task 2 is already merged, this test passes immediately — note that in the commit message and verify it would fail by temporarily reverting the Task 2 predicate. If running before Task 2, expected: FAIL — re-fetch returns `{"city":"Munich"}`.
+
+Run: `cd plugins/sqlite && go test ./... -run TestSqlitePIT_SearchSelect -v`
+
+- [ ] **Step 3: Confirm it PASSES with the Task 2 fix in place**
+
+Run: `cd plugins/sqlite && go test ./... -run TestSqlitePIT_SearchSelect -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/sqlite/pit_consistency_test.go
+git commit -m "test(sqlite): async select/re-fetch agree at PIT boundary
+
+Isolated single-backend consistency test: Search (raw <=) and GetAsAt
+re-fetch resolve the same version at a same-millisecond boundary. RED on
+the pre-fix rounded GetAsAt; green under the canonical inclusive bound.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Document the PIT contract + changelog
+
+**Files:**
+- Modify: `cmd/cyoda/help/content/crud.md` (add a "Point-in-time semantics" block)
+- Modify: `cmd/cyoda/help/content/search.md` (cross-reference)
+- Modify: `cmd/cyoda/help/content/analytics.md` (cross-reference)
+- Modify: `CHANGELOG.md`
+
+**Interfaces:** none (documentation only). No `errors/*.md` changes.
+
+- [ ] **Step 1: Add the canonical contract block to `crud.md`**
+
+In `cmd/cyoda/help/content/crud.md`, after the paragraph describing `pointInTime`/`transactionId` mutual exclusivity (around line 321), insert:
+
+```markdown
+## POINT-IN-TIME SEMANTICS
+
+A `pointInTime` read returns entity state **as at exactly that instant,
+inclusive**: a version whose write timestamp equals `pointInTime` is included
+(`<=`), and no rounding is applied to the requested time. The bound is compared
+against stored version timestamps at the storage engine's native precision.
+
+Behaviour is identical across every read path — single-entity read, list,
+search, grouped statistics, change history, and available transitions — and
+across storage backends. Because backends store timestamps at different
+precisions (down to milliseconds on some deployments), cross-backend results are
+guaranteed to agree at **millisecond granularity**; finer-grained ordering
+within a single millisecond is backend-defined. Timestamps are accepted and
+emitted as RFC 3339 with full fractional precision.
+```
+
+- [ ] **Step 2: Cross-reference from `search.md` and `analytics.md`**
+
+In `cmd/cyoda/help/content/search.md`, in the section describing `pointInTime` for search, add:
+
+```markdown
+Point-in-time search uses the canonical inclusive (`<=`, no rounding) bound —
+see `cyoda help crud` ("Point-in-time semantics").
+```
+
+In `cmd/cyoda/help/content/analytics.md`, near the grouped-stats `pointInTime` description, add the same one-line cross-reference.
+
+- [ ] **Step 3: Add a CHANGELOG entry**
+
+In `CHANGELOG.md`, under the unreleased / v0.8.2 "Fixed" section (create the section if absent, matching the file's existing Keep-a-Changelog style):
+
+```markdown
+### Fixed
+- Point-in-time ("as at T") reads now apply one canonical rule across all
+  storage engines and read paths: inclusive of the requested instant (`<=`),
+  compared at native precision, with no millisecond round-up. Previously the
+  memory engine and the SQL `GetAsAt`/`GetAllAsAt` paths rounded the requested
+  time up to the next millisecond (over-including later same-millisecond
+  versions), and sqlite used a strict `<` bound — so different backends, and
+  different read paths within one backend, could disagree at sub-millisecond
+  boundaries.
+```
+
+- [ ] **Step 4: Verify help content renders**
+
+Run: `go run ./cmd/cyoda help crud | sed -n '/POINT-IN-TIME/,/RFC 3339/p'`
+Expected: the new section prints without template errors.
+
+Run: `go test ./cmd/cyoda/... -run 'Help' -v`
+Expected: PASS (help-topic/error-code parity tests stay green — no new error codes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/cyoda/help/content/crud.md cmd/cyoda/help/content/search.md cmd/cyoda/help/content/analytics.md CHANGELOG.md
+git commit -m "docs: document canonical point-in-time read semantics
+
+Inclusive-of-T, no rounding, native precision, millisecond cross-backend
+fidelity floor. Documented in the crud help topic with cross-references
+from search and analytics; changelog entry under v0.8.2.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Full verification before PR
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run every module's tests**
+
+Run: `make test-all`
+Expected: root + `plugins/memory|sqlite|postgres` all green (Docker running for postgres + e2e testcontainers). This includes the new parity scenario across all in-tree backends.
+
+- [ ] **Step 2: Vet all modules**
+
+Run: `go vet ./...` (root), then `cd plugins/memory && go vet ./...`, `cd plugins/sqlite && go vet ./...`, `cd plugins/postgres && go vet ./...`
+Expected: clean.
+
+- [ ] **Step 3: Race sanity check (once, before PR)**
+
+Run: `make race`
+Expected: PASS. (Per `.claude/rules/race-testing.md` — single end-of-deliverable run, not per-step.)
+
+- [ ] **Step 4: Confirm no stray issue IDs or round-up sites remain**
+
+Run: `grep -rn "Truncate(time.Millisecond).Add(time.Millisecond)" plugins/ internal/ --include=*.go`
+Expected: no matches (all 7 production sites removed; the grep should return nothing in non-test code — any remaining hit is a missed site).
+
+Run: `grep -rn "349" plugins/ internal/ cmd/ e2e/ --include=*.go --include=*.md | grep -v docs/superpowers`
+Expected: no issue-ID leakage into shipped code/content.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Canonical rule (inclusive `<=`, no rounding, native precision) → Tasks 1–3 (per engine).
+- Remove 7 round-up sites → Task 1 (3 memory), Task 2 (2 sqlite), Task 3 (2 postgres).
+- sqlite `<`→`<=` flip → Task 2.
+- Already-correct paths unchanged (searcher/Iterate raw `<=`) → exercised by Task 4 parity + Task 5 consistency, not modified.
+- Per-engine white-box over-inclusion / strictness tests → Tasks 1, 2, 3.
+- Cross-backend exact-T inclusivity parity (incl. commercial) → Task 4.
+- Async self-consistency, isolated single-backend (sqlite) → Task 5.
+- Documentation (crud canonical block + search/analytics xref) + changelog → Task 6.
+- Verification (test-all, vet, race, no-residue greps) → Task 7.
+- Out of scope (storage-precision normalization, tx-snapshot semantics, commercial-repo change, #37 pushdown) → not present in any task. ✓
+
+**Placeholder scan:** The only intentional placeholder is the `uuidLike`/`fmtID` indirection in Task 4 Step 1, explicitly flagged with instructions to replace it with `uuid.UUID` straight-through calls and the exact driver line refs to confirm against. All other steps contain complete code and exact commands.
+
+**Type consistency:** `NewTestClockAt` added in memory (Task 1) and sqlite (Task 2) before use; `pitBase` defined in Task 2's `pit_boundary_test.go` and reused in Task 5 (same package `sqlite_test`); `RunPITBoundaryExactT`/`"PITBoundaryExactT"` consistent between Task 4 Steps 1 and 2; `EntityChangeMeta.TimeOfChange` and `EntityResult.Data` match `e2e/parity/client/types.go`.

--- a/docs/superpowers/specs/2026-06-27-pit-semantics-canonicalization-design.md
+++ b/docs/superpowers/specs/2026-06-27-pit-semantics-canonicalization-design.md
@@ -175,7 +175,7 @@ The behaviour-changing row is the exact-boundary case.
 | No over-inclusion (later sub-ms version excluded at `T_v`) | memory (ns), sqlite (µs), postgres (µs) — hand-placed timestamps | — | — (sub-ms not representable on Cassandra) | — |
 | sqlite `<` → `<=` (version at exactly creation-T visible) | sqlite | — | covered by exact-T parity | — |
 | PIT Search / Iterate / grouped-stats boundary | memory / sqlite / postgres | — | ✅ memory / sqlite / postgres (Cassandra path not implemented → gated) | ✅ |
-| Async self-consistency (Search select == `GetAsAt` re-fetch at boundary) | — | ✅ isolated single-backend (postgres) | — | — |
+| Async self-consistency (Search select == `GetAsAt` re-fetch at boundary) | — | ✅ isolated single-backend (**sqlite** — see rationale) | — | — |
 
 ### Test approach rationale
 
@@ -204,14 +204,33 @@ The behaviour-changing row is the exact-boundary case.
 - The **async self-consistency** check is consistency-flavoured (Search-select vs
   `GetAsAt` re-fetch agreeing at a boundary); it stays an **isolated single-backend
   e2e** rather than entering the shared parity suite, per `.claude/rules/test-coverage.md`.
+  It must target **sqlite**, not postgres: today sqlite's async *select* runs through
+  `searcher.Search` (raw `<=`) while its re-fetch runs through the rounded + strict-`<`
+  `GetAsAt`, so a boundary entity re-fetches to a different version or to
+  `ENTITY_NOT_FOUND` (which `search/service.go` silently skips → count mismatch) — a
+  genuine RED. Postgres has **no** sync `Searcher` until #37, so its async select falls
+  back to `GetAllAsAt` and its re-fetch to `GetAsAt` — both rounded pre-fix, hence
+  always in agreement: a postgres version of this test is a tautology (green→green) and
+  would violate the RED requirement. (Postgres becomes a meaningful target only after
+  #37 adds its Searcher.)
+- **Black-box exact-T tests must query at the *backend-reported* timestamp** of the
+  written version (read it back from the entity meta / change history), never a
+  client-side pre-storage nanosecond value. Stored precision truncates (ns→µs→ms) and
+  truncation is idempotent at the boundary, so inclusive `<=` holds across engines only
+  when the queried instant is the value the engine actually stored.
 
 ### Existing tests to review under GREEN
 
-Tests that encode the old rounded expectation must be re-derived (not blindly relaxed):
-`plugins/memory/search_store_test.go`, `plugins/postgres/model_store_test.go`,
-`plugins/postgres/model_extensions_*_test.go`, `plugins/sqlite/model_extensions_internal_test.go`.
-Any that constructed expected timestamps via `Truncate(time.Millisecond).Add(...)` to
-match the buggy bound are corrected to the canonical inclusive raw `<=`.
+The behavioural `GetAsAt`/`GetAllAsAt` tests live in `plugins/memory/entity_store_test.go`
+(e.g. `TestGetAllAsAt`, soft-delete-as-at cases) and `plugins/postgres/entity_store_test.go`
+(`TestEntityStore_GetAsAt`, `TestEntityStore_GetAllAsAt`). These are the tests to review
+under GREEN and the natural homes for the new white-box boundary tests; they currently
+stay green only because every case uses multi-millisecond gaps and samples mid-gap.
+**sqlite has no existing `GetAsAt`/`GetAllAsAt` test at all** — that path is currently
+fully untested, so the new sqlite white-box boundary tests are net-new coverage, not
+edits. (The `Truncate(time.Millisecond)` hits in `model_store_test.go` /
+`model_extensions_*_test.go` / `search_store_test.go` only build an `UpdateDate` field —
+they are *not* PIT-bound tests and need no change.)
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-06-27-pit-semantics-canonicalization-design.md
+++ b/docs/superpowers/specs/2026-06-27-pit-semantics-canonicalization-design.md
@@ -1,0 +1,201 @@
+# Point-in-time read semantics canonicalization (#349)
+
+**Status:** design agreed
+**Milestone:** v0.8.2
+**Relationship:** prerequisite for #37 (PostgreSQL predicate pushdown). #37 consumes
+the canonical bound this work establishes and introduces no PIT-bound logic of its own.
+
+## Problem
+
+Point-in-time ("as at T") reads do not apply a single consistent rule for bounding
+the snapshot timestamp. The behaviour diverges on two independent axes, so different
+storage engines — and different read paths within the same engine — can return
+different historical version sets for the same query.
+
+### Axis 1 — uneven millisecond round-up
+
+`GetAsAt`/`GetAllAsAt` and every memory-engine PIT path round the requested timestamp
+up to the next millisecond before comparing:
+
+```go
+asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
+```
+
+The Search / Iterate / grouped-stats PIT paths on the SQL engines bind the **raw**
+timestamp instead. The round-up originated in the memory engine with the rationale
+"clients work at millisecond precision but submitTime has micro/nanosecond precision."
+That premise is unverified and contradicted by the system itself: PIT input is parsed
+with `time.Parse(time.RFC3339, …)` (arbitrary fractional precision) and entity
+timestamps are emitted at nanosecond precision (`RFC3339Nano`). There is no
+millisecond-canonicalization layer anywhere.
+
+Effect: "as at 302.000ms" becomes `<= 303.000ms`, over-including a version written at
+302.9ms (later than asked for) by up to ~1ms. Raw paths correctly exclude it.
+
+### Axis 2 — strictness differs even among the rounded paths
+
+| Path | rounds asAt? | predicate | strictness |
+|---|---|---|---|
+| memory — all PIT paths | yes | `!submitTime.After(asAt)` | inclusive `<=` |
+| postgres `GetAsAt` / `GetAllAsAt` | yes | `valid_time <= $N` | inclusive `<=` |
+| postgres Search / Iterate / grouped-stats | no (raw) | `valid_time <= $N` | inclusive `<=` |
+| sqlite `GetAsAt` / `GetAllAsAt` | yes | `submit_time < ?` | **strict `<`** |
+| sqlite Search / Iterate / grouped-stats | no (raw) | `submit_time <= ?` | inclusive `<=` |
+| commercial (Cassandra) — all PIT paths | no | `<= asAtHLC` | inclusive `<=` |
+
+### Impact
+
+- **Cross-engine divergence (fidelity violation).** For the same "as at T" query the
+  memory backend can return a version set that sqlite/postgres do not, when a version
+  falls in the ≤1ms window around T. The digital-twin goal is engine-independent
+  behavioural fidelity; this breaks it.
+- **Self-inconsistency within an engine (user-visible).** Async search selects result
+  IDs via `Search` (raw bound on SQL engines) but `GetAsyncResults` re-fetches each
+  entity via `GetAsAt` (rounded). At a boundary a selected entity can re-fetch to a
+  different version or `ENTITY_NOT_FOUND`.
+- **No documented contract, no boundary test.** Every existing PIT test separates
+  versions by 20–100ms and samples mid-gap (`e2e/parity/temporal.go`,
+  `e2e/parity/externalapi/point_in_time.go`), so the boundary behaviour is entirely
+  untested — which is why this went unnoticed.
+
+Blast radius is a timing boundary (≤1ms window): no data loss, surfaces only under
+fine-grained / bursty-write timing. But it is a genuine consistency-contract violation.
+
+## Canonical rule
+
+**Point-in-time reads compare the requested instant against stored timestamps with
+inclusive `<=`, at the engine's native stored precision, with no artificial rounding.**
+
+Applied uniformly to `GetAsAt`, `GetAllAsAt`, PIT `Search`, PIT `Iterate`, and
+grouped-stats PIT, across memory, sqlite, postgres, and the commercial backend.
+
+**Precision floor.** Stored-timestamp precision differs per engine: memory nanosecond
+(`time.Time`), sqlite/postgres microsecond (`timeToMicro` / `timestamptz`), commercial
+millisecond (HLC `bigint`, high 48 bits = `UnixMilli`; sub-ms truncated on encode).
+Therefore **cross-engine behavioural fidelity is guaranteed to millisecond
+granularity** — the coarsest backend. Finer-grained distinctions are engine-defined.
+This is the honest digital-twin contract and is what we document. (Rejected
+alternative: normalize all engines to a common millisecond precision at storage —
+discards the `RFC3339Nano` wire format the API commits to and is a large, risky storage
+change for no real-world benefit, since the round-up artifact, not storage precision,
+is the defect.)
+
+"Full precision" in the issue means *removal of the artificial 1ms round-up*, not a
+sub-millisecond cross-engine guarantee that Cassandra physically cannot honour.
+
+## Production changes (cyoda-go only)
+
+Nine edits. No new types, no SPI change, no migration.
+
+| Engine | File:line | Change |
+|---|---|---|
+| memory | `plugins/memory/entity_store.go:324` (`GetAsAt`) | remove round-up |
+| memory | `plugins/memory/entity_store.go:420` (`GetAllAsAt`) | remove round-up |
+| memory | `plugins/memory/grouped_stats.go:90` (`buildSnapshot`, feeds `Iterate` + grouped-stats PIT) | remove round-up |
+| sqlite | `plugins/sqlite/entity_store.go:414` (`GetAsAt`) | remove round-up **and** flip `submit_time < ?` → `<= ?` |
+| sqlite | `plugins/sqlite/entity_store.go:549` (`GetAllAsAt`) | remove round-up **and** flip `submit_time < ?` → `<= ?` |
+| postgres | `plugins/postgres/entity_store.go:183` (`GetAsAt`) | remove round-up |
+| postgres | `plugins/postgres/entity_store.go:242` (`GetAllAsAt`) | remove round-up |
+
+All other PIT paths are already raw inclusive `<=` and become consistent automatically
+once the rounded paths stop rounding:
+
+- sqlite `searcher.go` PIT base query: already `submit_time <= ?` (raw).
+- postgres `searcher.go` / `grouped_stats.go` PIT: already `valid_time <= $N` (raw).
+- memory snapshot helpers (`getSnapshotVersion`, `getAllSnapshotUnlocked`,
+  `getAllSnapshotPointersUnlocked`): already `!submitTime.After(...)` = `<=`.
+
+**No collateral.** Transaction-snapshot reads use `tx.SnapshotTime` and never applied
+the round-up; they are untouched. The async-search self-inconsistency resolves for free
+once `GetAsAt` stops rounding (both Search-select and re-fetch then bind raw `<=`).
+
+**Commercial backend.** Cassandra already implements the canonical rule (inclusive
+`<=`, no round-up) at millisecond precision; it requires no production change. The new
+boundary parity scenarios run against it on its next cyoda-go dependency update and
+confirm convergence. Note Cassandra does **not** implement sync `Search`/`Iterate`/
+grouped-stats PIT (only `GetAsAt`/`GetAllAsAt` + index-reader/async-search PIT), so
+PIT-search parity scenarios that target those paths are gated to the engines that
+implement them, as today.
+
+### Comment hygiene
+
+Remove or correct the round-up rationale comments at each deleted site. The sqlite
+`searcher.go` comment that references "matching the memory plugin's convention" /
+`!v.submitTime.After(...)` remains accurate (it documents inclusive `<=`) and stays.
+
+## Documentation
+
+- Add a concise **"Point-in-time semantics"** block to `cmd/cyoda/help/content/crud.md`
+  as the canonical home: reads are inclusive of the requested instant (`<=`); no
+  rounding is applied; the bound is compared at the engine's native precision;
+  cross-engine behavioural fidelity is guaranteed to millisecond granularity.
+- Cross-reference that block from `cmd/cyoda/help/content/search.md` (PIT search) and
+  `cmd/cyoda/help/content/analytics.md` (grouped-stats PIT).
+- No `errors/*.md` changes — no new error codes (TestErrCode_Parity unaffected).
+- Gate-4: no env vars, no public Go interface, no chart/COMPATIBILITY/SPI-pin change.
+  Add a `CHANGELOG` entry under v0.8.2.
+
+## Error / status table (per PIT endpoint)
+
+The change alters *which version* is returned, not the status taxonomy. No new codes.
+The behaviour-changing row is the exact-boundary case.
+
+| Endpoint (HTTP / gRPC) | SPI path | Codes (unchanged) | Boundary behaviour after fix |
+|---|---|---|---|
+| `GET /api/entity/{id}?pointInTime` | `GetAsAt` | 200; 404 `ENTITY_NOT_FOUND`; 400 `INVALID_POINT_IN_TIME`; 400 `BAD_REQUEST` (pointInTime+transactionId) | as-at exactly a version's T → 200 that version (**sqlite previously 404 under strict `<` — fixed**); a later sub-ms version is not over-included |
+| `GET /api/entity/{name}/{ver}?pointInTime` | `GetAllAsAt` | 200; 400 `INVALID_POINT_IN_TIME` | set includes versions with T == bound; excludes T > bound (sqlite strictness fixed) |
+| `POST /api/entity/search/{…}` + gRPC `Search` (`pointInTime`) | PIT `Search` | 200/202; 400 | already raw `<=`; now identical to `GetAsAt` (async select == re-fetch) |
+| `POST /api/entity/stats/{…}/query` + gRPC (`pointInTime`) | grouped-stats / `Iterate` | 200; 400 `INVALID_POINT_IN_TIME`/`INVALID_LIMIT`; 422 `GROUP_CARDINALITY_EXCEEDED`; 501 `NOT_IMPLEMENTED_BY_BACKEND` | memory stops rounding → matches SQL engines |
+| `GET /api/entity/{id}/changes?pointInTime`, `…/transitions?pointInTime` + gRPC `GetChangesMetadata` | history / transitions as-at | 200; 404; 400 `INVALID_POINT_IN_TIME` | verify raw inclusive `<=` (no round-up site here today — add boundary assertion to prove it) |
+
+## Coverage matrix (scenario × layer)
+
+| Scenario | Unit (per-engine, white-box) | Running-backend e2e | Cross-backend parity | gRPC |
+|---|---|---|---|---|
+| Exact-T inclusive (`as-at T_v` returns v) | memory / sqlite / postgres | — | ✅ registry: `GetAsAt` + `GetAllAsAt` (all backends incl. Cassandra @ ms) | ✅ search / changes PIT envelope |
+| No over-inclusion (later sub-ms version excluded at `T_v`) | memory (ns), sqlite (µs), postgres (µs) — hand-placed timestamps | — | — (sub-ms not representable on Cassandra) | — |
+| sqlite `<` → `<=` (version at exactly creation-T visible) | sqlite | — | covered by exact-T parity | — |
+| PIT Search / Iterate / grouped-stats boundary | memory / sqlite / postgres | — | ✅ memory / sqlite / postgres (Cassandra path not implemented → gated) | ✅ |
+| Async self-consistency (Search select == `GetAsAt` re-fetch at boundary) | — | ✅ isolated single-backend (postgres) | — | — |
+
+### Test approach rationale
+
+- **Over-inclusion and strictness** are sub-millisecond / timing-sensitive defects, so
+  they are driven by **per-engine white-box unit tests with hand-placed version
+  timestamps** (deterministic; these are the RED tests). For each engine that rounds,
+  cover every affected path: `GetAsAt`, `GetAllAsAt`, and the engine's PIT
+  Search/Iterate/grouped-stats. Assertions: (a) a version written at exactly T is
+  included by `as-at T` (inclusive boundary); (b) a version written at T+ε within the
+  same millisecond is excluded by `as-at T` (no round-up over-inclusion); (c) sqlite:
+  the version at exactly its creation T is visible (`<=` not `<`).
+- **Exact-T inclusivity** is deterministic at millisecond granularity, so it is the
+  **cross-backend parity** guard — it runs on Cassandra too and asserts every backend
+  returns the same version when queried at a version's own reported timestamp. New
+  scenarios are registered in `e2e/parity/registry.go` (and the external-API
+  `parity.Register` set) so all backends, including the commercial one, run them.
+- The **async self-consistency** check is consistency-flavoured (Search-select vs
+  `GetAsAt` re-fetch agreeing at a boundary); it stays an **isolated single-backend
+  e2e** rather than entering the shared parity suite, per `.claude/rules/test-coverage.md`.
+
+### Existing tests to review under GREEN
+
+Tests that encode the old rounded expectation must be re-derived (not blindly relaxed):
+`plugins/memory/search_store_test.go`, `plugins/postgres/model_store_test.go`,
+`plugins/postgres/model_extensions_*_test.go`, `plugins/sqlite/model_extensions_internal_test.go`.
+Any that constructed expected timestamps via `Truncate(time.Millisecond).Add(...)` to
+match the buggy bound are corrected to the canonical inclusive raw `<=`.
+
+## Out of scope
+
+- Storage-precision normalization across engines (rejected above).
+- Any change to transaction-snapshot semantics (`tx.SnapshotTime`).
+- #37's predicate pushdown — separate work that builds on this canonical bound.
+- Commercial-repo changes — Cassandra is already canonical; convergence is verified by
+  the parity suite, not by a change in this milestone.
+
+## Verification
+
+- `make test-all` (root + memory/sqlite/postgres plugins; Docker for postgres
+  testcontainers) green, including the new unit, e2e, and parity scenarios.
+- `go vet ./...` and per-plugin vet clean.
+- `make race` once before PR.

--- a/docs/superpowers/specs/2026-06-27-pit-semantics-canonicalization-design.md
+++ b/docs/superpowers/specs/2026-06-27-pit-semantics-canonicalization-design.md
@@ -171,11 +171,20 @@ The behaviour-changing row is the exact-boundary case.
 
 | Scenario | Unit (per-engine, white-box) | Running-backend e2e | Cross-backend parity | gRPC |
 |---|---|---|---|---|
-| Exact-T inclusive (`as-at T_v` returns v) | memory / sqlite / postgres | — | ✅ registry: `GetAsAt` + `GetAllAsAt` (all backends incl. Cassandra @ ms) | ✅ search / changes PIT envelope |
+| Exact-T inclusive (`as-at T_v` returns v) | memory / sqlite / postgres | — | ✅ registry: `GetAsAt` + `GetAllAsAt` (all backends incl. Cassandra @ ms) | ↳ transitive (see note) |
 | No over-inclusion (later sub-ms version excluded at `T_v`) | memory (ns), sqlite (µs), postgres (µs) — hand-placed timestamps | — | — (sub-ms not representable on Cassandra) | — |
 | sqlite `<` → `<=` (version at exactly creation-T visible) | sqlite | — | covered by exact-T parity | — |
-| PIT Search / Iterate / grouped-stats boundary | memory / sqlite / postgres | — | ✅ memory / sqlite / postgres (Cassandra path not implemented → gated) | ✅ |
+| PIT Search / Iterate / grouped-stats boundary | memory / sqlite / postgres | — | ✅ memory / sqlite / postgres (Cassandra path not implemented → gated) | ↳ transitive (see note) |
 | Async self-consistency (Search select == `GetAsAt` re-fetch at boundary) | — | ✅ isolated single-backend (**sqlite** — see rationale) | — | — |
+
+**gRPC column — transitive, not a separate test.** PIT bounding lives entirely in
+the shared SPI engine layer; gRPC `Search`/`GetChangesMetadata` and the HTTP
+endpoints funnel the same `PointInTime` into the same engine bound. This change
+adds no gRPC-specific PIT logic and no new status/error codes (see the error
+table — "no new codes"), so the per-engine white-box + cross-backend parity
+coverage protects the gRPC path transitively. No dedicated `internal/grpc`
+boundary test is added; the `↳ transitive` cells mark this deliberate reading
+rather than a delivered gRPC-specific test.
 
 ### Test approach rationale
 

--- a/docs/superpowers/specs/2026-06-27-pit-semantics-canonicalization-design.md
+++ b/docs/superpowers/specs/2026-06-27-pit-semantics-canonicalization-design.md
@@ -85,7 +85,8 @@ sub-millisecond cross-engine guarantee that Cassandra physically cannot honour.
 
 ## Production changes (cyoda-go only)
 
-Nine edits. No new types, no SPI change, no migration.
+Seven sites, nine changes (7 round-up removals + 2 sqlite predicate flips). No new
+types, no SPI change, no migration.
 
 | Engine | File:line | Change |
 |---|---|---|
@@ -100,14 +101,31 @@ Nine edits. No new types, no SPI change, no migration.
 All other PIT paths are already raw inclusive `<=` and become consistent automatically
 once the rounded paths stop rounding:
 
-- sqlite `searcher.go` PIT base query: already `submit_time <= ?` (raw).
-- postgres `searcher.go` / `grouped_stats.go` PIT: already `valid_time <= $N` (raw).
+- sqlite `searcher.go` PIT base query: already `submit_time <= ?` (raw). This is the
+  tree's only sync `spi.Searcher`.
+- postgres `grouped_stats.go:93` (`Iterate` PIT): already `valid_time <= $4` (raw).
+  Postgres has **no** sync `Search` today — a sync `spi.Searcher` is exactly what #37
+  adds, on top of this canonical bound.
 - memory snapshot helpers (`getSnapshotVersion`, `getAllSnapshotUnlocked`,
   `getAllSnapshotPointersUnlocked`): already `!submitTime.After(...)` = `<=`.
 
+**All `GetAsAt` consumers whose boundary result changes after the fix** (covered
+automatically by the `GetAsAt` edit, but enumerated so the behavioural change is not
+silent): single-entity read (`internal/domain/entity/handler.go`, HTTP + gRPC); HTTP
+transitions-as-at handler (`internal/domain/entity/transitions_handler.go` →
+`GetAsAt`); workflow available-transitions-as-at
+(`internal/domain/workflow/transitions.go` `GetAvailableTransitions(…, pointInTime)` →
+`GetAsAt`); async-search re-fetch (`internal/domain/search/service.go` →
+`GetAsAt(…, job.PointInTime)`). The change-history-as-at path
+(`GetChangesMetadata`) is **not** a `GetAsAt` consumer — it does its own
+already-inclusive, non-rounded cutoff filter (`!Timestamp.After(cutoff)`), so it needs
+no production change, only a boundary assertion.
+
 **No collateral.** Transaction-snapshot reads use `tx.SnapshotTime` and never applied
-the round-up; they are untouched. The async-search self-inconsistency resolves for free
-once `GetAsAt` stops rounding (both Search-select and re-fetch then bind raw `<=`).
+the round-up; they are untouched (sqlite `getAllTx` binds `submit_time <= snapshotMicro`
+raw; memory snapshot helpers take `tx.SnapshotTime` directly). The async-search
+self-inconsistency resolves for free once `GetAsAt` stops rounding (both Search-select
+and re-fetch then bind raw `<=`).
 
 **Commercial backend.** Cassandra already implements the canonical rule (inclusive
 `<=`, no round-up) at millisecond precision; it requires no production change. The new
@@ -146,7 +164,8 @@ The behaviour-changing row is the exact-boundary case.
 | `GET /api/entity/{name}/{ver}?pointInTime` | `GetAllAsAt` | 200; 400 `INVALID_POINT_IN_TIME` | set includes versions with T == bound; excludes T > bound (sqlite strictness fixed) |
 | `POST /api/entity/search/{…}` + gRPC `Search` (`pointInTime`) | PIT `Search` | 200/202; 400 | already raw `<=`; now identical to `GetAsAt` (async select == re-fetch) |
 | `POST /api/entity/stats/{…}/query` + gRPC (`pointInTime`) | grouped-stats / `Iterate` | 200; 400 `INVALID_POINT_IN_TIME`/`INVALID_LIMIT`; 422 `GROUP_CARDINALITY_EXCEEDED`; 501 `NOT_IMPLEMENTED_BY_BACKEND` | memory stops rounding → matches SQL engines |
-| `GET /api/entity/{id}/changes?pointInTime`, `…/transitions?pointInTime` + gRPC `GetChangesMetadata` | history / transitions as-at | 200; 404; 400 `INVALID_POINT_IN_TIME` | verify raw inclusive `<=` (no round-up site here today — add boundary assertion to prove it) |
+| `GET /api/entity/{id}/transitions?pointInTime`; workflow available-transitions-as-at | `GetAsAt` (entity-as-at) | 200; 404; 400 `INVALID_POINT_IN_TIME` | routes through `GetAsAt`, which **rounds today** — fixed by the `GetAsAt` edit; add boundary assertion |
+| `GET /api/entity/{id}/changes?pointInTime` + gRPC `GetChangesMetadata` | history as-at (own cutoff filter) | 200; 404; 400 `INVALID_POINT_IN_TIME` | already inclusive raw `<=` (`!Timestamp.After(cutoff)`), no round-up — add boundary assertion to lock it |
 
 ## Coverage matrix (scenario × layer)
 
@@ -168,6 +187,15 @@ The behaviour-changing row is the exact-boundary case.
   included by `as-at T` (inclusive boundary); (b) a version written at T+ε within the
   same millisecond is excluded by `as-at T` (no round-up over-inclusion); (c) sqlite:
   the version at exactly its creation T is visible (`<=` not `<`).
+  - **Sequencing caveat (sqlite strictness is masked by the round-up).** On unmodified
+    sqlite the round-up hides the strict `<`: `as-at T_v` rounds up to the next ms then
+    does `< (T_v_ms + 1ms)`, so the version at `T_v` is already returned. A standalone
+    "version at exactly creation-T visible" test therefore passes green on current code
+    and proves nothing. The genuine RED driver for sqlite is the **over-inclusion** test
+    (a same-ms `T+ε` version *is* wrongly returned today and must be excluded). Sequence
+    the sqlite work: (1) write over-inclusion RED → remove the round-up (now the strict
+    `<` is observable and the exact-T test goes RED) → (2) flip `<`→`<=` to green it.
+    Do not treat the exact-T strictness test as RED before the round-up is removed.
 - **Exact-T inclusivity** is deterministic at millisecond granularity, so it is the
   **cross-backend parity** guard — it runs on Cassandra too and asserts every backend
   returns the same version when queried at a version's own reported timestamp. New

--- a/e2e/parity/pit_boundary.go
+++ b/e2e/parity/pit_boundary.go
@@ -1,0 +1,87 @@
+package parity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
+)
+
+// RunPITBoundaryExactT asserts exact-T inclusivity: querying as-at a version's
+// own reported timestamp returns that version, uniformly across backends. It is
+// the cross-engine guard for the canonical inclusive <= PIT rule. Sub-ms
+// over-inclusion is covered by per-engine white-box tests, not here, because
+// the commercial backend stores at millisecond precision.
+func RunPITBoundaryExactT(t *testing.T, fixture BackendFixture) {
+	t.Helper()
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "pitb"
+	const modelVersion = 1
+
+	if err := c.ImportModel(t, modelName, modelVersion, `{"k":1}`); err != nil {
+		t.Fatalf("create model: %v", err)
+	}
+	if err := c.LockModel(t, modelName, modelVersion); err != nil {
+		t.Fatalf("lock model: %v", err)
+	}
+
+	id, err := c.CreateEntity(t, modelName, modelVersion, `{"k":1}`)
+	if err != nil {
+		t.Fatalf("create entity: %v", err)
+	}
+	t1 := pitbLatestChangeTime(t, c, id)
+
+	if err := c.UpdateEntityData(t, id, `{"k":2}`); err != nil {
+		t.Fatalf("update k=2: %v", err)
+	}
+	t2 := pitbLatestChangeTime(t, c, id)
+
+	if err := c.UpdateEntityData(t, id, `{"k":3}`); err != nil {
+		t.Fatalf("update k=3: %v", err)
+	}
+	t3 := pitbLatestChangeTime(t, c, id)
+
+	// As-at exactly each version's write time returns that version.
+	pitbAssertKAt(t, c, id, t1, 1)
+	pitbAssertKAt(t, c, id, t2, 2)
+	pitbAssertKAt(t, c, id, t3, 3)
+}
+
+// pitbLatestChangeTime returns the most recent TimeOfChange for the entity —
+// the timestamp of the version just written.
+func pitbLatestChangeTime(t *testing.T, c *client.Client, id uuid.UUID) time.Time {
+	t.Helper()
+	changes, err := c.GetEntityChanges(t, id)
+	if err != nil {
+		t.Fatalf("GetEntityChanges: %v", err)
+	}
+	if len(changes) == 0 {
+		t.Fatal("GetEntityChanges returned no entries")
+	}
+	latest := changes[0].TimeOfChange
+	for _, ch := range changes[1:] {
+		if ch.TimeOfChange.After(latest) {
+			latest = ch.TimeOfChange
+		}
+	}
+	return latest
+}
+
+// pitbAssertKAt queries the entity at the exact timestamp at and asserts that
+// the returned data.k equals wantK. A failure indicates the backend is not
+// honouring the inclusive <= boundary for point-in-time reads.
+func pitbAssertKAt(t *testing.T, c *client.Client, id uuid.UUID, at time.Time, wantK float64) {
+	t.Helper()
+	got, err := c.GetEntityAt(t, id, at)
+	if err != nil {
+		t.Fatalf("GetEntityAt(%s): %v", at.Format(time.RFC3339Nano), err)
+	}
+	if got.Data["k"] != wantK {
+		t.Errorf("GetEntityAt(%s) k=%v, want %v (exact-T inclusivity violated)",
+			at.Format(time.RFC3339Nano), got.Data["k"], wantK)
+	}
+}

--- a/e2e/parity/pit_boundary.go
+++ b/e2e/parity/pit_boundary.go
@@ -35,15 +35,33 @@ func RunPITBoundaryExactT(t *testing.T, fixture BackendFixture) {
 	}
 	t1 := pitbLatestChangeTime(t, c, id)
 
+	// Space writes ≥1ms apart so each version lands in a distinct millisecond.
+	// The commercial backend stores timestamps at millisecond precision; two
+	// writes inside the same wall-clock millisecond would report identical
+	// TimeOfChange values, making the exact-T assertion for the earlier version
+	// ambiguous (as-at that millisecond inclusively resolves to the later one).
+	// This does not weaken the guard — each assertion still queries a version's
+	// own exact reported timestamp, which is what exposes a strict-`<` bound.
+	time.Sleep(2 * time.Millisecond)
 	if err := c.UpdateEntityData(t, id, `{"k":2}`); err != nil {
 		t.Fatalf("update k=2: %v", err)
 	}
 	t2 := pitbLatestChangeTime(t, c, id)
 
+	time.Sleep(2 * time.Millisecond)
 	if err := c.UpdateEntityData(t, id, `{"k":3}`); err != nil {
 		t.Fatalf("update k=3: %v", err)
 	}
 	t3 := pitbLatestChangeTime(t, c, id)
+
+	// Precondition: the spacing above must yield strictly increasing version
+	// timestamps on every supported backend. A violation means the backend's
+	// timestamp resolution is coarser than the spacing — surface it clearly
+	// rather than as a confusing exact-T failure below.
+	if !t1.Before(t2) || !t2.Before(t3) {
+		t.Fatalf("version timestamps not strictly increasing: t1=%s t2=%s t3=%s",
+			t1.Format(time.RFC3339Nano), t2.Format(time.RFC3339Nano), t3.Format(time.RFC3339Nano))
+	}
 
 	// As-at exactly each version's write time returns that version.
 	pitbAssertKAt(t, c, id, t1, 1)

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 143
+// Total parity scenarios: 144
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
 // distributed-safety contracts + schema extensions + Phase 9.2 OIDC CRUD/authz
 // + Phase 9.3 OIDC JWT validation + Phase 9.4 OIDC divergences
@@ -54,6 +54,7 @@ var allTests = []NamedTest{
 	// Phase 4a — bi-temporal (Task 4a.3)
 	{"TemporalPointInTimeRetrieval", RunTemporalPointInTimeRetrieval},
 	{"TemporalGetAsAtPopulatesFullMeta", RunTemporalGetAsAtPopulatesFullMeta},
+	{"PITBoundaryExactT", RunPITBoundaryExactT},
 
 	// Phase 4a — audit (Task 4a.4)
 	{"AuditEntityHistory", RunAuditEntityHistory},

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 145
+// Total parity scenarios: 162
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
 // distributed-safety contracts + schema extensions + Phase 9.2 OIDC CRUD/authz
 // + Phase 9.3 OIDC JWT validation + Phase 9.4 OIDC divergences

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 144
+// Total parity scenarios: 145
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
 // distributed-safety contracts + schema extensions + Phase 9.2 OIDC CRUD/authz
 // + Phase 9.3 OIDC JWT validation + Phase 9.4 OIDC divergences

--- a/plugins/memory/clock.go
+++ b/plugins/memory/clock.go
@@ -27,6 +27,13 @@ func NewTestClock() *TestClock {
 	return &TestClock{now: time.Now()}
 }
 
+// NewTestClockAt returns a TestClock whose virtual time starts at t.
+// Tests that need a millisecond-aligned base (so sub-millisecond Advance
+// steps land in a known millisecond) use this instead of NewTestClock.
+func NewTestClockAt(t time.Time) *TestClock {
+	return &TestClock{now: t}
+}
+
 // Now returns the current virtual time.
 func (c *TestClock) Now() time.Time {
 	c.mu.Lock()

--- a/plugins/memory/entity_store.go
+++ b/plugins/memory/entity_store.go
@@ -318,11 +318,6 @@ func (s *EntityStore) GetAsAt(ctx context.Context, entityID string, asAt time.Ti
 		return nil, fmt.Errorf("entity %s: %w", entityID, spi.ErrNotFound)
 	}
 
-	// Round asAt up to the next millisecond boundary. Clients work at
-	// millisecond precision but submitTime has microsecond/nanosecond
-	// precision. A query for "302ms" should include "302.306ms".
-	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
-
 	var result *spi.Entity
 	var wasDeleted bool
 	for _, v := range versions {
@@ -415,9 +410,6 @@ func (s *EntityStore) GetAll(ctx context.Context, modelRef spi.ModelRef) ([]*spi
 func (s *EntityStore) GetAllAsAt(ctx context.Context, modelRef spi.ModelRef, asAt time.Time) ([]*spi.Entity, error) {
 	s.factory.entityMu.RLock()
 	defer s.factory.entityMu.RUnlock()
-
-	// Round asAt up to the next millisecond boundary (same as GetAsAt).
-	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
 
 	// Historical query: always reads committed data.
 	result := make([]*spi.Entity, 0)

--- a/plugins/memory/grouped_stats.go
+++ b/plugins/memory/grouped_stats.go
@@ -86,13 +86,11 @@ func (s *EntityStore) Iterate(
 func (s *EntityStore) buildSnapshot(ctx context.Context, model spi.ModelRef, pit *time.Time) ([]*spi.Entity, error) {
 	// PIT path: historical read, bypass tx overlay.
 	if pit != nil {
-		// Round up to next millisecond boundary, matching GetAllAsAt.
-		asAt := pit.Truncate(time.Millisecond).Add(time.Millisecond)
 		var snapshot []*spi.Entity
 		func() {
 			s.factory.entityMu.RLock()
 			defer s.factory.entityMu.RUnlock()
-			snapshot = s.getAllSnapshotPointersUnlocked(model, asAt)
+			snapshot = s.getAllSnapshotPointersUnlocked(model, *pit)
 		}()
 		return snapshot, nil
 	}

--- a/plugins/memory/pit_boundary_test.go
+++ b/plugins/memory/pit_boundary_test.go
@@ -1,0 +1,96 @@
+package memory_test
+
+import (
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/memory"
+)
+
+// msBase is a millisecond-aligned instant (nanoseconds == 0) so that a
+// sub-millisecond Advance keeps both versions inside the same millisecond.
+var msBase = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// twoVersionsSameMillisecond saves v1 at msBase and v2 300µs later (same
+// millisecond) and returns the store. The buggy round-up rounds msBase up to
+// the next millisecond, so a query "as at msBase" wrongly includes v2.
+func twoVersionsSameMillisecond(t *testing.T) (spi.EntityStore, interface{ Now() time.Time }) {
+	t.Helper()
+	clock := memory.NewTestClockAt(msBase)
+	factory := memory.NewStoreFactory(memory.WithClock(clock))
+	ctx := ctxWithTenant("tenant-pit")
+	store, _ := factory.EntityStore(ctx)
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	e := &spi.Entity{
+		Meta: spi.EntityMeta{ID: "e-pit", TenantID: "tenant-pit", ModelRef: ref, State: "NEW"},
+		Data: []byte(`{"v":1}`),
+	}
+	if _, err := store.Save(ctx, e); err != nil {
+		t.Fatalf("Save v1: %v", err)
+	}
+	clock.Advance(300 * time.Microsecond)
+	e.Data = []byte(`{"v":2}`)
+	if _, err := store.Save(ctx, e); err != nil {
+		t.Fatalf("Save v2: %v", err)
+	}
+	return store, clock
+}
+
+func TestMemoryPIT_GetAsAt_InclusiveNoRoundUp(t *testing.T) {
+	store, _ := twoVersionsSameMillisecond(t)
+	ctx := ctxWithTenant("tenant-pit")
+
+	got, err := store.GetAsAt(ctx, "e-pit", msBase)
+	if err != nil {
+		t.Fatalf("GetAsAt(msBase): %v", err)
+	}
+	if string(got.Data) != `{"v":1}` {
+		t.Errorf("GetAsAt(msBase) = %s, want {\"v\":1} (round-up over-included the same-ms v2)", got.Data)
+	}
+}
+
+func TestMemoryPIT_GetAllAsAt_InclusiveNoRoundUp(t *testing.T) {
+	store, _ := twoVersionsSameMillisecond(t)
+	ctx := ctxWithTenant("tenant-pit")
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	got, err := store.GetAllAsAt(ctx, ref, msBase)
+	if err != nil {
+		t.Fatalf("GetAllAsAt(msBase): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("GetAllAsAt(msBase) returned %d entities, want 1", len(got))
+	}
+	if string(got[0].Data) != `{"v":1}` {
+		t.Errorf("GetAllAsAt(msBase) data = %s, want {\"v\":1}", got[0].Data)
+	}
+}
+
+func TestMemoryPIT_Iterate_InclusiveNoRoundUp(t *testing.T) {
+	store, _ := twoVersionsSameMillisecond(t)
+	ctx := ctxWithTenant("tenant-pit")
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	it := store.(spi.Iterable)
+	pit := msBase
+	iter, err := it.Iterate(ctx, ref, spi.Filter{}, spi.IterateOptions{PointInTime: &pit})
+	if err != nil {
+		t.Fatalf("Iterate(msBase): %v", err)
+	}
+	defer iter.Close()
+
+	var data string
+	var seen int
+	for iter.Next() {
+		seen++
+		data = string(iter.Entity().Data)
+	}
+	if err := iter.Err(); err != nil {
+		t.Fatalf("iter err: %v", err)
+	}
+	if seen != 1 || data != `{"v":1}` {
+		t.Errorf("Iterate(msBase) saw %d entities (data=%s), want 1 with {\"v\":1}", seen, data)
+	}
+}

--- a/plugins/postgres/entity_store.go
+++ b/plugins/postgres/entity_store.go
@@ -179,9 +179,6 @@ func (s *entityStore) Get(ctx context.Context, entityID string) (*spi.Entity, er
 
 // Deliberately not tracked in readSet: historical reads target immutable versions. See spec §Known limitation.
 func (s *entityStore) GetAsAt(ctx context.Context, entityID string, asAt time.Time) (*spi.Entity, error) {
-	// Round up to the next millisecond boundary (matching memory implementation).
-	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
-
 	var doc []byte
 	err := s.q.QueryRow(ctx,
 		`SELECT doc FROM entity_versions
@@ -239,8 +236,6 @@ func (s *entityStore) GetAll(ctx context.Context, modelRef spi.ModelRef) ([]*spi
 
 // Deliberately not tracked in readSet: historical reads target immutable versions. See spec §Known limitation.
 func (s *entityStore) GetAllAsAt(ctx context.Context, modelRef spi.ModelRef, asAt time.Time) ([]*spi.Entity, error) {
-	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
-
 	rows, err := s.q.Query(ctx,
 		`SELECT v.doc
 		 FROM entities e

--- a/plugins/postgres/pit_boundary_test.go
+++ b/plugins/postgres/pit_boundary_test.go
@@ -1,0 +1,84 @@
+package postgres_test
+
+import (
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+const (
+	pitTenant = "entity-tenant"
+	pitBaseTS = "2026-01-01 00:00:00+00"        // millisecond-aligned
+	pitNextTS = "2026-01-01 00:00:00.000300+00" // +300µs, same millisecond
+)
+
+func pitParseBase(t *testing.T) time.Time {
+	t.Helper()
+	bt, err := time.Parse(time.RFC3339Nano, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+	return bt
+}
+
+// pitSetup saves v1 then v2 on one entity, then forces deterministic,
+// same-millisecond valid_times (v1 at pitBaseTS, v2 300µs later).
+func pitSetup(t *testing.T) (*spi.Entity, spi.EntityStore, func() time.Time) {
+	t.Helper()
+	factory := setupEntityTest(t)
+	ctx := ctxWithTenant(pitTenant)
+	store, _ := factory.EntityStore(ctx)
+	pool := factory.Pool()
+
+	ent := makeEntity("ent-pit")
+	ent.Data = []byte(`{"value":"v1"}`)
+	if _, err := store.Save(ctx, ent); err != nil {
+		t.Fatalf("Save v1: %v", err)
+	}
+	ent.Data = []byte(`{"value":"v2"}`)
+	if _, err := store.Save(ctx, ent); err != nil {
+		t.Fatalf("Save v2: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx,
+		`UPDATE entity_versions SET valid_time=$1, transaction_time=$1
+		 WHERE tenant_id=$2 AND entity_id=$3 AND version=1`,
+		pitBaseTS, pitTenant, "ent-pit"); err != nil {
+		t.Fatalf("update v1 valid_time: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE entity_versions SET valid_time=$1, transaction_time=$1
+		 WHERE tenant_id=$2 AND entity_id=$3 AND version=2`,
+		pitNextTS, pitTenant, "ent-pit"); err != nil {
+		t.Fatalf("update v2 valid_time: %v", err)
+	}
+	return ent, store, func() time.Time { return pitParseBase(t) }
+}
+
+func TestPostgresPIT_GetAsAt_InclusiveNoRoundUp(t *testing.T) {
+	_, store, base := pitSetup(t)
+	ctx := ctxWithTenant(pitTenant)
+
+	got, err := store.GetAsAt(ctx, "ent-pit", base())
+	if err != nil {
+		t.Fatalf("GetAsAt(base): %v", err)
+	}
+	if string(got.Data) != `{"value":"v1"}` {
+		t.Errorf("GetAsAt(base) = %s, want v1 (round-up over-included same-ms v2)", got.Data)
+	}
+}
+
+func TestPostgresPIT_GetAllAsAt_InclusiveNoRoundUp(t *testing.T) {
+	_, store, base := pitSetup(t)
+	ctx := ctxWithTenant(pitTenant)
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	got, err := store.GetAllAsAt(ctx, ref, base())
+	if err != nil {
+		t.Fatalf("GetAllAsAt(base): %v", err)
+	}
+	if len(got) != 1 || string(got[0].Data) != `{"value":"v1"}` {
+		t.Errorf("GetAllAsAt(base) = %d entities, want 1 with v1", len(got))
+	}
+}

--- a/plugins/postgres/pit_boundary_test.go
+++ b/plugins/postgres/pit_boundary_test.go
@@ -79,6 +79,10 @@ func TestPostgresPIT_GetAllAsAt_InclusiveNoRoundUp(t *testing.T) {
 		t.Fatalf("GetAllAsAt(base): %v", err)
 	}
 	if len(got) != 1 || string(got[0].Data) != `{"value":"v1"}` {
-		t.Errorf("GetAllAsAt(base) = %d entities, want 1 with v1", len(got))
+		var data string
+		if len(got) > 0 {
+			data = string(got[0].Data)
+		}
+		t.Errorf("GetAllAsAt(base) = %d entities (first data=%q), want 1 with {\"value\":\"v1\"}", len(got), data)
 	}
 }

--- a/plugins/sqlite/clock.go
+++ b/plugins/sqlite/clock.go
@@ -27,6 +27,11 @@ func NewTestClock() *TestClock {
 	return &TestClock{now: time.Now()}
 }
 
+// NewTestClockAt returns a TestClock whose virtual time starts at t.
+func NewTestClockAt(t time.Time) *TestClock {
+	return &TestClock{now: t}
+}
+
 // Now returns the current virtual time.
 func (c *TestClock) Now() time.Time {
 	c.mu.Lock()

--- a/plugins/sqlite/entity_store.go
+++ b/plugins/sqlite/entity_store.go
@@ -409,10 +409,6 @@ func (s *entityStore) getSnapshot(ctx context.Context, entityID string, snapshot
 }
 
 func (s *entityStore) GetAsAt(ctx context.Context, entityID string, asAt time.Time) (*spi.Entity, error) {
-	// Round asAt up to the next millisecond boundary. Clients work at
-	// millisecond precision but submitTime has microsecond precision.
-	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
-
 	// Track in read set if in tx.
 	if tx := spi.GetTransaction(ctx); tx != nil {
 		tx.OpMu.RLock()
@@ -431,7 +427,7 @@ func (s *entityStore) GetAsAt(ctx context.Context, entityID string, asAt time.Ti
 		 INNER JOIN (
 		     SELECT entity_id, MAX(version) AS max_ver
 		     FROM entity_versions
-		     WHERE tenant_id = ? AND entity_id = ? AND submit_time < ?
+		     WHERE tenant_id = ? AND entity_id = ? AND submit_time <= ?
 		     GROUP BY entity_id
 		 ) latest ON ev.entity_id = latest.entity_id AND ev.version = latest.max_ver
 		 WHERE ev.tenant_id = ?`,
@@ -545,9 +541,6 @@ func (s *entityStore) getAllTx(ctx context.Context, tx *spi.TransactionState, mo
 }
 
 func (s *entityStore) GetAllAsAt(ctx context.Context, modelRef spi.ModelRef, asAt time.Time) ([]*spi.Entity, error) {
-	// Round asAt up to the next millisecond boundary.
-	asAt = asAt.Truncate(time.Millisecond).Add(time.Millisecond)
-
 	asAtMicro := timeToMicro(asAt)
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT ev.entity_id, ev.model_name, ev.model_version, ev.version,
@@ -556,7 +549,7 @@ func (s *entityStore) GetAllAsAt(ctx context.Context, modelRef spi.ModelRef, asA
 		 INNER JOIN (
 		     SELECT entity_id, MAX(version) AS max_ver
 		     FROM entity_versions
-		     WHERE tenant_id = ? AND model_name = ? AND model_version = ? AND submit_time < ?
+		     WHERE tenant_id = ? AND model_name = ? AND model_version = ? AND submit_time <= ?
 		     GROUP BY entity_id
 		 ) latest ON ev.entity_id = latest.entity_id AND ev.version = latest.max_ver
 		 WHERE ev.tenant_id = ? AND ev.change_type != 'DELETED'`,

--- a/plugins/sqlite/entity_store.go
+++ b/plugins/sqlite/entity_store.go
@@ -380,9 +380,8 @@ func (s *entityStore) getDirect(ctx context.Context, entityID string) (*spi.Enti
 //
 // Snapshot-time convention: submit_time <= snapshotTime (non-strict).
 // This matches the memory plugin's !v.submitTime.After(snapshotTime) and is
-// used consistently across getSnapshot, getAllTx, DeleteAll tx, and
-// searchPointInTimeBase. The separate GetAsAt/GetAllAsAt queries use strict <
-// because they first round asAt up to the next millisecond boundary.
+// used consistently across getSnapshot, getAllTx, DeleteAll tx,
+// searchPointInTimeBase, GetAsAt, and GetAllAsAt.
 func (s *entityStore) getSnapshot(ctx context.Context, entityID string, snapshotTime time.Time) (*spi.Entity, error) {
 	snapshotMicro := timeToMicro(snapshotTime)
 	row := s.db.QueryRowContext(ctx,

--- a/plugins/sqlite/pit_boundary_test.go
+++ b/plugins/sqlite/pit_boundary_test.go
@@ -1,0 +1,72 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/sqlite"
+)
+
+var pitBase = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// pitTwoVersions saves v1 at pitBase and v2 300µs later (same millisecond),
+// driven by a deterministic TestClock.
+func pitTwoVersions(t *testing.T) (*sqlite.StoreFactory, context.Context) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "pit.db")
+	clock := sqlite.NewTestClockAt(pitBase)
+	factory, err := sqlite.NewStoreFactoryForTest(context.Background(), dbPath, sqlite.WithClock(clock))
+	if err != nil {
+		t.Fatalf("create factory: %v", err)
+	}
+	t.Cleanup(func() { factory.Close() })
+
+	ctx := testCtx("tenant-1")
+	store, _ := factory.EntityStore(ctx)
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+
+	e := &spi.Entity{
+		Meta: spi.EntityMeta{ID: "e-pit", ModelRef: ref, State: "NEW"},
+		Data: []byte(`{"v":1}`),
+	}
+	if _, err := store.Save(ctx, e); err != nil {
+		t.Fatalf("Save v1: %v", err)
+	}
+	clock.Advance(300 * time.Microsecond)
+	e.Data = []byte(`{"v":2}`)
+	if _, err := store.Save(ctx, e); err != nil {
+		t.Fatalf("Save v2: %v", err)
+	}
+	return factory, ctx
+}
+
+func TestSqlitePIT_GetAsAt_InclusiveExactT(t *testing.T) {
+	factory, ctx := pitTwoVersions(t)
+	store, _ := factory.EntityStore(ctx)
+
+	got, err := store.GetAsAt(ctx, "e-pit", pitBase)
+	if err != nil {
+		t.Fatalf("GetAsAt(pitBase): %v", err)
+	}
+	if string(got.Data) != `{"v":1}` {
+		t.Errorf("GetAsAt(pitBase) = %s, want {\"v\":1} (inclusive of exactly T, no round-up)", got.Data)
+	}
+}
+
+func TestSqlitePIT_GetAllAsAt_InclusiveExactT(t *testing.T) {
+	factory, ctx := pitTwoVersions(t)
+	store, _ := factory.EntityStore(ctx)
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+
+	got, err := store.GetAllAsAt(ctx, ref, pitBase)
+	if err != nil {
+		t.Fatalf("GetAllAsAt(pitBase): %v", err)
+	}
+	if len(got) != 1 || string(got[0].Data) != `{"v":1}` {
+		t.Errorf("GetAllAsAt(pitBase) = %v entities, want 1 with {\"v\":1}", len(got))
+	}
+}

--- a/plugins/sqlite/pit_boundary_test.go
+++ b/plugins/sqlite/pit_boundary_test.go
@@ -67,6 +67,10 @@ func TestSqlitePIT_GetAllAsAt_InclusiveExactT(t *testing.T) {
 		t.Fatalf("GetAllAsAt(pitBase): %v", err)
 	}
 	if len(got) != 1 || string(got[0].Data) != `{"v":1}` {
-		t.Errorf("GetAllAsAt(pitBase) = %v entities, want 1 with {\"v\":1}", len(got))
+		var firstData string
+		if len(got) > 0 {
+			firstData = string(got[0].Data)
+		}
+		t.Errorf("GetAllAsAt(pitBase): got %d entities, data=%s; want 1 with {\"v\":1}", len(got), firstData)
 	}
 }

--- a/plugins/sqlite/pit_consistency_test.go
+++ b/plugins/sqlite/pit_consistency_test.go
@@ -1,0 +1,63 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/sqlite"
+)
+
+// At a same-millisecond boundary, the version selected by Search (raw <=)
+// must be the same version GetAsAt re-fetches. Pre-fix, Search matched v1
+// (city=Berlin) at pitBase while rounded GetAsAt resolved v2 (city=Munich).
+func TestSqlitePIT_SearchSelectMatchesGetAsAtRefetch(t *testing.T) {
+	dir := t.TempDir()
+	clock := sqlite.NewTestClockAt(pitBase) // pitBase from pit_boundary_test.go
+	factory, err := sqlite.NewStoreFactoryForTest(
+		context.Background(), filepath.Join(dir, "c.db"), sqlite.WithClock(clock))
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	t.Cleanup(func() { factory.Close() })
+
+	ctx := testCtx("tenant-1")
+	store, _ := factory.EntityStore(ctx)
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+
+	e := &spi.Entity{
+		Meta: spi.EntityMeta{ID: "e-c", ModelRef: ref, State: "NEW"},
+		Data: []byte(`{"city":"Berlin"}`),
+	}
+	if _, err := store.Save(ctx, e); err != nil { // v1 @ pitBase
+		t.Fatalf("save v1: %v", err)
+	}
+	clock.Advance(300 * time.Microsecond)
+	e.Data = []byte(`{"city":"Munich"}`)
+	if _, err := store.Save(ctx, e); err != nil { // v2 @ pitBase+300µs
+		t.Fatalf("save v2: %v", err)
+	}
+
+	pit := pitBase
+	searcher := store.(spi.Searcher)
+	results, err := searcher.Search(ctx,
+		spi.Filter{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Berlin"},
+		spi.SearchOptions{ModelName: "person", ModelVersion: "1", PointInTime: &pit})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Search(city=Berlin, as-at pitBase) returned %d, want 1", len(results))
+	}
+
+	// Re-fetch the selected entity at the same instant: must agree (Berlin).
+	got, err := store.GetAsAt(ctx, "e-c", pit)
+	if err != nil {
+		t.Fatalf("GetAsAt re-fetch: %v", err)
+	}
+	if string(got.Data) != `{"city":"Berlin"}` {
+		t.Errorf("re-fetch = %s, want {\"city\":\"Berlin\"} (select/re-fetch disagree at boundary)", got.Data)
+	}
+}


### PR DESCRIPTION
## Summary

Point-in-time ("as at T") reads did not apply one consistent rule for bounding the snapshot timestamp, so different storage engines — and different read paths within one engine — could return different historical version sets for the same query. This adopts **one canonical rule** and applies it uniformly:

> **Inclusive `<=`, compared at the engine's native stored precision, with no millisecond round-up.**

### What was wrong (two axes)

- **Uneven round-up.** `GetAsAt`/`GetAllAsAt` and every memory PIT path rounded the requested time up to the next millisecond (`Truncate(ms).Add(ms)`) before comparing, over-including later same-millisecond versions by up to ~1 ms. The SQL Search/Iterate/grouped-stats paths bound the raw time. The "clients work at ms" premise was never a real contract — input is parsed as RFC 3339 (arbitrary precision) and timestamps are emitted at nanosecond precision.
- **Strictness drift.** sqlite `GetAsAt`/`GetAllAsAt` used strict `<` (the round-up masked it); memory/postgres used `<=`.

This also caused user-visible **self-inconsistency**: async search selected IDs via `Search` (raw `<=`) but re-fetched via `GetAsAt` (rounded), so a selected entity could re-fetch to a different version or `ENTITY_NOT_FOUND` at a boundary.

## Changes

- Removed all **7** `Truncate(ms).Add(ms)` round-up sites: memory ×3 (`entity_store.go` GetAsAt/GetAllAsAt, `grouped_stats.go` buildSnapshot), sqlite ×2, postgres ×2.
- Flipped sqlite `GetAsAt`/`GetAllAsAt` from strict `<` to inclusive `<=`.
- All other PIT paths were already raw inclusive `<=` and become consistent automatically; transaction-snapshot reads were never rounded and are untouched.
- The commercial backend was already canonical (inclusive `<=`, no rounding) at millisecond precision — **no change**; the new parity scenario verifies convergence on its next dependency bump.
- Documented the contract (inclusive-of-T, no rounding, native precision, **millisecond cross-backend fidelity floor**) in the `crud` help topic, cross-referenced from `search`/`analytics`; CHANGELOG entry under `[Unreleased]`.

## Tests

- **Per-engine white-box boundary tests** (memory/sqlite/postgres) with hand-placed same-millisecond timestamps: a version at exactly `T` is included; a later sub-millisecond version is not over-included; sqlite's `<`→`<=` is exercised.
- **Cross-backend parity scenario** `PITBoundaryExactT` (registered in `e2e/parity`) asserting exact-T inclusivity at millisecond granularity — runs on memory/sqlite/postgres and the commercial backend.
- **Isolated sqlite** async select/re-fetch self-consistency test.
- `make test-all` green; `go vet` clean (all 4 modules); `make race` clean.

## Design & review trail

- Spec: `docs/superpowers/specs/2026-06-27-pit-semantics-canonicalization-design.md`
- Plan: `docs/superpowers/plans/2026-06-27-pit-semantics-canonicalization.md`
- Two independent fresh-context spec reviews + per-task reviews + a final whole-branch review (all clean).

Prerequisite for the PostgreSQL predicate-pushdown work (#37), which consumes this canonical bound and introduces no PIT-bound logic of its own.

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
