### PR TITLE
fix(sqlite): same-tx delete+reclaim of a composite unique-key value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,12 @@
 # Cyoda-Go
 
 Lightweight, multi-node Go implementation of the Cyoda platform.
-cyoda-go defines the API and integration contract; Cyoda Cloud aligns to it.
+cyoda-go **defines** the API and integration contract; Cyoda Cloud follows it
+(`docs/cloud-parity/`). cyoda-go's behaviour *is* the spec — a storage backend
+(memory/sqlite/postgres) diverging on the same contract is a bug to fix, not an
+"accepted divergence"; cross-backend parity tests only guard that consistency,
+they neither define behaviour nor equate to Cloud parity. OSS-only features
+Cloud lacks (e.g. composite keys) carry no Cloud-parity duty.
 
 ## Development Gates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,9 @@
 # Cyoda-Go
 
 Lightweight, multi-node Go implementation of the Cyoda platform.
-cyoda-go **defines** the API and integration contract; Cyoda Cloud follows it
-(`docs/cloud-parity/`). cyoda-go's behaviour *is* the spec — a storage backend
-(memory/sqlite/postgres) diverging on the same contract is a bug to fix, not an
-"accepted divergence"; cross-backend parity tests only guard that consistency,
-they neither define behaviour nor equate to Cloud parity. OSS-only features
-Cloud lacks (e.g. composite keys) carry no Cloud-parity duty.
+A storage backend (memory/sqlite/postgres) diverging from the others on the same
+contract is a bug to fix, not an "accepted divergence"; cross-backend parity tests
+guard that consistency, they don't define behaviour.
 
 ## Development Gates
 
@@ -68,6 +65,12 @@ If the fix is structural, requires a design decision, or would significantly
 expand the change, **stop and surface the choice to the human** rather than
 silently leaving it broken. Recording a `TODO(...)` is the last resort, not
 the first response.
+
+### Gate 7: Cloud-parity — cyoda-go leads the contract
+cyoda-go **defines** the API and integration contract; Cyoda Cloud follows it.
+Any change to the integration contract (API shape, wire/error semantics, entity
+or workflow behaviour Cloud mirrors) must be reconciled with cyoda-cloud and the
+change logged in `docs/cloud-parity/` — one file per feature/behaviour, as shown there.
 
 ## External Storage Plugins
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,7 @@
 # Cyoda-Go
 
 Lightweight, multi-node Go implementation of the Cyoda platform.
-A storage backend (memory/sqlite/postgres) diverging from the others on the same
-contract is a bug to fix, not an "accepted divergence"; cross-backend parity tests
-guard that consistency, they don't define behaviour.
+cyoda-go defines the API and integration contract; Cyoda Cloud aligns to it.
 
 ## Development Gates
 
@@ -70,7 +68,7 @@ the first response.
 cyoda-go **defines** the API and integration contract; Cyoda Cloud follows it.
 Any change to the integration contract (API shape, wire/error semantics, entity
 or workflow behaviour Cloud mirrors) must be reconciled with cyoda-cloud and the
-change logged in `docs/cloud-parity/` — one file per feature/behaviour, as shown there.
+change logged in `docs/cloud-parity/` — one file per feature/behaviour.
 
 ## External Storage Plugins
 
@@ -83,6 +81,10 @@ shared contracts), verify the change does not break the Cassandra plugin. The
 parity test registry (`e2e/parity/registry.go`) is picked up by all backends
 including Cassandra — new parity tests will surface there on their next
 dependency update.
+
+A storage backend (memory/sqlite/postgres) diverging from the others on the same
+contract is a bug to fix, not an "accepted divergence"; cross-backend parity tests
+guard that consistency, they don't define behaviour.
 
 ## Go Conventions
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4364,11 +4364,11 @@ paths:
         - All declared fields must be scalar leaf fields in the model schema
 
 
-        Enforcement and transactional ordering:
+        Enforcement:
 
         - A duplicate value-set is rejected with 409 UNIQUE_VIOLATION (non-retryable).
 
-        - Within one transaction (e.g. an automated workflow that deletes and creates/updates entities), free a unique-key value before claiming it on another entity: delete or update the holder, then create or update the claimant. Free-then-claim succeeds on every backend. Claiming a value while its current holder is still live in the same transaction is rejected by write-time-enforcing backends (PostgreSQL) and accepted by commit-time backends (in-memory, SQLite); for portable behavior, free before claiming.
+        - In one transaction, free a unique-key value (delete/re-key the holder) before claiming it elsewhere. Free-then-claim is portable; claim-before-free is rejected on write-time backends (PostgreSQL), accepted on commit-time ones (in-memory, SQLite).
 
         \        "
       operationId: setEntityModelUniqueKeys

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4363,6 +4363,13 @@ paths:
 
         - All declared fields must be scalar leaf fields in the model schema
 
