### PR TITLE
feat(postgres): search predicate pushdown (spi.Searcher)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ## [Unreleased]
 
+### Changed
+
+- PostgreSQL search now pushes supported predicates into SQL (JSONB `->>`
+  extraction, numeric/range/string comparisons) instead of loading every entity
+  of a model and filtering them in memory. Non-pushable operators (regex,
+  case-insensitive) are post-filtered while rows stream, and `LIMIT`/`OFFSET`
+  are pushed into SQL when no residual remains. This is a constant-factor win —
+  no full-result wire transfer, no decode of every document, filtering and
+  pagination done in the database — not a JSON-path-index speedup; adding
+  indexes on queried paths remains a separate operational step. SQLite already
+  did this; the memory backend keeps filtering in memory by design.
+  ([#37](https://github.com/Cyoda-platform/cyoda-go/issues/37))
+
 ### Fixed
 
 - Point-in-time ("as at T") reads now apply one canonical rule across all

--- a/docs/superpowers/plans/2026-06-28-postgres-searcher-pushdown.md
+++ b/docs/superpowers/plans/2026-06-28-postgres-searcher-pushdown.md
@@ -1,0 +1,1015 @@
+# PostgreSQL Search Predicate Pushdown (`spi.Searcher`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the PostgreSQL storage plugin implement `spi.Searcher` so entity searches push supported predicates into SQL (JSONB `->>` / numeric / range / string ops) instead of fetching every entity and filtering in memory.
+
+**Architecture:** Add `Search(ctx, filter, opts)` to the postgres `*entityStore`, mirroring the existing SQLite `Searcher`. It reuses the already-present query substrate — `planQuery` (pushable/residual split, `query_planner.go`), `postgresIter` + `evalPostFilter` (streaming residual eval, `grouped_stats.go`), `shiftPlaceholders`, and `unmarshalEntityDoc`. A shared base-query helper is extracted from `Iterate` (Gate-6 dedup) and carries a fix for a latent point-in-time projection defect (B1). No SPI change, no new env vars, no Cassandra impact. The service layer (`internal/domain/search/service.go`) already delegates to `spi.Searcher` when `tx == nil`, so no service-layer change is needed.
+
+**Tech Stack:** Go 1.26+, `github.com/jackc/pgx/v5`, PostgreSQL JSONB, testcontainers-go (postgres plugin tests require Docker), `cyoda-go-spi` (pinned, unchanged).
+
+## Global Constraints
+
+- Go 1.26+; use `log/slog` only (no code here logs, but never `fmt.Printf`). Wrap errors with `fmt.Errorf("...: %w", err)`.
+- **No SPI change.** `spi.Searcher`, `spi.Filter`, `spi.SearchOptions`, `spi.OrderSpec` are already in the pinned SPI. Do **not** bump `go.mod`; `COMPATIBILITY.md` is unaffected.
+- **Parity invariant:** the postgres pushable-op set (`isPushable` in `query_planner.go`) MUST stay identical to SQLite's. This plan does **not** change `isPushable` — do not touch it.
+- **Outer-projection invariant (S-1):** the outer search/iterate query MUST stay `SELECT doc` (one column) — `postgresIter` scans exactly one column (`it.rows.Scan(&doc)`, `grouped_stats.go:191`). The B1 fix adds columns to the **inner** `DISTINCT ON` only, never the outer select.
+- **PIT bound is canonical (#349/#350):** point-in-time uses raw inclusive `valid_time <= $N`, no rounding. Do not introduce `Truncate`/`Add(...Millisecond)`.
+- **Security (Gate 3):** every interpolated JSON path MUST pass `validateJSONPath` before reaching SQL. Tenant isolation is enforced by `tenant_id = $1` in every base query — never remove it.
+- **Postgres placeholders are `$N`** (1-based, positional), unlike SQLite's `?`. The pushdown WHERE fragment from `planQuery` starts at `$1` and MUST be renumbered via `shiftPlaceholders(frag, len(baseArgs))` before appending.
+- Plugin submodules have their own `go.mod`; run postgres tests with `cd plugins/postgres && go test ./...` (Docker required) — root `./...` does not recurse into them.
+
+Reference spec: `docs/superpowers/specs/2026-06-27-postgres-searcher-pushdown-design.md`.
+
+---
+
+## File Structure
+
+- **Create** `plugins/postgres/search_base.go` — `searchBaseQuery(entityName, modelVersion string, pit *time.Time) (string, []any)`, the shared current-state / point-in-time base SELECT used by both `Iterate` and `Search`.
+- **Create** `plugins/postgres/searcher.go` — `Search` (the `spi.Searcher` impl), `orderByClause`, `orderByFieldExpr`, and the `var _ spi.Searcher` assertion.
+- **Create** `plugins/postgres/searcher_test.go` — postgres-plugin unit tests (operators, residual, pagination, order, injection, point-in-time).
+- **Modify** `plugins/postgres/grouped_stats.go` — `Iterate` calls `searchBaseQuery` instead of building the base query inline (Gate-6 dedup).
+- **Modify** `plugins/postgres/path_validation.go` — add `validateOrderSpecs`.
+- **Modify** `e2e/parity/client/http.go` — add `SyncSearchAt` (point-in-time sync search helper).
+- **Create** `e2e/parity/search_pit.go` — `RunSearchPointInTime` cross-backend parity scenario.
+- **Modify** `e2e/parity/registry.go` — register `{"SearchPointInTime", RunSearchPointInTime}`.
+- **Modify** `CHANGELOG.md` — additive performance entry.
+
+---
+
+## Task 1: Extract shared base-query helper from `Iterate` (Gate-6 dedup, pure refactor)
+
+Carve the current-state / point-in-time base SELECT out of `Iterate` into a reusable helper so `Search` (Task 2) builds on the same literals. **Behavior-preserving** — this task copies the *existing* (still-unfixed) PIT query shape verbatim; the B1 fix lands in Task 3.
+
+**Files:**
+- Create: `plugins/postgres/search_base.go`
+- Modify: `plugins/postgres/grouped_stats.go:77-104` (the `Iterate` base-query construction)
+- Test: `plugins/postgres/grouped_stats_test.go` (existing `TestPostgresIterate_*` are the regression guard)
+
+**Interfaces:**
+- Produces: `func (s *entityStore) searchBaseQuery(entityName, modelVersion string, pit *time.Time) (string, []any)` — returns the base SQL (outer `SELECT doc`) and its positional args (`$1`=tenant, `$2`=name, `$3`=version, and for PIT `$4`=pit). Consumed by `Iterate` (this task) and `Search` (Task 2).
+
+- [ ] **Step 1: Create the helper, copying `Iterate`'s current query verbatim**
+
+Create `plugins/postgres/search_base.go`:
+
+```go
+package postgres
+
+import "time"
+
+// searchBaseQuery builds the base SELECT over a model for current-state
+// (pit == nil) or point-in-time (pit != nil) reads. The outer projection is
+// always `SELECT doc` (one column) — the S-1 invariant the row scanner
+// (postgresIter, grouped_stats.go) depends on.
+//
+// Positional args: $1 tenant, $2 entityName, $3 modelVersion, and for PIT
+// $4 the snapshot time. Callers append a pushdown WHERE fragment with
+// shiftPlaceholders(frag, len(args)) and (for Search) ORDER BY / LIMIT / OFFSET.
+//
+// PIT uses the canonical inclusive bound valid_time <= $4 (no rounding; #349).
+// Shared by Iterate and Search so both stay in lock-step.
+func (s *entityStore) searchBaseQuery(entityName, modelVersion string, pit *time.Time) (string, []any) {
+	tid := string(s.tenantID)
+	if pit != nil {
+		// Bi-temporal snapshot: inner DISTINCT ON picks the latest version per
+		// entity visible at the snapshot; outer drops deletion-marker versions
+		// AFTER the DISTINCT ON (so a delete shadows an older live version).
+		baseQuery := `SELECT doc FROM (
+		                SELECT DISTINCT ON (entity_id) doc
+		                FROM entity_versions
+		                WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3
+		                  AND valid_time <= $4
+		                  AND transaction_time <= CURRENT_TIMESTAMP
+		                ORDER BY entity_id, valid_time DESC, transaction_time DESC
+		             ) latest
+		             WHERE (doc->'_meta'->>'deleted')::boolean IS NOT TRUE`
+		return baseQuery, []any{tid, entityName, modelVersion, *pit}
+	}
+	baseQuery := `SELECT doc
+	             FROM entities
+	             WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3 AND NOT deleted`
+	return baseQuery, []any{tid, entityName, modelVersion}
+}
+```
+
+- [ ] **Step 2: Point `Iterate` at the helper**
+
+In `plugins/postgres/grouped_stats.go`, replace the inline base-query block (currently `grouped_stats.go:77-104`, the `tid := ...` through the `if opts.PointInTime != nil { ... } else { ... }` that sets `baseQuery`/`baseArgs`) with:
+
+```go
+	baseQuery, baseArgs := s.searchBaseQuery(model.EntityName, model.ModelVersion, opts.PointInTime)
+```
+
+Leave the rest of `Iterate` unchanged (the `if plan.where != "" { shifted := shiftPlaceholders(...) ... }` block and the `s.q.Query(...)` call still apply). Remove the now-unused `tid` local if the compiler flags it (it moved into the helper).
+
+- [ ] **Step 3: Run the Iterate regression tests — expect PASS (no behavior change)**
+
+Run: `cd plugins/postgres && go test ./... -run 'TestPostgresIterate' -v`
+Expected: PASS (Docker must be running). The base SQL is byte-identical to before, so every Iterate test — current-state and point-in-time — still passes.
+
+- [ ] **Step 4: Vet and commit**
+
+Run: `cd plugins/postgres && go vet ./...`
+Expected: clean.
+
+```bash
+git add plugins/postgres/search_base.go plugins/postgres/grouped_stats.go
+git commit -m "refactor(postgres): extract shared searchBaseQuery from Iterate
+
+Gate-6 dedup ahead of spi.Searcher: Iterate's current-state / point-in-time
+base SELECT moves into searchBaseQuery so Search reuses the same literals.
+Behavior-preserving; the PIT projection fix lands next.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Implement current-state `Search` (`spi.Searcher`)
+
+Add the `Search` method covering current-state queries: pushdown WHERE, residual post-filter, default + explicit `ORDER BY`, SQL/Go pagination, and injection-safe order-spec validation. Point-in-time is deliberately left for Task 3 (its B1 defect needs its own RED test).
+
+**Files:**
+- Create: `plugins/postgres/searcher.go`
+- Modify: `plugins/postgres/path_validation.go` (add `validateOrderSpecs`)
+- Test: `plugins/postgres/searcher_test.go`
+
+**Interfaces:**
+- Consumes: `searchBaseQuery` (Task 1); `planQuery`, `shiftPlaceholders`, `fieldExpr`, `directMetaColumns`, `jsonbExtractText`, `validateFilterPaths`, `validateJSONPath`, `postgresIter`, `unmarshalEntityDoc` (all already present).
+- Produces: `func (s *entityStore) Search(ctx context.Context, filter spi.Filter, opts spi.SearchOptions) ([]*spi.Entity, error)` (satisfies `spi.Searcher`); `validateOrderSpecs([]spi.OrderSpec) error`; `orderByClause(spi.SearchOptions) string`; `orderByFieldExpr(spi.OrderSpec) string`.
+
+- [ ] **Step 1: Write the failing test (current-state Eq + numeric Gt/Between, AND, OR, residual, pagination, order, injection)**
+
+Create `plugins/postgres/searcher_test.go`. It mirrors `plugins/sqlite/searcher_test.go` and reuses the existing postgres harness (`setupEntityTest`, `ctxWithTenant` from the `postgres_test` package). All values that exercise numeric translation use real numbers (spec caveat S4).
+
+```go
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/postgres"
+)
+
+var searchModel = spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+
+// setupSearcher seeds five people and returns a store + ctx. Numeric `age`
+// drives EQ/GT/BETWEEN through cyoda_try_float8 (S4: numeric paths must run
+// against a live backend, not just string-asserted).
+func setupSearcher(t *testing.T) (spi.EntityStore, context.Context) {
+	t.Helper()
+	factory := setupEntityTest(t)
+	ctx := ctxWithTenant("search-tenant")
+	store, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore: %v", err)
+	}
+	seed := []struct {
+		id, data string
+	}{
+		{"e1", `{"name":"Alice","age":30,"city":"Berlin"}`},
+		{"e2", `{"name":"Bob","age":25,"city":"Munich"}`},
+		{"e3", `{"name":"Charlie","age":35,"city":"Berlin"}`},
+		{"e4", `{"name":"Diana","age":28,"city":"Hamburg"}`},
+		{"e5", `{"name":"Eve","age":40,"city":"Munich"}`},
+	}
+	for _, s := range seed {
+		if _, err := store.Save(ctx, &spi.Entity{
+			Meta: spi.EntityMeta{ID: s.id, ModelRef: searchModel, State: "NEW"},
+			Data: []byte(s.data),
+		}); err != nil {
+			t.Fatalf("Save %s: %v", s.id, err)
+		}
+	}
+	return store, ctx
+}
+
+func searcherOf(t *testing.T, store spi.EntityStore) spi.Searcher {
+	t.Helper()
+	sr, ok := store.(spi.Searcher)
+	if !ok {
+		t.Fatal("postgres entityStore does not implement spi.Searcher")
+	}
+	return sr
+}
+
+func baseOpts() spi.SearchOptions {
+	return spi.SearchOptions{ModelName: "person", ModelVersion: "1"}
+}
+
+func TestPGSearcher_Eq(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Berlin"},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("city=Berlin: want 2, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_GtNumeric(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterGt, Path: "age", Source: spi.SourceData, Value: float64(30)},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 2 { // Charlie 35, Eve 40
+		t.Fatalf("age>30: want 2, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_BetweenNumeric(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterBetween, Path: "age", Source: spi.SourceData,
+			Values: []any{float64(28), float64(35)}},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 3 { // 30, 35, 28
+		t.Fatalf("age in [28,35]: want 3, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_And(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{
+		Op: spi.FilterAnd,
+		Children: []spi.Filter{
+			{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Berlin"},
+			{Op: spi.FilterGt, Path: "age", Source: spi.SourceData, Value: float64(31)},
+		},
+	}, baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 1 { // Charlie (Berlin, 35)
+		t.Fatalf("Berlin AND age>31: want 1, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_Or(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{
+		Op: spi.FilterOr,
+		Children: []spi.Filter{
+			{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Hamburg"},
+			{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Munich"},
+		},
+	}, baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 3 { // Bob, Eve (Munich), Diana (Hamburg)
+		t.Fatalf("Hamburg OR Munich: want 3, got %d", len(got))
+	}
+}
+
+// FilterMatchesRegex is non-pushable → becomes a residual evaluated by
+// postgresIter/evalPostFilter. Proves the residual path runs under Search.
+func TestPGSearcher_ResidualRegex(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterMatchesRegex, Path: "name", Source: spi.SourceData, Value: "^A"},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 1 { // Alice
+		t.Fatalf("name ~ ^A: want 1, got %d", len(got))
+	}
+}
+
+// Mixed: pushable city=Berlin AND residual regex on name.
+func TestPGSearcher_MixedPushAndResidual(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{
+		Op: spi.FilterAnd,
+		Children: []spi.Filter{
+			{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Berlin"},
+			{Op: spi.FilterMatchesRegex, Path: "name", Source: spi.SourceData, Value: "^C"},
+		},
+	}, baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 1 { // Charlie
+		t.Fatalf("Berlin AND name~^C: want 1, got %d", len(got))
+	}
+}
+
+// Pagination with NO residual → LIMIT/OFFSET pushed into SQL.
+func TestPGSearcher_PaginationNoResidual(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.Limit = 2
+	opts.Offset = 1
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{}, opts) // match-all, default order entity_id
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("limit 2 offset 1: want 2, got %d", len(got))
+	}
+}
+
+// Pagination WITH residual → LIMIT/OFFSET applied in Go after post-filter.
+func TestPGSearcher_PaginationWithResidual(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.Limit = 1
+	// Residual regex matching all five names (contains any letter), so the
+	// residual path is active and pagination is applied in Go.
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterMatchesRegex, Path: "name", Source: spi.SourceData, Value: "."},
+		opts)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("residual + limit 1: want 1, got %d", len(got))
+	}
+}
+
+// S1 guard: unbounded (Limit==0) + residual + non-zero offset must return the
+// correct page, not empty. A naive early-stop at offset+limit==offset breaks this.
+func TestPGSearcher_UnboundedOffsetWithResidual(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.Limit = 0 // unbounded
+	opts.Offset = 2
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterMatchesRegex, Path: "name", Source: spi.SourceData, Value: "."},
+		opts)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 3 { // 5 total, drop first 2
+		t.Fatalf("unbounded offset 2 + residual: want 3, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_OrderByDataPathDesc(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.OrderBy = []spi.OrderSpec{{Path: "name", Source: spi.SourceData, Desc: true}}
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{}, opts)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("want 5, got %d", len(got))
+	}
+	// Lexicographic desc: Eve, Diana, Charlie, Bob, Alice.
+	if string(got[0].Data) == "" || got[0].Meta.ID != "e5" {
+		t.Errorf("desc by name: want first=Eve(e5), got id=%s", got[0].Meta.ID)
+	}
+}
+
+func TestPGSearcher_InjectionFilterPath(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	_, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterEq, Path: "city'); DROP TABLE entities;--", Source: spi.SourceData, Value: "x"},
+		baseOpts())
+	if !errors.Is(err, postgres.ErrInvalidFilterPath) {
+		t.Fatalf("want ErrInvalidFilterPath, got %v", err)
+	}
+}
+
+func TestPGSearcher_InjectionOrderPath(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.OrderBy = []spi.OrderSpec{{Path: "name'); DROP TABLE entities;--", Source: spi.SourceData}}
+	_, err := searcherOf(t, store).Search(ctx, spi.Filter{}, opts)
+	if !errors.Is(err, postgres.ErrInvalidFilterPath) {
+		t.Fatalf("want ErrInvalidFilterPath for order path, got %v", err)
+	}
+}
+
+func TestPGSearcher_TenantIsolation(t *testing.T) {
+	// One factory (one database), two tenants. Tenant A is seeded with a
+	// Berlin entity; tenant B searches the same model and must see none of A's
+	// rows — every base query filters tenant_id = $1.
+	factory := setupEntityTest(t)
+	ctxA := ctxWithTenant("tenant-a")
+	ctxB := ctxWithTenant("tenant-b")
+
+	storeA, err := factory.EntityStore(ctxA)
+	if err != nil {
+		t.Fatalf("EntityStore A: %v", err)
+	}
+	if _, err := storeA.Save(ctxA, &spi.Entity{
+		Meta: spi.EntityMeta{ID: "a1", ModelRef: searchModel, State: "NEW"},
+		Data: []byte(`{"name":"Alice","city":"Berlin"}`),
+	}); err != nil {
+		t.Fatalf("Save A: %v", err)
+	}
+
+	storeB, err := factory.EntityStore(ctxB)
+	if err != nil {
+		t.Fatalf("EntityStore B: %v", err)
+	}
+	got, err := searcherOf(t, storeB).Search(ctxB,
+		spi.Filter{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Berlin"},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search B: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("cross-tenant leak: tenant B saw %d of tenant A's rows, want 0", len(got))
+	}
+}
+
+// Compile-time guard mirrored as a runtime assertion for clarity.
+func TestPGSearcher_ImplementsSearcher(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	if _, ok := store.(spi.Searcher); !ok {
+		t.Fatal("postgres entityStore must implement spi.Searcher")
+	}
+	_ = ctx
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they FAIL to compile (no `Search` method yet)**
+
+Run: `cd plugins/postgres && go test ./... -run 'TestPGSearcher' -v`
+Expected: build failure — `store.(spi.Searcher)` is never satisfied / `Search` undefined. (If Docker is off, the harness skips; ensure Docker is running so the failure is the real one.)
+
+- [ ] **Step 3: Add `validateOrderSpecs` to `path_validation.go`**
+
+Append to `plugins/postgres/path_validation.go`:
+
+```go
+// validateOrderSpecs checks every OrderSpec.Path against the same dotted-
+// identifier grammar as filter paths. Empty paths (direct-column / default
+// ordering) are skipped. MUST be called at the Search() boundary before any
+// OrderSpec.Path is interpolated into SQL (injection invariant).
+func validateOrderSpecs(specs []spi.OrderSpec) error {
+	for _, sp := range specs {
+		if sp.Path == "" {
+			continue
+		}
+		if err := validateJSONPath(sp.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Create `searcher.go` with `Search`, `orderByClause`, `orderByFieldExpr`**
+
+Create `plugins/postgres/searcher.go`:
+
+```go
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// Compile-time check that *entityStore implements spi.Searcher.
+var _ spi.Searcher = (*entityStore)(nil)
+
+// Search implements spi.Searcher for the PostgreSQL entity store. Pushable
+// predicates go into the SQL WHERE via planQuery; the residual (regex /
+// case-insensitive ops) is evaluated in Go by postgresIter/evalPostFilter.
+//
+// Pagination: when there is no residual, LIMIT/OFFSET are pushed into SQL.
+// With a residual, rows are streamed, post-filtered, and offset/limit applied
+// in Go — early-stopping once offset+limit matches are gathered, but ONLY when
+// Limit > 0 (an unbounded Limit<=0 request must drain all matches before
+// applying the offset, else a naive offset+limit==offset stop returns empty).
+//
+// No scan budget (unlike sqlite): the production engine streams in SQL order
+// and bounds memory via the early-stop when a limit is set. An unbounded
+// request with a residual is O(n) memory — the same profile as the in-memory
+// fallback it replaces.
+func (s *entityStore) Search(ctx context.Context, filter spi.Filter, opts spi.SearchOptions) ([]*spi.Entity, error) {
+	if err := validateFilterPaths(filter); err != nil {
+		return nil, err
+	}
+	if err := validateOrderSpecs(opts.OrderBy); err != nil {
+		return nil, err
+	}
+
+	// Zero-value Filter means "match all" — skip planQuery (it would treat the
+	// empty Op as non-pushable and install the zero filter as a residual).
+	var plan sqlPlan
+	if filter.Op != "" {
+		plan = planQuery(filter)
+	}
+
+	baseQuery, baseArgs := s.searchBaseQuery(opts.ModelName, opts.ModelVersion, opts.PointInTime)
+
+	if plan.where != "" {
+		shifted := shiftPlaceholders(plan.where, len(baseArgs))
+		baseQuery += " AND (" + shifted + ")"
+		baseArgs = append(baseArgs, plan.args...)
+	}
+
+	baseQuery += orderByClause(opts)
+
+	// No residual → LIMIT/OFFSET in SQL.
+	if plan.postFilter == nil {
+		if opts.Limit > 0 {
+			baseQuery += fmt.Sprintf(" LIMIT $%d", len(baseArgs)+1)
+			baseArgs = append(baseArgs, opts.Limit)
+		}
+		if opts.Offset > 0 {
+			baseQuery += fmt.Sprintf(" OFFSET $%d", len(baseArgs)+1)
+			baseArgs = append(baseArgs, opts.Offset)
+		}
+	}
+
+	rows, err := s.q.Query(ctx, baseQuery, baseArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("search query: %w", err)
+	}
+	it := &postgresIter{ctx: ctx, rows: rows, postFilter: plan.postFilter}
+	defer it.Close()
+
+	var results []*spi.Entity
+
+	// No residual: SQL already applied LIMIT/OFFSET; collect everything.
+	if plan.postFilter == nil {
+		for it.Next() {
+			results = append(results, it.Entity())
+		}
+		if err := it.Err(); err != nil {
+			return nil, err
+		}
+		return results, nil
+	}
+
+	// Residual present: postgresIter yields only post-filter matches. Apply
+	// offset/limit in Go. Early-stop only when a limit is set (S1 guard).
+	for it.Next() {
+		results = append(results, it.Entity())
+		if opts.Limit > 0 && len(results) >= opts.Offset+opts.Limit {
+			break
+		}
+	}
+	if err := it.Err(); err != nil {
+		return nil, err
+	}
+	if opts.Offset > 0 {
+		if opts.Offset >= len(results) {
+			return nil, nil
+		}
+		results = results[opts.Offset:]
+	}
+	if opts.Limit > 0 && len(results) > opts.Limit {
+		results = results[:opts.Limit]
+	}
+	return results, nil
+}
+
+// orderByClause builds the SQL ORDER BY from opts.OrderBy. Empty → default
+// "ORDER BY entity_id" (a unique, never-null key, so pages are deterministic).
+// Bare column names resolve against the entities table (current-state) or the
+// `latest` derived table (point-in-time), both of which expose entity_id.
+func orderByClause(opts spi.SearchOptions) string {
+	if len(opts.OrderBy) == 0 {
+		return " ORDER BY entity_id"
+	}
+	clauses := make([]string, 0, len(opts.OrderBy))
+	for _, spec := range opts.OrderBy {
+		expr := orderByFieldExpr(spec)
+		if spec.Desc {
+			expr += " DESC"
+		}
+		clauses = append(clauses, expr)
+	}
+	return " ORDER BY " + strings.Join(clauses, ", ")
+}
+
+// orderByFieldExpr returns the SQL ordering expression for an OrderSpec,
+// reusing the filter field rules (directMetaColumns / doc->'_meta'->>'p' /
+// doc->>'p').
+//
+// Safety invariant: spec.Path is interpolated into a JSON-key literal and
+// MUST have been validated by validateOrderSpecs at the Search() boundary.
+func orderByFieldExpr(spec spi.OrderSpec) string {
+	if spec.Source == spi.SourceMeta {
+		if directMetaColumns[spec.Path] {
+			return spec.Path
+		}
+		return jsonbExtractText("doc->'_meta'", spec.Path)
+	}
+	return jsonbExtractText("doc", spec.Path)
+}
+```
+
+- [ ] **Step 5: Run the current-state tests to verify they PASS**
+
+Run: `cd plugins/postgres && go test ./... -run 'TestPGSearcher' -v`
+Expected: PASS for every `TestPGSearcher_*` (Docker required).
+
+- [ ] **Step 6: Confirm the service layer now drives pushdown (no change, just verify) and vet**
+
+Run: `cd plugins/postgres && go vet ./...`
+Expected: clean. (No service-layer edit — `internal/domain/search/service.go` already type-asserts `spi.Searcher` and uses it when `tx == nil`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add plugins/postgres/searcher.go plugins/postgres/path_validation.go plugins/postgres/searcher_test.go
+git commit -m "feat(postgres): implement spi.Searcher for current-state search
+
+Pushes supported predicates into SQL (JSONB ->>, numeric via cyoda_try_float8,
+range, string ops), post-filters the residual via postgresIter, and applies
+LIMIT/OFFSET in SQL (no residual) or Go (residual, with the Limit<=0 drain-then-
+offset guard). Structural ORDER BY parity with sqlite; order paths are
+injection-validated. Point-in-time covered next.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Point-in-time `Search` + B1 projection fix
+
+A point-in-time search appends `ORDER BY entity_id`, but the PIT base query's inner `DISTINCT ON` projects only `doc`, so `entity_id` is unresolved in the outer query — every PIT search fails at runtime. This task drives that defect out RED-first and fixes the inner projection in the shared helper (closing the latent `Iterate` gap too).
+
+**Files:**
+- Modify: `plugins/postgres/search_base.go` (inner `DISTINCT ON` projection)
+- Test: `plugins/postgres/searcher_test.go` (add the PIT test)
+
+**Interfaces:**
+- Consumes: `searchBaseQuery` (Task 1), the `pitSetup`-style version-seeding pattern from `plugins/postgres/pit_boundary_test.go`.
+- Produces: a working point-in-time `Search`; no new exported symbols.
+
+- [ ] **Step 1: Write the failing point-in-time search test**
+
+Add to `plugins/postgres/searcher_test.go`. It seeds two versions of one entity at distinct, deterministic `valid_time`s (the `pit_boundary_test.go` pattern: save twice, then force valid_times via direct SQL), then searches at the base timestamp and asserts the v1 snapshot is returned. The `factory.Pool()` accessor used here already exists (used by `pit_boundary_test.go`).
+
+```go
+import "time" // add to the existing import block
+
+// pitSearchSetup saves v1 (active) then v2 (inactive) of one entity, then
+// pins v1's valid_time to baseTS and v2's to 300µs later (same millisecond),
+// mirroring pit_boundary_test.go. Returns the store, ctx, and the base time.
+func pitSearchSetup(t *testing.T) (spi.EntityStore, context.Context, time.Time) {
+	t.Helper()
+	const (
+		tenant = "pit-search-tenant"
+		baseTS = "2026-02-01 00:00:00+00"
+		nextTS = "2026-02-01 00:00:00.000300+00"
+	)
+	factory := setupEntityTest(t)
+	ctx := ctxWithTenant(tenant)
+	store, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore: %v", err)
+	}
+	ent := &spi.Entity{
+		Meta: spi.EntityMeta{ID: "pp1", ModelRef: searchModel, State: "NEW"},
+		Data: []byte(`{"name":"Alice","status":"active"}`),
+	}
+	if _, err := store.Save(ctx, ent); err != nil {
+		t.Fatalf("Save v1: %v", err)
+	}
+	ent.Data = []byte(`{"name":"Alice","status":"inactive"}`)
+	if _, err := store.Save(ctx, ent); err != nil {
+		t.Fatalf("Save v2: %v", err)
+	}
+	pool := factory.Pool()
+	if _, err := pool.Exec(ctx,
+		`UPDATE entity_versions SET valid_time=$1, transaction_time=$1
+		 WHERE tenant_id=$2 AND entity_id=$3 AND version=1`, baseTS, tenant, "pp1"); err != nil {
+		t.Fatalf("pin v1: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE entity_versions SET valid_time=$1, transaction_time=$1
+		 WHERE tenant_id=$2 AND entity_id=$3 AND version=2`, nextTS, tenant, "pp1"); err != nil {
+		t.Fatalf("pin v2: %v", err)
+	}
+	base, err := time.Parse(time.RFC3339Nano, "2026-02-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+	return store, ctx, base
+}
+
+// At the base timestamp only v1 (status=active) is visible, so a search for
+// status=active returns the entity; a search for status=inactive returns none.
+// This is the test that catches the B1 inner-projection defect — without the
+// fix the query errors with `column "entity_id" does not exist` (default
+// ORDER BY entity_id over a derived table that only projected doc).
+func TestPGSearcher_PointInTimeDefaultOrder(t *testing.T) {
+	store, ctx, base := pitSearchSetup(t)
+	opts := spi.SearchOptions{ModelName: "person", ModelVersion: "1", PointInTime: &base}
+
+	active, err := store.(spi.Searcher).Search(ctx,
+		spi.Filter{Op: spi.FilterEq, Path: "status", Source: spi.SourceData, Value: "active"}, opts)
+	if err != nil {
+		t.Fatalf("Search active@base: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("status=active @base: want 1 (v1 snapshot), got %d", len(active))
+	}
+
+	inactive, err := store.(spi.Searcher).Search(ctx,
+		spi.Filter{Op: spi.FilterEq, Path: "status", Source: spi.SourceData, Value: "inactive"}, opts)
+	if err != nil {
+		t.Fatalf("Search inactive@base: %v", err)
+	}
+	if len(inactive) != 0 {
+		t.Fatalf("status=inactive @base: want 0 (v2 not yet visible), got %d", len(inactive))
+	}
+}
+```
+
+- [ ] **Step 2: Run it to verify it FAILS with the projection error**
+
+Run: `cd plugins/postgres && go test ./... -run 'TestPGSearcher_PointInTimeDefaultOrder' -v`
+Expected: FAIL — the query errors with something like `ERROR: column "entity_id" does not exist (SQLSTATE 42703)`, surfaced as `search query: ...`. This is the B1 defect manifesting.
+
+- [ ] **Step 3: Fix the inner projection in `searchBaseQuery`**
+
+In `plugins/postgres/search_base.go`, change the PIT branch's inner `DISTINCT ON` to also project the real `entity_versions` direct columns (so the outer `ORDER BY entity_id` and any direct-column pushdown resolve). The outer projection stays `SELECT doc`. Do **not** project `deleted` — it is doc-only on `entity_versions`.
+
+```go
+		baseQuery := `SELECT doc FROM (
+		                SELECT DISTINCT ON (entity_id)
+		                       entity_id, model_name, model_version, version, doc
+		                FROM entity_versions
+		                WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3
+		                  AND valid_time <= $4
+		                  AND transaction_time <= CURRENT_TIMESTAMP
+		                ORDER BY entity_id, valid_time DESC, transaction_time DESC
+		             ) latest
+		             WHERE (doc->'_meta'->>'deleted')::boolean IS NOT TRUE`
+```
+
+(Only the inner `SELECT DISTINCT ON (entity_id) doc` line changes — it becomes the multi-column projection above. Everything else in the helper is untouched.)
+
+- [ ] **Step 4: Run the PIT test to verify it PASSES**
+
+Run: `cd plugins/postgres && go test ./... -run 'TestPGSearcher_PointInTimeDefaultOrder' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole postgres suite to confirm no regression (Iterate now also benefits from the fix)**
+
+Run: `cd plugins/postgres && go test ./... -v 2>&1 | tail -30`
+Expected: PASS, including all `TestPostgresIterate_*` and `TestPGSearcher_*`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugins/postgres/search_base.go plugins/postgres/searcher_test.go
+git commit -m "fix(postgres): project direct columns in PIT inner DISTINCT ON (B1)
+
+A point-in-time search appends ORDER BY entity_id, but the PIT base query's
+inner DISTINCT ON projected only doc, so entity_id was unresolved and every
+PIT search errored. Project entity_id/model_name/model_version/version on the
+inner select (outer stays SELECT doc; deleted is doc-only, not projected).
+Also closes the latent same-shape gap in Iterate, which shares the helper.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Cross-backend parity scenario `RunSearchPointInTime`
+
+Add the one genuinely backend-agnostic new behavior to the parity suite: a predicate search at a snapshot, asserting pushdown ≡ in-memory across memory / sqlite / postgres (and the commercial backend). Needs a point-in-time sync-search client helper.
+
+**Files:**
+- Modify: `e2e/parity/client/http.go` (add `SyncSearchAt`)
+- Create: `e2e/parity/search_pit.go`
+- Modify: `e2e/parity/registry.go` (register the scenario)
+- Test: the scenario itself runs under `TestParity` across backends.
+
+**Interfaces:**
+- Consumes: `client.Client` (`CreateEntity`, `UpdateEntityData`, `GetEntityChanges`, the new `SyncSearchAt`); `BackendFixture`; the `searchWorkflowJSON`/`setupSearchModel` helpers in `e2e/parity/search.go`; the `pit_boundary.go` timing pattern.
+- Produces: `func RunSearchPointInTime(t *testing.T, fixture BackendFixture)`; `func (c *Client) SyncSearchAt(t *testing.T, modelName string, modelVersion int, condition string, at time.Time) ([]EntityResult, error)`.
+
+- [ ] **Step 1: Add the `SyncSearchAt` client helper**
+
+In `e2e/parity/client/http.go`, immediately after `SyncSearch` (ends ~line 1218), add a point-in-time variant. It targets the same direct-search endpoint with a `pointInTime` query param (the handler reads `params.PointInTime`, `internal/domain/search/handler.go:126`) and parses the same NDJSON response.
+
+```go
+// SyncSearchAt issues POST /api/search/direct/{name}/{version}?pointInTime=<t>
+// with the given condition JSON and returns the entity results at the snapshot.
+// Mirrors SyncSearch (NDJSON response); the direct-search handler honours the
+// pointInTime query param.
+func (c *Client) SyncSearchAt(t *testing.T, modelName string, modelVersion int, condition string, at time.Time) ([]EntityResult, error) {
+	t.Helper()
+	path := fmt.Sprintf("/api/search/direct/%s/%d?pointInTime=%s",
+		modelName, modelVersion, at.UTC().Format(time.RFC3339Nano))
+	raw, err := c.doRaw(t, http.MethodPost, path, condition)
+	if err != nil {
+		return nil, err
+	}
+	var results []EntityResult
+	for _, line := range strings.Split(strings.TrimRight(string(raw), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var r EntityResult
+		dec := json.NewDecoder(strings.NewReader(line))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&r); err != nil {
+			return nil, fmt.Errorf("decode NDJSON line: %w", err)
+		}
+		results = append(results, r)
+	}
+	return results, nil
+}
+```
+
+(`time`, `net/http`, `strings`, `encoding/json`, `fmt` are already imported in `http.go`.)
+
+- [ ] **Step 2: Write the parity scenario**
+
+Create `e2e/parity/search_pit.go`. The timing mirrors `pit_boundary.go`: space writes ≥1ms apart, capture each version's change time via `GetEntityChanges`, then search at the captured snapshot.
+
+```go
+package parity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
+)
+
+// RunSearchPointInTime asserts that a predicate search at a snapshot returns
+// the snapshot-correct result set on every backend — exercising the Searcher
+// (or in-memory fallback) through a point-in-time read. It is the cross-engine
+// guard for predicate-pushdown ≡ in-memory at a PIT, and the parity counterpart
+// to the postgres B1 projection unit test.
+func RunSearchPointInTime(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "parity-search-pit"
+	const modelVersion = 1
+	setupSearchModel(t, c, modelName, modelVersion)
+
+	// v1: status=active.
+	id, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Alice","status":"active"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	t1 := latestChangeTime(t, c, id)
+
+	// Space ≥1ms so v2 lands in a distinct millisecond (commercial backend
+	// stores ms precision — see pit_boundary.go rationale).
+	time.Sleep(2 * time.Millisecond)
+	if err := c.UpdateEntityData(t, id, `{"name":"Alice","status":"inactive"}`); err != nil {
+		t.Fatalf("UpdateEntityData: %v", err)
+	}
+	t2 := latestChangeTime(t, c, id)
+	if !t1.Before(t2) {
+		t.Fatalf("version timestamps not increasing: t1=%s t2=%s",
+			t1.Format(time.RFC3339Nano), t2.Format(time.RFC3339Nano))
+	}
+
+	activeCond := `{"type":"simple","jsonPath":"$.status","operatorType":"EQUALS","value":"active"}`
+
+	// At t1 the snapshot shows status=active → 1 hit.
+	at1, err := c.SyncSearchAt(t, modelName, modelVersion, activeCond, t1)
+	if err != nil {
+		t.Fatalf("SyncSearchAt(t1): %v", err)
+	}
+	if len(at1) != 1 {
+		t.Errorf("status=active @t1: want 1, got %d", len(at1))
+	}
+
+	// At t2 the snapshot shows status=inactive → the active search misses.
+	at2, err := c.SyncSearchAt(t, modelName, modelVersion, activeCond, t2)
+	if err != nil {
+		t.Fatalf("SyncSearchAt(t2): %v", err)
+	}
+	if len(at2) != 0 {
+		t.Errorf("status=active @t2: want 0 (now inactive), got %d", len(at2))
+	}
+}
+
+// latestChangeTime returns the most recent change timestamp for the entity.
+func latestChangeTime(t *testing.T, c *client.Client, id interface{ String() string }) time.Time {
+	t.Helper()
+	// id is a uuid.UUID; reuse the pit_boundary helper signature.
+	return pitbLatestChangeTime(t, c, mustUUID(id))
+}
+```
+
+Note on the helper: `pit_boundary.go` already defines `pitbLatestChangeTime(t, c, uuid.UUID)`. To avoid a second copy, **do not** add `latestChangeTime`/`mustUUID` above — instead call `pitbLatestChangeTime` directly with the `uuid.UUID` that `CreateEntity` returns. Replace the two `latestChangeTime(t, c, id)` calls with `pitbLatestChangeTime(t, c, id)` and delete the `latestChangeTime`/`mustUUID` shim. (`CreateEntity` returns `uuid.UUID`, matching `pitbLatestChangeTime`'s signature.) Final imports: `testing`, `time`, and `client`.
+
+So the committed file uses `id` (a `uuid.UUID`) with `pitbLatestChangeTime(t, c, id)` and contains no shim helper.
+
+- [ ] **Step 3: Register the scenario**
+
+In `e2e/parity/registry.go`, add to the search block (after line 98, `{"SearchAfterUpdate", RunSearchAfterUpdate},`):
+
+```go
+	{"SearchPointInTime", RunSearchPointInTime},
+```
+
+- [ ] **Step 4: Build the parity package and run the scenario on the fast backends**
+
+Run: `go test ./e2e/parity/... -run 'TestParity' -v 2>&1 | grep -iE 'SearchPointInTime|FAIL|ok' | head`
+Expected: `SearchPointInTime` passes on the memory and sqlite fixtures (and postgres if that fixture runs in your environment; Docker required for postgres). If only memory/sqlite run locally, that is sufficient here — postgres parity also runs in CI.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/parity/client/http.go e2e/parity/search_pit.go e2e/parity/registry.go
+git commit -m "test(parity): add SearchPointInTime cross-backend scenario
+
+Predicate search at a snapshot must return the snapshot-correct set on every
+backend — the parity guard for pushdown ≡ in-memory at a PIT. Adds a
+point-in-time SyncSearchAt client helper.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: CHANGELOG + full verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the CHANGELOG entry**
+
+Open `CHANGELOG.md`, find the current unreleased section, and add under its performance/changed list (match the file's existing bullet style). Keep the wording bounded — constant-factor, not index-grade (no GIN index is added):
+
+```markdown
+- **Performance:** PostgreSQL search now pushes supported predicates into SQL
+  (JSONB operators, numeric/range/string comparisons) instead of loading every
+  entity of a model and filtering in memory. Non-pushable operators (regex,
+  case-insensitive) are post-filtered while streaming. This is a constant-factor
+  win (no full-result transfer/decode, DB-side filtering, LIMIT pushdown) — not
+  a JSON-path-index speedup; adding indexes remains a separate operational step.
+```
+
+- [ ] **Step 2: Commit the CHANGELOG**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): note PostgreSQL search predicate pushdown
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 3: Full verification — root module + postgres plugin**
+
+Run: `go build ./... && go vet ./...`
+Expected: clean.
+
+Run: `cd plugins/postgres && go vet ./... && go test ./... 2>&1 | tail -20`
+Expected: PASS (Docker required).
+
+Run (root, includes e2e + parity; Docker required): `go test ./... 2>&1 | tail -30`
+Expected: PASS. Pay attention to `e2e/parity` (the new scenario) and `internal/e2e` search tests.
+
+- [ ] **Step 4: Race sanity check (once, before PR)**
+
+Run: `make race`
+Expected: PASS. (Per `.claude/rules/race-testing.md`, this is the single end-of-deliverable race run; the target excludes `internal/e2e` by design.)
+
+- [ ] **Step 5: Verify the spec/plan are committed and the tree is clean**
+
+Run: `git status --short`
+Expected: clean (spec + plan already committed; all task commits landed).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- "Implement `spi.Searcher` on postgres `entityStore`" → Tasks 2 (current-state) + 3 (point-in-time). ✓
+- "Reuse existing substrate (`planQuery`/`evalPostFilter`/`postgresIter`/`shiftPlaceholders`/`unmarshalEntityDoc`)" → Task 2 `Search` reuses all. ✓
+- "B1 PIT projection fix (inner direct columns, outer stays `SELECT doc`, no `deleted`)" → Task 3. ✓
+- "Gate-6 dedup: shared base-query helper, parameterized by name+version, carrying the B1 fix; #350 left `grouped_stats.go` unchanged so #37 extracts it" → Task 1 (extract) + Task 3 (fix lands in the shared helper, benefiting Iterate). ✓
+- "No scan budget; early-stop only when Limit>0; Limit<=0 drain-then-offset" → Task 2 `Search` + `TestPGSearcher_UnboundedOffsetWithResidual`. ✓
+- "`OrderBy` structural parity; default `entity_id`; injection-validated paths" → Task 2 `orderByClause`/`orderByFieldExpr`/`validateOrderSpecs` + order tests + injection tests. ✓
+- "PIT bound = canonical raw `<=`, no rounding" → Task 1 helper uses `valid_time <= $4` verbatim; no `Truncate`. ✓
+- "Numeric EQ/GT/BETWEEN exercised live (S4)" → Task 2 uses `float64` values. ✓
+- "Coverage-matrix waiver (no new API/error/status)" → no endpoint/error-code task needed; the only domain error `ErrInvalidFilterPath` already has its help topic and pre-existing handling. ✓
+- "Required `RunSearchPointInTime` parity scenario" → Task 4. ✓
+- "CHANGELOG additive, wording bounded; no SPI bump / COMPATIBILITY change / new env var / help topic" → Task 5; no go.mod or docs/config edits. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step has complete code. ✓
+
+**Type consistency:** `searchBaseQuery(entityName, modelVersion string, pit *time.Time) (string, []any)` is defined in Task 1 and called identically in Iterate (Task 1) and Search (Task 2). `Search`/`orderByClause`/`orderByFieldExpr`/`validateOrderSpecs` signatures match between definition (Task 2) and use. `pitbLatestChangeTime(t, c, uuid.UUID)` is the existing helper reused in Task 4. `ErrInvalidFilterPath` is the existing exported sentinel asserted in injection tests. ✓
+
+**Note for the implementer:** Tasks are sequential (each builds on the prior). Postgres-plugin tests and the root `./...`/`e2e` tests require Docker (testcontainers). Run `cd plugins/postgres && go test ./...` for the plugin — root `./...` does not recurse into the submodule.

--- a/docs/superpowers/specs/2026-06-27-postgres-searcher-pushdown-design.md
+++ b/docs/superpowers/specs/2026-06-27-postgres-searcher-pushdown-design.md
@@ -1,0 +1,310 @@
+# PostgreSQL predicate pushdown — `spi.Searcher` (#37)
+
+## Problem
+
+The search service fetches **all** entities of a model via `GetAll` / `GetAllAsAt`
+and evaluates predicates in-memory. PostgreSQL stores entity data as JSONB but
+never uses JSONB operators in `WHERE`, so every search is O(n) over the whole
+model regardless of selectivity.
+
+`internal/domain/search/service.go` already delegates to `spi.Searcher` when the
+store implements it and there is no active transaction (`tx == nil`), falling
+back to `GetAll` + in-memory filtering otherwise. The SQLite plugin implements
+`Searcher`; PostgreSQL does not. This change makes PostgreSQL implement it.
+
+## Scope
+
+**In scope:** Implement `spi.Searcher` on the PostgreSQL `entityStore` —
+synchronous predicate pushdown for current-state and point-in-time searches,
+reusing the existing query substrate.
+
+**Prerequisite: #349 (point-in-time semantics canonicalization).** Review
+surfaced that PIT time-bounding is inconsistent across engines and read paths
+(memory/`GetAsAt`/`GetAllAsAt` round the timestamp up to the next ms; Search /
+Iterate / grouped-stats bind the raw value; sqlite uses strict `<` while
+postgres/memory use `<=`). The decided canonical rule is **full-precision,
+inclusive `<=`, no rounding, applied uniformly across every engine and path**.
+#349 lands that first. #37 then consumes the canonical bound — which, post-#349,
+is exactly the raw `valid_time <= $N` the grouped-stats PIT query already emits.
+**#37 introduces no rounding and no PIT-bound logic of its own.**
+
+**Out of scope (named to keep the boundary sharp):**
+- Client-facing sort parameter on the HTTP API — that is #347. This change only
+  ensures PostgreSQL *honours* `SearchOptions.OrderBy` symmetrically with SQLite;
+  no caller sends a non-empty `OrderBy` until #347 wires it.
+- **Cross-backend `ORDER BY` *value/ordering* fidelity** — deferred to #347, which
+  designs client-facing sort. This change ships structural ordering only and does
+  **not** attempt to make sort *results* byte-identical across backends. Known
+  divergences left for #347 (none are load-bearing pre-#347, since no caller sends
+  a non-empty `OrderBy` and the default key `entity_id` is unique and never null):
+  - *Type:* SQLite `json_extract` preserves type → numeric sort (`9 < 10`);
+    PostgreSQL `->>` yields text → lexicographic (`'10' < '9'`).
+  - *NULL placement:* SQLite sorts NULLs **first** in ascending order; PostgreSQL
+    defaults to **NULLS LAST**. A sort key some entities lack orders differently.
+  - *Tie-break stability:* neither backend appends a deterministic tiebreaker after
+    a non-unique sort key, so equal-key rows may interleave differently.
+- Async search store / job pipeline — unchanged. `SubmitAsync` calls the same
+  `SearchService.Search` *only when the store is not a `SelfExecutingSearchStore`*
+  (`service.go:241-243`); in that in-process case it inherits pushdown. A
+  self-executing async store generates IDs via its own executor and would not
+  pick up the sync pushdown — out of #37's scope. (The async ID-select-then-
+  re-fetch self-inconsistency at PIT boundaries is a symptom of the broader PIT
+  bug fixed uniformly by #349, not something #37 patches.)
+- PIT timestamp semantics — owned by #349 (prerequisite above). #37 neither
+  rounds nor changes the bound; it reuses the canonical query.
+- GIN / expression indexes on JSON paths. Pushdown delivers the correctness and
+  the WHERE-clause shape that *lets* an operator add indexes later; choosing and
+  shipping default indexes is a separate operational decision.
+
+## Existing substrate (already present, built for grouped-stats)
+
+No new query-translation logic is needed. The PostgreSQL plugin already has:
+
+- `query_planner.go` — `planQuery` splits a `spi.Filter` into a pushable SQL
+  `WHERE` fragment (`$N`-placeholder form) and a residual `*spi.Filter`. Greedy
+  AND, conservative OR, numeric ordering via `cyoda_try_float8`. The pushable-op
+  set is parity-locked to SQLite's.
+- `path_validation.go` — `validateFilterPaths` + injection-safe `validateJSONPath`.
+- `grouped_stats.go` — `evalPostFilter(filter, entity, doc)` residual evaluator,
+  the `postgresIter` streaming wrapper, the current-state and point-in-time base
+  queries (`SELECT doc FROM entities …` / bi-temporal `DISTINCT ON` over
+  `entity_versions`), and `shiftPlaceholders` (renumbers `planQuery`'s `$1…`
+  fragment after the base args).
+
+> **PIT base-query defect to fix (caught in review).** The current PIT query
+> (`grouped_stats.go:89-97`) wraps the `DISTINCT ON (entity_id)` in a derived
+> table that projects **only `doc`** — `entity_id` and the other direct columns
+> are not selected. The Searcher *always* appends an `ORDER BY` (default
+> `entity_id`), which would fail at runtime with `column "entity_id" does not
+> exist` on every PIT search. (This is a latent gap in `Iterate` too: a PIT
+> filter on a `SourceMeta` direct column would already fail today, untested.)
+> The fix lands in the shared base-query helper below: the inner `DISTINCT ON`
+> must also project the direct columns the outer `ORDER BY`/`WHERE` references.
+> **Project only columns that physically exist on `entity_versions`**
+> (`entity_id, model_name, model_version, version` — `entity_id` alone covers the
+> shipping default order). `directMetaColumns` *also* lists `deleted`, but
+> `entity_versions` has **no `deleted` column** — it lives only in
+> `doc->'_meta'->>'deleted'` (which is how the existing outer query already
+> computes it, `grouped_stats.go:97`). Projecting a raw `deleted` column would
+> raise `column "deleted" does not exist` and re-break every PIT search.
+> Projecting the *real* columns does not change `Iterate`'s output, so the fix is
+> safe to share. Note the `entity_id` ⇄ `_meta.id` key mismatch (`entity_doc.go`
+> stores the id under `_meta.id`, not `entity_id`): direct-column ordering must
+> use the real `entity_versions` columns, not a `doc->'_meta'` extraction.
+>
+> **PIT timestamp bound — owned by #349, not #37.** An earlier draft of this
+> spec prescribed making the Searcher *adopt* the `Truncate+Add(ms)` round-up to
+> match `GetAsAt`. That was backwards: the round-up is a cargo-culted in-memory
+> artifact whose premise (ms-precision clients) the system contradicts by emitting
+> nanosecond timestamps. #349 establishes the canonical rule — **full-precision,
+> inclusive `<=`, no rounding, uniform across all engines/paths** — and lands
+> before this work. Post-#349, the grouped-stats PIT query's raw `valid_time <=
+> $N` (`grouped_stats.go:98`) *is* the canonical form, so #37 reuses it unchanged.
+> #37 adds **only** the projection fix above (direct columns in the inner
+> `DISTINCT ON`); it does not touch the timestamp bound.
+>
+> **Known residual gap (deferred to #347):** a `SourceMeta` order/filter on
+> `deleted` under PIT cannot resolve against a real column — `deleted` is
+> **doc-only** on `entity_versions` (it lives in `doc->'_meta'->>'deleted'`,
+> `grouped_stats.go:97`), so the PIT inner projection cannot include it.
+> `fieldExpr`/`orderByFieldExpr` would emit the bare token `deleted`, unresolved
+> in the PIT derived table. (`tenant_id` is **not** in this gap — it *is* a real
+> `entity_versions` column, `migrations/000001:29`, so it would project fine; it
+> is simply never client-reachable as an order/filter key.) `directMetaColumns`
+> lists `deleted`, but the inner PIT projection must omit it. Not load-bearing
+> pre-#347 (no caller orders/filters on meta `deleted` under PIT); #347 resolves
+> it via a derived `(doc->'_meta'->>'deleted')::boolean AS deleted` expression if
+> needed.
+
+## Design decisions
+
+1. **No scan budget.** SQLite's `Searcher` caps residual post-filter scans at a
+   configurable `SearchScanLimit` (default 100k) and returns
+   `ErrScanBudgetExhausted`. That is a single-node-embedded-engine guardrail; the
+   production engine should not inherit it. PostgreSQL streams rows in SQL order
+   and **early-stops** once `offset + limit` matches are collected — bounded
+   memory *when a limit is set*, no new env var, no new help topic. (An unbounded
+   `Limit <= 0` request is O(n) memory either way, same as the fallback — see the
+   guard.) **Guard:** early-stop applies only when `Limit > 0`. When `Limit <= 0` (unbounded — the value the service
+   forwards when no client limit is set) `offset + limit == offset`, so a naive
+   early-stop would return an empty page past the offset; unbounded requests must
+   drain all matches and then apply the offset. **Accepted risk:** an unbounded
+   (`Limit <= 0`) request with a residual drains the entire matching set into a Go
+   slice with no guardrail. This is the same O(n) memory profile as the in-memory
+   fallback (`service.go` `GetAll` already loads everything), so #37 introduces no
+   *new* exposure — but a production PostgreSQL model can be far larger than a
+   single-node SQLite file, so the absence of any scan budget is a deliberate
+   inherited risk, not a free lunch. Revisit if/when an operator hits it.
+2. **`OrderBy` structural parity now.** Mirror SQLite's `orderByClause` /
+   `validateOrderSpecs`: default `ORDER BY entity_id` when `OrderBy` is empty;
+   otherwise emit one clause per `OrderSpec` mapped through the existing
+   `directMetaColumns` / `doc->>'path'` / `doc->'_meta'->>'path'` field rules.
+   `OrderSpec.Path` is validated through `validateJSONPath` before interpolation
+   (same injection invariant as filter paths).
+
+## Components — new file `plugins/postgres/searcher.go`
+
+```go
+var _ spi.Searcher = (*entityStore)(nil)
+```
+
+### `Search(ctx, filter, opts) ([]*spi.Entity, error)`
+
+1. `validateFilterPaths(filter)`; `validateOrderSpecs(opts.OrderBy)` — reject
+   bad input at the boundary before any interpolation.
+2. `plan := planQuery(filter)` (skip when `filter.Op == ""`, mirroring `Iterate`).
+3. Build the base query: point-in-time → the `DISTINCT ON (entity_id)` bi-temporal
+   form; otherwise → `SELECT doc FROM entities WHERE tenant/model/version AND NOT
+   deleted`. Extract these into a shared helper reused by `Iterate` (Gate 6 dedup;
+   the literals exist twice today). Two invariants the helper must carry:
+   - **PIT timestamp bound is #349's canonical raw `<=` — do not round.** Post-#349
+     the bound is full-precision `valid_time <= $N` (the form grouped-stats already
+     emits, `grouped_stats.go:98`). #37 must not reintroduce `Truncate+Add(ms)`.
+   - **Outer projection stays `SELECT doc` only (S-1).** The B1 fix adds direct
+     columns to the **inner** `DISTINCT ON`, never the outer select — `postgresIter`
+     and the row scanner read exactly one column (`it.rows.Scan(&doc)`,
+     `grouped_stats.go:191`). Adding columns to the outer select breaks `Scan` for
+     both `Iterate` and `Search` with a column/destination mismatch.
+4. Append `shiftPlaceholders(plan.where, len(baseArgs))` when pushable.
+5. Append `orderByClause(opts)`.
+6. **No residual** (`plan.postFilter == nil`): push `LIMIT`/`OFFSET` into SQL
+   (omit `LIMIT` when `Limit <= 0`, matching SQLite — unbounded).
+   **Residual present:** omit SQL `LIMIT`/`OFFSET`; stream rows, run
+   `evalPostFilter` per row, collect matches, apply `offset`/`limit` in Go.
+   Early-stop once `offset + limit` results are gathered **only when
+   `Limit > 0`**; when `Limit <= 0` drain all matches before applying `offset`
+   (see decision 1 guard). Note: with a residual, `ORDER BY` still sorts the
+   entire pushdown-matching set in SQL (no SQL `LIMIT` to enable a top-N);
+   early-stop saves only Go-side decode + post-filter work, not the sort. Page
+   determinism relies on a total sort key — the default `entity_id` is unique, so
+   it holds; #347's non-unique keys would need a tiebreaker (see ORDER divergences).
+7. Decode each `doc` into a `*spi.Entity` via `unmarshalEntityDoc` — the same
+   path `Iterate`/`GetAll` already use. The residual stream/decode/post-filter
+   loop is exactly `postgresIter.Next`; reuse `postgresIter` to drain rows rather
+   than re-implementing scan + `unmarshalEntityDoc` + `evalPostFilter` (Gate 6).
+
+### Helpers
+
+- `validateOrderSpecs([]spi.OrderSpec) error` — `validateJSONPath` on each
+  non-direct path; returns `ErrInvalidFilterPath` on the first bad one.
+- `orderByClause(opts) string` / `orderByFieldExpr(spec) string` — ordering-side
+  analogues of `fieldExpr`, reusing `directMetaColumns`. Default `entity_id`.
+
+## Data flow
+
+```
+SearchService.Search (tx == nil)
+  └─> entityStore.Search(filter, opts)
+        ├─ validate paths + order specs
+        ├─ planQuery → (pushable WHERE, residual)
+        ├─ base query (current-state | point-in-time) + WHERE + ORDER BY
+        ├─ no residual  → SQL LIMIT/OFFSET → decode rows
+        └─ residual     → stream → evalPostFilter → Go offset/limit (early-stop)
+```
+
+## Error handling
+
+- Invalid filter / order path → `ErrInvalidFilterPath` (maps to 4xx upstream,
+  unchanged).
+- Query / scan / decode failures → wrapped with `%w` context, surfaced as 5xx by
+  the service layer (no internals leaked — Gate 3).
+- No new sentinel errors; **no** `ErrScanBudgetExhausted` analogue (decision 1).
+
+## Testing (TDD)
+
+**Coverage-matrix waiver (gate-brainstorming / test-coverage rule).** #37
+introduces **no new HTTP endpoint, gRPC method, status code, or error code** —
+the search HTTP/gRPC surface, its pagination params, and its only domain error
+(`ErrInvalidFilterPath` → 4xx; everything else → 5xx-wrapped) are unchanged. It
+swaps the *storage implementation* behind an already-covered endpoint. The
+per-endpoint error/status table and scenario×layer matrix the rule normally
+requires are therefore **waived for the API surface** (no cell changes); the
+work is covered by (a) new postgres-plugin unit tests, and (b) a new
+cross-backend parity scenario for the one genuinely backend-agnostic new
+behavior — PIT search through the `Searcher` (see below).
+
+The current-state executable contract already exists and currently passes on
+PostgreSQL **via the fallback**: `e2e/parity/search.go` (`RunSearchSimpleCondition`,
+`…LifecycleCondition`, `…GroupCondition` with numeric `>`, `…NoMatches`,
+`…AfterUpdate`) and `search_consistency.go`. Once PostgreSQL implements
+`Searcher`, these exercise the pushdown path unchanged — the parity harness
+guarantees pushdown ≡ in-memory **for the result SET** of these scenarios.
+Caveat (review S3): result *equivalence* is not unconditional — the service
+applies its default `Limit` of 1000 only on the fallback path, not the Searcher
+path (pre-existing; SQLite already behaves this way), so an unbounded search can
+return more rows via a SQL Searcher than via the memory backend. This is
+orthogonal to #37 and left as-is; the spec does not claim equivalence past the
+default limit.
+
+Caveat (S4): most numeric filter translations (`EQ`/`BETWEEN` via
+`cyoda_try_float8`) have so far only been string-asserted in
+`query_planner_test.go`, never executed against a live PostgreSQL. (Once this
+lands, `RunSearchGroupCondition`'s `amount > 75` does give numeric `GT` live
+coverage — but `EQ`/`BETWEEN` remain unexercised.) The new unit tests below MUST
+use numeric values for `EQ`/`GT`/`BETWEEN` so every numeric translation is
+exercised end-to-end before we lean on the parity scenarios as a guarantee.
+
+New PostgreSQL-plugin unit tests (mirroring SQLite's `searcher_test.go` and
+`search_injection_test.go`), written RED first:
+- Each pushable operator returns the same rows as the in-memory matcher;
+  EQ/GT/BETWEEN tested with **numeric** values (S4).
+- OR / mixed pushable+residual → residual correctly post-filtered.
+- Pagination: `limit`/`offset` with and without a residual; the unbounded
+  (`Limit == 0`) + residual + non-zero `offset` case must return the correct
+  page, not empty (S1 guard).
+- Point-in-time search with the **default order** returns the snapshot-correct
+  version set — this is the test that catches the B1 projection defect; no
+  SQLite/PG PIT-search or OrderBy unit test exists today, so this is new coverage.
+  (PIT *boundary* correctness and cross-engine agreement are #349's parity tests,
+  not #37's — #37 reuses the canonical bound and asserts only the projection fix.)
+- `OrderBy`: default `entity_id`; explicit data-path and meta-path specs; `Desc`.
+- Injection: malicious `Filter.Path` / `OrderSpec.Path` rejected, never reaches SQL.
+- Compile-time `var _ spi.Searcher` assertion.
+
+**New cross-backend parity scenario — `RunSearchPointInTime`** (required, fills
+the one real coverage gap). All five existing parity scenarios are current-state,
+no-offset, no-OrderBy; none drives a PIT search through the `Searcher`. Since #37
+is the first code to run a predicate search at a snapshot through SQL — directly
+on top of the freshly canonicalized (#350) PIT bound — add a parity scenario that:
+saves an entity, advances it through ≥2 versions at distinct times, then searches
+with a predicate + `PointInTime` between versions and asserts the snapshot-correct
+result set. Registered in `e2e/parity/registry.go` so it runs on memory / sqlite /
+postgres (and the commercial backend) — asserting pushdown ≡ in-memory at a PIT.
+This is the cell that proves the B1 projection fix is correct cross-engine, not
+just in a postgres-only unit test. (PIT *boundary* exact-T agreement remains
+#349/#350's `pit_boundary` parity; this scenario asserts predicate+PIT *search*
+equivalence, which those do not cover.)
+
+Gate 5: `go test ./...` (root, incl. e2e — Docker), `plugins/postgres` suite,
+`go vet`. `make race` once before PR.
+
+## Gates / docs
+
+- **Gate 4:** No env-var or help-topic change (decision 1). No SPI change → no
+  `go.mod` pin bump, `COMPATIBILITY.md` unaffected. `CHANGELOG.md` gets an
+  additive entry under the current unreleased section (performance: PostgreSQL
+  search predicate pushdown). **Keep the CHANGELOG wording honest:** without a
+  GIN/expression index (deferred), pushdown narrows by `idx_entities_model` then
+  evaluates the JSONB predicate as a filter over that model's rows. The win is
+  **constant-factor** — no wire transfer of every doc, no Go-side decode of every
+  doc, DB-side filtering, and real `LIMIT` pushdown (early stop) for non-residual
+  queries — **not** selectivity-proportional / index-grade. Pushdown is the
+  prerequisite that makes JSON-path indexes useful later (separate operational
+  decision); the entry must not imply index-grade speedups.
+- **Gate 6:** Fold the duplicated current-state / point-in-time base-query
+  literals (`Iterate` + `Search`) into one shared helper as part of this change,
+  carrying the B1 PIT-projection fix (project the *real* `entity_versions` direct
+  columns — `entity_id`/`version`/… — on the **inner** `DISTINCT ON`, outer stays
+  `SELECT doc`; do **not** project `deleted`, which is doc-only on
+  `entity_versions`), which closes the latent `Iterate` PIT direct-column gap.
+  The shared helper is parameterized by entity name + model version, since its
+  two callers pass different shapes (`Iterate` takes a `spi.ModelRef`; `Search`
+  takes `opts.ModelName`/`opts.ModelVersion` off `SearchOptions`) — accept
+  name+version (or construct a `ModelRef`), not one caller's struct. The PIT
+  *timestamp* bound is canonicalized by #349 (full-precision `<=`, no rounding),
+  not here. The meta-`deleted`-under-PIT ordering gap remains deferred to #347.
+  Note: #349 (now landed as #350) did **not** extract a shared PIT base-query
+  helper and left `grouped_stats.go`'s PIT query unchanged, so #37 performs this
+  extraction.
+- Cross-plugin: no SPI or shared-contract change, so the Cassandra plugin and
+  the parity registry are unaffected beyond already running these scenarios.

--- a/e2e/parity/client/http.go
+++ b/e2e/parity/client/http.go
@@ -1217,6 +1217,34 @@ func (c *Client) SyncSearch(t *testing.T, modelName string, modelVersion int, co
 	return results, nil
 }
 
+// SyncSearchAt issues POST /api/search/direct/{name}/{version}?pointInTime=<t>
+// with the given condition JSON and returns the entity results at the snapshot.
+// Mirrors SyncSearch (NDJSON response); the direct-search handler honours the
+// pointInTime query param.
+func (c *Client) SyncSearchAt(t *testing.T, modelName string, modelVersion int, condition string, at time.Time) ([]EntityResult, error) {
+	t.Helper()
+	path := fmt.Sprintf("/api/search/direct/%s/%d?pointInTime=%s",
+		modelName, modelVersion, at.UTC().Format(time.RFC3339Nano))
+	raw, err := c.doRaw(t, http.MethodPost, path, condition)
+	if err != nil {
+		return nil, err
+	}
+	var results []EntityResult
+	for _, line := range strings.Split(strings.TrimRight(string(raw), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var r EntityResult
+		dec := json.NewDecoder(strings.NewReader(line))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&r); err != nil {
+			return nil, fmt.Errorf("decode NDJSON line: %w", err)
+		}
+		results = append(results, r)
+	}
+	return results, nil
+}
+
 // GetAuditEvents issues GET /api/audit/entity/{entityId} with optional
 // query parameters for filtering.
 // Canonical: docs/cyoda/api/openapi-audit.yml:31 (SearchEntityAuditEvents).

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 162
+// Total parity scenarios: 163
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
 // distributed-safety contracts + schema extensions + Phase 9.2 OIDC CRUD/authz
 // + Phase 9.3 OIDC JWT validation + Phase 9.4 OIDC divergences
@@ -96,6 +96,7 @@ var allTests = []NamedTest{
 	{"SearchGroupCondition", RunSearchGroupCondition},
 	{"SearchNoMatches", RunSearchNoMatches},
 	{"SearchAfterUpdate", RunSearchAfterUpdate},
+	{"SearchPointInTime", RunSearchPointInTime},
 
 	// Phase 4b — workflow selection (Task 4b.7)
 	{"WorkflowCriteriaSelectingWorkflow", RunWorkflowCriteriaSelectingWorkflow},

--- a/e2e/parity/search_pit.go
+++ b/e2e/parity/search_pit.go
@@ -1,0 +1,61 @@
+package parity
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
+)
+
+// RunSearchPointInTime asserts that a predicate search at a snapshot returns
+// the snapshot-correct result set on every backend — exercising the Searcher
+// (or in-memory fallback) through a point-in-time read. It is the cross-engine
+// guard for predicate-pushdown ≡ in-memory at a PIT, and the parity counterpart
+// to the postgres B1 projection unit test.
+func RunSearchPointInTime(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "parity-search-pit"
+	const modelVersion = 1
+	setupSearchModel(t, c, modelName, modelVersion)
+
+	// v1: status=active.
+	id, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Alice","status":"active"}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	t1 := pitbLatestChangeTime(t, c, id)
+
+	// Space ≥1ms so v2 lands in a distinct millisecond (commercial backend
+	// stores ms precision — see pit_boundary.go rationale).
+	time.Sleep(2 * time.Millisecond)
+	if err := c.UpdateEntityData(t, id, `{"name":"Alice","status":"inactive"}`); err != nil {
+		t.Fatalf("UpdateEntityData: %v", err)
+	}
+	t2 := pitbLatestChangeTime(t, c, id)
+	if !t1.Before(t2) {
+		t.Fatalf("version timestamps not increasing: t1=%s t2=%s",
+			t1.Format(time.RFC3339Nano), t2.Format(time.RFC3339Nano))
+	}
+
+	activeCond := `{"type":"simple","jsonPath":"$.status","operatorType":"EQUALS","value":"active"}`
+
+	// At t1 the snapshot shows status=active → 1 hit.
+	at1, err := c.SyncSearchAt(t, modelName, modelVersion, activeCond, t1)
+	if err != nil {
+		t.Fatalf("SyncSearchAt(t1): %v", err)
+	}
+	if len(at1) != 1 {
+		t.Errorf("status=active @t1: want 1, got %d", len(at1))
+	}
+
+	// At t2 the snapshot shows status=inactive → the active search misses.
+	at2, err := c.SyncSearchAt(t, modelName, modelVersion, activeCond, t2)
+	if err != nil {
+		t.Fatalf("SyncSearchAt(t2): %v", err)
+	}
+	if len(at2) != 0 {
+		t.Errorf("status=active @t2: want 0 (now inactive), got %d", len(at2))
+	}
+}

--- a/plugins/postgres/grouped_stats.go
+++ b/plugins/postgres/grouped_stats.go
@@ -74,34 +74,7 @@ func (s *entityStore) Iterate(
 		plan = planQuery(filter)
 	}
 
-	tid := string(s.tenantID)
-	var baseQuery string
-	var baseArgs []any
-
-	if opts.PointInTime != nil {
-		// Bi-temporal pattern from GetAsAt. Two-stage filter:
-		//  1. Inner: DISTINCT ON picks the latest version per entity visible at
-		//     the snapshot (ORDER BY drives the pick).
-		//  2. Outer: drop versions whose deletion-marker is set. This MUST
-		//     happen AFTER the DISTINCT ON, not inside it — otherwise the
-		//     deletion-marker version is filtered out and an older non-deleted
-		//     version surfaces, falsely showing the entity as live post-delete.
-		baseQuery = `SELECT doc FROM (
-		                SELECT DISTINCT ON (entity_id) doc
-		                FROM entity_versions
-		                WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3
-		                  AND valid_time <= $4
-		                  AND transaction_time <= CURRENT_TIMESTAMP
-		                ORDER BY entity_id, valid_time DESC, transaction_time DESC
-		             ) latest
-		             WHERE (doc->'_meta'->>'deleted')::boolean IS NOT TRUE`
-		baseArgs = []any{tid, model.EntityName, model.ModelVersion, *opts.PointInTime}
-	} else {
-		baseQuery = `SELECT doc
-		             FROM entities
-		             WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3 AND NOT deleted`
-		baseArgs = []any{tid, model.EntityName, model.ModelVersion}
-	}
+	baseQuery, baseArgs := s.searchBaseQuery(model.EntityName, model.ModelVersion, opts.PointInTime)
 
 	if plan.where != "" {
 		// planQuery starts its placeholder counter at 1, but we've already

--- a/plugins/postgres/path_validation.go
+++ b/plugins/postgres/path_validation.go
@@ -97,3 +97,19 @@ func validateFilterPaths(f spi.Filter) error {
 	}
 	return validateJSONPath(f.Path)
 }
+
+// validateOrderSpecs checks every OrderSpec.Path against the same dotted-
+// identifier grammar as filter paths. Empty paths (direct-column / default
+// ordering) are skipped. MUST be called at the Search() boundary before any
+// OrderSpec.Path is interpolated into SQL (injection invariant).
+func validateOrderSpecs(specs []spi.OrderSpec) error {
+	for _, sp := range specs {
+		if sp.Path == "" {
+			continue
+		}
+		if err := validateJSONPath(sp.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/plugins/postgres/query_planner.go
+++ b/plugins/postgres/query_planner.go
@@ -285,6 +285,10 @@ func nextPlaceholder(counter *int) string {
 func leafToSQL(f spi.Filter, counter *int) (string, []any) {
 	switch f.Op {
 	case spi.FilterEq:
+		// Numeric operand: cyoda_try_float8 coerces the field to float8, so a field stored
+		// as a numeric-looking string (e.g. "30") coerces and matches — intentional, matching
+		// sqlite's type-coercing comparison and the S4 numeric-equality intent; string operands
+		// use plain text comparison.
 		if isNumericValue(f.Value) {
 			col := orderExpr(f, true)
 			p := nextPlaceholder(counter)

--- a/plugins/postgres/query_planner.go
+++ b/plugins/postgres/query_planner.go
@@ -276,10 +276,12 @@ func nextPlaceholder(counter *int) string {
 //   - String ops (contains, starts_with, ends_with): use strpos/substr, not LIKE
 //   - like: uses LIKE with ESCAPE '\' and value preprocessing
 //
-// Numeric ordering ops route the field expression through cyoda_try_float8
-// and cast the placeholder to float8 so overflow/non-numeric content returns
-// NULL rather than raising 22003 — the regex+EXCEPTION helper is defined in
-// migration 000002.
+// Numeric eq/ne and ordering ops route the field expression through
+// cyoda_try_float8 and cast the placeholder to float8 so overflow/non-numeric
+// content returns NULL rather than raising 22003, and so a numeric operand is
+// compared numerically against the text-typed doc->>'path' extraction (a raw
+// numeric bind against a text column fails to encode) — the regex+EXCEPTION
+// helper is defined in migration 000002. String values keep text comparison.
 func leafToSQL(f spi.Filter, counter *int) (string, []any) {
 	switch f.Op {
 	case spi.FilterEq:

--- a/plugins/postgres/query_planner.go
+++ b/plugins/postgres/query_planner.go
@@ -283,10 +283,20 @@ func nextPlaceholder(counter *int) string {
 func leafToSQL(f spi.Filter, counter *int) (string, []any) {
 	switch f.Op {
 	case spi.FilterEq:
+		if isNumericValue(f.Value) {
+			col := orderExpr(f, true)
+			p := nextPlaceholder(counter)
+			return fmt.Sprintf("(%s IS NOT NULL AND %s = %s::float8)", col, col, p), []any{f.Value}
+		}
 		col := fieldExpr(f)
 		p := nextPlaceholder(counter)
 		return fmt.Sprintf("(%s IS NOT NULL AND %s = %s)", col, col, p), []any{f.Value}
 	case spi.FilterNe:
+		if isNumericValue(f.Value) {
+			col := orderExpr(f, true)
+			p := nextPlaceholder(counter)
+			return fmt.Sprintf("(%s IS NULL OR %s != %s::float8)", col, col, p), []any{f.Value}
+		}
 		col := fieldExpr(f)
 		p := nextPlaceholder(counter)
 		return fmt.Sprintf("(%s IS NULL OR %s != %s)", col, col, p), []any{f.Value}
@@ -301,17 +311,19 @@ func leafToSQL(f spi.Filter, counter *int) (string, []any) {
 	case spi.FilterContains:
 		col := fieldExpr(f)
 		p := nextPlaceholder(counter)
-		return fmt.Sprintf("strpos(%s, %s) > 0", col, p), []any{f.Value}
+		return fmt.Sprintf("strpos(%s, %s) > 0", col, p), []any{fmt.Sprint(f.Value)}
 	case spi.FilterStartsWith:
 		col := fieldExpr(f)
 		p1 := nextPlaceholder(counter)
 		p2 := nextPlaceholder(counter)
-		return fmt.Sprintf("substr(%s, 1, length(%s)) = %s", col, p1, p2), []any{f.Value, f.Value}
+		sv := fmt.Sprint(f.Value)
+		return fmt.Sprintf("substr(%s, 1, length(%s)) = %s", col, p1, p2), []any{sv, sv}
 	case spi.FilterEndsWith:
 		col := fieldExpr(f)
 		p1 := nextPlaceholder(counter)
 		p2 := nextPlaceholder(counter)
-		return fmt.Sprintf("substr(%s, -length(%s)) = %s", col, p1, p2), []any{f.Value, f.Value}
+		sv := fmt.Sprint(f.Value)
+		return fmt.Sprintf("substr(%s, -length(%s)) = %s", col, p1, p2), []any{sv, sv}
 	case spi.FilterLike:
 		col := fieldExpr(f)
 		p := nextPlaceholder(counter)

--- a/plugins/postgres/search_base.go
+++ b/plugins/postgres/search_base.go
@@ -20,7 +20,8 @@ func (s *entityStore) searchBaseQuery(entityName, modelVersion string, pit *time
 		// entity visible at the snapshot; outer drops deletion-marker versions
 		// AFTER the DISTINCT ON (so a delete shadows an older live version).
 		baseQuery := `SELECT doc FROM (
-		                SELECT DISTINCT ON (entity_id) doc
+		                SELECT DISTINCT ON (entity_id)
+		                       entity_id, model_name, model_version, version, doc
 		                FROM entity_versions
 		                WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3
 		                  AND valid_time <= $4

--- a/plugins/postgres/search_base.go
+++ b/plugins/postgres/search_base.go
@@ -1,0 +1,37 @@
+package postgres
+
+import "time"
+
+// searchBaseQuery builds the base SELECT over a model for current-state
+// (pit == nil) or point-in-time (pit != nil) reads. The outer projection is
+// always `SELECT doc` (one column) — the S-1 invariant the row scanner
+// (postgresIter, grouped_stats.go) depends on.
+//
+// Positional args: $1 tenant, $2 entityName, $3 modelVersion, and for PIT
+// $4 the snapshot time. Callers append a pushdown WHERE fragment with
+// shiftPlaceholders(frag, len(args)) and (for Search) ORDER BY / LIMIT / OFFSET.
+//
+// PIT uses the canonical inclusive bound valid_time <= $4 (no rounding; #349).
+// Shared by Iterate and Search so both stay in lock-step.
+func (s *entityStore) searchBaseQuery(entityName, modelVersion string, pit *time.Time) (string, []any) {
+	tid := string(s.tenantID)
+	if pit != nil {
+		// Bi-temporal snapshot: inner DISTINCT ON picks the latest version per
+		// entity visible at the snapshot; outer drops deletion-marker versions
+		// AFTER the DISTINCT ON (so a delete shadows an older live version).
+		baseQuery := `SELECT doc FROM (
+		                SELECT DISTINCT ON (entity_id) doc
+		                FROM entity_versions
+		                WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3
+		                  AND valid_time <= $4
+		                  AND transaction_time <= CURRENT_TIMESTAMP
+		                ORDER BY entity_id, valid_time DESC, transaction_time DESC
+		             ) latest
+		             WHERE (doc->'_meta'->>'deleted')::boolean IS NOT TRUE`
+		return baseQuery, []any{tid, entityName, modelVersion, *pit}
+	}
+	baseQuery := `SELECT doc
+	             FROM entities
+	             WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3 AND NOT deleted`
+	return baseQuery, []any{tid, entityName, modelVersion}
+}

--- a/plugins/postgres/search_base.go
+++ b/plugins/postgres/search_base.go
@@ -11,7 +11,7 @@ import "time"
 // $4 the snapshot time. Callers append a pushdown WHERE fragment with
 // shiftPlaceholders(frag, len(args)) and (for Search) ORDER BY / LIMIT / OFFSET.
 //
-// PIT uses the canonical inclusive bound valid_time <= $4 (no rounding; #349).
+// PIT uses the canonical inclusive bound valid_time <= $4 (no rounding).
 // Shared by Iterate and Search so both stay in lock-step.
 func (s *entityStore) searchBaseQuery(entityName, modelVersion string, pit *time.Time) (string, []any) {
 	tid := string(s.tenantID)
@@ -31,7 +31,7 @@ func (s *entityStore) searchBaseQuery(entityName, modelVersion string, pit *time
 		return baseQuery, []any{tid, entityName, modelVersion, *pit}
 	}
 	baseQuery := `SELECT doc
-	             FROM entities
-	             WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3 AND NOT deleted`
+		             FROM entities
+		             WHERE tenant_id = $1 AND model_name = $2 AND model_version = $3 AND NOT deleted`
 	return baseQuery, []any{tid, entityName, modelVersion}
 }

--- a/plugins/postgres/searcher.go
+++ b/plugins/postgres/searcher.go
@@ -1,0 +1,141 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// Compile-time check that *entityStore implements spi.Searcher.
+var _ spi.Searcher = (*entityStore)(nil)
+
+// Search implements spi.Searcher for the PostgreSQL entity store. Pushable
+// predicates go into the SQL WHERE via planQuery; the residual (regex /
+// case-insensitive ops) is evaluated in Go by postgresIter/evalPostFilter.
+//
+// Pagination: when there is no residual, LIMIT/OFFSET are pushed into SQL.
+// With a residual, rows are streamed, post-filtered, and offset/limit applied
+// in Go — early-stopping once offset+limit matches are gathered, but ONLY when
+// Limit > 0 (an unbounded Limit<=0 request must drain all matches before
+// applying the offset, else a naive offset+limit==offset stop returns empty).
+//
+// No scan budget (unlike sqlite): the production engine streams in SQL order
+// and bounds memory via the early-stop when a limit is set. An unbounded
+// request with a residual is O(n) memory — the same profile as the in-memory
+// fallback it replaces.
+func (s *entityStore) Search(ctx context.Context, filter spi.Filter, opts spi.SearchOptions) ([]*spi.Entity, error) {
+	if err := validateFilterPaths(filter); err != nil {
+		return nil, err
+	}
+	if err := validateOrderSpecs(opts.OrderBy); err != nil {
+		return nil, err
+	}
+
+	// Zero-value Filter means "match all" — skip planQuery (it would treat the
+	// empty Op as non-pushable and install the zero filter as a residual).
+	var plan sqlPlan
+	if filter.Op != "" {
+		plan = planQuery(filter)
+	}
+
+	baseQuery, baseArgs := s.searchBaseQuery(opts.ModelName, opts.ModelVersion, opts.PointInTime)
+
+	if plan.where != "" {
+		shifted := shiftPlaceholders(plan.where, len(baseArgs))
+		baseQuery += " AND (" + shifted + ")"
+		baseArgs = append(baseArgs, plan.args...)
+	}
+
+	baseQuery += orderByClause(opts)
+
+	// No residual → LIMIT/OFFSET in SQL.
+	if plan.postFilter == nil {
+		if opts.Limit > 0 {
+			baseQuery += fmt.Sprintf(" LIMIT $%d", len(baseArgs)+1)
+			baseArgs = append(baseArgs, opts.Limit)
+		}
+		if opts.Offset > 0 {
+			baseQuery += fmt.Sprintf(" OFFSET $%d", len(baseArgs)+1)
+			baseArgs = append(baseArgs, opts.Offset)
+		}
+	}
+
+	rows, err := s.q.Query(ctx, baseQuery, baseArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("search query: %w", err)
+	}
+	it := &postgresIter{ctx: ctx, rows: rows, postFilter: plan.postFilter}
+	defer it.Close()
+
+	var results []*spi.Entity
+
+	// No residual: SQL already applied LIMIT/OFFSET; collect everything.
+	if plan.postFilter == nil {
+		for it.Next() {
+			results = append(results, it.Entity())
+		}
+		if err := it.Err(); err != nil {
+			return nil, err
+		}
+		return results, nil
+	}
+
+	// Residual present: postgresIter yields only post-filter matches. Apply
+	// offset/limit in Go. Early-stop only when a limit is set (S1 guard).
+	for it.Next() {
+		results = append(results, it.Entity())
+		if opts.Limit > 0 && len(results) >= opts.Offset+opts.Limit {
+			break
+		}
+	}
+	if err := it.Err(); err != nil {
+		return nil, err
+	}
+	if opts.Offset > 0 {
+		if opts.Offset >= len(results) {
+			return nil, nil
+		}
+		results = results[opts.Offset:]
+	}
+	if opts.Limit > 0 && len(results) > opts.Limit {
+		results = results[:opts.Limit]
+	}
+	return results, nil
+}
+
+// orderByClause builds the SQL ORDER BY from opts.OrderBy. Empty → default
+// "ORDER BY entity_id" (a unique, never-null key, so pages are deterministic).
+// Bare column names resolve against the entities table (current-state) or the
+// `latest` derived table (point-in-time), both of which expose entity_id.
+func orderByClause(opts spi.SearchOptions) string {
+	if len(opts.OrderBy) == 0 {
+		return " ORDER BY entity_id"
+	}
+	clauses := make([]string, 0, len(opts.OrderBy))
+	for _, spec := range opts.OrderBy {
+		expr := orderByFieldExpr(spec)
+		if spec.Desc {
+			expr += " DESC"
+		}
+		clauses = append(clauses, expr)
+	}
+	return " ORDER BY " + strings.Join(clauses, ", ")
+}
+
+// orderByFieldExpr returns the SQL ordering expression for an OrderSpec,
+// reusing the filter field rules (directMetaColumns / doc->'_meta'->>'p' /
+// doc->>'p').
+//
+// Safety invariant: spec.Path is interpolated into a JSON-key literal and
+// MUST have been validated by validateOrderSpecs at the Search() boundary.
+func orderByFieldExpr(spec spi.OrderSpec) string {
+	if spec.Source == spi.SourceMeta {
+		if directMetaColumns[spec.Path] {
+			return spec.Path
+		}
+		return jsonbExtractText("doc->'_meta'", spec.Path)
+	}
+	return jsonbExtractText("doc", spec.Path)
+}

--- a/plugins/postgres/searcher_test.go
+++ b/plugins/postgres/searcher_test.go
@@ -1,0 +1,294 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/plugins/postgres"
+)
+
+var searchModel = spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+
+// setupSearcher seeds five people and returns a store + ctx. Numeric `age`
+// drives EQ/GT/BETWEEN through cyoda_try_float8 (S4: numeric paths must run
+// against a live backend, not just string-asserted).
+func setupSearcher(t *testing.T) (spi.EntityStore, context.Context) {
+	t.Helper()
+	factory := setupEntityTest(t)
+	ctx := ctxWithTenant("search-tenant")
+	store, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore: %v", err)
+	}
+	seed := []struct {
+		id, data string
+	}{
+		{"e1", `{"name":"Alice","age":30,"city":"Berlin"}`},
+		{"e2", `{"name":"Bob","age":25,"city":"Munich"}`},
+		{"e3", `{"name":"Charlie","age":35,"city":"Berlin"}`},
+		{"e4", `{"name":"Diana","age":28,"city":"Hamburg"}`},
+		{"e5", `{"name":"Eve","age":40,"city":"Munich"}`},
+	}
+	for _, s := range seed {
+		if _, err := store.Save(ctx, &spi.Entity{
+			Meta: spi.EntityMeta{ID: s.id, ModelRef: searchModel, State: "NEW"},
+			Data: []byte(s.data),
+		}); err != nil {
+			t.Fatalf("Save %s: %v", s.id, err)
+		}
+	}
+	return store, ctx
+}
+
+func searcherOf(t *testing.T, store spi.EntityStore) spi.Searcher {
+	t.Helper()
+	sr, ok := store.(spi.Searcher)
+	if !ok {
+		t.Fatal("postgres entityStore does not implement spi.Searcher")
+	}
+	return sr
+}
+
+func baseOpts() spi.SearchOptions {
+	return spi.SearchOptions{ModelName: "person", ModelVersion: "1"}
+}
+
+func TestPGSearcher_Eq(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Berlin"},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("city=Berlin: want 2, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_GtNumeric(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterGt, Path: "age", Source: spi.SourceData, Value: float64(30)},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 2 { // Charlie 35, Eve 40
+		t.Fatalf("age>30: want 2, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_BetweenNumeric(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterBetween, Path: "age", Source: spi.SourceData,
+			Values: []any{float64(28), float64(35)}},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 3 { // 30, 35, 28
+		t.Fatalf("age in [28,35]: want 3, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_And(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{
+		Op: spi.FilterAnd,
+		Children: []spi.Filter{
+			{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Berlin"},
+			{Op: spi.FilterGt, Path: "age", Source: spi.SourceData, Value: float64(31)},
+		},
+	}, baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 1 { // Charlie (Berlin, 35)
+		t.Fatalf("Berlin AND age>31: want 1, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_Or(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{
+		Op: spi.FilterOr,
+		Children: []spi.Filter{
+			{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Hamburg"},
+			{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Munich"},
+		},
+	}, baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 3 { // Bob, Eve (Munich), Diana (Hamburg)
+		t.Fatalf("Hamburg OR Munich: want 3, got %d", len(got))
+	}
+}
+
+// FilterMatchesRegex is non-pushable → becomes a residual evaluated by
+// postgresIter/evalPostFilter. Proves the residual path runs under Search.
+func TestPGSearcher_ResidualRegex(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterMatchesRegex, Path: "name", Source: spi.SourceData, Value: "^A"},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 1 { // Alice
+		t.Fatalf("name ~ ^A: want 1, got %d", len(got))
+	}
+}
+
+// Mixed: pushable city=Berlin AND residual regex on name.
+func TestPGSearcher_MixedPushAndResidual(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{
+		Op: spi.FilterAnd,
+		Children: []spi.Filter{
+			{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Berlin"},
+			{Op: spi.FilterMatchesRegex, Path: "name", Source: spi.SourceData, Value: "^C"},
+		},
+	}, baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 1 { // Charlie
+		t.Fatalf("Berlin AND name~^C: want 1, got %d", len(got))
+	}
+}
+
+// Pagination with NO residual → LIMIT/OFFSET pushed into SQL.
+func TestPGSearcher_PaginationNoResidual(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.Limit = 2
+	opts.Offset = 1
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{}, opts) // match-all, default order entity_id
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("limit 2 offset 1: want 2, got %d", len(got))
+	}
+}
+
+// Pagination WITH residual → LIMIT/OFFSET applied in Go after post-filter.
+func TestPGSearcher_PaginationWithResidual(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.Limit = 1
+	// Residual regex matching all five names (contains any letter), so the
+	// residual path is active and pagination is applied in Go.
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterMatchesRegex, Path: "name", Source: spi.SourceData, Value: "."},
+		opts)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("residual + limit 1: want 1, got %d", len(got))
+	}
+}
+
+// S1 guard: unbounded (Limit==0) + residual + non-zero offset must return the
+// correct page, not empty. A naive early-stop at offset+limit==offset breaks this.
+func TestPGSearcher_UnboundedOffsetWithResidual(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.Limit = 0 // unbounded
+	opts.Offset = 2
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterMatchesRegex, Path: "name", Source: spi.SourceData, Value: "."},
+		opts)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 3 { // 5 total, drop first 2
+		t.Fatalf("unbounded offset 2 + residual: want 3, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_OrderByDataPathDesc(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.OrderBy = []spi.OrderSpec{{Path: "name", Source: spi.SourceData, Desc: true}}
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{}, opts)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("want 5, got %d", len(got))
+	}
+	// Lexicographic desc: Eve, Diana, Charlie, Bob, Alice.
+	if string(got[0].Data) == "" || got[0].Meta.ID != "e5" {
+		t.Errorf("desc by name: want first=Eve(e5), got id=%s", got[0].Meta.ID)
+	}
+}
+
+func TestPGSearcher_InjectionFilterPath(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	_, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterEq, Path: "city'); DROP TABLE entities;--", Source: spi.SourceData, Value: "x"},
+		baseOpts())
+	if !errors.Is(err, postgres.ErrInvalidFilterPath) {
+		t.Fatalf("want ErrInvalidFilterPath, got %v", err)
+	}
+}
+
+func TestPGSearcher_InjectionOrderPath(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.OrderBy = []spi.OrderSpec{{Path: "name'); DROP TABLE entities;--", Source: spi.SourceData}}
+	_, err := searcherOf(t, store).Search(ctx, spi.Filter{}, opts)
+	if !errors.Is(err, postgres.ErrInvalidFilterPath) {
+		t.Fatalf("want ErrInvalidFilterPath for order path, got %v", err)
+	}
+}
+
+func TestPGSearcher_TenantIsolation(t *testing.T) {
+	// One factory (one database), two tenants. Tenant A is seeded with a
+	// Berlin entity; tenant B searches the same model and must see none of A's
+	// rows — every base query filters tenant_id = $1.
+	factory := setupEntityTest(t)
+	ctxA := ctxWithTenant("tenant-a")
+	ctxB := ctxWithTenant("tenant-b")
+
+	storeA, err := factory.EntityStore(ctxA)
+	if err != nil {
+		t.Fatalf("EntityStore A: %v", err)
+	}
+	if _, err := storeA.Save(ctxA, &spi.Entity{
+		Meta: spi.EntityMeta{ID: "a1", ModelRef: searchModel, State: "NEW"},
+		Data: []byte(`{"name":"Alice","city":"Berlin"}`),
+	}); err != nil {
+		t.Fatalf("Save A: %v", err)
+	}
+
+	storeB, err := factory.EntityStore(ctxB)
+	if err != nil {
+		t.Fatalf("EntityStore B: %v", err)
+	}
+	got, err := searcherOf(t, storeB).Search(ctxB,
+		spi.Filter{Op: spi.FilterEq, Path: "city", Source: spi.SourceData, Value: "Berlin"},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search B: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("cross-tenant leak: tenant B saw %d of tenant A's rows, want 0", len(got))
+	}
+}
+
+// Compile-time guard mirrored as a runtime assertion for clarity.
+func TestPGSearcher_ImplementsSearcher(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	if _, ok := store.(spi.Searcher); !ok {
+		t.Fatal("postgres entityStore must implement spi.Searcher")
+	}
+	_ = ctx
+}

--- a/plugins/postgres/searcher_test.go
+++ b/plugins/postgres/searcher_test.go
@@ -248,6 +248,67 @@ func TestPGSearcher_OrderByDataPathDesc(t *testing.T) {
 	}
 }
 
+func TestPGSearcher_OrderByDataPathAsc(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.OrderBy = []spi.OrderSpec{{Path: "name", Source: spi.SourceData}} // Desc omitted → ascending
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{}, opts)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("asc by name: want 5, got %d", len(got))
+	}
+	// Lexicographic asc: Alice, Bob, Charlie, Diana, Eve → e1 first, e5 last.
+	if got[0].Meta.ID != "e1" {
+		t.Errorf("asc by name: want first=Alice(e1), got id=%s", got[0].Meta.ID)
+	}
+	if got[4].Meta.ID != "e5" {
+		t.Errorf("asc by name: want last=Eve(e5), got id=%s", got[4].Meta.ID)
+	}
+}
+
+func TestPGSearcher_OrderByMetaDirectColumn(t *testing.T) {
+	// entity_id is in directMetaColumns so orderByFieldExpr emits the bare column
+	// name instead of a doc->'_meta'->>'entity_id' expression. Exercises that branch.
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.OrderBy = []spi.OrderSpec{{Path: "entity_id", Source: spi.SourceMeta}}
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{}, opts)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("asc by entity_id: want 5, got %d", len(got))
+	}
+	// Lexicographic asc over "e1".."e5" → e1 first, e5 last.
+	if got[0].Meta.ID != "e1" {
+		t.Errorf("asc by entity_id: want first=e1, got %s", got[0].Meta.ID)
+	}
+	if got[4].Meta.ID != "e5" {
+		t.Errorf("asc by entity_id: want last=e5, got %s", got[4].Meta.ID)
+	}
+}
+
+func TestPGSearcher_OrderByMetaJSONPath(t *testing.T) {
+	// "state" is NOT in directMetaColumns, so orderByFieldExpr emits
+	// doc->'_meta'->>'state' — the SourceMeta non-direct branch. All five seed
+	// rows have state="NEW", so ordering is uniform; this test's purpose is to
+	// confirm the meta-JSONPath ORDER BY expression is valid SQL and executes
+	// without error. A meaningful ordering assertion is deferred until the seed
+	// carries state variation (all current seed states are uniform).
+	store, ctx := setupSearcher(t)
+	opts := baseOpts()
+	opts.OrderBy = []spi.OrderSpec{{Path: "state", Source: spi.SourceMeta}}
+	got, err := searcherOf(t, store).Search(ctx, spi.Filter{}, opts)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("order by meta state: want 5, got %d", len(got))
+	}
+}
+
 func TestPGSearcher_InjectionFilterPath(t *testing.T) {
 	store, ctx := setupSearcher(t)
 	_, err := searcherOf(t, store).Search(ctx,

--- a/plugins/postgres/searcher_test.go
+++ b/plugins/postgres/searcher_test.go
@@ -176,6 +176,13 @@ func TestPGSearcher_PaginationNoResidual(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("limit 2 offset 1: want 2, got %d", len(got))
 	}
+	// Offset 1 over e1..e5 → page is e2 then e3.
+	if got[0].Meta.ID != "e2" {
+		t.Errorf("limit 2 offset 1: want got[0]=e2, got %s", got[0].Meta.ID)
+	}
+	if got[1].Meta.ID != "e3" {
+		t.Errorf("limit 2 offset 1: want got[1]=e3, got %s", got[1].Meta.ID)
+	}
 }
 
 // Pagination WITH residual → LIMIT/OFFSET applied in Go after post-filter.
@@ -212,6 +219,16 @@ func TestPGSearcher_UnboundedOffsetWithResidual(t *testing.T) {
 	if len(got) != 3 { // 5 total, drop first 2
 		t.Fatalf("unbounded offset 2 + residual: want 3, got %d", len(got))
 	}
+	// Offset 2 over e1..e5 → page is e3, e4, e5.
+	if got[0].Meta.ID != "e3" {
+		t.Errorf("unbounded offset 2: want got[0]=e3, got %s", got[0].Meta.ID)
+	}
+	if got[1].Meta.ID != "e4" {
+		t.Errorf("unbounded offset 2: want got[1]=e4, got %s", got[1].Meta.ID)
+	}
+	if got[2].Meta.ID != "e5" {
+		t.Errorf("unbounded offset 2: want got[2]=e5, got %s", got[2].Meta.ID)
+	}
 }
 
 func TestPGSearcher_OrderByDataPathDesc(t *testing.T) {
@@ -226,7 +243,7 @@ func TestPGSearcher_OrderByDataPathDesc(t *testing.T) {
 		t.Fatalf("want 5, got %d", len(got))
 	}
 	// Lexicographic desc: Eve, Diana, Charlie, Bob, Alice.
-	if string(got[0].Data) == "" || got[0].Meta.ID != "e5" {
+	if got[0].Meta.ID != "e5" {
 		t.Errorf("desc by name: want first=Eve(e5), got id=%s", got[0].Meta.ID)
 	}
 }
@@ -322,6 +339,40 @@ func TestPGSearcher_ContainsNumericValue(t *testing.T) {
 	}
 	if len(got) != 2 { // Alice 30, Charlie 35
 		t.Fatalf("age contains '3': want 2, got %d", len(got))
+	}
+}
+
+// TestPGSearcher_NeNumeric_MissingFieldMatches verifies 3VL: a row that has no
+// "age" field at all must be included in age!=30 results (missing != value is
+// true under three-valued logic).
+func TestPGSearcher_NeNumeric_MissingFieldMatches(t *testing.T) {
+	store, ctx := setupSearcher(t) // seeds e1..e5
+	// Save an extra entity with no "age" field.
+	if _, err := store.Save(ctx, &spi.Entity{
+		Meta: spi.EntityMeta{ID: "e6", ModelRef: searchModel, State: "NEW"},
+		Data: []byte(`{"name":"Frank","city":"Bremen"}`),
+	}); err != nil {
+		t.Fatalf("Save e6: %v", err)
+	}
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterNe, Path: "age", Source: spi.SourceData, Value: float64(30)},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	// Alice (age=30) is excluded; Bob/Charlie/Diana/Eve (age≠30) + Frank (no age) = 5.
+	if len(got) != 5 {
+		t.Fatalf("age!=30 with missing-field row: want 5, got %d", len(got))
+	}
+	found := false
+	for _, e := range got {
+		if e.Meta.ID == "e6" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("age!=30: e6 (no age field) must be included but was absent")
 	}
 }
 

--- a/plugins/postgres/searcher_test.go
+++ b/plugins/postgres/searcher_test.go
@@ -285,6 +285,46 @@ func TestPGSearcher_TenantIsolation(t *testing.T) {
 	}
 }
 
+func TestPGSearcher_EqNumeric(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterEq, Path: "age", Source: spi.SourceData, Value: float64(30)},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 1 { // Alice age=30
+		t.Fatalf("age=30: want 1, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_NeNumeric(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterNe, Path: "age", Source: spi.SourceData, Value: float64(30)},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 4 { // Bob 25, Charlie 35, Diana 28, Eve 40
+		t.Fatalf("age!=30: want 4, got %d", len(got))
+	}
+}
+
+func TestPGSearcher_ContainsNumericValue(t *testing.T) {
+	store, ctx := setupSearcher(t)
+	// value is float64(3); string-op treats it as "3"; ages 30 and 35 contain "3"
+	got, err := searcherOf(t, store).Search(ctx,
+		spi.Filter{Op: spi.FilterContains, Path: "age", Source: spi.SourceData, Value: float64(3)},
+		baseOpts())
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(got) != 2 { // Alice 30, Charlie 35
+		t.Fatalf("age contains '3': want 2, got %d", len(got))
+	}
+}
+
 // Compile-time guard mirrored as a runtime assertion for clarity.
 func TestPGSearcher_ImplementsSearcher(t *testing.T) {
 	store, ctx := setupSearcher(t)

--- a/plugins/postgres/searcher_test.go
+++ b/plugins/postgres/searcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/plugins/postgres"
@@ -291,4 +292,77 @@ func TestPGSearcher_ImplementsSearcher(t *testing.T) {
 		t.Fatal("postgres entityStore must implement spi.Searcher")
 	}
 	_ = ctx
+}
+
+// pitSearchSetup saves v1 (active) then v2 (inactive) of one entity, then
+// pins v1's valid_time to baseTS and v2's to 300µs later (same millisecond),
+// mirroring pit_boundary_test.go. Returns the store, ctx, and the base time.
+func pitSearchSetup(t *testing.T) (spi.EntityStore, context.Context, time.Time) {
+	t.Helper()
+	const (
+		tenant = "pit-search-tenant"
+		baseTS = "2026-02-01 00:00:00+00"
+		nextTS = "2026-02-01 00:00:00.000300+00"
+	)
+	factory := setupEntityTest(t)
+	ctx := ctxWithTenant(tenant)
+	store, err := factory.EntityStore(ctx)
+	if err != nil {
+		t.Fatalf("EntityStore: %v", err)
+	}
+	ent := &spi.Entity{
+		Meta: spi.EntityMeta{ID: "pp1", ModelRef: searchModel, State: "NEW"},
+		Data: []byte(`{"name":"Alice","status":"active"}`),
+	}
+	if _, err := store.Save(ctx, ent); err != nil {
+		t.Fatalf("Save v1: %v", err)
+	}
+	ent.Data = []byte(`{"name":"Alice","status":"inactive"}`)
+	if _, err := store.Save(ctx, ent); err != nil {
+		t.Fatalf("Save v2: %v", err)
+	}
+	pool := factory.Pool()
+	if _, err := pool.Exec(ctx,
+		`UPDATE entity_versions SET valid_time=$1, transaction_time=$1
+		 WHERE tenant_id=$2 AND entity_id=$3 AND version=1`, baseTS, tenant, "pp1"); err != nil {
+		t.Fatalf("pin v1: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE entity_versions SET valid_time=$1, transaction_time=$1
+		 WHERE tenant_id=$2 AND entity_id=$3 AND version=2`, nextTS, tenant, "pp1"); err != nil {
+		t.Fatalf("pin v2: %v", err)
+	}
+	base, err := time.Parse(time.RFC3339Nano, "2026-02-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("parse base: %v", err)
+	}
+	return store, ctx, base
+}
+
+// At the base timestamp only v1 (status=active) is visible, so a search for
+// status=active returns the entity; a search for status=inactive returns none.
+// This is the test that catches the B1 inner-projection defect — without the
+// fix the query errors with `column "entity_id" does not exist` (default
+// ORDER BY entity_id over a derived table that only projected doc).
+func TestPGSearcher_PointInTimeDefaultOrder(t *testing.T) {
+	store, ctx, base := pitSearchSetup(t)
+	opts := spi.SearchOptions{ModelName: "person", ModelVersion: "1", PointInTime: &base}
+
+	active, err := store.(spi.Searcher).Search(ctx,
+		spi.Filter{Op: spi.FilterEq, Path: "status", Source: spi.SourceData, Value: "active"}, opts)
+	if err != nil {
+		t.Fatalf("Search active@base: %v", err)
+	}
+	if len(active) != 1 {
+		t.Fatalf("status=active @base: want 1 (v1 snapshot), got %d", len(active))
+	}
+
+	inactive, err := store.(spi.Searcher).Search(ctx,
+		spi.Filter{Op: spi.FilterEq, Path: "status", Source: spi.SourceData, Value: "inactive"}, opts)
+	if err != nil {
+		t.Fatalf("Search inactive@base: %v", err)
+	}
+	if len(inactive) != 0 {
+		t.Fatalf("status=inactive @base: want 0 (v2 not yet visible), got %d", len(inactive))
+	}
 }


### PR DESCRIPTION
Closes #37.

## Problem

PostgreSQL searches loaded **every** entity of a model via `GetAll`/`GetAllAsAt` and filtered predicates in memory — O(n) regardless of selectivity — while the JSONB column was never used in `WHERE`. SQLite already pushed predicates down (#38) and the SPI `Searcher`/`Filter` contract + service-layer delegation already existed; PostgreSQL was the missing implementation.

## What this does

Implements `spi.Searcher` on the PostgreSQL `entityStore`, reusing the query substrate already present (built for grouped-stats):

- **`plugins/postgres/searcher.go`** — `Search` pushes supported predicates into SQL: JSONB `->>` extraction, numeric comparisons via `cyoda_try_float8`, range (`BETWEEN`), and string ops (`strpos`/`substr`/`LIKE`). Non-pushable operators (regex, case-insensitive) are post-filtered while rows stream through the existing `postgresIter`. `LIMIT`/`OFFSET` push into SQL when no residual remains; otherwise pagination is applied in Go (with the unbounded `Limit<=0` drain-then-offset guard). Structural `ORDER BY` parity with SQLite; order-spec paths are injection-validated.
- **`plugins/postgres/search_base.go`** — shared `searchBaseQuery` helper extracted from `Iterate` (Gate-6 dedup), parameterized by name+version+PIT.
- **Point-in-time projection fix (B1):** the PIT base query's inner `DISTINCT ON (entity_id)` projected only `doc`, so any `ORDER BY entity_id` on a PIT search failed at runtime (`column "entity_id" does not exist`). The shared helper now projects the real `entity_versions` direct columns on the inner select (outer stays `SELECT doc`; `deleted` is doc-only and correctly not projected). This also closed a latent same-shape gap in `Iterate`.
- **Numeric-EQUALS regression fix:** `FilterEq`/`FilterNe` emitted `doc->>'x' = $N` (text) and bound a numeric operand, failing at the pgx encode stage (`unable to encode 777 into text`). Now numeric operands route through `cyoda_try_float8(col) <op> $N::float8` (mirroring the ordering ops); string ops bind the stringified operand. Caught by the cross-backend parity suite, not by unit tests — the latter is now closed.

## Tests

- New `plugins/postgres/searcher_test.go` — per-operator parity (numeric EQ/NE/GT/BETWEEN run live), OR + residual, mixed push/residual, pagination (incl. the unbounded-offset guard and page-identity asserts), point-in-time default-order (catches B1), missing-field numeric NE (3VL), `ORDER BY`, injection (filter + order paths), tenant isolation.
- New cross-backend parity scenario **`RunSearchPointInTime`** + a `SyncSearchAt` point-in-time sync-search client helper — asserts pushdown ≡ in-memory at a snapshot across memory/sqlite/postgres (and the commercial backend).
- Full root `go test ./...` (incl. `internal/e2e` and `e2e/parity` on all backends): green. `make race`: clean.

## Scope / non-goals

No SPI change, no `go.mod` bump, no new env vars or help topics, no Cassandra impact. Deferred (per spec): GIN/expression indexes, client-facing sort (#347), async self-executing search store. The performance win here is constant-factor (no full-result transfer/decode, DB-side filtering, `LIMIT` pushdown) — not index-grade; pushdown is the prerequisite that makes path indexes useful later.

Design spec and implementation plan: `docs/superpowers/specs/2026-06-27-postgres-searcher-pushdown-design.md`, `docs/superpowers/plans/2026-06-28-postgres-searcher-pushdown.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)