+
+        Enforcement and transactional ordering:
+
+        - A duplicate value-set is rejected with 409 UNIQUE_VIOLATION (non-retryable).
+
+        - Within one transaction (e.g. an automated workflow that deletes and creates/updates entities), free a unique-key value before claiming it on another entity: delete or update the holder, then create or update the claimant. Free-then-claim succeeds on every backend. Claiming a value while its current holder is still live in the same transaction is rejected by write-time-enforcing backends (PostgreSQL) and accepted by commit-time backends (in-memory, SQLite); for portable behavior, free before claiming.
+
         \        "
       operationId: setEntityModelUniqueKeys
       security:

--- a/cmd/cyoda/help/content/errors/UNIQUE_VIOLATION.md
+++ b/cmd/cyoda/help/content/errors/UNIQUE_VIOLATION.md
@@ -24,6 +24,8 @@ The entity payload contains field values that collide with an existing entity's 
 
 To resolve: change the values of the fields that form the unique key so they no longer duplicate an existing entity.
 
+On storage backends that enforce uniqueness at write time (PostgreSQL), this error can also occur **within a single transaction** when a value is claimed before its current holder is freed — for example a workflow that creates or re-keys an entity onto a value before deleting the entity that still holds it. Free the value first (delete or update the holder), then claim it. Backends that validate at commit (the in-memory and SQLite engines) accept either order; for portable behavior, always free before claiming. See the unique-keys section of `cyoda help models` for details.
+
 ## SEE ALSO
 
 - errors

--- a/cmd/cyoda/help/content/errors/UNIQUE_VIOLATION.md
+++ b/cmd/cyoda/help/content/errors/UNIQUE_VIOLATION.md
@@ -24,7 +24,7 @@ The entity payload contains field values that collide with an existing entity's 
 
 To resolve: change the values of the fields that form the unique key so they no longer duplicate an existing entity.
 
-On storage backends that enforce uniqueness at write time (PostgreSQL), this error can also occur **within a single transaction** when a value is claimed before its current holder is freed — for example a workflow that creates or re-keys an entity onto a value before deleting the entity that still holds it. Free the value first (delete or update the holder), then claim it. Backends that validate at commit (the in-memory and SQLite engines) accept either order; for portable behavior, always free before claiming. See the unique-keys section of `cyoda help models` for details.
+On write-time backends (PostgreSQL) this can also fire within one transaction when a value is claimed before its holder is freed; free-before-claim is portable (see `cyoda help models`).
 
 ## SEE ALSO
 

--- a/cmd/cyoda/help/content/models.md
+++ b/cmd/cyoda/help/content/models.md
@@ -153,6 +153,8 @@ Returns `200 OK` with `EntityModelActionResultDto` on success.
 - `409 MODEL_ALREADY_LOCKED` — model is not in `UNLOCKED` state.
 - `422 INVALID_UNIQUE_KEY_DEFINITION` — a field path references a non-scalar/unknown/array field, a key `id` is duplicated, or `fields` is empty.
 
+**Transactional ordering — freeing and reclaiming a value.** A unique-key value is freed when the entity holding it is deleted, or updated so its key field changes. When a single transaction both frees a value and claims it on another entity — e.g. an automated workflow whose processors delete and create/update entities in one transaction — **free the value before claiming it**: delete or update the holder, then create or update the claimant. Free-then-claim succeeds on every storage backend. The reverse order — claiming a value while its current holder is still live in the same transaction — is **rejected** by backends that enforce uniqueness at write time (PostgreSQL) and **accepted** by backends that validate at commit (the in-memory and SQLite engines). For backend-portable behavior always free before claiming; claim-before-free is a workflow-wiring smell.
+
 **GET /api/model/{entityName}/{modelVersion}/workflow/export**
 
 Export all workflow configurations for the model. Returns `404 WORKFLOW_NOT_FOUND` if no workflows exist.

--- a/cmd/cyoda/help/content/models.md
+++ b/cmd/cyoda/help/content/models.md
@@ -153,7 +153,7 @@ Returns `200 OK` with `EntityModelActionResultDto` on success.
 - `409 MODEL_ALREADY_LOCKED` — model is not in `UNLOCKED` state.
 - `422 INVALID_UNIQUE_KEY_DEFINITION` — a field path references a non-scalar/unknown/array field, a key `id` is duplicated, or `fields` is empty.
 
-**Transactional ordering — freeing and reclaiming a value.** A unique-key value is freed when the entity holding it is deleted, or updated so its key field changes. When a single transaction both frees a value and claims it on another entity — e.g. an automated workflow whose processors delete and create/update entities in one transaction — **free the value before claiming it**: delete or update the holder, then create or update the claimant. Free-then-claim succeeds on every storage backend. The reverse order — claiming a value while its current holder is still live in the same transaction — is **rejected** by backends that enforce uniqueness at write time (PostgreSQL) and **accepted** by backends that validate at commit (the in-memory and SQLite engines). For backend-portable behavior always free before claiming; claim-before-free is a workflow-wiring smell.
+**Transactional ordering.** When one transaction (e.g. a workflow) both frees a unique-key value — by deleting or re-keying its holder — and claims it on another entity, free it before claiming. Free-then-claim works on every backend; the reverse is rejected on write-time backends (PostgreSQL) and accepted on commit-time ones (in-memory, SQLite), so free-before-claim for portable behavior.
 
 **GET /api/model/{entityName}/{modelVersion}/workflow/export**
 

--- a/e2e/parity/unique_keys.go
+++ b/e2e/parity/unique_keys.go
@@ -27,10 +27,13 @@ package parity
 //
 // What this suite does NOT cover:
 //   - Same-transaction delete+reclaim (delete A holding value V, create B
-//     wanting V, in one tx → commit succeeds). This is a STORE-LEVEL behaviour:
-//     no HTTP endpoint mixes a delete and a create in one transaction, so the
-//     parity suite cannot reach it. Covered identically on all three engines by
-//     TestUniqueClaims_SameTransactionDeleteAndReclaim in plugins/{memory,sqlite,postgres}.
+//     wanting V, in one tx → commit succeeds). Reachable in production via
+//     automated workflow traversal, where a processor/transition may delete and
+//     create entities within one engine transaction. Tested deterministically at
+//     the store level on all three engines by
+//     TestUniqueClaims_SameTransactionDeleteAndReclaim in plugins/{memory,sqlite,postgres}
+//     (a single plain HTTP call cannot stage a mixed delete+create, so it is not
+//     a parity HTTP scenario).
 //   - Concurrency/race tests: isolated single-backend (task 8.4).
 //   - COMPOSITE_KEY_UNSUPPORTED coverage: all in-repo backends support it;
 //     the negative case is covered by a unit test with a fake StoreFactory (task 8).

--- a/e2e/parity/unique_keys.go
+++ b/e2e/parity/unique_keys.go
@@ -26,7 +26,11 @@ package parity
 //  8. UniqueKeys_ProcessorRewritesKeyField    — processor overwrites the key field → enforcement on the POST-MERGE value (two distinct inputs collide → 409)
 //
 // What this suite does NOT cover:
-//   - Same-transaction delete+reclaim: backend-divergent, out of scope.
+//   - Same-transaction delete+reclaim (delete A holding value V, create B
+//     wanting V, in one tx → commit succeeds). This is a STORE-LEVEL behaviour:
+//     no HTTP endpoint mixes a delete and a create in one transaction, so the
+//     parity suite cannot reach it. Covered identically on all three engines by
+//     TestUniqueClaims_SameTransactionDeleteAndReclaim in plugins/{memory,sqlite,postgres}.
 //   - Concurrency/race tests: isolated single-backend (task 8.4).
 //   - COMPOSITE_KEY_UNSUPPORTED coverage: all in-repo backends support it;
 //     the negative case is covered by a unit test with a fake StoreFactory (task 8).

--- a/internal/e2e/unique_keys_processor_test.go
+++ b/internal/e2e/unique_keys_processor_test.go
@@ -238,3 +238,113 @@ func TestUniqueKeys_ProcessorOverBoundValue_422(t *testing.T) {
 	}
 	assertErrorCode(t, body, "INVALID_UNIQUE_KEY")
 }
+
+// TestUniqueKeys_ProcessorDeletesAndReclaims_SameTx proves the same-transaction
+// delete+reclaim works through the REAL reachable path. A SYNC processor runs
+// INSIDE the engine transaction (its ctx carries the tx-token, so a store call
+// joins that tx); it deletes entity A — freeing A's unique-key value — and
+// rewrites entity B's key onto that just-freed value, all committed atomically.
+// Must succeed (200): A's claim is released before B's claim is inserted, in one
+// tx. This is the production-reachable counterpart of
+// TestUniqueKeys_ProcessorRewrite_IfMatchUpdate_409, which is identical EXCEPT it
+// does not delete A and therefore 409s — so the delete is provably what frees the
+// value. Store-level equivalents live in plugins/{memory,sqlite,postgres}.
+func TestUniqueKeys_ProcessorDeletesAndReclaims_SameTx(t *testing.T) {
+	const model = "e2e-uk-proc-delete-reclaim"
+	const procName = "uk-delete-a-reclaim-b"
+
+	var aID string // A's id; set after A is created, read by the processor closure.
+
+	procSvc.RegisterProcessor(procName, func(ctx context.Context, entity *spi.Entity, proc spi.ProcessorDefinition) (*spi.Entity, error) {
+		// ctx carries the engine transaction, so this Delete joins the SAME tx as
+		// B's pending update — releasing A's claim before B's claim is inserted.
+		store, err := testApp.StoreFactory().EntityStore(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if err := store.Delete(ctx, aID); err != nil {
+			return nil, err
+		}
+		var data map[string]any
+		if err := json.Unmarshal(entity.Data, &data); err != nil {
+			return nil, err
+		}
+		data["name"] = "shared" // B claims A's just-freed value
+		updated, err := json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
+		return &spi.Entity{Meta: entity.Meta, Data: updated}, nil
+	})
+	defer procSvc.Reset()
+
+	importModelWithSample(t, model, 1, ukSampleData)
+	keysJSON := `{"uniqueKeys":[{"id":"name-key","fields":["$.name"]}]}`
+	if status, body := setUniqueKeysE2E(t, model, 1, keysJSON); status != http.StatusOK {
+		t.Fatalf("setUniqueKeys: expected 200, got %d: %s", status, body)
+	}
+	lockModelE2E(t, model, 1)
+
+	// NONE -init(no proc)-> PENDING -reclaim(SYNC proc)-> DONE
+	wf := fmt.Sprintf(`{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "%s-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE":    {"transitions": [{"name": "init", "next": "PENDING", "manual": false}]},
+				"PENDING": {"transitions": [{"name": "reclaim", "next": "DONE", "manual": true,
+					"processors": [{"type": "calculator", "name": "%s", "executionMode": "SYNC",
+						"config": {"attachEntity": true, "calculationNodesTags": ""}}]
+				}]},
+				"DONE":    {}
+			}
+		}]
+	}`, model, procName)
+	if status, body := importWorkflowE2E(t, model, 1, wf); status != http.StatusOK {
+		t.Fatalf("importWorkflow: expected 200, got %d: %s", status, body)
+	}
+
+	// Entity A claims "shared".
+	{
+		status, body := createEntityRaw(t, model, 1, `{"name":"shared","amount":1,"status":"draft"}`)
+		if status != http.StatusOK {
+			t.Fatalf("create A: expected 200, got %d: %s", status, body)
+		}
+		aID = extractEntityID(t, body)
+	}
+
+	// Entity B claims "b-orig".
+	status, body := createEntityRaw(t, model, 1, `{"name":"b-orig","amount":2,"status":"draft"}`)
+	if status != http.StatusOK {
+		t.Fatalf("create B: expected 200, got %d: %s", status, body)
+	}
+	bID := extractEntityID(t, body)
+
+	// If-Match PUT firing "reclaim": the SYNC processor deletes A (freeing
+	// "shared") and rewrites B's name to "shared", in ONE tx → must be 200, NOT 409.
+	ifMatch := getEntityTxID(t, bID)
+	path := fmt.Sprintf("/api/entity/JSON/%s/reclaim", bID)
+	req := authRequest(t, http.MethodPut, path, strings.NewReader(`{"name":"b-orig","amount":2,"status":"draft"}`))
+	req.Header.Set("If-Match", ifMatch)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("If-Match PUT reclaim failed: %v", err)
+	}
+	respBody := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("same-tx delete+reclaim: expected 200, got %d: %s", resp.StatusCode, respBody)
+	}
+
+	// A is gone (deleted in the same tx).
+	getA := doAuth(t, http.MethodGet, fmt.Sprintf("/api/entity/%s", aID), "")
+	if getA.StatusCode != http.StatusNotFound {
+		t.Errorf("A after same-tx delete: expected 404, got %d: %s", getA.StatusCode, readBody(t, getA))
+	}
+
+	// B now holds "shared": a fresh create of "shared" collides → 409.
+	if st, body := createEntityRaw(t, model, 1, `{"name":"shared","amount":9,"status":"draft"}`); st != http.StatusConflict {
+		t.Errorf("reclaimed value must be enforced for B: expected 409, got %d: %s", st, body)
+	} else {
+		assertErrorCode(t, body, "UNIQUE_VIOLATION")
+	}
+}

--- a/plugins/memory/unique_claims_test.go
+++ b/plugins/memory/unique_claims_test.go
@@ -403,3 +403,42 @@ func TestUniqueClaims_ConcurrentWinnerLoser(t *testing.T) {
 		t.Errorf("expected exactly 1 winner and 1 ErrUniqueViolation, got %d wins %d violations", wins, violations)
 	}
 }
+
+// TestUniqueClaims_SameTxReclaimBeforeDelete_AcceptedAtCommit documents the
+// save-first (claim-before-free) ordering: creating B with value V BEFORE
+// deleting A (which holds V), in one tx. memory (like sqlite) validates the NET
+// claim state at commit and cannot distinguish save-first from delete-first —
+// both commit successfully. Postgres enforces inline and REJECTS this ordering
+// (see plugins/postgres). The divergence on this discouraged "claim-before-free"
+// wiring is documented (models.md / errors/UNIQUE_VIOLATION.md / OpenAPI).
+func TestUniqueClaims_SameTxReclaimBeforeDelete_AcceptedAtCommit(t *testing.T) {
+	factory, store := setupUCFactory(t)
+	baseCtx := ctxWithTenant("uc-tenant")
+	ctx := spi.WithUniqueKeys(baseCtx, ucEmailKeys())
+
+	if _, err := store.Save(ctx, ucEntity("a", "shared@x.com")); err != nil {
+		t.Fatalf("pre-save A: %v", err)
+	}
+	tm, err := factory.TransactionManager(baseCtx)
+	if err != nil {
+		t.Fatalf("TransactionManager: %v", err)
+	}
+	txID, txCtx, err := tm.Begin(baseCtx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	// SAVE-FIRST: claim V on B before freeing it on A. Buffered → no error here.
+	if _, err := store.Save(spi.WithUniqueKeys(txCtx, ucEmailKeys()), ucEntity("b", "shared@x.com")); err != nil {
+		t.Fatalf("buffered Save-before-Delete must not error at Save time: %v", err)
+	}
+	if err := store.Delete(txCtx, "a"); err != nil {
+		t.Fatalf("tx Delete a: %v", err)
+	}
+	// Commit succeeds: net state at commit is "A gone, B holds V" — order-blind.
+	if err := tm.Commit(txCtx, txID); err != nil {
+		t.Fatalf("buffered same-tx reclaim-before-delete: expected commit success, got %v", err)
+	}
+	if _, err := store.Save(ctx, ucEntity("c", "shared@x.com")); !errors.Is(err, spi.ErrUniqueViolation) {
+		t.Errorf("c with b's value: expected ErrUniqueViolation, got %v", err)
+	}
+}

--- a/plugins/postgres/unique_claims_test.go
+++ b/plugins/postgres/unique_claims_test.go
@@ -304,3 +304,37 @@ func TestUniqueClaims_SameTransactionDeleteAndReclaim(t *testing.T) {
 		t.Errorf("c with b's value: expected ErrUniqueViolation, got %v", err)
 	}
 }
+
+// TestUniqueClaims_SameTxReclaimBeforeDelete_RejectedAtInsert documents that
+// postgres REJECTS the save-first (claim-before-free) ordering. Unlike the
+// buffered engines (memory/sqlite), postgres enforces the unique_claims_uq index
+// inline at insert time, so claiming value V on B while A still holds it fails AT
+// THE SAVE — A has not been deleted yet. This is the legitimate, stricter
+// interpretation (claim-before-free is an application smell). The divergence is
+// documented (models.md / errors/UNIQUE_VIOLATION.md / OpenAPI), not reconciled:
+// the buffered engines cannot replicate insert-time ordering without abandoning
+// commit-time validation.
+func TestUniqueClaims_SameTxReclaimBeforeDelete_RejectedAtInsert(t *testing.T) {
+	factory, tm := setupEntityTestWithTM(t)
+	baseCtx := ctxWithTenant("uc-tenant")
+	store, err := factory.EntityStore(baseCtx)
+	if err != nil {
+		t.Fatalf("EntityStore: %v", err)
+	}
+	ctx := spi.WithUniqueKeys(baseCtx, emailKeys())
+
+	if _, err := store.Save(ctx, ucEntity("a", "shared@x.com")); err != nil {
+		t.Fatalf("pre-save A: %v", err)
+	}
+	txID, txCtx, err := tm.Begin(baseCtx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	// SAVE-FIRST: claim V on B before freeing it on A. Postgres enforces inline,
+	// so this fails AT THE SAVE (A still holds V) — not deferred to commit.
+	_, errSave := store.Save(spi.WithUniqueKeys(txCtx, emailKeys()), ucEntity("b", "shared@x.com"))
+	if !errors.Is(errSave, spi.ErrUniqueViolation) {
+		t.Fatalf("postgres save-before-delete: expected ErrUniqueViolation at Save, got %v", errSave)
+	}
+	_ = tm.Rollback(txCtx, txID)
+}

--- a/plugins/postgres/unique_claims_test.go
+++ b/plugins/postgres/unique_claims_test.go
@@ -247,3 +247,60 @@ func TestUniqueClaims_UpdateToAllNullFreesValue(t *testing.T) {
 		t.Fatalf("Save e2 with freed value: %v", err)
 	}
 }
+
+// TestUniqueClaims_SameTransactionDeleteAndReclaim verifies that within ONE
+// transaction, deleting entity A (which holds a key value) and creating entity B
+// with that same value commits successfully — A's delete frees the value for B.
+// Mirrors plugins/memory and plugins/sqlite. Postgres enforces claims inline
+// (no buffer), so the delete's claim-release must precede B's claim-insert within
+// the tx — which the delete-first ordering here guarantees.
+func TestUniqueClaims_SameTransactionDeleteAndReclaim(t *testing.T) {
+	factory, tm := setupEntityTestWithTM(t)
+	baseCtx := ctxWithTenant("uc-tenant")
+	store, err := factory.EntityStore(baseCtx)
+	if err != nil {
+		t.Fatalf("EntityStore: %v", err)
+	}
+
+	ctx := spi.WithUniqueKeys(baseCtx, emailKeys())
+
+	// Pre-condition (non-tx): entity A holds "shared@x.com".
+	if _, err := store.Save(ctx, ucEntity("a", "shared@x.com")); err != nil {
+		t.Fatalf("pre-save A: %v", err)
+	}
+
+	txID, txCtx, err := tm.Begin(baseCtx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+
+	// Same transaction: delete A, then create B with A's former value.
+	if err := store.Delete(txCtx, "a"); err != nil {
+		t.Fatalf("tx Delete a: %v", err)
+	}
+	if _, err := store.Save(spi.WithUniqueKeys(txCtx, emailKeys()), ucEntity("b", "shared@x.com")); err != nil {
+		t.Fatalf("tx Save b: %v", err)
+	}
+
+	// Commit must succeed: A's claim is released by the delete, so B may hold it.
+	if err := tm.Commit(txCtx, txID); err != nil {
+		t.Fatalf("Commit: expected success (delete-then-reclaim), got %v", err)
+	}
+
+	// Post-conditions: A is gone, B holds the value.
+	if exists, err := store.Exists(baseCtx, "a"); err != nil || exists {
+		t.Errorf("a should not exist after tx delete: exists=%v err=%v", exists, err)
+	}
+	b, err := store.Get(baseCtx, "b")
+	if err != nil {
+		t.Fatalf("Get b: %v", err)
+	}
+	if string(b.Data) != `{"email":"shared@x.com"}` {
+		t.Errorf("b.Data = %s, want {\"email\":\"shared@x.com\"}", b.Data)
+	}
+
+	// B's claim is enforced: a third entity cannot steal the value.
+	if _, err := store.Save(ctx, ucEntity("c", "shared@x.com")); !errors.Is(err, spi.ErrUniqueViolation) {
+		t.Errorf("c with b's value: expected ErrUniqueViolation, got %v", err)
+	}
+}

--- a/plugins/sqlite/txmanager.go
+++ b/plugins/sqlite/txmanager.go
@@ -338,6 +338,19 @@ func (m *transactionManager) flushToSQLite(ctx context.Context, tx *spi.Transact
 	submitMicro := timeToMicro(submitTime)
 	tid := string(tx.TenantID)
 
+	// Release unique-key claims held by entities deleted in THIS transaction
+	// BEFORE flushing buffered creates/updates (which insert claims). Otherwise a
+	// same-transaction "delete A holding value V, create B wanting V" sees A's
+	// claim still present when B's is inserted and wrongly fails with a unique
+	// violation. The whole flush is one sqlite tx, so this early release rolls
+	// back atomically with everything else on any later error. releaseClaims is a
+	// no-op (idempotent DELETE) for a delete target that holds no claims.
+	for entityID := range tx.Deletes {
+		if err := releaseClaims(ctx, sqlTx, tid, entityID); err != nil {
+			return fmt.Errorf("release claims on delete %s: %w", entityID, err)
+		}
+	}
+
 	// Flush buffered entities.
 	for entityID, entity := range tx.Buffer {
 		var existingVersion sql.NullInt64
@@ -449,11 +462,8 @@ func (m *transactionManager) flushToSQLite(ctx context.Context, tx *spi.Transact
 		if err != nil {
 			return fmt.Errorf("insert delete version %s: %w", entityID, err)
 		}
-
-		// Release unique-key claims so the freed values can be claimed immediately.
-		if err := releaseClaims(ctx, sqlTx, tid, entityID); err != nil {
-			return fmt.Errorf("release claims on delete %s: %w", entityID, err)
-		}
+		// (Claims for deleted entities are released in the pre-pass above, before
+		// the buffer flush, so a same-tx delete+reclaim does not falsely conflict.)
 	}
 
 	// Record submit time.

--- a/plugins/sqlite/unique_claims_test.go
+++ b/plugins/sqlite/unique_claims_test.go
@@ -335,3 +335,71 @@ func TestUniqueClaims_UpdateToAllNullFreesValue(t *testing.T) {
 		t.Fatalf("Save e2 with freed value: %v", err)
 	}
 }
+
+// TestUniqueClaims_SameTransactionDeleteAndReclaim verifies that within ONE
+// transaction, deleting entity A (which holds a key value) and creating entity B
+// with that same value commits successfully — A's delete frees the value for B.
+// Mirrors plugins/memory/unique_claims_test.go and plugins/postgres. The sqlite
+// flush must release deleted entities' claims BEFORE inserting buffered entities'
+// claims; otherwise B's claim insert collides with A's not-yet-released row.
+func TestUniqueClaims_SameTransactionDeleteAndReclaim(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "delete-reclaim.db")
+	factory, err := sqlite.NewStoreFactoryForTest(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("NewStoreFactoryForTest: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+
+	baseCtx := testCtx("uc-tenant")
+	store, err := factory.EntityStore(baseCtx)
+	if err != nil {
+		t.Fatalf("EntityStore: %v", err)
+	}
+	tm, err := factory.TransactionManager(baseCtx)
+	if err != nil {
+		t.Fatalf("TransactionManager: %v", err)
+	}
+
+	ctx := spi.WithUniqueKeys(baseCtx, emailKeys())
+
+	// Pre-condition (non-tx): entity A holds "shared@x.com".
+	if _, err := store.Save(ctx, ucEntity("a", "shared@x.com")); err != nil {
+		t.Fatalf("pre-save A: %v", err)
+	}
+
+	txID, txCtx, err := tm.Begin(baseCtx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+
+	// Same transaction: delete A, then create B with A's former value.
+	if err := store.Delete(txCtx, "a"); err != nil {
+		t.Fatalf("tx Delete a: %v", err)
+	}
+	if _, err := store.Save(spi.WithUniqueKeys(txCtx, emailKeys()), ucEntity("b", "shared@x.com")); err != nil {
+		t.Fatalf("tx Save b: %v", err)
+	}
+
+	// Commit must succeed: A's claim is released by the delete, so B may hold it.
+	if err := tm.Commit(txCtx, txID); err != nil {
+		t.Fatalf("Commit: expected success (delete-then-reclaim), got %v", err)
+	}
+
+	// Post-conditions: A is gone, B holds the value.
+	if exists, err := store.Exists(baseCtx, "a"); err != nil || exists {
+		t.Errorf("a should not exist after tx delete: exists=%v err=%v", exists, err)
+	}
+	b, err := store.Get(baseCtx, "b")
+	if err != nil {
+		t.Fatalf("Get b: %v", err)
+	}
+	if string(b.Data) != `{"email":"shared@x.com"}` {
+		t.Errorf("b.Data = %s, want {\"email\":\"shared@x.com\"}", b.Data)
+	}
+
+	// B's claim is enforced: a third entity cannot steal the value.
+	if _, err := store.Save(ctx, ucEntity("c", "shared@x.com")); !errors.Is(err, spi.ErrUniqueViolation) {
+		t.Errorf("c with b's value: expected ErrUniqueViolation, got %v", err)
+	}
+}

--- a/plugins/sqlite/unique_claims_test.go
+++ b/plugins/sqlite/unique_claims_test.go
@@ -403,3 +403,53 @@ func TestUniqueClaims_SameTransactionDeleteAndReclaim(t *testing.T) {
 		t.Errorf("c with b's value: expected ErrUniqueViolation, got %v", err)
 	}
 }
+
+// TestUniqueClaims_SameTxReclaimBeforeDelete_AcceptedAtCommit documents the
+// save-first (claim-before-free) ordering: creating B with value V BEFORE
+// deleting A (which holds V), in one tx. sqlite (like memory) buffers writes and
+// validates the NET claim state at commit, so it cannot distinguish save-first
+// from delete-first — both commit successfully. Postgres, which enforces inline
+// at insert time, REJECTS this ordering (see plugins/postgres). This divergence
+// on a discouraged "claim-before-free" wiring is documented (models.md /
+// errors/UNIQUE_VIOLATION.md / OpenAPI), not reconciled.
+func TestUniqueClaims_SameTxReclaimBeforeDelete_AcceptedAtCommit(t *testing.T) {
+	dir := t.TempDir()
+	factory, err := sqlite.NewStoreFactoryForTest(context.Background(), filepath.Join(dir, "reclaim-first.db"))
+	if err != nil {
+		t.Fatalf("NewStoreFactoryForTest: %v", err)
+	}
+	t.Cleanup(func() { _ = factory.Close() })
+
+	baseCtx := testCtx("uc-tenant")
+	store, err := factory.EntityStore(baseCtx)
+	if err != nil {
+		t.Fatalf("EntityStore: %v", err)
+	}
+	tm, err := factory.TransactionManager(baseCtx)
+	if err != nil {
+		t.Fatalf("TransactionManager: %v", err)
+	}
+	ctx := spi.WithUniqueKeys(baseCtx, emailKeys())
+
+	if _, err := store.Save(ctx, ucEntity("a", "shared@x.com")); err != nil {
+		t.Fatalf("pre-save A: %v", err)
+	}
+	txID, txCtx, err := tm.Begin(baseCtx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	// SAVE-FIRST: claim V on B before freeing it on A. Buffered → no error here.
+	if _, err := store.Save(spi.WithUniqueKeys(txCtx, emailKeys()), ucEntity("b", "shared@x.com")); err != nil {
+		t.Fatalf("buffered Save-before-Delete must not error at Save time: %v", err)
+	}
+	if err := store.Delete(txCtx, "a"); err != nil {
+		t.Fatalf("tx Delete a: %v", err)
+	}
+	// Commit succeeds: net state at commit is "A gone, B holds V" — order-blind.
+	if err := tm.Commit(txCtx, txID); err != nil {
+		t.Fatalf("buffered same-tx reclaim-before-delete: expected commit success, got %v", err)
+	}
+	if _, err := store.Save(ctx, ucEntity("c", "shared@x.com")); !errors.Is(err, spi.ErrUniqueViolation) {
+		t.Errorf("c with b's value: expected ErrUniqueViolation, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a composite-unique-key defect in the **sqlite** backend: a same-transaction
*delete A (holding key value V) + create B (wanting V)* wrongly failed with a
unique violation. memory already did this correctly; this brings sqlite in line
with the contract and adds equivalent store-level tests to **all three engines**.

Also aligns `CLAUDE.md` with the contract direction (cyoda-go defines, Cloud
follows) and the principle that surfaced this fix: a storage backend diverging on
the same contract is a **bug to fix**, not an "accepted divergence" — cross-backend
parity tests guard consistency, they don't define behaviour or equate to Cloud parity.

## The bug

`plugins/sqlite/txmanager.go` `flushToSQLite` flushed `tx.Buffer` (which **inserts**
unique_claims rows) **before** `tx.Deletes` (which **releases** them). So B's claim
insert collided with A's not-yet-released row → `ErrUniqueViolation`, even though A
is deleted in the same tx. Fix: release deleted entities' claims in a pre-pass
before the buffer flush (one atomic sqlite tx — rolls back together on any error).

## Tests — equivalent on all three engines

`TestUniqueClaims_SameTransactionDeleteAndReclaim` in `plugins/{memory,sqlite,postgres}`:
- memory — already present, still green.
- sqlite — **red before, green after** the fix.
- postgres — green (inline enforcement; delete-first releases A's claim before B's insert).

`make test-all` (51 pkgs, 0 fail) + `make race` (0 races) green; full postgres plugin
suite green against a real DB.

**Workflow-reachable e2e** (`internal/e2e`, Postgres): `TestUniqueKeys_ProcessorDeletesAndReclaims_SameTx`
— a SYNC processor deletes A *inside the engine transaction* and the cascade reclaims A's
value onto B → 200. Proves the production-reachable path end-to-end; it's the exact
counterpart of the existing `TestUniqueKeys_ProcessorRewrite_IfMatchUpdate_409` (which omits
the delete and therefore 409s).

## Reachability + a residual divergence

1. **Reachable in production.** Automated workflow traversal can delete and create
   entities within one engine transaction (processors/transitions), so this was an
   active correctness bug, not just future-proofing. (A single plain HTTP call can't
   stage a mixed delete+create, which is why the test lives at the store level and
   runs deterministically on all three engines rather than as a parity HTTP scenario.)
2. **Save-first (claim-before-free) divergence — documented, not reconciled.** This fix
   covers *delete-first* (free then claim), now identical on all engines. The reverse —
   claiming a value before its holder is freed, in one tx — diverges: write-time PostgreSQL
   rejects it at insert (409); commit-time buffered engines (memory, sqlite) validate net
   state and accept it. Claim-before-free is an application smell, so rather than reconcile
   (deferrable constraints on postgres, or save-time enforcement on the buffered side — both
   unwarranted), it's **documented** for users: `cyoda help models` (unique-keys), the
   UNIQUE_VIOLATION error topic, and the `setEntityModelUniqueKeys` OpenAPI description, plus
   per-engine store tests pinning the behavior (memory/sqlite accept, postgres reject).
