### PR TITLE
feat(openapi): contract status markers + live-or-marked conformance gate (Spec 1, ADR 0003)

### DIFF
--- a/.github/workflows/openapi-breaking-change.yml
+++ b/.github/workflows/openapi-breaking-change.yml
@@ -1,0 +1,42 @@
+name: openapi-breaking-change
+
+# Enforces the additive-only evolution discipline from ADR 0003:
+# api/openapi.yaml may gain new operations, parameters, and optional response
+# fields, but MUST NOT remove operations/parameters, narrow types, add required
+# fields to existing responses, or seal objects with additionalProperties:false.
+#
+# Deletion-interaction note (Task 7 / ErrorResponse removal):
+#   The prior task deleted the unreferenced `components/schemas/ErrorResponse`
+#   schema.  oasdiff keys breaking-change detection on operations and the
+#   schemas they transitively reference.  A component that no operation resolves
+#   is invisible to the breaking-change analyser, so removing it does NOT
+#   trigger a failure here.  This was verified with the fixture test in
+#   internal/oasdiffcheck/ (additive_is_not_breaking / sealing… cases).
+#   If a future deletion touches a *referenced* component, the workflow will
+#   catch it correctly — no --exclude-elements override is needed for the
+#   current or anticipated schema cleanup.
+
+on:
+  pull_request:
+    paths:
+      - "api/openapi.yaml"
+
+jobs:
+  oasdiff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Install oasdiff
+        run: go install github.com/oasdiff/oasdiff@latest
+
+      - name: Breaking-change check (base..PR)
+        run: |
+          git show origin/${{ github.base_ref }}:api/openapi.yaml > /tmp/base-openapi.yaml
+          oasdiff breaking /tmp/base-openapi.yaml api/openapi.yaml --fail-on ERR

--- a/.github/workflows/openapi-breaking-change.yml
+++ b/.github/workflows/openapi-breaking-change.yml
@@ -11,9 +11,12 @@ name: openapi-breaking-change
 #   schemas they transitively reference.  A component that no operation resolves
 #   is invisible to the breaking-change analyser, so removing it does NOT
 #   trigger a failure here.  The expected additive-vs-breaking classification
-#   is documented by the local premise test in internal/oasdiffcheck/
-#   (additive_is_not_breaking / sealing cases); that test is a local check, not
-#   run by this job — this workflow invokes the oasdiff binary directly.
+#   is checked by the premise test in internal/oasdiffcheck/
+#   (additive_is_not_breaking / request_param_type_change_is_breaking), run by
+#   the "Verify oasdiff classification premise" step below.
+#   Note: oasdiff does NOT classify sealing a response schema
+#   (additionalProperties: false) as breaking; the never-seal rule is enforced
+#   separately by TestSpecHasNoSealedSchemas in the normal go-test suite.
 #   If a future deletion touches a *referenced* component, the workflow will
 #   catch it correctly — no --exclude-elements override is needed for the
 #   current or anticipated schema cleanup.
@@ -22,6 +25,10 @@ on:
   pull_request:
     paths:
       - "api/openapi.yaml"
+      # Re-run when the gate itself changes (e.g. an oasdiff version bump) so the
+      # premise test re-validates the pinned oasdiff's classification behaviour.
+      - ".github/workflows/openapi-breaking-change.yml"
+      - "internal/oasdiffcheck/**"
 
 jobs:
   oasdiff:
@@ -39,6 +46,14 @@ jobs:
         # Pinned (not @latest): oasdiff is a merge gate; an unpinned release could
         # shift breaking-change classification. Bump intentionally.
         run: go install github.com/oasdiff/oasdiff@v1.21.0
+
+      - name: Verify oasdiff classification premise
+        # oasdiff is now on PATH, so the premise test actually RUNS (it t.Skips
+        # when the binary is absent). It guards that the pinned oasdiff still
+        # treats an additive change as non-breaking and a client-breaking change
+        # (a request-parameter type narrowing) as breaking — the assumption the
+        # gate rests on.
+        run: go test ./internal/oasdiffcheck/ -count=1 -v
 
       - name: Breaking-change check (base..PR)
         run: |

--- a/.github/workflows/openapi-breaking-change.yml
+++ b/.github/workflows/openapi-breaking-change.yml
@@ -10,8 +10,10 @@ name: openapi-breaking-change
 #   schema.  oasdiff keys breaking-change detection on operations and the
 #   schemas they transitively reference.  A component that no operation resolves
 #   is invisible to the breaking-change analyser, so removing it does NOT
-#   trigger a failure here.  This was verified with the fixture test in
-#   internal/oasdiffcheck/ (additive_is_not_breaking / sealing… cases).
+#   trigger a failure here.  The expected additive-vs-breaking classification
+#   is documented by the local premise test in internal/oasdiffcheck/
+#   (additive_is_not_breaking / sealing cases); that test is a local check, not
+#   run by this job — this workflow invokes the oasdiff binary directly.
 #   If a future deletion touches a *referenced* component, the workflow will
 #   catch it correctly — no --exclude-elements override is needed for the
 #   current or anticipated schema cleanup.
@@ -34,7 +36,9 @@ jobs:
           go-version: "stable"
 
       - name: Install oasdiff
-        run: go install github.com/oasdiff/oasdiff@latest
+        # Pinned (not @latest): oasdiff is a merge gate; an unpinned release could
+        # shift breaking-change classification. Bump intentionally.
+        run: go install github.com/oasdiff/oasdiff@v1.21.0
 
       - name: Breaking-change check (base..PR)
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,19 @@ govulncheck ./...
 
 Release builds additionally run a Trivy scan against the published GHCR image (`.github/workflows/release.yml`). Results are surfaced in the release run's job summary. This is advisory — the tag is already published by the time Trivy runs; pre-merge gating is the `security` job's responsibility.
 
+## OpenAPI operation status & evolution
+
+Every operation in `api/openapi.yaml` must be in one of two states:
+
+- **Live** — exercised by at least one test in `internal/e2e/`. No marker required.
+- **Not-live** — carries `x-cyoda-status: planned` or `x-cyoda-status: unimplemented`.
+
+The E2E conformance gate enforces both sides of this rule: an unmarked operation with no E2E coverage fails CI; a marked operation that returns 2xx fails CI (the marker must be removed once the operation is implemented and exercised).
+
+**Schema authoring rule (ADR 0003).** Schemas are *typed-but-open*: enumerate every property the service emits, but never set `additionalProperties: false` on an evolvable schema. Sealing an object makes every additive field addition a breaking change and is rejected at review.
+
+**Breaking-change gate.** The `openapi-breaking-change` CI job (`.github/workflows/openapi-breaking-change.yml`) runs `oasdiff` on every PR that touches `api/openapi.yaml` and rejects: sealing an open object, removing a field or operation, narrowing a type, or adding a required field to an existing response.
+
 ## Dependencies
 
 No external web frameworks. No DI frameworks. No ORM.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,9 +92,9 @@ Every operation in `api/openapi.yaml` must be in one of two states:
 
 The E2E conformance gate enforces both sides of this rule: an unmarked operation with no E2E coverage fails CI; a marked operation that returns 2xx fails CI (the marker must be removed once the operation is implemented and exercised).
 
-**Schema authoring rule (ADR 0003).** Schemas are *typed-but-open*: enumerate every property the service emits, but never set `additionalProperties: false` on an evolvable schema. Sealing an object makes every additive field addition a breaking change and is rejected at review.
+**Schema authoring rule (ADR 0003).** Schemas are *typed-but-open*: enumerate every property the service emits, but never set `additionalProperties: false` on an evolvable schema. Sealing an object makes every additive field addition a breaking change. This is enforced automatically by `TestSpecHasNoSealedSchemas` (`internal/oasdiffcheck`), which fails if `api/openapi.yaml` contains `additionalProperties: false`.
 
-**Breaking-change gate.** The `openapi-breaking-change` CI job (`.github/workflows/openapi-breaking-change.yml`) runs `oasdiff` on every PR that touches `api/openapi.yaml` and rejects: sealing an open object, removing a field or operation, narrowing a type, or adding a required field to an existing response.
+**Breaking-change gate.** The `openapi-breaking-change` CI job (`.github/workflows/openapi-breaking-change.yml`) runs `oasdiff` on every PR that touches `api/openapi.yaml` and rejects client-breaking edits: narrowing a type, removing an operation or parameter, or adding a required request field. (`oasdiff` does not classify response-sealing as breaking — that is caught by the `additionalProperties: false` check above.)
 
 ## Dependencies
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10146,23 +10146,6 @@ components:
               - POLYMORPHIC
       required:
         - typeReferences
-    ErrorResponse:
-      type: object
-      properties:
-        status:
-          type: integer
-          format: int32
-        message:
-          type: string
-        errorCode:
-          type: string
-          enum:
-            - "2"
-            - "10"
-            - "11"
-        timestamp:
-          type: string
-          format: date-time
     EntityChangeMeta:
       type: object
       properties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -344,9 +344,11 @@ paths:
       tags:
         - User, Account
       summary: Retrieve all subscriptions available for the current user's legal entity.
-      description: Fetch all subscription details associated with the legal entity of
-        the current user.
+      description: |
+        NOT YET IMPLEMENTED in cyoda-go (tracked for implementation).
+        Fetch all subscription details associated with the legal entity of the current user.
       operationId: accountSubscriptionsGet
+      x-cyoda-status: planned
       responses:
         "200":
           description: Collection of all subscriptions for the user's legal entity
@@ -5644,8 +5646,11 @@ paths:
       tags:
         - Stream Data
       summary: Get a stream data configuration by ID
-      description: Retrieves a specific stream data configuration by its UUID.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Retrieves a specific stream data configuration by its UUID.
       operationId: getStreamDataConfig
+      x-cyoda-status: unimplemented
       parameters:
         - name: configId
           in: query
@@ -5673,8 +5678,11 @@ paths:
       tags:
         - Stream Data
       summary: Update an existing stream data configuration
-      description: Updates an existing stream data configuration definition.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Updates an existing stream data configuration definition.
       operationId: updateStreamDataConfig
+      x-cyoda-status: unimplemented
       requestBody:
         description: Stream data configuration with updated values
         content:
@@ -5701,8 +5709,11 @@ paths:
       tags:
         - Stream Data
       summary: Save a new stream data configuration
-      description: Creates and persists a new stream data configuration definition.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Creates and persists a new stream data configuration definition.
       operationId: saveStreamDataConfig
+      x-cyoda-status: unimplemented
       requestBody:
         description: Stream data configuration to save
         content:
@@ -5734,8 +5745,11 @@ paths:
       tags:
         - Stream Data
       summary: Delete a stream data configuration
-      description: Deletes a stream data configuration by its UUID.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Deletes a stream data configuration by its UUID.
       operationId: deleteStreamDataConfig
+      x-cyoda-status: unimplemented
       parameters:
         - name: configId
           in: query
@@ -5764,8 +5778,11 @@ paths:
       tags:
         - Stream Data
       summary: List all stream data configurations
-      description: Returns all available stream data configurations.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Returns all available stream data configurations.
       operationId: getAllConfigs
+      x-cyoda-status: unimplemented
       responses:
         "200":
           description: List of all stream data configurations
@@ -5792,8 +5809,11 @@ paths:
       tags:
         - Stream Data
       summary: Delete stream data
-      description: Deletes entities matching the stream data request criteria.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Deletes entities matching the stream data request criteria.
       operationId: delete
+      x-cyoda-status: unimplemented
       requestBody:
         description: Stream data request defining the entities to delete
         content:
@@ -5825,9 +5845,11 @@ paths:
       tags:
         - Stream Data
       summary: Export all stream data configurations
-      description: Exports all stream data configurations as a container for backup or
-        transfer.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Exports all stream data configurations as a container for backup or transfer.
       operationId: exportAll_1
+      x-cyoda-status: unimplemented
       responses:
         "200":
           description: Container with all stream data configurations
@@ -5852,9 +5874,11 @@ paths:
       tags:
         - Stream Data
       summary: Export stream data configurations by entity class
-      description: Exports all stream data configurations associated with a specific
-        entity class.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Exports all stream data configurations associated with a specific entity class.
       operationId: exportAll
+      x-cyoda-status: unimplemented
       parameters:
         - name: entityClass
           in: query
@@ -5883,8 +5907,11 @@ paths:
       tags:
         - Stream Data
       summary: Export stream data configurations by IDs
-      description: Exports specific stream data configurations identified by their UUIDs.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Exports specific stream data configurations identified by their UUIDs.
       operationId: exportByIds
+      x-cyoda-status: unimplemented
       parameters:
         - name: includeIds
           in: query
@@ -5919,9 +5946,11 @@ paths:
       tags:
         - Stream Data
       summary: Fetch stream data
-      description: Retrieves paginated stream data based on the provided request
-        definition, including conditions, columns, and pagination parameters.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Retrieves paginated stream data based on the provided request definition, including conditions, columns, and pagination parameters.
       operationId: getStreamData
+      x-cyoda-status: unimplemented
       requestBody:
         description: Stream data request containing definition, pagination, and
           point-in-time parameters
@@ -5954,9 +5983,11 @@ paths:
       tags:
         - Stream Data
       summary: Import stream data configurations
-      description: Imports stream data configurations from a container. Can optionally
-        fail if configurations already exist.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Imports stream data configurations from a container. Can optionally fail if configurations already exist.
       operationId: importContainer
+      x-cyoda-status: unimplemented
       parameters:
         - name: failOnExists
           in: query
@@ -5989,9 +6020,11 @@ paths:
       tags:
         - Stream Data
       summary: List index configurations for an entity class
-      description: Returns all index configurations available for the specified entity
-        class.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Returns all index configurations available for the specified entity class.
       operationId: getIndexs
+      x-cyoda-status: unimplemented
       parameters:
         - name: entityClass
           in: query
@@ -6022,9 +6055,11 @@ paths:
       tags:
         - Stream Data
       summary: Get query execution plan
-      description: Returns the original and optimized query execution plan for the
-        given entity class, condition, and alias definitions.
+      description: |
+        NOT IMPLEMENTED in cyoda-go (disposition under review).
+        Returns the original and optimized query execution plan for the given entity class, condition, and alias definitions.
       operationId: getQueryPlan
+      x-cyoda-status: unimplemented
       requestBody:
         description: Query plan request containing entity class, condition, and alias
           definitions
@@ -6649,8 +6684,11 @@ paths:
       tags:
         - SQL-Schema
       summary: Get schema by name
-      description: Retrieves a schema configuration using its name
+      description: |
+        NOT YET IMPLEMENTED in cyoda-go. Planned for the Trino SQL surface.
+        Retrieves a schema configuration using its name
       operationId: getSchemaByName
+      x-cyoda-status: planned
       parameters:
         - name: schemaName
           in: query
@@ -6804,8 +6842,11 @@ paths:
       tags:
         - SQL-Schema
       summary: Save schema
-      description: Saves a new or updates an existing schema configuration
+      description: |
+        NOT YET IMPLEMENTED in cyoda-go. Planned for the Trino SQL surface.
+        Saves a new or updates an existing schema configuration
       operationId: saveSchema
+      x-cyoda-status: planned
       requestBody:
         content:
           application/json:
@@ -6961,8 +7002,11 @@ paths:
       tags:
         - SQL-Schema
       summary: Delete schema by name
-      description: Deletes an existing schema configuration using its name
+      description: |
+        NOT YET IMPLEMENTED in cyoda-go. Planned for the Trino SQL surface.
+        Deletes an existing schema configuration using its name
       operationId: deleteSchemaByName
+      x-cyoda-status: planned
       parameters:
         - name: schemaName
           in: query
@@ -6995,8 +7039,11 @@ paths:
       tags:
         - SQL-Schema
       summary: Generate SQL tables from an entity model
-      description: Generates table configurations based on entity model ID
+      description: |
+        NOT YET IMPLEMENTED in cyoda-go. Planned for the Trino SQL surface.
+        Generates table configurations based on entity model ID
       operationId: genTables
+      x-cyoda-status: planned
       parameters:
         - name: entityModelId
           in: path
@@ -7137,8 +7184,11 @@ paths:
       tags:
         - SQL-Schema
       summary: List all schemas
-      description: Retrieves all available schema configurations
+      description: |
+        NOT YET IMPLEMENTED in cyoda-go. Planned for the Trino SQL surface.
+        Retrieves all available schema configurations
       operationId: getSchemas
+      x-cyoda-status: planned
       responses:
         "200":
           description: List of schemas retrieved successfully
@@ -7273,9 +7323,11 @@ paths:
       tags:
         - SQL-Schema
       summary: Create default schema
-      description: Creates a new schema configuration that includes all available
-        entity models with their complete field structures
+      description: |
+        NOT YET IMPLEMENTED in cyoda-go. Planned for the Trino SQL surface.
+        Creates a new schema configuration that includes all available entity models with their complete field structures
       operationId: putSchema
+      x-cyoda-status: planned
       parameters:
         - name: schemaName
           in: path
@@ -7431,10 +7483,11 @@ paths:
       tags:
         - SQL-Schema
       summary: Synchronize given SQL table configurations with the current entity model
-      description: Synchronizes given table configurations with the current entity
-        model structure, preserving custom settings while incorporating any
-        model changes
+      description: |
+        NOT YET IMPLEMENTED in cyoda-go. Planned for the Trino SQL surface.
+        Synchronizes given table configurations with the current entity model structure, preserving custom settings while incorporating any model changes
       operationId: updateTables
+      x-cyoda-status: planned
       parameters:
         - name: entityModelId
           in: path
@@ -7703,8 +7756,11 @@ paths:
       tags:
         - SQL-Schema
       summary: Get schema by ID
-      description: Retrieves a schema configuration using its UUID
+      description: |
+        NOT YET IMPLEMENTED in cyoda-go. Planned for the Trino SQL surface.
+        Retrieves a schema configuration using its UUID
       operationId: getSchema
+      x-cyoda-status: planned
       parameters:
         - name: schemaId
           in: path
@@ -7857,8 +7913,11 @@ paths:
       tags:
         - SQL-Schema
       summary: Delete schema by ID
-      description: Deletes a schema configuration using its UUID
+      description: |
+        NOT YET IMPLEMENTED in cyoda-go. Planned for the Trino SQL surface.
+        Deletes a schema configuration using its UUID
       operationId: deleteSchema
+      x-cyoda-status: planned
       parameters:
         - name: schemaId
           in: path

--- a/docs/adr/0001-openapi-server-spec-conformance.md
+++ b/docs/adr/0001-openapi-server-spec-conformance.md
@@ -1,6 +1,6 @@
 # 0001. OpenAPI Server-Spec Conformance Approach
 
-**Status:** Accepted
+**Status:** Superseded by 0003
 **Date:** 2026-04-29
 
 ## Context

--- a/docs/adr/0003-openapi-contract-conformance-and-evolution.md
+++ b/docs/adr/0003-openapi-contract-conformance-and-evolution.md
@@ -25,10 +25,11 @@ chosen:
   fidelity between the two implementations is now a first-class concern rather
   than an informal shared-document convention.
 
-An audit of the contract (`docs/analysis/openapi/README.md`) found roughly 55
-spec-vs-server divergences, including about 61 objects modelled as unspecified
-"loose bags" (`type: object` with no properties, or `additionalProperties: true`
-with no enumerated fields). A dedicated research pass
+An audit of the contract (`docs/analysis/openapi/README.md`) found that roughly 55
+of the 87 operations carry at least one spec-vs-server divergence, and that many
+response objects are modelled as unspecified "loose bags" (`type: object` with no
+properties, or `additionalProperties: true` with no enumerated fields) rather than
+as enumerated shapes. A dedicated research pass
 (`docs/analysis/openapi/schema-strictness-research.md`, whose claims were
 adversarially verified against the Zalando RESTful API Guidelines, Google API
 Improvement Proposals, Stripe, RFC 9457, protobuf, and JSON Schema 2020-12)
@@ -59,9 +60,10 @@ service knows it emits, but do not seal the object — leave `additionalProperti
 absent (or `true`), never `false`. Enumerating properties gives code generators
 and LLMs the true shape; leaving the object open keeps a later field addition
 additive and non-breaking, and such additions still pass runtime validation.
-(Empirically confirmed against the pinned validator: an object with an
+(Confirmed against the pinned validator via a probe — an object with an
 un-declared extra member validates against an open schema and fails against
-`additionalProperties: false`.) If a schema composed with `allOf` must ever be
+`additionalProperties: false`; a permanent fixture test lands with the
+implementation.) If a schema composed with `allOf` must ever be
 closed, close it with `unevaluatedProperties: false` at the composition point,
 never with `additionalProperties: false` on the base — the latter cannot see
 into `allOf` branches and would reject a child's own declared fields.
@@ -100,9 +102,10 @@ contract, classified per finding as: spec-stale (server is right, fix the spec),
 spec-incomplete (server is right, enrich the spec), server-gap (the spec states
 intended behaviour the server never implemented, fix the server), or
 needs-decision (record the decision, then it becomes one of the former). Some
-existing code comments in the entity domain assert that "the server is the source
-of truth"; those originate from an earlier defect-reconciliation effort (issue
-#21) in which the server's behaviour happened to be the intended one, and they
+existing code comments (in the entity handler and the e2e conformance test)
+assert that "the server is the source of truth"; those originate from an earlier
+defect-reconciliation effort (issue #21) in which the server's behaviour happened
+to be the intended one, and they
 are not a general rule — this ADR replaces that framing with the per-finding
 classification above.
 

--- a/docs/adr/0003-openapi-contract-conformance-and-evolution.md
+++ b/docs/adr/0003-openapi-contract-conformance-and-evolution.md
@@ -1,0 +1,106 @@
+# 0003. OpenAPI Contract Conformance & Evolution
+
+**Status:** Proposed
+**Date:** 2026-07-03
+**Supersedes:** 0001 (OpenAPI Server-Spec Conformance Approach)
+
+## Context
+
+ADR 0001 adopted runtime response-shape validation of `api/openapi.yaml` at the E2E
+boundary (kin-openapi, enforce mode) and deferred compile-time strict typing. It listed
+reconsideration triggers requiring a superseding ADR. Two have now fired:
+
+- **Consumers that generate clients from the published spec now exist** — codegen clients
+  and LLMs that read `api/openapi.yaml` and reach materially wrong conclusions when shapes
+  are under-specified (e.g. concluding from `GET /entity/{entityId}` that there is no way
+  to learn the entity model, because `meta` is an opaque bag).
+- **cyoda-go now leads the contract and Cyoda Cloud conforms to it** (Gate 7); contract
+  parity is first-class, no longer a "spec-as-shared-document" posture.
+
+A full audit (`docs/analysis/openapi/README.md`) found ~55 spec-vs-server divergences,
+including ~61 objects modelled as unspecified "loose bags." A dedicated research pass
+(`docs/analysis/openapi/schema-strictness-research.md`, 24/25 claims adversarially
+verified against Zalando, Google AIP, Stripe, RFC 9457, protobuf, JSON Schema 2020-12)
+established how to model open vs closed schemas. This ADR records the resulting policy.
+
+The core tension: strict validation with `additionalProperties: false` conflicts with
+additive forward-compatibility (sealing turns "add a field / add an event type" into a
+breaking change), while leaving schemas as loose bags hides shape from consumers.
+
+## Decision
+
+**1. Retain runtime response validation; continue to defer compile-time strict typing.**
+ADR 0001's mechanism stands: kin-openapi enforce-mode validation at the E2E boundary,
+loose `WriteJSON`/`WriteError` handlers, no generated strict-server migration. Typed-but-open
+(below) achieves shape precision without that migration.
+
+**2. Model response schemas typed-but-OPEN.** Enumerate every known property, but do **not**
+seal — `additionalProperties` stays absent/`true`, never `false`. This gives codegen/LLMs
+the real shape while additive fields remain non-breaking and still validate under enforce
+mode (empirically confirmed for kin-openapi v0.140.0). If a composed (`allOf`) schema ever
+must be closed, use `unevaluatedProperties: false` at the composition point — never
+`additionalProperties: false` on the base (it cannot see into `allOf` branches).
+
+**3. Choose strictness by direction.** Requests the service owns may reject unknown *input*
+fields (HTTP 400) on the service-controlled envelope; the user-supplied document region of
+a request stays open. Responses stay open for evolution; the must-ignore-unknown
+(tolerant-reader) obligation sits on the **consumer** (Cloud), documented as a contract
+expectation, not enforced by sealing cyoda-go's schema.
+
+**4. Evolve value sets and unions additively.** Frequently-changing enumerations (event
+types, states) are modelled as documented open value sets (open string with documented
+examples / "[Extensible enum]"), not closed response enums. Discriminated unions carry an
+explicit unknown/default variant so new variants are additive and consumers degrade
+gracefully.
+
+**5. RFC 9457 problem-details are open by standard.** Extension members are permitted and
+consumers must ignore unrecognised ones; problem-detail schemas must not be sealed.
+
+**6. Enforce additive-only evolution with a CI gate.** A breaking-change detector
+(oasdiff or equivalent) runs on `api/openapi.yaml` as a merge gate — catching sealing,
+field removal, type narrowing, and required-field additions — so precision is maintained
+by tooling rather than by a sealed schema.
+
+**7. Reconciliation direction.** The authored `api/openapi.yaml` is the canonical contract
+and source of intent. When spec and server disagree, the defect is on whichever side left
+the contract, decided per finding (spec-stale / spec-incomplete / server-gap /
+needs-decision). This refines the #21 seed's "server is source of truth" framing, which was
+correct only for the specific #21 defects.
+
+## Consequences
+
+**Positive.** Consumers (codegen, LLMs, Cloud) get the true shape of every service-owned
+object while cyoda-go retains full freedom to add fields and event types without a version
+bump or a breaking change. The loose-bag anti-pattern is eliminated for known-shape objects
+without reintroducing the brittleness of sealed schemas. The CI gate makes breaking edits
+visible before they reach the conforming Cloud implementation.
+
+**Negative / cost.** Commits the project to maintaining a breaking-change gate and to
+enumerating properties that were previously dumped into bags. Response validation remains a
+runtime (test-time) guarantee, inherited from ADR 0001. Tolerant-reader correctness on the
+Cloud side is a contract expectation this repo cannot enforce directly — it is recorded in
+`docs/cloud-parity/` and handed off.
+
+**Neutral.** No change to the served artefact shape, the help subsystem, or codegen mode.
+Only schema *content* and the addition of a CI gate change.
+
+**Supersession.** ADR 0001 is marked *Superseded by 0003*. Its runtime-validation decision
+is carried forward here verbatim; only the surrounding context and the schema-authoring /
+evolution policy are new.
+
+## Alternatives considered
+
+- **Seal schemas with `additionalProperties: false` for precision.** Rejected: the research
+  is unanimous (Zalando Rule #111 mandates *not* sealing; JSON Schema is open-by-default)
+  that sealing converts every additive change into a breaking one. It would trade the
+  loose-bag problem for a brittleness problem.
+- **Migrate to compile-time strict typing** (ADR 0001's deferred option A/B). Still
+  deferred: typed-but-open + the CI gate delivers the shape precision the strict-typing
+  migration was wanted for, without its multi-week cost or its inability to validate
+  genuinely polymorphic payloads.
+- **Keep loose bags for extensibility.** Rejected: it was the original motive, but it
+  destroys shape information for consumers; open-enum/additive-union techniques satisfy the
+  same extensibility goal while preserving shape.
+- **Complement ADR 0001 without superseding.** Rejected: ADR 0001 explicitly states that
+  revisiting (which its fired triggers now require) is done via a superseding ADR, and the
+  registry status vocabulary supports supersession, not "extended by."

--- a/docs/adr/0003-openapi-contract-conformance-and-evolution.md
+++ b/docs/adr/0003-openapi-contract-conformance-and-evolution.md
@@ -91,9 +91,14 @@ Error schemas therefore enumerate their known members but are not sealed.
 
 **6. Enforce additive-only evolution with a CI gate.** A breaking-change
 detector (for example, `oasdiff`) runs against `api/openapi.yaml` as a merge
-gate and flags breaking edits — sealing a previously-open object, removing a
-field, narrowing a type, or adding a required field. Precision is thus maintained
-by tooling that catches regressions, rather than by sealing schemas.
+gate and flags client-breaking edits — narrowing a type, adding a required
+request field or parameter, removing an operation or parameter. Note that
+`oasdiff` does NOT flag sealing a response schema (`additionalProperties:
+false`) as breaking, because a stricter response is not client-breaking; the
+"never seal" rule (Decision 2) is therefore enforced by a separate direct check
+that fails if `api/openapi.yaml` contains `additionalProperties: false`.
+Precision is thus maintained by tooling that catches regressions, rather than by
+sealing schemas.
 
 **7. Reconcile drift by direction, per finding.** The authored `api/openapi.yaml`
 is the canonical contract and the source of intent. When the spec and the server

--- a/docs/adr/0003-openapi-contract-conformance-and-evolution.md
+++ b/docs/adr/0003-openapi-contract-conformance-and-evolution.md
@@ -1,6 +1,6 @@
 # 0003. OpenAPI Contract Conformance & Evolution
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-07-03
 **Supersedes:** 0001 (OpenAPI Server-Spec Conformance Approach)
 

--- a/docs/adr/0003-openapi-contract-conformance-and-evolution.md
+++ b/docs/adr/0003-openapi-contract-conformance-and-evolution.md
@@ -6,101 +6,163 @@
 
 ## Context
 
-ADR 0001 adopted runtime response-shape validation of `api/openapi.yaml` at the E2E
-boundary (kin-openapi, enforce mode) and deferred compile-time strict typing. It listed
-reconsideration triggers requiring a superseding ADR. Two have now fired:
+cyoda-go publishes a single, hand-authored OpenAPI 3.1 contract
+(`api/openapi.yaml`) — embedded in the binary and served at `/openapi.json` — as
+the authoritative definition of its HTTP API. Every HTTP response is validated
+against that contract at the end-to-end test boundary, so a response whose shape
+or status code diverges from the spec fails the test suite. This conformance
+posture was established by ADR 0001.
 
-- **Consumers that generate clients from the published spec now exist** — codegen clients
-  and LLMs that read `api/openapi.yaml` and reach materially wrong conclusions when shapes
-  are under-specified (e.g. concluding from `GET /entity/{entityId}` that there is no way
-  to learn the entity model, because `meta` is an opaque bag).
-- **cyoda-go now leads the contract and Cyoda Cloud conforms to it** (Gate 7); contract
-  parity is first-class, no longer a "spec-as-shared-document" posture.
+Two developments have since changed the constraints under which that posture was
+chosen:
 
-A full audit (`docs/analysis/openapi/README.md`) found ~55 spec-vs-server divergences,
-including ~61 objects modelled as unspecified "loose bags." A dedicated research pass
-(`docs/analysis/openapi/schema-strictness-research.md`, 24/25 claims adversarially
-verified against Zalando, Google AIP, Stripe, RFC 9457, protobuf, JSON Schema 2020-12)
-established how to model open vs closed schemas. This ADR records the resulting policy.
+- **Consumers now generate clients directly from the published contract** — both
+  code generators and LLMs read `api/openapi.yaml` and produce clients from it.
+  When a shape is under-specified they reach wrong conclusions (for example,
+  reading `GET /entity/{entityId}` and concluding there is no way to learn an
+  entity's model, because the `meta` object is declared as an opaque bag).
+- **cyoda-go leads the contract and Cyoda Cloud conforms to it.** Contract
+  fidelity between the two implementations is now a first-class concern rather
+  than an informal shared-document convention.
 
-The core tension: strict validation with `additionalProperties: false` conflicts with
-additive forward-compatibility (sealing turns "add a field / add an event type" into a
-breaking change), while leaving schemas as loose bags hides shape from consumers.
+An audit of the contract (`docs/analysis/openapi/README.md`) found roughly 55
+spec-vs-server divergences, including about 61 objects modelled as unspecified
+"loose bags" (`type: object` with no properties, or `additionalProperties: true`
+with no enumerated fields). A dedicated research pass
+(`docs/analysis/openapi/schema-strictness-research.md`, whose claims were
+adversarially verified against the Zalando RESTful API Guidelines, Google API
+Improvement Proposals, Stripe, RFC 9457, protobuf, and JSON Schema 2020-12)
+established the open-vs-closed schema policy recorded below.
+
+The central tension this ADR resolves: validating responses strictly with
+`additionalProperties: false` conflicts with additive forward-compatibility —
+sealing a schema makes "add a field" or "add an event-type variant" a breaking
+change — while modelling shapes as loose bags hides the structure that
+consumers need. The team's original motive for loose bags was extensibility:
+not wanting to revise a schema every time a new aspect (such as a new
+state-machine event type) is added.
 
 ## Decision
 
-**1. Retain runtime response validation; continue to defer compile-time strict typing.**
-ADR 0001's mechanism stands: kin-openapi enforce-mode validation at the E2E boundary,
-loose `WriteJSON`/`WriteError` handlers, no generated strict-server migration. Typed-but-open
-(below) achieves shape precision without that migration.
+**1. Validate responses at runtime; do not adopt compile-time strict typing.**
+The service validates each HTTP response against its operation's schema in
+`api/openapi.yaml` at the end-to-end test boundary (using the `kin-openapi`
+response validator in enforcing mode); a mismatch fails the test naming the
+operation and the offending JSON path. Handlers remain free-form JSON writers
+and are not generated from the spec, and the service does not produce
+strict-typed server stubs. This keeps validation of genuinely polymorphic
+payloads possible (a value strict code generation cannot express) and keeps
+handler code decoupled from generated wire types.
 
-**2. Model response schemas typed-but-OPEN.** Enumerate every known property, but do **not**
-seal — `additionalProperties` stays absent/`true`, never `false`. This gives codegen/LLMs
-the real shape while additive fields remain non-breaking and still validate under enforce
-mode (empirically confirmed for kin-openapi v0.140.0). If a composed (`allOf`) schema ever
-must be closed, use `unevaluatedProperties: false` at the composition point — never
-`additionalProperties: false` on the base (it cannot see into `allOf` branches).
+**2. Model response schemas typed-but-OPEN.** Enumerate every property the
+service knows it emits, but do not seal the object — leave `additionalProperties`
+absent (or `true`), never `false`. Enumerating properties gives code generators
+and LLMs the true shape; leaving the object open keeps a later field addition
+additive and non-breaking, and such additions still pass runtime validation.
+(Empirically confirmed against the pinned validator: an object with an
+un-declared extra member validates against an open schema and fails against
+`additionalProperties: false`.) If a schema composed with `allOf` must ever be
+closed, close it with `unevaluatedProperties: false` at the composition point,
+never with `additionalProperties: false` on the base — the latter cannot see
+into `allOf` branches and would reject a child's own declared fields.
 
-**3. Choose strictness by direction.** Requests the service owns may reject unknown *input*
-fields (HTTP 400) on the service-controlled envelope; the user-supplied document region of
-a request stays open. Responses stay open for evolution; the must-ignore-unknown
-(tolerant-reader) obligation sits on the **consumer** (Cloud), documented as a contract
-expectation, not enforced by sealing cyoda-go's schema.
+**3. Choose strictness by data direction.** For request bodies, the service may
+reject unknown fields on the portion of the envelope it owns (responding
+`400`), giving callers early feedback; the user-supplied document region of a
+request (an arbitrary entity payload) stays open. For responses, schemas stay
+open for evolution, and the obligation to ignore unrecognised fields rests on
+the consumer. That consumer obligation is recorded as a contract expectation for
+the conforming implementation, not enforced by sealing this service's schemas.
 
-**4. Evolve value sets and unions additively.** Frequently-changing enumerations (event
-types, states) are modelled as documented open value sets (open string with documented
-examples / "[Extensible enum]"), not closed response enums. Discriminated unions carry an
-explicit unknown/default variant so new variants are additive and consumers degrade
-gracefully.
+**4. Evolve value sets and unions additively.** Model a frequently-changing set
+of values (event types, workflow states) as a documented open value set — an
+open string annotated with its currently-known values — rather than a closed
+response `enum`, so a new value does not break consumers pinned to the old set.
+Model a discriminated union so that it carries an explicit unknown/default
+variant, so a new variant is an additive change and consumers degrade gracefully
+instead of failing to match.
 
-**5. RFC 9457 problem-details are open by standard.** Extension members are permitted and
-consumers must ignore unrecognised ones; problem-detail schemas must not be sealed.
+**5. Keep error objects open.** Problem-details error responses (RFC 9457) are
+an open content model by that standard: responses may carry problem-specific
+extension members and consumers must ignore members they do not recognise.
+Error schemas therefore enumerate their known members but are not sealed.
 
-**6. Enforce additive-only evolution with a CI gate.** A breaking-change detector
-(oasdiff or equivalent) runs on `api/openapi.yaml` as a merge gate — catching sealing,
-field removal, type narrowing, and required-field additions — so precision is maintained
-by tooling rather than by a sealed schema.
+**6. Enforce additive-only evolution with a CI gate.** A breaking-change
+detector (for example, `oasdiff`) runs against `api/openapi.yaml` as a merge
+gate and flags breaking edits — sealing a previously-open object, removing a
+field, narrowing a type, or adding a required field. Precision is thus maintained
+by tooling that catches regressions, rather than by sealing schemas.
 
-**7. Reconciliation direction.** The authored `api/openapi.yaml` is the canonical contract
-and source of intent. When spec and server disagree, the defect is on whichever side left
-the contract, decided per finding (spec-stale / spec-incomplete / server-gap /
-needs-decision). This refines the #21 seed's "server is source of truth" framing, which was
-correct only for the specific #21 defects.
+**7. Reconcile drift by direction, per finding.** The authored `api/openapi.yaml`
+is the canonical contract and the source of intent. When the spec and the server
+disagree, the divergence is a defect on whichever side departed from the
+contract, classified per finding as: spec-stale (server is right, fix the spec),
+spec-incomplete (server is right, enrich the spec), server-gap (the spec states
+intended behaviour the server never implemented, fix the server), or
+needs-decision (record the decision, then it becomes one of the former). Some
+existing code comments in the entity domain assert that "the server is the source
+of truth"; those originate from an earlier defect-reconciliation effort (issue
+#21) in which the server's behaviour happened to be the intended one, and they
+are not a general rule — this ADR replaces that framing with the per-finding
+classification above.
 
 ## Consequences
 
-**Positive.** Consumers (codegen, LLMs, Cloud) get the true shape of every service-owned
-object while cyoda-go retains full freedom to add fields and event types without a version
-bump or a breaking change. The loose-bag anti-pattern is eliminated for known-shape objects
-without reintroducing the brittleness of sealed schemas. The CI gate makes breaking edits
-visible before they reach the conforming Cloud implementation.
+**Positive.** Consumers — code generators, LLMs, and the conforming Cloud
+implementation — receive the true shape of every object the service controls,
+while the service keeps full freedom to add fields and event variants without a
+version bump or a breaking change. The loose-bag anti-pattern is eliminated for
+objects whose shape is known, without reintroducing the brittleness of sealed
+schemas. The CI gate surfaces breaking edits before they reach the conforming
+implementation.
 
-**Negative / cost.** Commits the project to maintaining a breaking-change gate and to
-enumerating properties that were previously dumped into bags. Response validation remains a
-runtime (test-time) guarantee, inherited from ADR 0001. Tolerant-reader correctness on the
-Cloud side is a contract expectation this repo cannot enforce directly — it is recorded in
-`docs/cloud-parity/` and handed off.
+**Negative / cost.** The project commits to maintaining a breaking-change gate
+and to enumerating properties previously dumped into bags. Response-shape
+conformance is a test-time guarantee: a wrong shape is caught at the next
+end-to-end run, not at compile time — acceptable given a broad end-to-end suite
+across all storage backends, and weaker only on paths that suite does not cover.
+Correct handling of unrecognised fields on the consumer side is a contract
+expectation this repository cannot enforce directly; it is recorded for the
+conforming implementation and handed off.
 
-**Neutral.** No change to the served artefact shape, the help subsystem, or codegen mode.
-Only schema *content* and the addition of a CI gate change.
+**Neutral.** The served artefact, the help subsystem, and handler code shape are
+unchanged; only schema *content* and the addition of a CI gate change.
 
-**Supersession.** ADR 0001 is marked *Superseded by 0003*. Its runtime-validation decision
-is carried forward here verbatim; only the surrounding context and the schema-authoring /
-evolution policy are new.
+## Supersession of ADR 0001
+
+ADR 0001 decided to validate response shapes at runtime with `kin-openapi` at
+the end-to-end boundary and to defer compile-time strict typing, on the reasoning
+that there were then no consumers generating clients from the contract and that
+the contract was a shared document rather than a led specification. ADR 0001
+listed the conditions under which that reasoning should be revisited — consumers
+generating clients from the spec, and contract parity becoming a first-class
+argument — and stated that revisiting requires a superseding ADR.
+
+Both conditions have now occurred (see Context). This ADR therefore supersedes
+ADR 0001. It carries ADR 0001's runtime-validation mechanism forward unchanged
+(Decision 1, stated in full above so this document stands alone) and adds the
+schema-authoring and evolution policy (Decisions 2–7). ADR 0001's status is set
+to "Superseded by 0003."
+
+Supersession — rather than leaving ADR 0001 in force and adding a separate,
+parallel ADR — is used because ADR 0001 itself requires a superseding ADR on
+revisit, and because the registry's status vocabulary expresses this
+relationship directly ("Superseded by NNNN") whereas it has no "amended-by" or
+"extended-by" status.
 
 ## Alternatives considered
 
-- **Seal schemas with `additionalProperties: false` for precision.** Rejected: the research
-  is unanimous (Zalando Rule #111 mandates *not* sealing; JSON Schema is open-by-default)
-  that sealing converts every additive change into a breaking one. It would trade the
-  loose-bag problem for a brittleness problem.
-- **Migrate to compile-time strict typing** (ADR 0001's deferred option A/B). Still
-  deferred: typed-but-open + the CI gate delivers the shape precision the strict-typing
-  migration was wanted for, without its multi-week cost or its inability to validate
-  genuinely polymorphic payloads.
-- **Keep loose bags for extensibility.** Rejected: it was the original motive, but it
-  destroys shape information for consumers; open-enum/additive-union techniques satisfy the
-  same extensibility goal while preserving shape.
-- **Complement ADR 0001 without superseding.** Rejected: ADR 0001 explicitly states that
-  revisiting (which its fired triggers now require) is done via a superseding ADR, and the
-  registry status vocabulary supports supersession, not "extended by."
+- **Seal schemas with `additionalProperties: false` for precision.** Rejected:
+  sealing converts every additive change into a breaking one, and the surveyed
+  guidance is unanimous that object schemas should be left open for extension by
+  default. It would trade the loose-bag problem for a brittleness problem and
+  make routine field additions breaking.
+- **Generate strict-typed server stubs from the spec (compile-time
+  conformance).** Not adopted: the typed-but-open policy plus the CI gate
+  delivers the shape precision this option is wanted for, without a large
+  generator migration, and without giving up runtime validation of genuinely
+  polymorphic payloads (which strict code generation must model as opaque).
+- **Keep loose bags for extensibility.** Rejected: this was the original motive,
+  but loose bags destroy the shape information consumers need; documented
+  open-value-sets and additive unions satisfy the same extensibility goal while
+  preserving shape.

--- a/docs/analysis/openapi/README.md
+++ b/docs/analysis/openapi/README.md
@@ -106,6 +106,16 @@ The spec declares parameters/bodies expressing real intent that the handler neve
 - Message `transactionTimeoutMillis` / `transactionSize` are inert.
 
 ### P3 — Loose `additionalProperties:true` response bags hiding real fields  (`spec-incomplete`)
+
+> **Update 2026-07-03 (fix policy — see ADR 0003 + `schema-strictness-research.md`):** the fix
+> is **typed-but-open**, NOT `additionalProperties: false`. Enumerate the known properties so
+> consumers get the shape, but leave the object open so additive fields stay non-breaking.
+> Two consequences for this list: (1) genuinely-open values — entity `data`, `JsonNode`, and
+> RFC 9457 `ProblemDetail.properties` extension bags — are **correct as open** and come *off*
+> the tightenable set; (2) the state-machine audit-event union is tightened as a discriminated
+> `oneOf` + unknown/default variant + open-enum discriminator, not a sealed object. "Tighten"
+> below means "enumerate + keep open," never "seal."
+
 The class that triggered this audit.
 - **`Envelope.meta`** — documented as an opaque object; actually carries
   `modelKey{name,version}`, `state`, `creationDate`, `lastUpdateTime`, `transactionId`,

--- a/docs/analysis/openapi/README.md
+++ b/docs/analysis/openapi/README.md
@@ -168,7 +168,7 @@ Direction: `spec-stale` · `spec-incomplete` · `server-gap` · `needs-decision`
 | Op | Sev | Dir | Pattern | Detail |
 |---|---|---|---|---|
 | deleteEntities | High | server-gap | P2 | Condition body + `pointInTime` + `verbose` ignored; `DeleteAllEntities` wipes whole model (`handler.go:592-611`, `service.go:748`). **Data loss.** |
-| getAllEntities | High | server-gap | P2 | `pointInTime` parsed but never plumbed into `ListEntities` (`handler.go:613-654`, `service.go:825`). |
+| getAllEntities | High | server-gap | P2 | `pointInTime` never read by the handler / not plumbed into `ListEntities` (`handler.go:613-654`, `service.go:825`). |
 | getOneEntity, getAllEntities | High | spec-stale + spec-incomplete | P3/P4 | `Envelope.meta` opaque bag; desc names fossil `previousTransition`; server emits `modelKey`/`transactionId`/`lastUpdateTime`/`transitionForLatestSave` (`service.go:433-446`, `875-884`; `openapi.yaml:7913-7917`). |
 | createCollection | High | spec-incomplete | P6 | Request body `type:object` empty; server requires array of `{model{name,version}, payload:<json-string>}` (`handler.go:797-816`). |
 | getEntityChangesMetadata | Med | spec-stale | P4 | `EntityChangeMeta.fieldsChangedCount` advertised, never emitted (`handler.go:576-587`). |

--- a/docs/analysis/openapi/README.md
+++ b/docs/analysis/openapi/README.md
@@ -1,0 +1,280 @@
+# OpenAPI Contract Drift — Findings & Scale
+
+**Status:** analysis / point-of-reference. Not a plan. The remediation approach is a
+separate brainstorming + spec effort; this document exists only to size the problem.
+
+**Date:** 2026-07-02
+**Scope:** all 87 HTTP operations in `api/openapi.yaml`, audited against the actual Go
+handler behaviour.
+
+---
+
+## 1. Why this document exists
+
+`api/openapi.yaml` is a **deliberate design choice**: a definitive, static, explicitly
+maintained contract that is the *common ground* between `cyoda-go` and `cyoda-cloud`.
+Both sides are meant to conform to it. It is intentionally **not** generated from Go
+types — the whole point is that the contract is authored and owned, not derived.
+
+The consequence of that choice is that nothing mechanically holds either side to the
+contract. Over time the spec and the `cyoda-go` server have drifted, in **both
+directions**, and the drift is now large enough that an LLM (or a human) generating a
+client from the published spec reaches materially wrong conclusions — the trigger for
+this audit was an app-builder concluding, from `GET /entity/{entityId}`, that *there is
+no way to learn the entity model*, because the `meta` object is documented as an opaque
+bag with a stale field list.
+
+This report is the reference for **how big the mess is** before we design the way out.
+
+## 2. The key reframe: drift is bidirectional
+
+Because the spec is the agreed contract (not a mirror of the server), a divergence is a
+defect on **whichever side left the contract**. Every finding therefore carries a
+**reconciliation direction**, and this is the crux of why a mechanical "make the spec
+match the server" pass would be *wrong*:
+
+| Direction | Meaning | Correct fix |
+|---|---|---|
+| **`spec-stale`** | Server evolved correctly; spec still describes the old shape. | Update the spec. |
+| **`spec-incomplete`** | Server behaviour is right and intended; spec under-describes it (missing fields, missing real error codes). | Enrich the spec. |
+| **`server-gap`** | Spec expresses the intended contract; the server never implemented it (or implemented something else). | Fix the **server**. |
+| **`needs-decision`** | Genuine ambiguity about what the contract *should* be; neither side is self-evidently right. | Decide intent, then fix the losing side. |
+
+The single most important observation for the brainstorming: **~a third of the findings
+are `server-gap` or `needs-decision`**, not `spec-stale`. The spec is often *more*
+correct about intent than the server. This is not a documentation-cleanup task.
+
+## 3. Root cause
+
+- `api/openapi.yaml` was imported wholesale from the upstream `cyoda-light-go` prototype
+  (commit `d1f6875`, "Initial import from cyoda-light-go") and has been hand-maintained
+  and `//go:embed`'d ever since (`embedded-spec: false` in `api/config.yaml` — see the
+  existing note on why native embed is not used).
+- Server responses are frequently built as inline `map[string]any` literals with **no Go
+  struct behind them**, so there is no type the spec could even be checked against.
+- Codegen (`oapi-codegen` → `api/generated.go`) covers only request/response *models* and
+  the router interface; it does **not** verify that handlers populate those models, and
+  `api/config.yaml` **excludes three whole tags** from generation (below) while the spec
+  continues to publish them.
+- The one prior reconciliation pass (commit `9c721b4`, "reconcile spec with server") was
+  scoped to a handful of confirmed defects. It fixed the `Envelope` wrapper but left
+  `meta` as an open bag and **copied the prototype's stale field list** (`previousTransition`)
+  into the description — a microcosm of the whole problem.
+
+Net: there is no enforced binding in **either** direction. Drift is structural, not
+accidental, and will recur after any manual cleanup unless the binding is added.
+
+## 4. Scale at a glance
+
+| Metric | Value |
+|---|---|
+| HTTP operations audited | **87** |
+| Operations with ≥1 finding | ~55 |
+| **Dead operations** (published but unrouted → 404 at runtime) | **22** (25%) |
+| High-severity findings | ~20 |
+| Medium-severity findings | ~30 |
+| Low-severity findings | ~12 |
+| Findings requiring a **contract decision** (`server-gap` / `needs-decision`) | ~1/3 of total |
+| Data-loss-class defects | **1** (`deleteEntities`) |
+
+**Dead tags** (excluded from codegen in `api/config.yaml`, still shipped in the spec):
+
+| Tag | Ops | Reality |
+|---|---|---|
+| `Stream Data` | 13 | Excluded from codegen; no route; 404 at runtime. |
+| `SQL-Schema` | 9 | Excluded from codegen; no route; 404 at runtime. |
+| `CQL Execution Statistics` | 0 | Vestigial exclude entry — no ops currently carry the tag. |
+
+## 5. The drift taxonomy (six recurring patterns)
+
+### P1 — Dead / unwired spec surface  (`needs-decision`)
+22 operations are published in the contract but excluded from codegen and unrouted, so
+they 404. Also here: `accountSubscriptionsGet` documents a `200` shape but the handler
+always returns `501`. **Decision required:** are these part of the `cyoda-go` ↔ Cloud
+contract at all? Either implement them or remove them from the published contract; do
+not leave a quarter of the surface as advertised-but-absent.
+
+### P2 — Advertised-but-unwired request semantics  (`server-gap` — the dangerous class)
+The spec declares parameters/bodies expressing real intent that the handler never reads.
+- 🔴 **`deleteEntities` — data loss.** Contract: delete only entities matching an
+  `AbstractConditionDto` body (+ `pointInTime`, `verbose`). Handler ignores the body and
+  params entirely and calls `DeleteAllEntities` → a client asking to delete a filtered
+  subset **silently wipes the whole model**.
+- **`getAllEntities`**, **`getAsyncSearchResults`** ignore `pointInTime` → "as-at"
+  queries silently return *current* data (same class as the already-fixed
+  `getOneEntity` `transactionId` bug).
+- Message `transactionTimeoutMillis` / `transactionSize` are inert.
+
+### P3 — Loose `additionalProperties:true` response bags hiding real fields  (`spec-incomplete`)
+The class that triggered this audit.
+- **`Envelope.meta`** — documented as an opaque object; actually carries
+  `modelKey{name,version}`, `state`, `creationDate`, `lastUpdateTime`, `transactionId`,
+  and (conditionally) `transitionForLatestSave`. The described field `previousTransition`
+  **does not exist**.
+- **`exportMetadata`** hides a real top-level `uniqueKeys` array.
+- **Message `metaData`** — server emits a flat map, not the typed `ValueMaps` buckets.
+
+### P4 — Stale fossil names / over-promising enums  (`spec-stale`)
+Inherited from the prototype and never trued-up:
+`previousTransition` → `transitionForLatestSave`; `EntityChangeMeta.fieldsChangedCount`
+(never emitted); trusted-key "EC / OKP supported" (RS256-only); multi-algorithm keypair
+enums (RS256-only); `issued_token_type=access_token` (server sends `...jwt`); import
+`converter` enum listing `JSON_SCHEMA` / `SIMPLE_VIEW` (only `SAMPLE_DATA` accepted).
+
+### P5 — Conflated error envelopes + systematically missing error codes  (mixed)
+- **Envelope family mismatch** (`needs-decision`): the entire OIDC-provider group is
+  speced with the OAuth `application/json` `ErrorResponseDto` (`{error, error_description}`),
+  but the server emits RFC-9457 `application/problem+json` `ProblemDetail` with the code
+  in `properties.errorCode`. Only the genuine `/oauth/token` endpoint actually uses the
+  OAuth shape. A client built to the spec cannot parse OIDC errors.
+- **Missing real error codes** (`spec-incomplete`): documented-and-emitted `409`/`422`/
+  `404`/`400` are omitted across nearly every model-management op (lock/unlock/delete/
+  import/unique-keys), plus `501` everywhere in mock-IAM mode.
+- **Fictional error codes** (`needs-decision`): stats/search document `404 model not
+  found` and a `408` timeout the handlers never emit — unknown model returns `200` +
+  empty. Should the server validate existence, or should the contract drop the 404?
+
+### P6 — Mis-typed request bodies + stale prose defaults  (mixed)
+- Request bodies typed as bare `object` / `string` that erase the real shape
+  (`createCollection`, `create`, `deleteMessages`, `newMessage`, `updateTables`) — codegen
+  clients send the wrong body type and get 400s.
+- Prose defaults that lie: `getAsyncSearchResults` documents default page size **10**;
+  server default is **1000** (100×). `issueJwtKeyPair` says algorithm "defaults to RS256";
+  it is actually **required**.
+- Malformed schema constructs: `type: array` with a sibling `$ref` (no `items`) erasing
+  item typing (`genTables`, `getSchemas`), and examples that violate their own declared
+  schema (`FieldConfigDto` uses a non-existent `arrayFields`, omits required `hidden`).
+
+## 6. Full findings by area
+
+Severity: **High** = wrong shape/type, data loss, or advertises non-existent behaviour
+(misleads codegen or endangers clients). **Medium** = missing real fields / missing or
+fictional error codes / silently-ignored params. **Low** = example or cosmetic drift.
+
+Direction: `spec-stale` · `spec-incomplete` · `server-gap` · `needs-decision`.
+
+### 6A — Entity CRUD & envelope  (`internal/domain/entity/*`)
+
+| Op | Sev | Dir | Pattern | Detail |
+|---|---|---|---|---|
+| deleteEntities | High | server-gap | P2 | Condition body + `pointInTime` + `verbose` ignored; `DeleteAllEntities` wipes whole model (`handler.go:592-611`, `service.go:748`). **Data loss.** |
+| getAllEntities | High | server-gap | P2 | `pointInTime` parsed but never plumbed into `ListEntities` (`handler.go:613-654`, `service.go:825`). |
+| getOneEntity, getAllEntities | High | spec-stale + spec-incomplete | P3/P4 | `Envelope.meta` opaque bag; desc names fossil `previousTransition`; server emits `modelKey`/`transactionId`/`lastUpdateTime`/`transitionForLatestSave` (`service.go:433-446`, `875-884`; `openapi.yaml:7913-7917`). |
+| createCollection | High | spec-incomplete | P6 | Request body `type:object` empty; server requires array of `{model{name,version}, payload:<json-string>}` (`handler.go:797-816`). |
+| getEntityChangesMetadata | Med | spec-stale | P4 | `EntityChangeMeta.fieldsChangedCount` advertised, never emitted (`handler.go:576-587`). |
+| getEntityChangesMetadata | Med | spec-stale | — | Desc says chronological/ascending; server sorts newest-first (`service.go:719-722`). |
+| create, createCollection | Med | spec-incomplete | P5 | Composite-unique-key `409 UNIQUE_VIOLATION` / `422 INVALID_UNIQUE_KEY[_DEFINITION]` emitted but undocumented; `createCollection` omits the `409` its sibling `updateCollection` documents (`service.go:1762-1767`). |
+| updateSingle(+Loopback), patchSingle(+Loopback), updateCollection | Med | spec-incomplete | P5 | Same shared save path can emit `422` unique-key codes; none listed. |
+| create | Med | spec-incomplete | P6 | `type:object` body hides accepted array/batch form (`handler.go:372-410`). |
+| getOneEntity | Low | spec-incomplete | P3 | 200 example shows only `{id,state}`. |
+| getEntityChangesMetadata | Low | spec-stale | — | Prose says `CREATE/UPDATE/DELETE`; enum & server use `CREATED/UPDATED/DELETED`. |
+| deleteSingleEntity, getEntityTransitions, fetchEntityTransitions | — | clean | — | Shapes & error paths match. |
+
+### 6B — Stats / audit / search  (`internal/domain/{entity,audit,search}/*`)
+
+| Op | Sev | Dir | Pattern | Detail |
+|---|---|---|---|---|
+| searchEntities | High | needs-decision | P2 | `timeoutMillis` + `408` documented; handler never reads/emits them (`search/handler.go:105-191`). |
+| searchEntities | High | needs-decision | — | Spec: result "silently limited to 10000"; server **hard-400s** on `limit>10000` (`search/handler.go:150-153`). |
+| getEntityStatisticsForModel, ...ByStateForModel | Med | needs-decision | P5 | Documented `404 model not found`; unknown model returns `200`+`0`/empty (`entity/service.go:554-612`). |
+| submitAsyncSearchJob, searchEntities | Med | needs-decision | P5 | Documented `404 model not found`; unknown model → job/stream over empty population (`search/service.go:122-199`). |
+| getStateMachineFinishedEvent | Med | server-gap | — | Desc/`400` require time-based v1 UUIDs; handler does no version check (`audit/handler.go:231-270`). |
+| getAsyncSearchResults | Med | server-gap | P2 | `pointInTime` never read (`search/handler.go:274-316`). |
+| getAsyncSearchResults | Med | needs-decision | P6 | Documented default page size 10; server default 1000 (`search/handler.go:277`). |
+| searchEntities | Med | spec-stale | P6 | 200 offers `application/json`; server always sends `application/x-ndjson` (`search/handler.go:178`). |
+| searchEntityAuditEvents | Med | server-gap | P3 | `EntityChangeAuditEventDto.changes` before/after diff never emitted (`audit/handler.go:70-97`). |
+| searchEntities | Low | spec-stale | — | Error bodies advertise ndjson variant; errors are `problem+json` only. |
+| getAsyncSearchStatus | Low | spec-stale | — | `searchJobStatus` enum includes `NOT_FOUND`, unreachable (404 instead). |
+| searchEntityAuditEvents | Low | spec-stale | — | `eventType` enum includes `System`; no System source exists. |
+| getEntityStatistics, ...ByState, queryGroupedEntityStatisticsForModel, cancelAsyncSearch, getAsyncSearchStatus (shape) | — | clean | — | Generated-DTO or purpose-built; accurate. |
+
+### 6C — Entity-model & workflow  (`internal/domain/{model,workflow}/*`)
+
+| Op | Sev | Dir | Pattern | Detail |
+|---|---|---|---|---|
+| deleteEntityModel | High | spec-incomplete | P5 | `409 MODEL_HAS_ENTITIES` emitted, undocumented (`service.go:393-404`). |
+| unlockEntityModel | High | spec-incomplete | P5 | `409 MODEL_ALREADY_UNLOCKED` / `409 MODEL_HAS_ENTITIES` undocumented (`service.go:318-352`). |
+| lockEntityModel | High | spec-incomplete | P5 | `409 MODEL_ALREADY_LOCKED` undocumented (`service.go:274-286`). |
+| setEntityModelUniqueKeys | High | spec-incomplete | P5 | `404 MODEL_NOT_FOUND` undocumented (`service.go:563-569`). |
+| importEntityModel | High | spec-incomplete | P5 | `409 MODEL_ALREADY_LOCKED` undocumented (`service.go:115-125`). |
+| importEntityModel | Med | needs-decision | P4 | `converter` enum lists `JSON_SCHEMA`/`SIMPLE_VIEW`; only `SAMPLE_DATA` accepted (`service.go:94-96`). |
+| setEntityModelChangeLevel | Med | spec-incomplete | P5 | `400 INVALID_CHANGE_LEVEL` undocumented (`service.go:517-532`). |
+| deleteEntityModel | Med | needs-decision | — | Desc claims "must be UNLOCKED"; handler never checks lock state (`service.go:365-408`). |
+| setEntityModelUniqueKeys | Med | spec-incomplete | P5 | `400` on malformed body undocumented (`handler.go:230-233`). |
+| importEntityModel | Med | spec-incomplete | P5 | `422 INVALID_UNIQUE_KEY_DEFINITION` on re-import undocumented (`service.go:164-178`). |
+| exportMetadata | Med | spec-incomplete | P3 | 200 is opaque bag; hides real `uniqueKeys` array (`service.go:229-249`). |
+| setEntityModelChangeLevel | Low | spec-stale | — | Desc "set to null to disallow"; `changeLevel` is a required enum path segment. |
+| exportMetadata, deleteEntityModel | Low | spec-stale | — | Error example `detail` strings don't match server output. |
+| importEntityModelWorkflow | Low | spec-incomplete | P5 | `VALIDATION_FAILED` / `WORKFLOW_SCHEMA_VERSION_UNSUPPORTED` folded under generic 400. |
+| getAvailableEntityModels, validateEntityModel, exportEntityModelWorkflow, importEntityModelWorkflow (shapes) | — | clean | — | DTOs faithful to SPI types (`desc` not `description`, etc.). |
+
+### 6D — SQL-Schema  (`/sql/schema/*` — entire tag)
+
+| Op | Sev | Dir | Pattern | Detail |
+|---|---|---|---|---|
+| all 9 ops | High | needs-decision | P1 | Tag excluded in `api/config.yaml`; no route in `api/generated.go`; 404 at runtime (`app/app.go:645`). |
+| genTables, getSchemas | High | spec-stale | P6 | `type:array` + sibling `$ref`, no `items` → untyped `[]interface{}` (`openapi.yaml:7013-7015,7147-7149`). |
+| updateTables | High | spec-stale | P6 | Request body `type:string`, example is an array of `TableConfigDto`. |
+| getSchemaByName, deleteSchemaByName, getSchema, deleteSchema | Med | spec-stale | P5 | 404 bodies lack `schema:` and use `application/json` where the platform uses `application/problem+json`. |
+| all (FieldConfigDto) | Low | spec-stale | P6 | Examples use non-existent `arrayFields`, omit required `hidden`. |
+
+### 6E — Auth / OIDC / clients / token  (`internal/api/*`, `internal/domain/*` adapters)
+
+| Op | Sev | Dir | Pattern | Detail |
+|---|---|---|---|---|
+| all 7 OIDC ops | High | needs-decision | P5 | Errors speced `application/json ErrorResponseDto`; server emits `application/problem+json ProblemDetail` (`common/errors.go:234,240`; `oidc_adapter.go` throughout). |
+| registerOidcProvider | Med | needs-decision | P5 | Duplicate → `400 OIDC_PROVIDER_DUPLICATE`, not the speced `409` (`oidc_adapter.go:176-178`). |
+| updateOidcProvider | Med | spec-incomplete | P5 | `409 OIDC_PROVIDER_INACTIVE` undocumented (`oidc_adapter.go:297-299`). |
+| getTechnicalUserToken | Med | spec-stale | P4 | `issued_token_type` enum lacks the emitted `...:jwt` (`token.go:240`); `grant_type` enum omits accepted `client_credentials`; `error` enum lacks `server_error`; `405` undocumented. |
+| accountSubscriptionsGet | Med | server-gap | P1 | Documents `200`; always returns `501 NOT_IMPLEMENTED` (`handler.go:87-88`). |
+| invalidateJwtKeyPair, deleteTrustedKey, invalidateTrustedKey | Med | spec-incomplete | P5 | `400` on bad id/body/grace undocumented (`keys_adapter.go:170-181`, `trusted_adapter.go:201-231`). |
+| registerTrustedKey | Med | needs-decision | P4 | Desc says RSA/EC/OKP supported; only RSA accepted (`trusted_adapter.go:132-133`). |
+| issueJwtKeyPair | Med | needs-decision | P6 | Desc "defaults to RS256"; `algorithm` is required (`keys_adapter.go:44-46`). |
+| 14 clients/keys/trusted ops | Med | spec-incomplete | P5 | Return `501` in mock-IAM mode; never documented. |
+| issue/getCurrent/reactivate JwtKeyPair | Low | needs-decision | P4 | `algorithm` enum lists many; only RS256 honoured. |
+| listOidcProviders | Low | spec-stale | — | Documents `403`; no admin guard, never emitted. |
+| accountGet | Low | spec-incomplete | — | `featureToggles` never populated. |
+| listOidcProviders | Low | spec-stale | — | `activeOnly` typed `string`, compared literally to `"true"`. |
+| **security check** | — | clean | — | No secret leakage in examples/schemas; private keys never marshalled; tenant scoping enforced with uniform 404. |
+
+### 6F — Stream-data & message  (`internal/domain/messaging/*`; stream-data unrouted)
+
+| Op | Sev | Dir | Pattern | Detail |
+|---|---|---|---|---|
+| all 13 stream-data ops | High | needs-decision | P1 | Tag `Stream Data` excluded in `api/config.yaml`; unrouted; 404 at runtime. Carries operationId fossils (`delete`, `exportAll`, `exportAll_1`). |
+| deleteMessages | High | spec-incomplete | P6 | Body schema `type:string uuid`; server needs `[]string` (`messaging/handler.go:235-239`). |
+| newMessage | High | spec-incomplete | P6 | Body schema `type:string`; server needs JSON object envelope (`handler.go:45-52`). |
+| newMessage | Med | spec-stale | — | Desc claims array body accepted; handler unmarshals single struct only. |
+| newMessage, deleteMessages | Med | server-gap | P2 | `transactionTimeoutMillis` / `transactionSize` params ignored (`handler.go:32-114,247`). |
+| getMessage, deleteMessage, deleteMessages | Med | server-gap | P5 | Documented `400 "not a time-based UUID"`; no v1 validation performed. |
+| getMessage | Med | spec-stale | P3 | `metaData` typed as `ValueMaps` buckets; server emits a flat map (`handler.go:165-177`). |
+| getMessage | Low | spec-stale | — | 200 example omits always-injected `typeReferences:{}`. |
+| message error examples | Low | spec-stale | — | Omit always-present `properties.errorCode` (`common/errors.go:234`). |
+
+## 7. What this means for the way out
+
+A mechanical "sync the spec to the server" is the wrong instinct and would *destroy*
+contract intent (e.g. it would delete `deleteEntities`' conditional-delete and turn a
+data-loss bug into a documented feature). The problems that need design, not cleanup:
+
+1. **Restore an enforced binding** in a spec-first world — how do we make the server
+   provably conform to the authored contract (contract tests? a generated conformance
+   suite? the `entity_conformance_test.go` seed extended to every op?) *without* giving
+   up authored ownership of the spec.
+2. **A per-finding reconciliation-direction decision process** — who decides
+   `server-gap` vs `spec-stale` vs `needs-decision`, and how it's recorded (this is a
+   Cloud-parity concern; each decision is a contract decision).
+3. **The dead-surface decision** — implement, or formally remove from the published
+   contract, the 22 excluded-tag operations and the always-501 stubs. Shipping a
+   contract that is 25% fiction is the loudest single signal of the problem.
+4. **The one urgent correctness item** — `deleteEntities` data loss is not a doc issue
+   and should not wait for the broader effort.
+
+These four are the inputs to the brainstorming session; this document is the evidence
+base for their scale.
+
+---
+
+*Generated from a 6-way parallel audit of `api/openapi.yaml` against the Go handlers.
+Every "server does" claim above is cited to `file:line` in the working tree at the date
+above; line numbers will drift as the code changes.*

--- a/docs/analysis/openapi/schema-strictness-research.md
+++ b/docs/analysis/openapi/schema-strictness-research.md
@@ -1,0 +1,122 @@
+# Schema Strictness in a Spec-First OpenAPI Contract — Research & Rubric
+
+**Status:** research reference (input to ADR 0003).
+**Date:** 2026-07-03
+**Method:** deep-research fan-out (5 angles, 19 sources, 79 claims extracted, 25
+adversarially verified 3-vote, 24 confirmed / 1 refuted).
+
+## Question
+
+When should schemas in `api/openapi.yaml` be strictly typed/closed
+(`properties` + `additionalProperties: false`, discriminated `oneOf`) versus
+intentionally open (`additionalProperties: true`, bare `type: object`)? Constraint:
+response shapes are validated at runtime by kin-openapi in enforce mode (ADR 0001)
+— fixed. Consumers include codegen clients and LLMs. The team's original motive for
+loose bags was extensibility (add an event type / field without a schema-version bump).
+
+## Resolution
+
+Accepted practice resolves the strict-validation-vs-additive-compatibility tension by
+**separating responsibilities by direction**, not by picking a global posture:
+
+- **Enumerate every known property, but keep the schema OPEN** (`additionalProperties`
+  absent/`true`, never `false`). Enumeration gives codegen/LLMs the real shape (fixes
+  the loose-bag problem); leaving it open keeps additive changes non-breaking.
+- **The tolerant-reader / must-ignore-unknown obligation sits on the CONSUMER**, not on
+  the producer's schema. Additive producer changes (new field, new event type) are
+  backward-compatible by contract; consumers must ignore what they don't recognise.
+- **Strictness is per-direction:** requests the service owns may reject unknown input
+  (HTTP 400); responses the service emits stay open for evolution.
+- **Extensibility is better served by typed-but-open + extensible-enums than by loose
+  bags** — same freedom to avoid version bumps, but the shape is preserved. Loose bags
+  were solving a real problem the wrong way.
+- **Enforce additive-only discipline with a CI gate** (oasdiff / Specmatic) instead of a
+  sealed schema — the gate catches genuinely breaking edits (sealing, field removal,
+  type change) while letting additive ones through.
+
+## The decision rubric
+
+| Category | cyoda-go example | Recommendation |
+|---|---|---|
+| (a) user/polymorphic request body | `create`/`patch` payload | **Strict envelope** (reject unknown *input* fields → 400) + **open document** region |
+| (b) service-owned response envelope / metadata | `Envelope.meta`, `exportMetadata` | **Typed-but-open** — enumerate all fields, do **not** seal |
+| (c) evolving discriminated union | state-machine audit events | **Discriminated `oneOf` + explicit unknown/default variant + open-enum discriminator** |
+| (d) RFC 9457 problem-details | `ProblemDetail` | **Open by standard** — extension members allowed; sealing is non-conformant |
+| (e) genuinely "any JSON" | entity `data`, `JsonNode` | **Open bag is correct** — no fixed shape to convey |
+
+Discriminating question for any object: *does the service know this object's shape?*
+If yes → typed-but-open (b/c/d). If genuinely no → open bag (e). "Unspecified" is only
+honest for (e); using it for (b)/(c)/(d) is the anti-pattern that hides shape from
+consumers.
+
+## Key verified findings (with sources)
+
+1. **`properties` alone does not seal a schema**; `additionalProperties: false` is an
+   explicit opt-in, and it is what converts additive changes into breaking ones. Zalando
+   Rule #111 *mandates* not declaring `additionalProperties: false` "as this prevents
+   objects being extended in the future." (learnjsonschema.com; Zalando compatibility.adoc)
+2. **`allOf` composition gotcha:** `additionalProperties` only restricts *sibling*
+   `properties` and cannot see into `allOf` branches — so a sealed base extended via
+   `allOf` rejects the child's new fields. If a composed schema must be closed, use
+   **`unevaluatedProperties: false`** at the composition point, never
+   `additionalProperties: false` on the base. (learnjsonschema.com)
+3. **Tolerant-reader belongs on the consumer** (Fowler: "only take the elements you need,
+   ignore anything you don't"; Zalando Rule #108; RFC 9457 "clients... MUST ignore any
+   such extensions that they don't recognize").
+4. **Strictness is per-direction:** Zalando Rule #109 rejects unknown *input* fields with
+   HTTP 400, while output evolution stays safe via consumer tolerance (#108) and open
+   definitions (#111).
+5. **Additive evolution within a major version is sanctioned:** Google AIP-180 permits
+   adding fields/messages/enums/enum-values; Zalando Rule #107 gives the additive-only
+   matrix (inputs add optional-only; outputs may add fields).
+6. **Frequently-changing value sets → open string + documented values, not a closed
+   enum** (Google AIP-126). Zalando #112 documents known values via `examples` with an
+   "[Extensible enum]" prefix; `x-extensible-enum` is its now-deprecated predecessor
+   (changelog 2025-11-27).
+7. **Stripe (production scale)** classifies "adding new properties to responses" and
+   "adding new event types" as backward-compatible, and instructs consumers to "gracefully
+   handle unfamiliar event types" — the discriminated-union-with-unknown-fallback pattern.
+8. **RFC 9457 problem-details are open by standard** (§3.2): extension members are allowed
+   and consumers MUST ignore unknown ones. Sealing a `ProblemDetail` schema is
+   non-conformant.
+9. **Breaking-change gates (oasdiff, Specmatic)** treat added optional response fields as
+   safe, flag added response enum values as a warning (mitigation: extensible-enum), and
+   are the mechanism to keep responses open-but-documented while catching real breaks in CI.
+
+**Refuted (did not survive verification):** the claim that AIP-126 *requires* an
+`_UNSPECIFIED`/`UNKNOWN` zero-value enum default (0-3). An explicit unknown/default variant
+is a recommended *pattern* (Stripe, protobuf) but not an AIP-126 mandate.
+
+## Caveats / must-verify
+
+- **kin-openapi enforce behaviour (load-bearing):** no source covered kin-openapi
+  specifically. The rubric assumes standard JSON-Schema open-by-default semantics — that
+  enforce mode **passes** an additive/unknown response field against a typed-but-open
+  schema and **fails** it against `additionalProperties: false`. **Verify empirically
+  against the pinned kin-openapi version before relying on this.** (See ADR 0003 gating.)
+- `x-extensible-enum` is deprecated by Zalando in favour of `examples` + "[Extensible
+  enum]"; both express the same intent. Pick whichever cyoda-go's toolchain/consumers read
+  best; note `x-extensible-enum` is a proprietary extension some validators reject.
+- Protobuf unknown-field *preservation* is binary-wire-only (JSON drops unknowns) — it is
+  an analogy for tolerant-reading, not a directly transferable JSON mechanism.
+
+## Consequences for the cyoda-go reconciliation
+
+1. The earlier "tighten with `additionalProperties: false`" prescription (in the
+   entity-slice spec and the drift audit) is **wrong** → replace with **typed-but-open**.
+2. `ProblemDetail.properties`, entity `data`, and `JsonNode` come **off** the tightenable
+   list — they are correct as open.
+3. The state-machine audit-event union should be integrated as category (c): discriminated
+   `oneOf` + unknown/default variant + open-enum discriminator.
+4. Add an **additive-only breaking-change CI gate** on `api/openapi.yaml` as the evolution
+   discipline (replacing "seal the schema").
+5. Anchor all of the above in **ADR 0003** (supersedes ADR 0001), gated on the kin-openapi
+   empirical check.
+
+## Sources
+
+Primary: RFC 9457; Google AIP-180/126/185; Zalando RESTful API Guidelines
+(compatibility.adoc, json-guidelines.adoc); Stripe API upgrades; protobuf.dev
+(UnknownFieldSet). Secondary/community: learnjsonschema.com (2020-12
+additionalProperties, unevaluatedProperties); oasdiff; Specmatic; Martin Fowler
+(TolerantReader).

--- a/docs/analysis/openapi/schema-strictness-research.md
+++ b/docs/analysis/openapi/schema-strictness-research.md
@@ -92,8 +92,10 @@ is a recommended *pattern* (Stripe, protobuf) but not an AIP-126 mandate.
 - **kin-openapi enforce behaviour (load-bearing):** no source covered kin-openapi
   specifically. The rubric assumes standard JSON-Schema open-by-default semantics — that
   enforce mode **passes** an additive/unknown response field against a typed-but-open
-  schema and **fails** it against `additionalProperties: false`. **Verify empirically
-  against the pinned kin-openapi version before relying on this.** (See ADR 0003 gating.)
+  schema and **fails** it against `additionalProperties: false`. **Confirmed 2026-07-03**
+  via a probe against kin-openapi v0.140.0 (`Schema.VisitJSON`): additive field passes the
+  open schema, `additionalProperties: false` rejects it. A permanent fixture test lands with
+  the implementation (the probe was temporary). ADR 0003 records this as confirmed.
 - `x-extensible-enum` is deprecated by Zalando in favour of `examples` + "[Extensible
   enum]"; both express the same intent. Pick whichever cyoda-go's toolchain/consumers read
   best; note `x-extensible-enum` is a proprietary extension some validators reject.

--- a/docs/cloud-parity/README.md
+++ b/docs/cloud-parity/README.md
@@ -20,3 +20,4 @@ Cloud needs to adopt.
 | File | Covers |
 |---|---|
 | `entity-patch.md` | PATCH single-entity contract (RFC 7386 merge patch) |
+| `openapi-conformance.md` | OpenAPI operation status, live common ground, tolerant-reader obligation, deferred open questions (E6, D2) |

--- a/docs/cloud-parity/openapi-conformance.md
+++ b/docs/cloud-parity/openapi-conformance.md
@@ -1,0 +1,74 @@
+# OpenAPI conformance — Cloud hand-off
+
+Tracked in issue #369.
+
+## Roles
+
+cyoda-go **leads** `api/openapi.yaml`. Cyoda Cloud **conforms** to it — not the
+reverse. Cloud aligns its contract to cyoda-go's; when the two disagree it is
+Cloud that must reconcile, unless cyoda-go's spec is stale (tracked per-finding
+in `../cyoda/cloud-divergences.md`).
+
+## Live common ground
+
+Operations **without** an `x-cyoda-status` extension are live — exercised end-to-end
+in `internal/e2e/` and validated against the declared schema. This is the
+shared contract surface Cloud MUST implement and conform to.
+
+Operations carrying `x-cyoda-status: planned` or `x-cyoda-status: unimplemented`
+are shared intent — both sides intend to implement them — but Cloud MAY or MAY
+NOT have them yet. They are not part of the current conformance obligation.
+
+## Contract access points
+
+Cloud consumes the spec from either:
+
+- `GET /openapi.json` (served at runtime by the cyoda-go binary)
+- `cyoda help openapi json` / `cyoda help openapi yaml` (help subsystem artefact)
+
+Both surfaces serve identical content from the embedded `api/openapi.yaml`.
+
+## Tolerant-reader obligation
+
+Response schemas in `api/openapi.yaml` are typed-but-open (ADR 0003, Decision 3):
+properties are enumerated but objects are not sealed (`additionalProperties`
+absent or `true`, never `false`). Cloud, as a consumer of cyoda-go responses,
+MUST ignore unrecognised fields — new fields are additive, non-breaking changes.
+
+The same obligation applies in the reverse direction: cyoda-go, as a consumer of
+Cloud-emitted data in shared scenarios, also ignores unrecognised fields. Neither
+side seals the envelope.
+
+## Breaking-change discipline (cyoda-go side)
+
+A CI gate (`openapi-breaking-change.yml`, using `oasdiff`) blocks merges that
+introduce breaking spec changes — removing an operation or field, sealing an
+open object, narrowing a type, or adding a required field to an existing
+response. Cloud may rely on this gate as a stability guarantee: the live common
+ground only grows; it does not shrink.
+
+## Complement: field-level divergence catalog
+
+`../cyoda/cloud-divergences.md` is the **inverse** catalog: fields declared in
+`api/openapi.yaml` that cyoda-go does not yet implement server-side. This file
+covers operation-level status and conformance obligations; the two are
+complementary, not overlapping.
+
+## Deferred open questions (resolve with Cloud team)
+
+These two items are Cloud-fact-blocked and must be decided jointly before the
+entity-slice spec can be closed:
+
+**E6 — `EntityChangeMeta.fieldsChangedCount`.**
+The canonical schema (`docs/cyoda/schema/common/EntityChangeMeta.json`) declares
+`fieldsChangedCount`; cyoda-go's `getEntityChangesMetadata` handler never emits
+it. Before cyoda-go implements it, we need to know: **does Cloud currently emit
+`fieldsChangedCount`?** If yes, cyoda-go aligns to Cloud's existing behaviour.
+If no, both sides implement it together from the spec's declaration.
+
+**D2 — gRPC conditional-delete parity for `deleteEntities`.**
+The HTTP `DELETE /entity/{entityName}/{modelVersion}` supports a condition body
+(delete matching entities only). The gRPC `EntityService.DeleteEntityList` proto
+takes an unconditional `EntityDeleteRequest`. **Does Cloud expect gRPC
+conditional-delete parity**, and if so, what is the expected proto shape? Answer
+needed before adding conditional-delete logic to the gRPC path.

--- a/docs/superpowers/plans/2026-07-03-openapi-contract-status-and-parity-plan.md
+++ b/docs/superpowers/plans/2026-07-03-openapi-contract-status-and-parity-plan.md
@@ -265,12 +265,17 @@ Per-op runtime status verified; OIDC group: <live vs 501 finding>. Refs #369."
 
 ---
 
-### Task 5: Give `fetchEntityTransitions` real e2e coverage
+### Task 5: e2e coverage for the now-known-live ops (`fetchEntityTransitions` + 7 OIDC provider ops)
 
 **Files:**
 - Test: `internal/e2e/entity_transitions_test.go` (create or extend an existing entity e2e test)
+- Test: `internal/e2e/oidc_providers_test.go` (create)
+
+**Scope note (from Task 4's finding):** Task 4's probe confirmed the 7 OIDC provider ops are **live** (`GET /oauth/oidc/providers` → 200 in JWT-mode e2e; adapter wired via `WithOIDCAdapter`), so they were NOT marked. The new gate (Task 6) requires every live op be *exercised*. This task therefore covers **both** `fetchEntityTransitions` **and** the 7 OIDC ops (`registerOidcProvider`, `listOidcProviders`, `reloadOidcProviders`, `updateOidcProvider`, `invalidateOidcProvider`, `reactivateOidcProvider`, `deleteOidcProvider`). Coverage here is **exercise-level** (hit each op, assert a sane status) — exhaustive OIDC error-code coverage is deferred to the auth/OIDC follow-on group.
 
 `fetchEntityTransitions` (`GET /platform-api/entity/fetch/transitions`) is **live** — routed at `app/app.go:607` outside the generated `ServerInterface`. It is exempted today only via `knownUncoveredOps`; the new gate requires it be *exercised*.
+
+**OIDC lifecycle test (`oidc_providers_test.go`):** authenticate with an admin token (reuse the existing e2e auth helper — see `helpers_test.go` / `clients_test.go` / `oauth_keys_test.go` for the admin-token pattern), then exercise all 7 ops in one flow: `registerOidcProvider` (create a provider) → `listOidcProviders` → `reloadOidcProviders` → `updateOidcProvider` → `invalidateOidcProvider` → `reactivateOidcProvider` → `deleteOidcProvider`, asserting each returns a success status (2xx). Model request bodies on the OIDC DTOs in `api/openapi.yaml` (`RegisterOidcProviderRequestDto`, etc.). Each op must be hit at least once so the conformance gate marks it exercised.
 
 - [ ] **Step 1: Write an e2e test** that creates an entity in a known state and calls the endpoint, asserting a `200` and a JSON array (`TransitionNameList`). Model it on the existing `getEntityTransitions` e2e test (search `internal/e2e` for `transitions`). Include the required query params the handler reads (`HandleFetchTransitions`, `internal/domain/entity/transitions_handler.go`).
 

--- a/docs/superpowers/plans/2026-07-03-openapi-contract-status-and-parity-plan.md
+++ b/docs/superpowers/plans/2026-07-03-openapi-contract-status-and-parity-plan.md
@@ -1,0 +1,493 @@
+# OpenAPI Contract Status & Parity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `api/openapi.yaml` honest and enforceable — every published operation is either *live* (routed + e2e-exercised) or *explicitly marked* not-live, with an additive-only CI gate guarding schema evolution.
+
+**Architecture:** Add an `x-cyoda-status` operation-status extension to the spec; rework the existing e2e conformance gate (`internal/e2e`) from "skip excluded-tag ops + `knownUncoveredOps` allowlist" to a spec-derived "exactly-one-of {exercised, marked}" rule; add an `oasdiff` breaking-change CI gate; delete genuinely-dead schemas; record a Cloud-parity hand-off.
+
+**Tech Stack:** Go 1.26; `github.com/getkin/kin-openapi v0.140.0`; existing `internal/e2e/openapivalidator` (kin-openapi response validation, `ModeEnforce`); testcontainers Postgres for e2e; GitHub Actions CI.
+
+**Spec:** `docs/superpowers/specs/2026-07-03-openapi-contract-status-and-parity-design.md`. **ADR:** `docs/adr/0003-openapi-contract-conformance-and-evolution.md`. **Issue:** #369.
+
+## Global Constraints
+
+- Go 1.26+; `log/slog` only; wrap errors `fmt.Errorf("...: %w", err)`.
+- `api/openapi.yaml` is embedded verbatim via `//go:embed` in `api/spec.go` (`embedded-spec: false`). Editing the file is sufficient — **there is no snapshot to regenerate.**
+- **`docs/cyoda/` is read-only vendored Cloud reference — no code, test, or gate may read or assert against it.** cyoda-go leads the contract; Cloud conforms.
+- Typed-but-open policy (ADR 0003): never `additionalProperties: false` on evolvable schemas.
+- **Ordering invariant:** markers + `fetchEntityTransitions` coverage (Task 4/5) land *before* the gate rework (Task 6). Each task must leave `go test ./internal/e2e/... -run TestOpenAPIConformanceReport` green.
+- Run e2e with Docker running: `go test ./internal/e2e/... -run <Name> -v`.
+
+---
+
+### Task 1: Collector records per-operation 2xx-success
+
+**Files:**
+- Modify: `internal/e2e/openapivalidator/collector.go`
+- Modify: `internal/e2e/openapivalidator/validator.go` (add the `recordStatus` call at the existing `recordExercised` site)
+- Test: `internal/e2e/openapivalidator/collector_test.go`
+
+**Interfaces:**
+- Produces: `func Success2xxSet() map[string]bool` (package-level; reads `defaultCollector`). `func (c *collector) recordStatus(operationId string, status int)`.
+
+- [ ] **Step 1: Write the failing test** in `collector_test.go`:
+
+```go
+func TestCollector_recordStatus_tracks2xx(t *testing.T) {
+	c := newCollector()
+	c.recordStatus("opA", 200)
+	c.recordStatus("opB", 501)
+	c.recordStatus("opC", 404)
+	got := c.success2xxSet()
+	if !got["opA"] {
+		t.Errorf("opA (200) should be in the 2xx set")
+	}
+	if got["opB"] || got["opC"] {
+		t.Errorf("opB (501) / opC (404) must not be in the 2xx set: %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/e2e/openapivalidator/ -run TestCollector_recordStatus_tracks2xx -v`
+Expected: FAIL — `recordStatus`/`success2xxSet` undefined.
+
+- [ ] **Step 3: Implement in `collector.go`.** Add `saw2xx map[string]struct{}` to the `collector` struct; initialise it in `newCollector` (`saw2xx: make(map[string]struct{})`). Add:
+
+```go
+func (c *collector) recordStatus(operationId string, status int) {
+	if status < 200 || status >= 300 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.saw2xx[operationId] = struct{}{}
+}
+
+func (c *collector) success2xxSet() map[string]bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]bool, len(c.saw2xx))
+	for k := range c.saw2xx {
+		out[k] = true
+	}
+	return out
+}
+
+// Success2xxSet returns the set of operationIds that returned a 2xx during the run.
+func Success2xxSet() map[string]bool { return defaultCollector.success2xxSet() }
+```
+
+- [ ] **Step 4: Wire the recording.** In `validator.go`, at every site that calls `c.recordExercised(op)` (the successful route-match path), add immediately after it: `c.recordStatus(op, resp.StatusCode)`. (`resp *http.Response` is in scope there.)
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `go test ./internal/e2e/openapivalidator/ -v`
+Expected: PASS (all, including existing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/e2e/openapivalidator/collector.go internal/e2e/openapivalidator/validator.go internal/e2e/openapivalidator/collector_test.go
+git commit -m "feat(e2e): collector tracks per-op 2xx success for the marker gate"
+```
+
+---
+
+### Task 2: Permanent kin-openapi typed-but-open fixture (ADR 0003 evidence)
+
+**Files:**
+- Test: `internal/e2e/openapivalidator/typed_but_open_test.go` (create)
+
+**Interfaces:** none exported; a standalone behavioral guard.
+
+- [ ] **Step 1: Write the test** (this is the permanent version of the 2026-07-03 probe ADR 0003 references):
+
+```go
+package openapivalidator
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Guards the typed-but-open policy (ADR 0003): an additive/unknown member
+// validates against an open schema and is rejected by additionalProperties:false.
+func TestTypedButOpen_AdditionalPropertiesSemantics(t *testing.T) {
+	body := map[string]any{"id": "x", "extra": "y"} // "extra" = additive/unknown
+
+	open := openapi3.NewObjectSchema().WithProperty("id", openapi3.NewStringSchema())
+	if err := open.VisitJSON(body); err != nil {
+		t.Fatalf("open schema must ACCEPT an additive field: %v", err)
+	}
+
+	sealed := openapi3.NewObjectSchema().WithProperty("id", openapi3.NewStringSchema())
+	sealed.AdditionalProperties = openapi3.AdditionalProperties{Has: openapi3.BoolPtr(false)}
+	if err := sealed.VisitJSON(body); err == nil {
+		t.Fatal("additionalProperties:false must REJECT an additive field")
+	}
+}
+```
+
+- [ ] **Step 2: Run — expected PASS immediately** (documents current validator behaviour):
+
+Run: `go test ./internal/e2e/openapivalidator/ -run TestTypedButOpen -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/e2e/openapivalidator/typed_but_open_test.go
+git commit -m "test(e2e): pin kin-openapi typed-but-open semantics (ADR 0003)"
+```
+
+---
+
+### Task 3: Marker-set plumbing (read `x-cyoda-status` in TestMain)
+
+**Files:**
+- Modify: `internal/e2e/e2e_test.go` (the `TestMain` loop that builds `allOperationIds` by iterating `swagger.Paths.Map()`)
+- Test: `internal/e2e/marker_plumbing_test.go` (create)
+
+**Interfaces:**
+- Produces: package var `markedOps map[string]string` (operationId → status value, e.g. `"planned"`/`"unimplemented"`), populated in `TestMain` alongside `allOperationIds`.
+
+- [ ] **Step 1: Write the failing test.** A pure helper is easier to test than `TestMain`; extract the extension read into a helper and test that:
+
+```go
+package e2e
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestReadCyodaStatus(t *testing.T) {
+	op := &openapi3.Operation{
+		OperationID: "foo",
+		Extensions:  map[string]any{"x-cyoda-status": "planned"},
+	}
+	if got := readCyodaStatus(op); got != "planned" {
+		t.Errorf("got %q, want planned", got)
+	}
+	bare := &openapi3.Operation{OperationID: "bar"}
+	if got := readCyodaStatus(bare); got != "" {
+		t.Errorf("unmarked op should return empty, got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`readCyodaStatus` undefined):
+
+Run: `go test ./internal/e2e/ -run TestReadCyodaStatus -v`
+
+- [ ] **Step 3: Implement `readCyodaStatus`** in `e2e_test.go`:
+
+```go
+// readCyodaStatus returns the x-cyoda-status marker on an operation, or "".
+func readCyodaStatus(op *openapi3.Operation) string {
+	if op == nil || op.Extensions == nil {
+		return ""
+	}
+	if v, ok := op.Extensions["x-cyoda-status"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+```
+
+Add a package var `var markedOps = map[string]string{}`. In `TestMain`, inside the existing `for _, op := range item.Operations()` loop (where `allOperationIds` is appended), add — **before** the exclude-tag skip is removed in Task 6, place it after the `op.OperationID == ""` guard so it sees every op:
+
+```go
+if s := readCyodaStatus(op); s != "" {
+	markedOps[op.OperationID] = s
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `go test ./internal/e2e/ -run TestReadCyodaStatus -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/e2e/e2e_test.go internal/e2e/marker_plumbing_test.go
+git commit -m "feat(e2e): read x-cyoda-status markers into markedOps"
+```
+
+---
+
+### Task 4: Add `x-cyoda-status` markers to the spec (per-op status verified)
+
+**Files:**
+- Modify: `api/openapi.yaml` (add `x-cyoda-status` + a description caveat to each not-live operation)
+
+**Pre-work — verify actual runtime status (do NOT trust the stale "stub" comment).** For each candidate op, determine whether it returns `501` or a real `2xx` under the e2e server config:
+- `Stream Data` (13 ops) + `SQL-Schema` (9 ops): tag-excluded from codegen, unrouted → 404/501 → **`unimplemented`** / **`planned`** respectively (`planned` for SQL-Schema per the Trino decision, issue #83).
+- `accountSubscriptionsGet`: genuine stub, always `501` (`internal/domain/account/handler.go:87`) → **`planned`**.
+- OIDC provider ops (`registerOidcProvider`, `deleteOidcProvider`, `invalidateOidcProvider`, `reactivateOidcProvider`, `listOidcProviders`, `reloadOidcProviders`, `updateOidcProvider`): dispatched via `s.Account.<Op>` when wired else `501` (`internal/api/server.go:531+`). **Check `s.Account` in the e2e server construction (`app/app.go` / the e2e server setup).** If `s.Account == nil` in e2e → they return `501` → mark `planned`. If wired and returning `2xx` → they are **live**: do NOT mark; instead add e2e coverage (fold into Task 5). Record the finding in the commit message.
+
+- [ ] **Step 1: Add markers.** For each not-live op, add the extension and a description caveat, e.g.:
+
+```yaml
+  /sql/schema/:
+    get:
+      operationId: getSchemaByName
+      x-cyoda-status: planned
+      description: |
+        NOT YET IMPLEMENTED in cyoda-go. Planned for the Trino SQL surface.
+        <existing description...>
+```
+
+`unimplemented` caveat wording: `NOT IMPLEMENTED in cyoda-go (disposition under review).`
+
+- [ ] **Step 2: Verify the spec still parses** (the served spec + validator load it):
+
+Run: `go test ./internal/e2e/ -run TestHealth -v`
+Expected: PASS (server boots, `//go:embed` spec loads).
+
+- [ ] **Step 3: Verify markers are read:** temporarily log `len(markedOps)` or add an assertion test that `markedOps` contains `getSchemaByName` → `planned`. Expected count ≈ 22 excluded-tag + verified stubs.
+
+- [ ] **Step 4: Commit** (markers are inert under the *current* gate — CI stays green):
+
+```bash
+git add api/openapi.yaml
+git commit -m "feat(openapi): mark not-live ops with x-cyoda-status (planned|unimplemented)
+
+Per-op runtime status verified; OIDC group: <live vs 501 finding>. Refs #369."
+```
+
+---
+
+### Task 5: Give `fetchEntityTransitions` real e2e coverage
+
+**Files:**
+- Test: `internal/e2e/entity_transitions_test.go` (create or extend an existing entity e2e test)
+
+`fetchEntityTransitions` (`GET /platform-api/entity/fetch/transitions`) is **live** — routed at `app/app.go:607` outside the generated `ServerInterface`. It is exempted today only via `knownUncoveredOps`; the new gate requires it be *exercised*.
+
+- [ ] **Step 1: Write an e2e test** that creates an entity in a known state and calls the endpoint, asserting a `200` and a JSON array (`TransitionNameList`). Model it on the existing `getEntityTransitions` e2e test (search `internal/e2e` for `transitions`). Include the required query params the handler reads (`HandleFetchTransitions`, `internal/domain/entity/transitions_handler.go`).
+
+- [ ] **Step 2: Run — expect PASS** and confirm the op is now exercised:
+
+Run: `go test ./internal/e2e/ -run TestFetchEntityTransitions -v`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/e2e/entity_transitions_test.go
+git commit -m "test(e2e): cover fetchEntityTransitions (removes knownUncoveredOps exemption)"
+```
+
+---
+
+### Task 6: Rework the coverage gate (live-or-marked) — the flip
+
+**Files:**
+- Modify: `internal/e2e/e2e_test.go` (remove the exclude-tag skip so `allOperationIds` = every published op)
+- Modify: `internal/e2e/zzz_openapi_conformance_test.go` (delete `knownUncoveredOps`; new rules)
+- Test: `internal/e2e/gate_logic_test.go` (create — unit-test the pure rule function)
+
+**Interfaces:**
+- Produces: `func uncoveredOps(all []string, exercised, success2xx map[string]bool, marked map[string]string) (unmarkedUncovered, staleMarkers []string)`.
+
+- [ ] **Step 1: Write the failing unit test** for the pure rule:
+
+```go
+func TestUncoveredOps_rules(t *testing.T) {
+	all := []string{"live", "liveUncovered", "planned", "staleMarked"}
+	exercised := map[string]bool{"live": true, "staleMarked": true}
+	success2xx := map[string]bool{"live": true, "staleMarked": true}
+	marked := map[string]string{"planned": "planned", "staleMarked": "planned"}
+
+	unmarked, stale := uncoveredOps(all, exercised, success2xx, marked)
+
+	// liveUncovered: neither exercised nor marked -> unmarked-uncovered
+	if len(unmarked) != 1 || unmarked[0] != "liveUncovered" {
+		t.Errorf("unmarked-uncovered = %v, want [liveUncovered]", unmarked)
+	}
+	// staleMarked: marked but returned 2xx -> stale marker
+	if len(stale) != 1 || stale[0] != "staleMarked" {
+		t.Errorf("stale = %v, want [staleMarked]", stale)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`uncoveredOps` undefined):
+
+Run: `go test ./internal/e2e/ -run TestUncoveredOps_rules -v`
+
+- [ ] **Step 3: Implement `uncoveredOps`** in `zzz_openapi_conformance_test.go`:
+
+```go
+func uncoveredOps(all []string, exercised, success2xx map[string]bool, marked map[string]string) (unmarkedUncovered, staleMarkers []string) {
+	for _, op := range all {
+		_, isMarked := marked[op]
+		switch {
+		case !exercised[op] && !isMarked:
+			unmarkedUncovered = append(unmarkedUncovered, op) // silent 404 or untested live op
+		case isMarked && success2xx[op]:
+			staleMarkers = append(staleMarkers, op) // marker on an op that is actually live
+		}
+	}
+	return
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+Run: `go test ./internal/e2e/ -run TestUncoveredOps_rules -v`
+
+- [ ] **Step 5: Wire it into the enforce check and delete the old escape hatches.**
+  - In `e2e_test.go` `TestMain`: **remove** the `for _, tag := range op.Tags { if excludeTags[tag] { skip } }` block so `allOperationIds` includes every operation. (Leave `api/config.yaml` `exclude-tags` untouched — that governs codegen, not coverage.)
+  - In `zzz_openapi_conformance_test.go`: **delete** the `knownUncoveredOps` map and its usage. Replace the coverage block (currently `if !exercised[op] && !knownUncoveredOps[op]`) with:
+
+```go
+if !RunFilterActive() { // keep the existing single-test-run guard
+	unmarked, stale := uncoveredOps(allOperationIds, exercised, openapivalidator.Success2xxSet(), markedOps)
+	if len(unmarked) > 0 {
+		t.Fatalf("openapi conformance: %d published ops are neither exercised nor x-cyoda-status-marked (silent 404 or untested live op): %v", len(unmarked), unmarked)
+	}
+	if len(stale) > 0 {
+		t.Fatalf("openapi conformance: %d x-cyoda-status-marked ops returned 2xx (marker is stale — op is live): %v", len(stale), stale)
+	}
+}
+```
+
+  (`exercised` is the existing exercised set; `RunFilterActive()` is the existing guard from `openapivalidator`.)
+
+- [ ] **Step 6: Run the full e2e conformance suite — expect GREEN** (markers from Task 4 + coverage from Task 5 make every op live-or-marked):
+
+Run: `go test ./internal/e2e/ -run TestOpenAPIConformanceReport -v`
+Expected: PASS. If it fails listing an op, that op is a real gap → cover it (if live) or mark it (if not) — do not re-add an allowlist.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/e2e/e2e_test.go internal/e2e/zzz_openapi_conformance_test.go internal/e2e/gate_logic_test.go
+git commit -m "feat(e2e): live-or-marked coverage gate; retire knownUncoveredOps + exclude-tag skip"
+```
+
+---
+
+### Task 7: Delete genuinely-dead schemas
+
+**Files:**
+- Modify: `api/openapi.yaml` (remove verified-dead component schemas)
+
+- [ ] **Step 1: Verify `ErrorResponse` (bare) is dead.** It is defined once and never `$ref`d (every reference is `ErrorResponseDto`):
+
+Run: `grep -n "ErrorResponse\b" api/openapi.yaml` and confirm the only hit is its `components.schemas.ErrorResponse:` definition (no `$ref: '#/components/schemas/ErrorResponse'`). Also confirm no generated Go type: `grep -n "type ErrorResponse struct" api/generated.go` (expect only `ErrorResponseDto`).
+
+- [ ] **Step 2: Delete the `ErrorResponse` schema block** from `api/openapi.yaml`. Do **not** touch `StateMachine*Dto` (under-integrated, not dead — audit-group follow-on).
+
+- [ ] **Step 3: Verify the spec still loads and no dangling ref**
+
+Run: `go test ./internal/e2e/ -run TestHealth -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/openapi.yaml
+git commit -m "chore(openapi): remove dead ErrorResponse schema (duplicate of ErrorResponseDto)"
+```
+
+---
+
+### Task 8: oasdiff additive-only breaking-change CI gate
+
+**Files:**
+- Create: `.github/workflows/openapi-breaking-change.yml`
+- Create: `internal/e2e/openapi_breaking_change_test.go` (the trust fixture — one breaking + one additive case)
+
+**Interfaces:** none exported; a CI gate + a self-test of the gate's premise.
+
+- [ ] **Step 1: Fixture test** proving oasdiff's premise holds (run oasdiff via `go run` or a vendored binary in CI; the Go test asserts the *classification* on two tiny in-repo fixture specs):
+
+Write two fixture specs under `internal/e2e/testdata/oasdiff/` — `base.yaml`, `additive.yaml` (adds an optional response field), `breaking.yaml` (sets `additionalProperties: false`). The test shells out to `oasdiff breaking base additive` (expect exit 0 / no breaking) and `oasdiff breaking base breaking` (expect non-zero / breaking reported). Skip the test if the `oasdiff` binary is absent (`t.Skip`) so local runs without it still pass; CI installs it.
+
+- [ ] **Step 2: CI workflow.** `.github/workflows/openapi-breaking-change.yml`:
+
+```yaml
+name: openapi-breaking-change
+on:
+  pull_request:
+    paths: ["api/openapi.yaml"]
+jobs:
+  oasdiff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - name: Install oasdiff
+        run: go install github.com/oasdiff/oasdiff@latest
+      - name: Breaking-change check (base..PR)
+        run: |
+          git show origin/${{ github.base_ref }}:api/openapi.yaml > /tmp/base-openapi.yaml
+          oasdiff breaking /tmp/base-openapi.yaml api/openapi.yaml --fail-on ERR
+```
+
+- [ ] **Step 3: Resolve the deletion interaction (§5/§7 of the spec).** Confirm removing the unreferenced `ErrorResponse` (Task 7) is **not** flagged breaking (oasdiff keys on operations/referenced schemas; an unreferenced component removal is typically not breaking). If it *is* flagged, add `--exclude-elements` for that component or land Task 7 in a commit the gate's base already contains. Document the outcome in the workflow comments.
+
+- [ ] **Step 4: Run the fixture test locally** (with oasdiff installed) — expect PASS; without it — expect SKIP:
+
+Run: `go test ./internal/e2e/ -run TestOpenapiBreakingChange -v`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/openapi-breaking-change.yml internal/e2e/openapi_breaking_change_test.go internal/e2e/testdata/oasdiff/
+git commit -m "ci(openapi): additive-only breaking-change gate (oasdiff) per ADR 0003"
+```
+
+---
+
+### Task 9: Docs — marker convention + Cloud-parity hand-off
+
+**Files:**
+- Modify: `CONTRIBUTING.md` (document the `x-cyoda-status` convention + the gate)
+- Create: `docs/cloud-parity/openapi-conformance.md` (the Cloud-side hand-off record)
+
+- [ ] **Step 1: `CONTRIBUTING.md`** — add a short "OpenAPI operation status" section: every published operation must be either e2e-exercised (live) or carry `x-cyoda-status: planned|unimplemented` (not-live); the e2e conformance gate enforces this; an `oasdiff` CI gate rejects breaking spec edits (sealing an open object, removing a field/op, narrowing a type). Note `additionalProperties: false` is disallowed on evolvable schemas (ADR 0003).
+
+- [ ] **Step 2: `docs/cloud-parity/openapi-conformance.md`** — record the contract expectation for Cyoda Cloud: Cloud consumes the published `api/openapi.yaml` (served at `/openapi.json`, help subsystem); the **live common ground** = operations *without* `x-cyoda-status`; Cloud MUST conform to it and MAY only extend it; the tolerant-reader (must-ignore-unknown) obligation sits on Cloud (ADR 0003 Decision 3). List the **deferred open questions** for the entity slice: E6 `fieldsChangedCount` (does Cloud emit it?), D2 gRPC conditional-delete parity (does Cloud expect it?). Mark this as a hand-off to the Cloud team (issue #369).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CONTRIBUTING.md docs/cloud-parity/openapi-conformance.md
+git commit -m "docs: x-cyoda-status convention + Cloud-parity conformance hand-off (#369)"
+```
+
+---
+
+## Coverage matrix (carried from the spec)
+
+| Scenario | Unit | Running-backend e2e | Parity | gRPC |
+|---|---|---|---|---|
+| Collector 2xx flag | ✓ (Task 1) | — | — | — |
+| kin-openapi typed-but-open | ✓ (Task 2) | — | — | — |
+| Marker read | ✓ (Task 3) | — | — | — |
+| Gate rules (unmarked-uncovered / stale-marker) | ✓ (Task 6) | ✓ (suite enforces, Task 6.6) | — | — |
+| `fetchEntityTransitions` exercised | — | ✓ (Task 5) | — | — |
+| oasdiff breaking vs additive | ✓ fixture (Task 8) | — | — | — |
+
+No new error codes (no `errors/<CODE>.md` needed); no new endpoints (no per-endpoint error table). Concurrency: n/a. gRPC: unaffected by this plan (entity slice handles gRPC).
+
+## Gate obligations (Gate 4 / 7)
+
+- Gate 4 docs: `CONTRIBUTING.md` (Task 9); no README/COMPATIBILITY/CHANGELOG change (no env var, no version bump, no public API surface change). If the oasdiff job is later added to a `make` target, update `CONTRIBUTING.md`.
+- Gate 7: `docs/cloud-parity/openapi-conformance.md` (Task 9).
+
+## Notes for the executor / a fresh session
+
+- Full effort context: memory note `project_openapi_reconciliation_effort_state` + issue #369.
+- This is **Spec 1** (prerequisite). After it merges, write + execute the **entity slice** plan from `docs/superpowers/specs/2026-07-02-openapi-contract-reconciliation-design.md`.
+- Do not re-verify: kin-openapi typed-but-open semantics (Task 2 pins them); the `//go:embed` mechanism (no snapshot).

--- a/docs/superpowers/specs/2026-07-02-openapi-contract-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-07-02-openapi-contract-reconciliation-design.md
@@ -2,6 +2,9 @@
 
 **Date:** 2026-07-02
 **Status:** design / awaiting review
+**Runs after:** Spec 1 (`2026-07-03-openapi-contract-status-and-parity-design.md`), which
+establishes the marker-aware coverage gate (`markedOps`, replacing `knownUncoveredOps`) that
+this slice's error-code matrix builds on.
 **Reference evidence:** `docs/analysis/openapi/README.md` (full 87-op audit, six-pattern
 taxonomy, per-finding reconciliation direction).
 **Builds on:** ADR 0003 (`docs/adr/0003-openapi-contract-conformance-and-evolution.md`,
@@ -82,8 +85,9 @@ exactly that delta plus schema tightening:
   `common.WriteError`); absent for success responses.
 - Add a static **`ErrorCodeMatrix`**: `operationId → {documented (status, errorCode)}`,
   authored from the spec's per-endpoint error tables (§7), scoped to the **entity group**
-  in this spec (other ops listed as pending, reusing the existing `knownUncoveredOps`
-  mechanism — do not introduce a second pending list).
+  in this spec (out-of-scope ops are exempted via the **marker-aware coverage gate Spec 1
+  establishes** — `x-cyoda-status` / the `markedOps` set — which replaces the retired
+  `knownUncoveredOps`; this slice runs *after* Spec 1).
 - Two aggregate checks at suite end (bidirectional drift detection):
   - **producible** — every documented `(status, errorCode)` in scope was observed by ≥1
     E2E (catches *fictional* codes, audit pattern P5).
@@ -131,9 +135,9 @@ schema sealing.
 **Canonical-schema reconciliation:** several entity wire shapes have a *canonical* JSON
 schema under `docs/cyoda/schema/common/` (embedded, consumed by cyoda-docs/Cloud) **and** a
 mirror in `e2e/parity/client/types.go`. Fixes to these shapes must reconcile **all**
-definitions (canonical JSON schema ↔ OpenAPI ↔ parity client), not author a fourth. ADR
-0001 Consequences explicitly flags the `e2e/parity/client/types.go` update (it is the
-commercial plugin's import surface).
+definitions (canonical JSON schema ↔ OpenAPI ↔ parity client), not author a fourth. The
+`e2e/parity/client/types.go` mirror updates whenever a corrected wire shape changes it (it is
+the commercial plugin's import surface).
 
 ## 6. The entity slice — findings, directions, fixes
 
@@ -144,9 +148,9 @@ commercial plugin's import surface).
 | E3 | `getAllEntities` ignores `pointInTime` | server-gap | Plumb `pointInTime` into the list read via **`GetAllAsAt`** (the model-scoped list-PIT primitive in all 3 backends, already used by search at `internal/domain/search/service.go:161`) — **not** `getOneEntity`'s single-entity `GetAsAt`. Also populate `meta.pointInTime` (E1). | as-at e2e + parity |
 | E4 | `createCollection` / `create` request body `type:object` erases real shape | spec-incomplete | Tighten request schemas to the array-of-`{model{name,version},payload}` shape; document the batch/array `create` form. Reconcile `e2e/parity/client/types.go` (S5). | request validation |
 | E5 | create/update/patch/collection composite-unique-key `409`/`422` codes undocumented | spec-incomplete | Add codes to the endpoints' error tables | error-code matrix (producible+declared) |
-| E6 | `EntityChangeMeta.fieldsChangedCount` advertised (in **canonical** `docs/cyoda/schema/common/EntityChangeMeta.json`), never emitted by server | **needs-decision** | See §6.2 | per decision |
+| E6 | `EntityChangeMeta.fieldsChangedCount` advertised (in **canonical** `EntityChangeMeta.json`), never emitted | **needs-decision (deferred)** | **Out of this slice** — Cloud-fact-blocked; §6.2 | — |
 | E7 | `getEntityChangesMetadata` ordering prose says chronological; server is newest-first | spec-stale | Fix prose to reverse-chronological | (doc-only) |
-| E8 | `changeType` prose `CREATE/UPDATE/DELETE` vs enum/emit `CREATED/UPDATED/DELETED` | spec-stale | Fix prose to match enum | response validation (enum) |
+| E8 | `changeType` spelling diverges across surfaces: canonical `EntityChangeMeta.json` `CREATE/UPDATE/DELETE`, OpenAPI+HTTP `CREATED/UPDATED/DELETED`, **gRPC `CREATE/UPDATE/DELETE`** (`mapChangeType`, `grpc/search.go:591`) | **needs-decision** | Decide canonical spelling, then align canonical JSON ↔ OpenAPI ↔ HTTP ↔ gRPC (§6.3) | response validation (enum) + gRPC |
 | E9 | `getOneEntity` 200 example shows only `{id,state}` | spec-incomplete | Enrich example to full meta shape | (validated structurally by E1) |
 
 ### 6.1 `deleteEntities` — implementing conditional delete
@@ -174,20 +178,28 @@ Feasibility confirmed against code, with three implementation realities the plan
   never ignored.
 - **gRPC:** see §8 / decision D2.
 
-### 6.2 E6 `fieldsChangedCount` — the decision
-The field is declared in the **canonical, Cloud-consumed** `EntityChangeMeta.json`, but the
+### 6.2 E6 `fieldsChangedCount` — deferred (Cloud-fact-blocked)
+The field is declared in the **canonical, Cloud-consumed** `EntityChangeMeta.json` but the
 cyoda-go server never emits it (`internal/domain/entity/handler.go:576-587`). Direction is
-genuinely ambiguous:
-- **(a) server-gap** — the contract intends it; **implement** emission (compute the
-  changed-field count on the change path). Keeps the canonical schema; small server addition.
-- **(b) spec-stale** — remove it from the canonical schema. **But** this is a Cloud-parity
-  contract change to an embedded, downstream-consumed CloudEvents schema; risky if Cloud
-  already emits it.
+genuinely ambiguous — (a) `server-gap`: implement emission (compute the changed-field count);
+(b) `spec-stale`: remove it from the canonical schema (risky if Cloud emits it). Resolving it
+needs a Cloud-parity fact we do not yet have: **does Cloud emit `fieldsChangedCount`?**
+**This slice does not implement E6** — a `needs-decision` must not drive net-new speculative
+server code. E6 is recorded as an open question in `docs/cloud-parity/` and decided once the
+Cloud fact is gathered; the leaning is (a) implement (removing a Cloud-consumed canonical field
+is the higher-risk direction).
 
-**Recommendation:** (a) implement server-side — removing a field from a Cloud-consumed
-canonical schema is the higher-risk direction, and the field carries real audit-UI value. To
-be confirmed with the Cloud-parity check (does Cloud emit it?) before finalizing. Recorded in
-`docs/cloud-parity/`.
+### 6.3 HTTP ↔ gRPC divergences to reconcile
+Two entity shapes already differ between the HTTP and gRPC entry points; typed-but-open schemas
+would *mask* these, so — per the project's "an entry-point divergence is a bug" stance — the
+slice reconciles them explicitly rather than letting the open schema hide them:
+- **`changeType` spelling (E8):** HTTP emits `CREATED/UPDATED/DELETED`; gRPC emits
+  `CREATE/UPDATE/DELETE` (`mapChangeType`, `internal/grpc/search.go:591`); the canonical
+  `EntityChangeMeta.json` sides with gRPC. Decide one spelling and align all four surfaces.
+- **`meta` fields:** HTTP `meta` includes `modelKey` (and, after E3, `pointInTime`); gRPC
+  `buildEntityMeta` (`internal/grpc/search.go:577-589`) omits both. Add `modelKey` and
+  `pointInTime` to the gRPC builder so both entry points emit the same metadata (E1 fixes the
+  HTTP side).
 
 ## 7. Per-endpoint error/status tables (in-scope endpoints)
 
@@ -213,7 +225,7 @@ MODEL_NOT_FOUND (create); 401/403.
 415/428/501 existing (PATCH); 422 INVALID_UNIQUE_KEY[_DEFINITION] ✎.
 
 **`GET /entity/{entityId}/changes` (getEntityChangesMetadata)** — response-shape fixes
-(E6/E7/E8); error table unchanged (200/404/401/403).
+(E7/E8; E6 deferred); error table unchanged (200/404/401/403).
 
 ## 8. Coverage matrix (scenario × layer)
 
@@ -223,23 +235,23 @@ covered** (no false waivers; the gRPC meta and delete surfaces both exist).
 | Scenario | Unit | Running-backend e2e | Cross-backend parity | gRPC |
 |---|---|---|---|---|
 | Error-code matrix (producible + declared), entity scope | ✓ (collector logic) | ✓ (aggregate) | — | — |
-| E1 meta shape (mirror canonical; typed-but-open — no `additionalProperties:false`; no `previousTransition`) | — | ✓ | ✓ (backend-agnostic) | ✓ — assert `buildEntityMeta` output (`internal/grpc/search.go:377,577`) matches the tightened shape |
-| E2 conditional delete (matching subset only) | condition→ids selection ✓ | ✓ | ✓ (inside tx — §6.1) | per decision D2 |
-| E2 `pointInTime` + `verbose` (ids returned) | — | ✓ | ✓ | per D2 |
+| E1 meta shape (mirror canonical; typed-but-open — no `additionalProperties:false`; no `previousTransition`) | — | ✓ | ✓ (backend-agnostic) | ✓ — reconcile gRPC `buildEntityMeta` (`internal/grpc/search.go:577`) to add `modelKey`+`pointInTime` (§6.3), then assert it matches the tightened shape |
+| E2 conditional delete (matching subset only) | condition→ids selection ✓ | ✓ | ✓ (inside tx — §6.1) | gRPC stays unconditional (D2 deferred, §8) |
+| E2 `pointInTime` + `verbose` (ids returned) | — | ✓ | ✓ | — |
 | E3 `getAllEntities` as-at (`GetAllAsAt`) | — | ✓ | ✓ | — |
 | E4 request-body shape (array-of-`{model,payload}`) | — | ✓ | ✓ | — |
 | E5 unique-key `409`/`422` codes | — | ✓ (per code) | ✓ | ✓ — assert envelope; note N1: gRPC `Error.Code` is a coarse CLIENT/SERVER bucket, the unique-key code is in `Error.Message` (`internal/grpc/errors.go`), matching `TestRPC_EntityCreate_UniqueViolation` (`rpc_test.go:654`) |
-| E6 `fieldsChangedCount` (per §6.2 decision) | — | ✓ | ✓ | ✓ if emitted on gRPC change path |
-| E7/E8 changes ordering/enum | — | ✓ (gate-validated) | — | — |
+| E8 `changeType` spelling aligned across HTTP + gRPC (§6.3) | — | ✓ (gate-validated enum) | — | ✓ (gRPC enum) |
+| E7 changes ordering | — | ✓ (gate-validated) | — | — |
 
-**Decision D2 — gRPC conditional delete.** gRPC exposes `EntityDeleteAllRequest`
-(unconditional; `internal/grpc/entity.go:391`) and per-entity `EntityDeleteRequest`, but no
-*conditional* delete. The OpenAPI conditional-delete is an **HTTP-contract** feature; the
-gRPC/proto contract does not promise conditional delete. **Recommendation:** implement E2 on
-HTTP only; keep gRPC `DeleteAll` as-is (it conforms to its own proto contract), and add/verify
-gRPC test coverage for the existing `DeleteAll` behaviour so the gRPC entry point is covered,
-not waived. Record the HTTP-only scope in `docs/cloud-parity/`. (Confirm with Cloud that gRPC
-parity is not expected before finalizing — Gate 7 / multi-node.)
+**Decision D2 — gRPC conditional delete (deferred, Cloud-fact-blocked).** gRPC exposes
+`EntityDeleteAllRequest` (unconditional; `internal/grpc/entity.go:391`) and per-entity
+`EntityDeleteRequest`, but no *conditional* delete. The OpenAPI conditional-delete is an
+**HTTP-contract** feature; the gRPC/proto contract does not promise it. **This slice implements
+E2 on HTTP only**; gRPC `DeleteAll` stays unconditional and gets test coverage for its existing
+behaviour (so the gRPC entry point is covered, not waived). Whether Cloud expects gRPC
+conditional-delete parity is an **open question recorded in `docs/cloud-parity/`**, decided when
+the Cloud fact is gathered (Gate 7 / multi-node).
 
 **Concurrency:** entity-slice changes need no isolated concurrency test; `deleteEntities` is
 select-then-delete over a snapshot; parity asserts the surviving subset, not an interleave.
@@ -249,34 +261,40 @@ select-then-delete over a snapshot; parity asserts the surviving subset, not an 
 - **Gate 4:** new error codes → `cmd/cyoda/help/content/errors/<CODE>.md`
   (`TestErrCode_Parity` bijection). E2/E5 surface `INVALID_CONDITION`, `UNIQUE_VIOLATION`,
   `INVALID_UNIQUE_KEY[_DEFINITION]` at these endpoints.
-- **Gate 7:** `docs/cloud-parity/` entry per reconciled behaviour (E1 meta; E2 conditional-
-  delete + D2 gRPC scope; E3 as-at; E6 decision). Each states direction + rationale.
+- **Gate 7:** `docs/cloud-parity/` entry per reconciled behaviour (E1 meta; E2 conditional
+  delete; E3 as-at; E8 `changeType` spelling) — each states direction + rationale — **plus two
+  open questions** (E6 `fieldsChangedCount` direction; D2 gRPC conditional-delete parity),
+  decided when the Cloud facts are gathered.
 - **Canonical schemas / parity mirror:** reconcile `docs/cyoda/schema/common/EntityMetadata.json`
-  (E1) and `EntityChangeMeta.json` (E6) with the OpenAPI, and update `e2e/parity/client/types.go`
-  (S5) for E1/E4 wire-shape changes.
+  (E1) and `EntityChangeMeta.json` (E8 `changeType`; E6 deferred) with the OpenAPI, and update
+  `e2e/parity/client/types.go` (S5) for E1/E4 wire-shape changes.
 - **Codegen:** `api/generated.go` regenerated (or hand-updated) on model changes (E1, E4).
   Note: tree is on **oapi-codegen v2.7.0** with a `//go:generate` directive
   (`api/generate.go`); re-verify whether the Go 1.26 regen caveat still applies before relying
   on `go generate`.
-- **ADR:** reference ADR 0001; no superseding ADR needed (we stay within it).
+- **ADR:** governed by **ADR 0003** (typed-but-open, additive-only gate, reconciliation
+  direction); ADR 0003 supersedes 0001.
 
 ## 10. Decomposition — follow-on plans (out of scope here)
 
 Each reuses the Pillar-B loop and the extended validator:
 1. stats / audit / search · 2. entity-model & workflow · 3. auth / OIDC (error-envelope
-family decision) · 4. message · 5. **dead-surface decision** (implement vs remove 22
-excluded-tag ops + always-501 stubs — its own brainstorm; highest single scale signal).
+family decision) · 4. message · 5. **dead-surface disposition** — Spec 1 already assigns each
+not-live op a machine-readable `x-cyoda-status` (SQL-Schema `planned`/Trino, Stream Data
+`unimplemented`, IAM/OIDC stubs `planned`); the eventual *implement-vs-remove* call for the
+`unimplemented` set remains a follow-on decision.
 
 ## 11. Risks
 
 - **Spec precision debt:** the validator only guards precisely-declared schemas. Mitigation:
-  in-scope schemas tightened; matrix reuses `knownUncoveredOps` so out-of-scope coverage is
-  never overstated.
+  in-scope schemas tightened; out-of-scope coverage is exempted via Spec 1's marker-aware gate
+  (`markedOps`), so it is never overstated.
 - **`deleteEntities` blast radius:** destructive path. Mitigation: reuse the proven search
   condition primitive, backward-compatible empty-body behaviour, parity asserts the surviving
   subset **inside the tx** (§6.1), per-id delete loop, data-loss closed by construction.
 - **Canonical-schema coupling:** E1/E6 touch embedded, Cloud-consumed schemas; changes must
   reconcile all mirrors (§5) and be recorded in cloud-parity — mishandling risks silent
   cross-repo drift.
-- **Two open decisions (E6 direction, D2 gRPC scope):** recommendations given; confirm the
-  Cloud-parity facts before finalizing.
+- **Two deferred decisions (E6 `fieldsChangedCount`, D2 gRPC conditional-delete parity):**
+  both Cloud-fact-blocked and out of this slice (§6.2, §8); recorded as `docs/cloud-parity/`
+  open questions, decided when the Cloud facts are gathered.

--- a/docs/superpowers/specs/2026-07-02-openapi-contract-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-07-02-openapi-contract-reconciliation-design.md
@@ -4,8 +4,11 @@
 **Status:** design / awaiting review
 **Reference evidence:** `docs/analysis/openapi/README.md` (full 87-op audit, six-pattern
 taxonomy, per-finding reconciliation direction).
-**Builds on:** ADR 0001 (`docs/adr/0001-openapi-server-spec-conformance.md`), the
-`internal/e2e/openapivalidator` package, and the #21 reconciliation seed.
+**Builds on:** ADR 0003 (`docs/adr/0003-openapi-contract-conformance-and-evolution.md`,
+which supersedes 0001 and codifies the reconciliation-direction and typed-but-open policies
+applied here), the `internal/e2e/openapivalidator` package, the schema-strictness research
+(`docs/analysis/openapi/schema-strictness-research.md`), and the earlier defect-reconciliation
+seed (issue #21).
 
 ---
 
@@ -28,35 +31,20 @@ loose `additionalProperties:true` bags let real drift through; (b) it validates 
 *shapes* but not *error-code coverage* (documented-but-fictional codes, emitted-but-
 undocumented codes). This effort closes both, and reconciles the entity group under them.
 
-## 2. Reconciliation policy (refines the #21 "server is source of truth" framing)
+## 2. Reconciliation policy (per ADR 0003)
 
-The #21 seed carries "server is source of truth" language (`entity_conformance_test.go:6`,
-`internal/domain/entity/handler.go:601` "Server is source of truth per design §3"). That
-was correct for the four #21 defects, where the server's behaviour was the intended one and
-the spec was stale. But it is **not** a universal reconciliation rule, and stating it as one
-contradicts ADR 0001's "spec is canonical."
+ADR 0003 (Decision 7) governs: the authored `api/openapi.yaml` is the canonical contract and
+source of intent; when spec and server disagree the defect is on whichever side left the
+contract, classified per finding — `spec-stale` (fix spec), `spec-incomplete` (enrich spec),
+`server-gap` (fix server), `needs-decision` (record, then reclassify). This spec applies that
+policy to the entity group.
 
-**Refined policy (this effort):** the *authored spec is the canonical contract and the
-source of intent*; when spec and server disagree it is a **defect on whichever side left
-the contract**, decided per finding:
-
-- `spec-stale` — server evolved correctly; fix the spec.
-- `spec-incomplete` — server is right and intended; enrich the spec.
-- `server-gap` — the spec expresses intended contract the server never implemented; fix the
-  **server**.
-- `needs-decision` — genuine ambiguity; record the decision, then it becomes one of the
-  above.
-
-~⅓ of audit findings are `server-gap`/`needs-decision`, so a mechanical "sync spec→server"
-would *destroy* contract intent (it would turn the `deleteEntities` data-loss bug into a
-documented feature). This policy refinement is itself recorded (Gate 6): the stale
-"server is source of truth" comments in the seed are corrected to point here as part of the
-entity slice.
-
-**Relationship to ADR 0001:** this effort stays within ADR 0001 (runtime validation, no
-strict-typing migration). It does not supersede it. It *does* move us toward one of ADR
-0001's stated reconsideration triggers (Cloud parity as a first-class argument); if that
-trigger fires later it gets its own superseding ADR — out of scope here.
+A mechanical "sync spec→server" is wrong here: ~⅓ of audit findings are
+`server-gap`/`needs-decision` (e.g. syncing would turn the `deleteEntities` data-loss bug into
+a documented feature). Some entity-domain code comments assert "the server is the source of
+truth" (`entity_conformance_test.go:6`, `internal/domain/entity/handler.go:601`) — inherited
+from the issue #21 defect-reconciliation, where the server happened to be the intended one;
+this slice corrects those comments to the per-finding policy above (Gate 6).
 
 ## 3. Goals / Non-goals
 
@@ -102,11 +90,15 @@ exactly that delta plus schema tightening:
   - **declared** — no in-scope E2E produced a `(status, errorCode)` absent from the matrix
     (catches *missing* codes, P5).
 
-### 4.2 Schema tightening (what makes the existing validator bite)
-The validator passes anything against `additionalProperties:true`. For each entity-group
-finding we tighten the relevant schema (add `properties`, set `additionalProperties:false`,
-correct types) so the *already-present* enforce-mode validator now fails on regression. No
-new validation engine — we feed the existing one a precise schema.
+### 4.2 Schema tightening — typed-but-open (per ADR 0003)
+The validator passes anything against an `additionalProperties:true` bag. For each
+entity-group finding we make the schema precise **without sealing it**: enumerate every
+property the server emits (correct types, required vs optional), but leave
+`additionalProperties` open (absent/`true`), never `false`. The enforce-mode validator then
+fails when a documented field is missing or mistyped, while a future additive field still
+validates — the binding is on the known shape, not on rejecting extras. A composed (`allOf`)
+schema that must ever close uses `unevaluatedProperties:false`, never `additionalProperties:false`
+on the base. No new validation engine — we feed the existing one a precise-but-open schema.
 
 ### 4.3 Seed cleanup (Gate 6)
 Once `meta`/envelope are tightened under enforce mode, most hand-parsed key assertions in
@@ -128,9 +120,13 @@ For each finding: **classify direction** (§2) → **fix the losing side** via r
 (Gate 1) → **lock it** (tighten schema and/or add the matrix entry) → **record the contract
 decision** in `docs/cloud-parity/` (Gate 7).
 
-**Tightening policy:** tightened response objects use declared `properties` +
-`additionalProperties:false`. Consequence: adding a new field later fails CI until the spec
-is updated. In a spec-first world that is the intended binding.
+**Tightening policy (typed-but-open, per ADR 0003):** enumerate every known property
+(correct types, required vs optional) but do **not** seal — `additionalProperties` stays open,
+never `false`. The validator binds the known shape (missing/mistyped documented fields fail)
+while additive fields stay non-breaking. Genuinely open values (entity `data`, error extension
+bags) stay open by design. Discipline against breaking edits (sealing, field removal, type
+narrowing) is an **additive-only CI gate** on `api/openapi.yaml` (ADR 0003, Decision 6), not
+schema sealing.
 
 **Canonical-schema reconciliation:** several entity wire shapes have a *canonical* JSON
 schema under `docs/cyoda/schema/common/` (embedded, consumed by cyoda-docs/Cloud) **and** a
@@ -143,7 +139,7 @@ commercial plugin's import surface).
 
 | # | Finding | Direction | Fix | Lock |
 |---|---|---|---|---|
-| E1 | `Envelope.meta` opaque bag + `previousTransition` fossil (`getOneEntity`, `getAllEntities`) | spec-incomplete + spec-stale | Add an `EntityMeta` OpenAPI schema **mirroring the canonical `docs/cyoda/schema/common/EntityMetadata.json`**: required `{id, state, creationDate, lastUpdateTime}`; **optional** `{modelKey, transactionId, transitionForLatestSave, pointInTime}`; `additionalProperties:false`; delete `previousTransition`; fix examples. Reconcile OpenAPI ↔ canonical JSON ↔ `e2e/parity/client/types.go` (S5). | enforce-mode response validation on both ops |
+| E1 | `Envelope.meta` opaque bag + `previousTransition` fossil (`getOneEntity`, `getAllEntities`) | spec-incomplete + spec-stale | Add an `EntityMeta` OpenAPI schema **mirroring the canonical `docs/cyoda/schema/common/EntityMetadata.json`**: required `{id, state, creationDate, lastUpdateTime}`; **optional** `{modelKey, transactionId, transitionForLatestSave, pointInTime}`; **typed-but-open** (`additionalProperties` absent, never `false`); delete `previousTransition`; fix examples. Reconcile OpenAPI ↔ canonical JSON ↔ `e2e/parity/client/types.go` (S5). | enforce-mode response validation on both ops |
 | E2 | `deleteEntities` ignores condition body + `pointInTime` + `verbose`; wipes whole model | server-gap (data loss) | **Implement** the documented contract (§6.1) | e2e (subset survives) + parity (inside tx) + matrix |
 | E3 | `getAllEntities` ignores `pointInTime` | server-gap | Plumb `pointInTime` into the list read via **`GetAllAsAt`** (the model-scoped list-PIT primitive in all 3 backends, already used by search at `internal/domain/search/service.go:161`) — **not** `getOneEntity`'s single-entity `GetAsAt`. Also populate `meta.pointInTime` (E1). | as-at e2e + parity |
 | E4 | `createCollection` / `create` request body `type:object` erases real shape | spec-incomplete | Tighten request schemas to the array-of-`{model{name,version},payload}` shape; document the batch/array `create` form. Reconcile `e2e/parity/client/types.go` (S5). | request validation |
@@ -227,7 +223,7 @@ covered** (no false waivers; the gRPC meta and delete surfaces both exist).
 | Scenario | Unit | Running-backend e2e | Cross-backend parity | gRPC |
 |---|---|---|---|---|
 | Error-code matrix (producible + declared), entity scope | ✓ (collector logic) | ✓ (aggregate) | — | — |
-| E1 meta shape (mirror canonical; `additionalProperties:false`; no `previousTransition`) | — | ✓ | ✓ (backend-agnostic) | ✓ — assert `buildEntityMeta` output (`internal/grpc/search.go:377,577`) matches the tightened shape |
+| E1 meta shape (mirror canonical; typed-but-open — no `additionalProperties:false`; no `previousTransition`) | — | ✓ | ✓ (backend-agnostic) | ✓ — assert `buildEntityMeta` output (`internal/grpc/search.go:377,577`) matches the tightened shape |
 | E2 conditional delete (matching subset only) | condition→ids selection ✓ | ✓ | ✓ (inside tx — §6.1) | per decision D2 |
 | E2 `pointInTime` + `verbose` (ids returned) | — | ✓ | ✓ | per D2 |
 | E3 `getAllEntities` as-at (`GetAllAsAt`) | — | ✓ | ✓ | — |

--- a/docs/superpowers/specs/2026-07-02-openapi-contract-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-07-02-openapi-contract-reconciliation-design.md
@@ -71,8 +71,9 @@ this slice corrects those comments to the per-finding policy above (Gate 6).
 **Do not build a parallel system.** `internal/e2e/openapivalidator` already loads
 `api/openapi.yaml` via kin-openapi, validates every E2E response body + status against the
 operation schema, runs in `ModeEnforce`, accumulates a `collector`, emits a `report`, and
-tracks operation/status coverage (failing on uncovered *in-scope* ops via
-`zzz_openapi_conformance_test.go`'s `knownUncoveredOps`). ADR 0001 governs it.
+tracks operation/status coverage (today via `zzz_openapi_conformance_test.go`'s
+`knownUncoveredOps`, which Spec 1 replaces with the `x-cyoda-status` marker gate). ADR 0003
+governs this conformance machinery.
 
 The **only genuinely new capability** is error-code coverage at **errorCode-string
 granularity** (the existing coverage is operation/status granularity). Scope Pillar A to

--- a/docs/superpowers/specs/2026-07-02-openapi-contract-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-07-02-openapi-contract-reconciliation-design.md
@@ -1,0 +1,291 @@
+# OpenAPI Contract Reconciliation — Phase 0 Gate + Entity Slice
+
+**Date:** 2026-07-02
+**Status:** design / awaiting review
+**Reference evidence:** `docs/analysis/openapi/README.md` (full 87-op audit, six-pattern
+taxonomy, per-finding reconciliation direction).
+
+---
+
+## 1. Problem
+
+`api/openapi.yaml` is a deliberate, authored, `//go:embed`'d contract — the definitive
+common ground between `cyoda-go` and `cyoda-cloud`. It is intentionally **not** generated
+from Go. The cost of that choice is that nothing binds either side to the contract, and
+the audit (`docs/analysis/openapi/README.md`) found ~55 divergences across 87 operations,
+including a data-loss defect and a 25%-dead published surface. An app-builder generating a
+client from the spec reaches materially wrong conclusions — the trigger case: concluding
+from `GET /entity/{entityId}` that there is *no way to learn the entity model*, because
+`meta` is an opaque bag whose prose names a field (`previousTransition`) that does not
+exist.
+
+The mess is not the 55 findings. It is that **any fix rots**, because there is no
+enforced binding. This effort installs the binding first, then reconciles under it.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- A durable **conformance gate** that makes server↔spec drift fail CI, with a portable
+  core decoupled from `cyoda-go` internals (liftable to a shared cyoda-go/Cloud kit later).
+- A repeatable **reconciliation loop** (classify → fix losing side → lock → record) that
+  every follow-on group reuses.
+- Apply both to the **entity group** end-to-end as the proving vertical, including
+  implementing the documented conditional `deleteEntities`.
+
+**Non-goals (this spec)**
+- Reconciling the other five groups (stats/audit/search, model, auth/oidc, message) — each
+  is its own spec→plan cycle fed through the loop established here.
+- The dead-surface disposition (22 excluded-tag ops + always-501 stubs) — a contract
+  decision deferred to its own spec.
+- Lifting the gate into a shared cross-repo kit — the core is *structured* to allow it;
+  extraction is future work.
+- Changing the authoring model: the spec stays hand-authored and owned. The gate binds the
+  **server** to the authored spec; it does not generate the spec.
+
+## 3. Architecture — two pillars
+
+```
+                 api/openapi.yaml  (authored contract, source of intent)
+                          │
+          ┌───────────────┴────────────────┐
+          │                                 │
+   PILLAR A: conformance gate        PILLAR B: reconciliation loop
+   (portable core + e2e harness)     (per-finding process + recording)
+          │                                 │
+          │  validates every e2e response   │  classify direction
+          │  against the op schema;         │  → fix losing side (TDD)
+          │  asserts error-code matrix      │  → tighten schema / matrix (locks it)
+          │  (bidirectional)                │  → record contract decision
+          └───────────────┬────────────────┘
+                          │
+              tightening a loose schema is simultaneously
+              the FIX (B) and what makes the GATE (A) enforceable
+```
+
+The two pillars are coupled by design: the gate without tightening validates nothing
+meaningful (an `additionalProperties:true` bag passes anything); tightening without the
+gate rots. They advance together, per finding.
+
+## 4. Pillar A — the conformance gate
+
+### 4.1 Portable core (`internal/e2e/conformance/`, no cyoda-go internals)
+
+A self-contained package that depends only on the spec file, an HTTP response, and a
+static error-code registry — deliberately free of cyoda-go domain types so it can later be
+lifted into a shared kit.
+
+- **`SpecSet`** — loads and indexes `api/openapi.yaml` (via the existing
+  `kin-openapi/openapi3` dependency already used by the e2e `openapivalidator`). Resolves
+  an `(method, path-template)` → operation, request schema, per-status response schema,
+  and declared content-types.
+- **`ValidateResponse(op, status, contentType, body) []Violation`** — asserts the response
+  body validates against the operation's schema for that status, the status is a declared
+  response, and the `Content-Type` matches a declared media type. Returns structured
+  violations (never panics; never mutates).
+- **`ErrorCodeMatrix`** — a static registry: `operationId → {documented status/error
+  codes}`, authored from the spec's per-endpoint error tables (§7). Exposes two checks used
+  by the harness aggregation:
+  - **producible**: every documented code was observed by ≥1 e2e (catches *fictional*
+    codes — P5).
+  - **declared**: no e2e produced a status/error-code absent from the registry (catches
+    *missing* codes — P5).
+
+The core is unit-tested in isolation (§8.1): a fixture spec + hand-built good/mutated
+responses prove both validation directions and both matrix directions fail exactly when
+they should. This is what makes the gate trustworthy enough to gate everything else.
+
+### 4.2 e2e harness integration (`internal/e2e/`, cyoda-go-aware)
+
+- A thin `recordAndAssert` helper wraps existing e2e request execution: after each call it
+  feeds `(op, status, contentType, body)` to the core validator and accumulates the
+  observed `(op, status/errorCode)` pairs into a run-scoped collector.
+- Builds on the existing e2e-only `openapivalidator` and the `entity_conformance_test.go`
+  seed rather than replacing them; the seed's ad-hoc assertions are migrated to the core.
+- A `TestConformance_ErrorCodeMatrix` aggregates the run-scoped collector at suite end and
+  runs the producible+declared checks **for the operations in scope** (entity group in this
+  spec). Out-of-scope operations are explicitly listed as `pending` so the matrix never
+  silently claims coverage it doesn't have (no-silent-caps).
+
+### 4.3 What the gate does *not* do
+
+- It does not validate the polymorphic entity `data` payload — that stays
+  `additionalProperties:true` by contract (user-defined shape). The gate validates the
+  **envelope** (`type`/`data`/`meta`), not the user's document.
+- It is only as strong as the spec is precise. For the entity slice we tighten the relevant
+  schemas (§6); still-loose schemas in other groups will pass permissively until their own
+  plans tighten them — the gate must not false-fail on them.
+
+## 5. Pillar B — the reconciliation loop
+
+For each finding, in order:
+
+1. **Classify direction** — `spec-stale` (server right, fix spec) · `spec-incomplete`
+   (server right, enrich spec) · `server-gap` (spec is intended contract, fix server) ·
+   `needs-decision` (record the decision, then it becomes one of the above).
+2. **Fix the losing side** via red/green TDD (Gate 1). Spec-side fixes are edits to
+   `api/openapi.yaml` (+ `api/generated.go` regen where models change); server-side fixes
+   follow the bugfix TDD protocol.
+3. **Lock it** — tighten the schema (add `properties`, set `additionalProperties:false`,
+   correct types) and/or add the `ErrorCodeMatrix` entry, so the gate now fails if the
+   fix regresses.
+4. **Record the contract decision** in `docs/cloud-parity/` (Gate 7) — one file per
+   behaviour, stating the direction chosen and why, so Cloud mirrors the same contract.
+
+**Tightening policy:** tightened response objects use declared `properties` +
+`additionalProperties:false`. Consequence: adding a new field later fails CI until the spec
+is updated. In a spec-first world this is the intended binding, not a regression.
+
+## 6. The entity slice — findings, directions, fixes
+
+| # | Finding | Direction | Fix | Lock |
+|---|---|---|---|---|
+| E1 | `Envelope.meta` opaque bag + `previousTransition` fossil (`getOneEntity`, `getAllEntities`) | spec-incomplete + spec-stale | Named `EntityMeta` schema: `id`, `modelKey{name,version}`, `state`, `creationDate`, `lastUpdateTime`, `transactionId`, optional `transitionForLatestSave`; `additionalProperties:false`; delete `previousTransition`; fix examples | response validation asserts meta shape on both ops |
+| E2 | `deleteEntities` ignores condition body + `pointInTime` + `verbose`; wipes whole model | server-gap (data loss) | **Implement** the documented contract (§6.1) | e2e (subset survives) + parity + matrix |
+| E3 | `getAllEntities` ignores `pointInTime` | server-gap | Plumb `pointInTime` into `ListEntities` reusing the existing PIT path (`getOneEntity` has it) | as-at e2e + parity |
+| E4 | `createCollection` / `create` request body `type:object` erases real shape | spec-incomplete | Tighten request schemas to the array-of-`{model{name,version},payload}` shape; document the batch/array `create` form | request validation |
+| E5 | create/update/patch/collection composite-unique-key `409`/`422` codes undocumented | spec-incomplete | Add codes to the endpoints' error tables | error-code matrix (producible+declared) |
+| E6 | `EntityChangeMeta.fieldsChangedCount` advertised, never emitted | spec-stale | Remove `fieldsChangedCount` from schema + examples | response validation |
+| E7 | `getEntityChangesMetadata` ordering prose says chronological; server is newest-first | spec-stale | Fix prose to reverse-chronological (newest-first is the correct audit default) | (doc-only; no gate assertion) |
+| E8 | `changeType` prose `CREATE/UPDATE/DELETE` vs enum/emit `CREATED/UPDATED/DELETED` | spec-stale | Fix prose to match enum | response validation (enum) |
+| E9 | `getOneEntity` 200 example shows only `{id,state}` | spec-incomplete | Enrich example to the full meta shape | (example; validated structurally by E1) |
+
+### 6.1 `deleteEntities` — implementing the documented contract
+
+The contract: delete only entities matching an `AbstractConditionDto` body, honouring
+`pointInTime` selection and `verbose` (return deleted ids). Implementation principle
+(no special engine rights — reuse existing primitives):
+
+> **select-then-delete.** Evaluate the condition using the *same condition-evaluation
+> primitive `searchEntities` already uses* to obtain the matching entity ids (at
+> `pointInTime` when supplied), then delete those ids. When `verbose`, return the deleted
+> ids in `StreamDeleteResult.ids`.
+
+- No new engine capability, no new cross-node invariant. Condition evaluation already works
+  consistently across backends, so cross-backend parity follows from reusing it.
+- **Absent/empty body** preserves today's "delete all of the model" behaviour (backward
+  compatible). A **present** condition scopes the delete. `verbose` toggles id return.
+- Data-loss is eliminated structurally: a condition that is present is *honoured*, never
+  silently ignored.
+- Records a `docs/cloud-parity/` entry: "server now conforms to conditional delete."
+
+## 7. Per-endpoint error/status tables (in-scope endpoints)
+
+Authored into the `ErrorCodeMatrix`. `✎` = added/changed by this spec.
+
+**`GET /entity/{entityId}` (getOneEntity)**
+
+| Status | Code | Producing scenario |
+|---|---|---|
+| 200 | — | entity found |
+| 400 | (conflicting `pointInTime`+`transactionId`) | both query params supplied |
+| 404 | ENTITY_NOT_FOUND | unknown id |
+| 401/403 | — | auth |
+
+**`GET /entity/{entityName}/{modelVersion}` (getAllEntities)**
+
+| Status | Code | Producing scenario |
+|---|---|---|
+| 200 | — | list (now honouring `pointInTime` ✎) |
+| 400 | — | invalid page params |
+| 404 | MODEL_NOT_FOUND | unknown model |
+| 401/403 | — | auth |
+
+**`DELETE /entity/{entityName}/{modelVersion}` (deleteEntities)** ✎
+
+| Status | Code | Producing scenario |
+|---|---|---|
+| 200 | — | delete (all, or condition-scoped ✎); `ids` when `verbose` ✎ |
+| 400 | MALFORMED_REQUEST / INVALID_CONDITION ✎ | unparseable body / invalid condition |
+| 404 | MODEL_NOT_FOUND | unknown model |
+| 401/403 | — | auth |
+
+**`POST /entity/{format}/{entityName}/{modelVersion}` (create)** and
+**`POST|PUT /entity/{format}` (createCollection / updateCollection)**
+
+| Status | Code | Producing scenario |
+|---|---|---|
+| 200 | — | success |
+| 400 | MALFORMED_REQUEST / INCOMPATIBLE_TYPE / POLYMORPHIC_SLOT | bad body shape ✎ / type mismatch |
+| 409 | UNIQUE_VIOLATION ✎ | composite-unique-key conflict |
+| 422 | INVALID_UNIQUE_KEY / INVALID_UNIQUE_KEY_DEFINITION ✎ | null/invalid unique-key field or definition |
+| 404 | MODEL_NOT_FOUND | unknown model (create) |
+| 401/403 | — | auth |
+
+**`PUT|PATCH /entity/{format}/{entityId}[/{transition}]` (updateSingle[WithLoopback], patchSingle[WithLoopback])**
+
+| Status | Code | Producing scenario |
+|---|---|---|
+| 200 | — | success |
+| 400 / 404 / 409 / 412 | (existing) | as documented |
+| 415 / 428 / 501 | (existing, PATCH) | as documented |
+| 422 | INVALID_UNIQUE_KEY[_DEFINITION] ✎ | unique-key violation on the save path |
+
+**`GET /entity/{entityId}/changes` (getEntityChangesMetadata)** — response-shape fixes
+(E6/E7/E8); error table unchanged (200/404/401/403).
+
+## 8. Coverage matrix (scenario × layer)
+
+Per `.claude/rules/test-coverage.md`. `✓` required · `—` n/a · `waive` = waived with reason.
+
+| Scenario | Unit | Running-backend e2e | Cross-backend parity | gRPC |
+|---|---|---|---|---|
+| Conformance core: response validation both directions | ✓ | — | — | — |
+| Conformance core: error-code matrix both directions | ✓ | — | — | — |
+| E1 meta shape (fields present, no `previousTransition`, `additionalProperties:false`) | — | ✓ | ✓ (backend-agnostic) | verify gRPC GetEntity meta if it returns one; else `waive`: gRPC entity read has no meta envelope |
+| E2 conditional delete (matching subset only) | condition→ids selection ✓ | ✓ | ✓ | verify gRPC delete if present; else `waive` |
+| E2 `pointInTime` + `verbose` (ids returned) | — | ✓ | ✓ | per above |
+| E3 `getAllEntities` as-at `pointInTime` | — | ✓ | ✓ | — |
+| E4 request-body shape (array-of-`{model,payload}`) | — | ✓ | ✓ | — |
+| E5 unique-key `409`/`422` codes | — | ✓ (per code) | ✓ | ✓ (gRPC error envelope: `Success`,`Error.Code`) |
+| E6/E7/E8 changes shape/enum/ordering | — | ✓ (gate-validated) | — | — |
+
+**Concurrency:** none of the entity-slice changes need the isolated concurrency-test
+treatment. `deleteEntities` is select-then-delete over a snapshot; parity asserts the
+correct subset survives, not an interleave (per `.claude/rules/test-coverage.md`, concurrency
+tests stay out of the shared parity suite).
+
+**gRPC applicability** is confirmed per row during implementation; any `waive` records a
+one-line reason in the plan (no silent gaps).
+
+### 8.1 Test infrastructure notes
+- Core unit tests live beside the core (`internal/e2e/conformance/`), runnable with
+  `-short` (no Docker).
+- e2e conformance assertions run in the existing `internal/e2e` suite (Postgres testcontainer).
+- Backend-agnostic scenarios register in `e2e/parity/registry.go` (picked up by all
+  backends incl. the commercial one).
+
+## 9. Documentation & gate obligations
+
+- **Gate 4:** any new error code → `cmd/cyoda/help/content/errors/<CODE>.md`
+  (`TestErrCode_Parity` enforces the bijection). E2/E5 introduce/surface
+  `INVALID_CONDITION`, `UNIQUE_VIOLATION`, `INVALID_UNIQUE_KEY[_DEFINITION]` at these
+  endpoints — ensure topics exist.
+- **Gate 7:** `docs/cloud-parity/` entry per reconciled behaviour (E1 meta shape; E2
+  conditional-delete conformance; E3 as-at list). Each states the reconciliation direction
+  and rationale.
+- `api/generated.go` is regenerated (or hand-updated, per the existing oapi-codegen/Go 1.26
+  caveat) whenever request/response models change (E1, E4).
+
+## 10. Decomposition — follow-on plans (out of scope here)
+
+Each reuses the Pillar-B loop and the Pillar-A gate:
+1. stats / audit / search (fictional 404/408, page-size default, ndjson, `pointInTime`).
+2. entity-model & workflow (missing 409/422/404 on lock/unlock/delete/import).
+3. auth / OIDC (error-envelope family decision: problem+json vs OAuth `ErrorResponseDto`).
+4. message (mis-typed bodies, v1-UUID validation, `ValueMaps`).
+5. **dead-surface decision** — implement vs remove the 22 excluded-tag ops + always-501
+   stubs from the published contract. Highest single "scale" signal; it's a contract
+   decision, so it gets its own brainstorm.
+
+## 11. Risks
+
+- **Spec precision debt:** the gate only guards what the spec declares precisely. Mitigation:
+  in-scope schemas are tightened; the matrix explicitly lists out-of-scope ops as `pending`
+  so coverage is never overstated.
+- **`deleteEntities` blast radius:** implementing conditional delete touches a
+  destructive path. Mitigation: reuse the proven `searchEntities` condition primitive,
+  backward-compatible empty-body behaviour, parity asserts the surviving subset, and the
+  data-loss failure mode is closed by construction (present conditions are honoured).
+- **`api/generated.go` regen friction** (known oapi-codegen v2.6.0 / Go 1.26 incompatibility):
+  model changes may need the same manual-edit approach used in commit `9c721b4`.
+```

--- a/docs/superpowers/specs/2026-07-02-openapi-contract-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-07-02-openapi-contract-reconciliation-design.md
@@ -4,288 +4,283 @@
 **Status:** design / awaiting review
 **Reference evidence:** `docs/analysis/openapi/README.md` (full 87-op audit, six-pattern
 taxonomy, per-finding reconciliation direction).
+**Builds on:** ADR 0001 (`docs/adr/0001-openapi-server-spec-conformance.md`), the
+`internal/e2e/openapivalidator` package, and the #21 reconciliation seed.
 
 ---
 
 ## 1. Problem
 
-`api/openapi.yaml` is a deliberate, authored, `//go:embed`'d contract — the definitive
-common ground between `cyoda-go` and `cyoda-cloud`. It is intentionally **not** generated
-from Go. The cost of that choice is that nothing binds either side to the contract, and
-the audit (`docs/analysis/openapi/README.md`) found ~55 divergences across 87 operations,
-including a data-loss defect and a 25%-dead published surface. An app-builder generating a
-client from the spec reaches materially wrong conclusions — the trigger case: concluding
-from `GET /entity/{entityId}` that there is *no way to learn the entity model*, because
-`meta` is an opaque bag whose prose names a field (`previousTransition`) that does not
-exist.
+`api/openapi.yaml` is a deliberate, hand-authored, `//go:embed`'d OpenAPI 3.1 contract —
+the canonical common ground across `cyoda-go`, the commercial (Cassandra) plugin,
+`cyoda-docs`, and Cyoda Cloud. Per ADR 0001, **code is derived from the spec**, not the
+reverse. The audit (`docs/analysis/openapi/README.md`) found ~55 divergences across 87
+operations, including a data-loss defect and a 25%-dead published surface. An app-builder
+generating a client from the spec reaches materially wrong conclusions — the trigger case:
+concluding from `GET /entity/{entityId}` that there is *no way to learn the entity model*,
+because `meta` is an opaque bag whose prose names a field (`previousTransition`) that does
+not exist.
 
-The mess is not the 55 findings. It is that **any fix rots**, because there is no
-enforced binding. This effort installs the binding first, then reconciles under it.
+ADR 0001 already installed the *mechanism* to catch shape drift: runtime `kin-openapi`
+response validation at the E2E boundary (`internal/e2e/openapivalidator`, enforce mode).
+But two gaps remain: (a) the validator is only as strong as the spec is precise, and the
+loose `additionalProperties:true` bags let real drift through; (b) it validates response
+*shapes* but not *error-code coverage* (documented-but-fictional codes, emitted-but-
+undocumented codes). This effort closes both, and reconciles the entity group under them.
 
-## 2. Goals / Non-goals
+## 2. Reconciliation policy (refines the #21 "server is source of truth" framing)
+
+The #21 seed carries "server is source of truth" language (`entity_conformance_test.go:6`,
+`internal/domain/entity/handler.go:601` "Server is source of truth per design §3"). That
+was correct for the four #21 defects, where the server's behaviour was the intended one and
+the spec was stale. But it is **not** a universal reconciliation rule, and stating it as one
+contradicts ADR 0001's "spec is canonical."
+
+**Refined policy (this effort):** the *authored spec is the canonical contract and the
+source of intent*; when spec and server disagree it is a **defect on whichever side left
+the contract**, decided per finding:
+
+- `spec-stale` — server evolved correctly; fix the spec.
+- `spec-incomplete` — server is right and intended; enrich the spec.
+- `server-gap` — the spec expresses intended contract the server never implemented; fix the
+  **server**.
+- `needs-decision` — genuine ambiguity; record the decision, then it becomes one of the
+  above.
+
+~⅓ of audit findings are `server-gap`/`needs-decision`, so a mechanical "sync spec→server"
+would *destroy* contract intent (it would turn the `deleteEntities` data-loss bug into a
+documented feature). This policy refinement is itself recorded (Gate 6): the stale
+"server is source of truth" comments in the seed are corrected to point here as part of the
+entity slice.
+
+**Relationship to ADR 0001:** this effort stays within ADR 0001 (runtime validation, no
+strict-typing migration). It does not supersede it. It *does* move us toward one of ADR
+0001's stated reconsideration triggers (Cloud parity as a first-class argument); if that
+trigger fires later it gets its own superseding ADR — out of scope here.
+
+## 3. Goals / Non-goals
 
 **Goals**
-- A durable **conformance gate** that makes server↔spec drift fail CI, with a portable
-  core decoupled from `cyoda-go` internals (liftable to a shared cyoda-go/Cloud kit later).
-- A repeatable **reconciliation loop** (classify → fix losing side → lock → record) that
+- Extend the existing conformance validator with **error-code-coverage** enforcement and
+  **tighten** the entity-group schemas so drift there fails CI.
+- Establish a repeatable **reconciliation loop** (classify → fix losing side → lock → record)
   every follow-on group reuses.
 - Apply both to the **entity group** end-to-end as the proving vertical, including
   implementing the documented conditional `deleteEntities`.
 
 **Non-goals (this spec)**
-- Reconciling the other five groups (stats/audit/search, model, auth/oidc, message) — each
-  is its own spec→plan cycle fed through the loop established here.
-- The dead-surface disposition (22 excluded-tag ops + always-501 stubs) — a contract
-  decision deferred to its own spec.
-- Lifting the gate into a shared cross-repo kit — the core is *structured* to allow it;
-  extraction is future work.
-- Changing the authoring model: the spec stays hand-authored and owned. The gate binds the
-  **server** to the authored spec; it does not generate the spec.
+- Reconciling the other five groups (stats/audit/search, model, auth/oidc, message).
+- The dead-surface disposition (22 excluded-tag ops + always-501 stubs).
+- A strict-typing migration or extracting a portable cross-repo conformance kit — both are
+  explicitly out (ADR 0001 defers the former; the latter is speculative generality).
+- Changing the authoring model: the spec stays hand-authored and canonical.
 
-## 3. Architecture — two pillars
+## 4. Pillar A — extend the existing conformance validator
 
-```
-                 api/openapi.yaml  (authored contract, source of intent)
-                          │
-          ┌───────────────┴────────────────┐
-          │                                 │
-   PILLAR A: conformance gate        PILLAR B: reconciliation loop
-   (portable core + e2e harness)     (per-finding process + recording)
-          │                                 │
-          │  validates every e2e response   │  classify direction
-          │  against the op schema;         │  → fix losing side (TDD)
-          │  asserts error-code matrix      │  → tighten schema / matrix (locks it)
-          │  (bidirectional)                │  → record contract decision
-          └───────────────┬────────────────┘
-                          │
-              tightening a loose schema is simultaneously
-              the FIX (B) and what makes the GATE (A) enforceable
-```
+**Do not build a parallel system.** `internal/e2e/openapivalidator` already loads
+`api/openapi.yaml` via kin-openapi, validates every E2E response body + status against the
+operation schema, runs in `ModeEnforce`, accumulates a `collector`, emits a `report`, and
+tracks operation/status coverage (failing on uncovered *in-scope* ops via
+`zzz_openapi_conformance_test.go`'s `knownUncoveredOps`). ADR 0001 governs it.
 
-The two pillars are coupled by design: the gate without tightening validates nothing
-meaningful (an `additionalProperties:true` bag passes anything); tightening without the
-gate rots. They advance together, per finding.
+The **only genuinely new capability** is error-code coverage at **errorCode-string
+granularity** (the existing coverage is operation/status granularity). Scope Pillar A to
+exactly that delta plus schema tightening:
 
-## 4. Pillar A — the conformance gate
+### 4.1 Error-code matrix (extension of the collector)
+- Extend the `openapivalidator` collector to record, per response, the
+  `(operationId, status, errorCode)` triple. The `errorCode` is read from the response
+  body's `properties.errorCode` (the `ProblemDetail` shape produced by
+  `common.WriteError`); absent for success responses.
+- Add a static **`ErrorCodeMatrix`**: `operationId → {documented (status, errorCode)}`,
+  authored from the spec's per-endpoint error tables (§7), scoped to the **entity group**
+  in this spec (other ops listed as pending, reusing the existing `knownUncoveredOps`
+  mechanism — do not introduce a second pending list).
+- Two aggregate checks at suite end (bidirectional drift detection):
+  - **producible** — every documented `(status, errorCode)` in scope was observed by ≥1
+    E2E (catches *fictional* codes, audit pattern P5).
+  - **declared** — no in-scope E2E produced a `(status, errorCode)` absent from the matrix
+    (catches *missing* codes, P5).
 
-### 4.1 Portable core (`internal/e2e/conformance/`, no cyoda-go internals)
+### 4.2 Schema tightening (what makes the existing validator bite)
+The validator passes anything against `additionalProperties:true`. For each entity-group
+finding we tighten the relevant schema (add `properties`, set `additionalProperties:false`,
+correct types) so the *already-present* enforce-mode validator now fails on regression. No
+new validation engine — we feed the existing one a precise schema.
 
-A self-contained package that depends only on the spec file, an HTTP response, and a
-static error-code registry — deliberately free of cyoda-go domain types so it can later be
-lifted into a shared kit.
+### 4.3 Seed cleanup (Gate 6)
+Once `meta`/envelope are tightened under enforce mode, most hand-parsed key assertions in
+`entity_conformance_test.go` become redundant (the ambient validator enforces them). Thin
+that seed rather than migrating it into a new package; correct its "server is source of
+truth" comment per §2.
 
-- **`SpecSet`** — loads and indexes `api/openapi.yaml` (via the existing
-  `kin-openapi/openapi3` dependency already used by the e2e `openapivalidator`). Resolves
-  an `(method, path-template)` → operation, request schema, per-status response schema,
-  and declared content-types.
-- **`ValidateResponse(op, status, contentType, body) []Violation`** — asserts the response
-  body validates against the operation's schema for that status, the status is a declared
-  response, and the `Content-Type` matches a declared media type. Returns structured
-  violations (never panics; never mutates).
-- **`ErrorCodeMatrix`** — a static registry: `operationId → {documented status/error
-  codes}`, authored from the spec's per-endpoint error tables (§7). Exposes two checks used
-  by the harness aggregation:
-  - **producible**: every documented code was observed by ≥1 e2e (catches *fictional*
-    codes — P5).
-  - **declared**: no e2e produced a status/error-code absent from the registry (catches
-    *missing* codes — P5).
-
-The core is unit-tested in isolation (§8.1): a fixture spec + hand-built good/mutated
-responses prove both validation directions and both matrix directions fail exactly when
-they should. This is what makes the gate trustworthy enough to gate everything else.
-
-### 4.2 e2e harness integration (`internal/e2e/`, cyoda-go-aware)
-
-- A thin `recordAndAssert` helper wraps existing e2e request execution: after each call it
-  feeds `(op, status, contentType, body)` to the core validator and accumulates the
-  observed `(op, status/errorCode)` pairs into a run-scoped collector.
-- Builds on the existing e2e-only `openapivalidator` and the `entity_conformance_test.go`
-  seed rather than replacing them; the seed's ad-hoc assertions are migrated to the core.
-- A `TestConformance_ErrorCodeMatrix` aggregates the run-scoped collector at suite end and
-  runs the producible+declared checks **for the operations in scope** (entity group in this
-  spec). Out-of-scope operations are explicitly listed as `pending` so the matrix never
-  silently claims coverage it doesn't have (no-silent-caps).
-
-### 4.3 What the gate does *not* do
-
+### 4.4 What the validator does *not* do
 - It does not validate the polymorphic entity `data` payload — that stays
-  `additionalProperties:true` by contract (user-defined shape). The gate validates the
-  **envelope** (`type`/`data`/`meta`), not the user's document.
-- It is only as strong as the spec is precise. For the entity slice we tighten the relevant
-  schemas (§6); still-loose schemas in other groups will pass permissively until their own
-  plans tighten them — the gate must not false-fail on them.
+  `additionalProperties:true` by contract. Confirmed separable in code: `EntityEnvelope`
+  has `Data any` cleanly split from `Meta` (`internal/domain/entity/service.go:64-69`). We
+  tighten the **envelope/meta**, never `data`.
+- It remains only as strong as the spec is precise; still-loose out-of-scope schemas pass
+  permissively until their own plans tighten them (must not false-fail).
 
 ## 5. Pillar B — the reconciliation loop
 
-For each finding, in order:
-
-1. **Classify direction** — `spec-stale` (server right, fix spec) · `spec-incomplete`
-   (server right, enrich spec) · `server-gap` (spec is intended contract, fix server) ·
-   `needs-decision` (record the decision, then it becomes one of the above).
-2. **Fix the losing side** via red/green TDD (Gate 1). Spec-side fixes are edits to
-   `api/openapi.yaml` (+ `api/generated.go` regen where models change); server-side fixes
-   follow the bugfix TDD protocol.
-3. **Lock it** — tighten the schema (add `properties`, set `additionalProperties:false`,
-   correct types) and/or add the `ErrorCodeMatrix` entry, so the gate now fails if the
-   fix regresses.
-4. **Record the contract decision** in `docs/cloud-parity/` (Gate 7) — one file per
-   behaviour, stating the direction chosen and why, so Cloud mirrors the same contract.
+For each finding: **classify direction** (§2) → **fix the losing side** via red/green TDD
+(Gate 1) → **lock it** (tighten schema and/or add the matrix entry) → **record the contract
+decision** in `docs/cloud-parity/` (Gate 7).
 
 **Tightening policy:** tightened response objects use declared `properties` +
 `additionalProperties:false`. Consequence: adding a new field later fails CI until the spec
-is updated. In a spec-first world this is the intended binding, not a regression.
+is updated. In a spec-first world that is the intended binding.
+
+**Canonical-schema reconciliation:** several entity wire shapes have a *canonical* JSON
+schema under `docs/cyoda/schema/common/` (embedded, consumed by cyoda-docs/Cloud) **and** a
+mirror in `e2e/parity/client/types.go`. Fixes to these shapes must reconcile **all**
+definitions (canonical JSON schema ↔ OpenAPI ↔ parity client), not author a fourth. ADR
+0001 Consequences explicitly flags the `e2e/parity/client/types.go` update (it is the
+commercial plugin's import surface).
 
 ## 6. The entity slice — findings, directions, fixes
 
 | # | Finding | Direction | Fix | Lock |
 |---|---|---|---|---|
-| E1 | `Envelope.meta` opaque bag + `previousTransition` fossil (`getOneEntity`, `getAllEntities`) | spec-incomplete + spec-stale | Named `EntityMeta` schema: `id`, `modelKey{name,version}`, `state`, `creationDate`, `lastUpdateTime`, `transactionId`, optional `transitionForLatestSave`; `additionalProperties:false`; delete `previousTransition`; fix examples | response validation asserts meta shape on both ops |
-| E2 | `deleteEntities` ignores condition body + `pointInTime` + `verbose`; wipes whole model | server-gap (data loss) | **Implement** the documented contract (§6.1) | e2e (subset survives) + parity + matrix |
-| E3 | `getAllEntities` ignores `pointInTime` | server-gap | Plumb `pointInTime` into `ListEntities` reusing the existing PIT path (`getOneEntity` has it) | as-at e2e + parity |
-| E4 | `createCollection` / `create` request body `type:object` erases real shape | spec-incomplete | Tighten request schemas to the array-of-`{model{name,version},payload}` shape; document the batch/array `create` form | request validation |
+| E1 | `Envelope.meta` opaque bag + `previousTransition` fossil (`getOneEntity`, `getAllEntities`) | spec-incomplete + spec-stale | Add an `EntityMeta` OpenAPI schema **mirroring the canonical `docs/cyoda/schema/common/EntityMetadata.json`**: required `{id, state, creationDate, lastUpdateTime}`; **optional** `{modelKey, transactionId, transitionForLatestSave, pointInTime}`; `additionalProperties:false`; delete `previousTransition`; fix examples. Reconcile OpenAPI ↔ canonical JSON ↔ `e2e/parity/client/types.go` (S5). | enforce-mode response validation on both ops |
+| E2 | `deleteEntities` ignores condition body + `pointInTime` + `verbose`; wipes whole model | server-gap (data loss) | **Implement** the documented contract (§6.1) | e2e (subset survives) + parity (inside tx) + matrix |
+| E3 | `getAllEntities` ignores `pointInTime` | server-gap | Plumb `pointInTime` into the list read via **`GetAllAsAt`** (the model-scoped list-PIT primitive in all 3 backends, already used by search at `internal/domain/search/service.go:161`) — **not** `getOneEntity`'s single-entity `GetAsAt`. Also populate `meta.pointInTime` (E1). | as-at e2e + parity |
+| E4 | `createCollection` / `create` request body `type:object` erases real shape | spec-incomplete | Tighten request schemas to the array-of-`{model{name,version},payload}` shape; document the batch/array `create` form. Reconcile `e2e/parity/client/types.go` (S5). | request validation |
 | E5 | create/update/patch/collection composite-unique-key `409`/`422` codes undocumented | spec-incomplete | Add codes to the endpoints' error tables | error-code matrix (producible+declared) |
-| E6 | `EntityChangeMeta.fieldsChangedCount` advertised, never emitted | spec-stale | Remove `fieldsChangedCount` from schema + examples | response validation |
-| E7 | `getEntityChangesMetadata` ordering prose says chronological; server is newest-first | spec-stale | Fix prose to reverse-chronological (newest-first is the correct audit default) | (doc-only; no gate assertion) |
+| E6 | `EntityChangeMeta.fieldsChangedCount` advertised (in **canonical** `docs/cyoda/schema/common/EntityChangeMeta.json`), never emitted by server | **needs-decision** | See §6.2 | per decision |
+| E7 | `getEntityChangesMetadata` ordering prose says chronological; server is newest-first | spec-stale | Fix prose to reverse-chronological | (doc-only) |
 | E8 | `changeType` prose `CREATE/UPDATE/DELETE` vs enum/emit `CREATED/UPDATED/DELETED` | spec-stale | Fix prose to match enum | response validation (enum) |
-| E9 | `getOneEntity` 200 example shows only `{id,state}` | spec-incomplete | Enrich example to the full meta shape | (example; validated structurally by E1) |
+| E9 | `getOneEntity` 200 example shows only `{id,state}` | spec-incomplete | Enrich example to full meta shape | (validated structurally by E1) |
 
-### 6.1 `deleteEntities` — implementing the documented contract
+### 6.1 `deleteEntities` — implementing conditional delete
 
-The contract: delete only entities matching an `AbstractConditionDto` body, honouring
-`pointInTime` selection and `verbose` (return deleted ids). Implementation principle
-(no special engine rights — reuse existing primitives):
+Principle (no special engine rights — reuse existing primitives): **select-then-delete.**
+Evaluate the `AbstractConditionDto` to obtain matching entity ids (at `pointInTime` when
+supplied), then delete those ids; return them when `verbose`.
 
-> **select-then-delete.** Evaluate the condition using the *same condition-evaluation
-> primitive `searchEntities` already uses* to obtain the matching entity ids (at
-> `pointInTime` when supplied), then delete those ids. When `verbose`, return the deleted
-> ids in `StreamDeleteResult.ids`.
+Feasibility confirmed against code, with three implementation realities the plan must name:
+- **Reuse primitives:** `predicate.ParseCondition` parses the body; `match.Match(...)` is a
+  free function (`internal/match/match.go:17`); `SearchService.Search` returns `[]*spi.Entity`
+  with ids off `e.Meta.ID` and honours `pointInTime`. Selection reuses these.
+- **Handler wiring task (name it):** `entity.Handler` currently holds `StoreFactory` but not
+  search/match — wiring them in is mechanical but is a real task, not free.
+- **Transaction visibility (parity implication):** `SearchService.Search` bypasses backend
+  pushdown when a tx is on the context (`internal/domain/search/service.go:140-141`), and
+  delete runs *inside* a tx. Buffered-write visibility therefore differs by backend, so the
+  cross-backend parity test must exercise conditional delete **inside the tx** — parity is
+  *not* automatic. (Removes the earlier "parity is free" over-claim.)
+- **No batch delete:** `EntityStore` has no `DeleteByIDs` (SPI `persistence.go`); a per-id
+  `Delete` loop is required.
+- **Backward compatible:** absent/empty body ⇒ delete-all (today's behaviour, preserves
+  `TestDeleteEntities_ResponseShape`); a present condition scopes the delete; `verbose`
+  toggles id return. Data loss is closed by construction — present conditions are honoured,
+  never ignored.
+- **gRPC:** see §8 / decision D2.
 
-- No new engine capability, no new cross-node invariant. Condition evaluation already works
-  consistently across backends, so cross-backend parity follows from reusing it.
-- **Absent/empty body** preserves today's "delete all of the model" behaviour (backward
-  compatible). A **present** condition scopes the delete. `verbose` toggles id return.
-- Data-loss is eliminated structurally: a condition that is present is *honoured*, never
-  silently ignored.
-- Records a `docs/cloud-parity/` entry: "server now conforms to conditional delete."
+### 6.2 E6 `fieldsChangedCount` — the decision
+The field is declared in the **canonical, Cloud-consumed** `EntityChangeMeta.json`, but the
+cyoda-go server never emits it (`internal/domain/entity/handler.go:576-587`). Direction is
+genuinely ambiguous:
+- **(a) server-gap** — the contract intends it; **implement** emission (compute the
+  changed-field count on the change path). Keeps the canonical schema; small server addition.
+- **(b) spec-stale** — remove it from the canonical schema. **But** this is a Cloud-parity
+  contract change to an embedded, downstream-consumed CloudEvents schema; risky if Cloud
+  already emits it.
+
+**Recommendation:** (a) implement server-side — removing a field from a Cloud-consumed
+canonical schema is the higher-risk direction, and the field carries real audit-UI value. To
+be confirmed with the Cloud-parity check (does Cloud emit it?) before finalizing. Recorded in
+`docs/cloud-parity/`.
 
 ## 7. Per-endpoint error/status tables (in-scope endpoints)
 
 Authored into the `ErrorCodeMatrix`. `✎` = added/changed by this spec.
 
-**`GET /entity/{entityId}` (getOneEntity)**
+**`GET /entity/{entityId}` (getOneEntity)** — 200; 400 (both `pointInTime`+`transactionId`);
+404 ENTITY_NOT_FOUND; 401/403.
 
-| Status | Code | Producing scenario |
-|---|---|---|
-| 200 | — | entity found |
-| 400 | (conflicting `pointInTime`+`transactionId`) | both query params supplied |
-| 404 | ENTITY_NOT_FOUND | unknown id |
-| 401/403 | — | auth |
+**`GET /entity/{entityName}/{modelVersion}` (getAllEntities)** — 200 (now honouring
+`pointInTime` ✎); 400 invalid page; 404 MODEL_NOT_FOUND; 401/403.
 
-**`GET /entity/{entityName}/{modelVersion}` (getAllEntities)**
+**`DELETE /entity/{entityName}/{modelVersion}` (deleteEntities)** ✎ — 200 (all, or
+condition-scoped ✎; `ids` when `verbose` ✎); 400 MALFORMED_REQUEST / INVALID_CONDITION ✎;
+404 MODEL_NOT_FOUND; 401/403.
 
-| Status | Code | Producing scenario |
-|---|---|---|
-| 200 | — | list (now honouring `pointInTime` ✎) |
-| 400 | — | invalid page params |
-| 404 | MODEL_NOT_FOUND | unknown model |
-| 401/403 | — | auth |
+**`POST /entity/{format}/{entityName}/{modelVersion}` (create)**,
+**`POST|PUT /entity/{format}` (createCollection / updateCollection)** — 200; 400
+MALFORMED_REQUEST / INCOMPATIBLE_TYPE / POLYMORPHIC_SLOT (bad body shape ✎); 409
+UNIQUE_VIOLATION ✎; 422 INVALID_UNIQUE_KEY / INVALID_UNIQUE_KEY_DEFINITION ✎; 404
+MODEL_NOT_FOUND (create); 401/403.
 
-**`DELETE /entity/{entityName}/{modelVersion}` (deleteEntities)** ✎
-
-| Status | Code | Producing scenario |
-|---|---|---|
-| 200 | — | delete (all, or condition-scoped ✎); `ids` when `verbose` ✎ |
-| 400 | MALFORMED_REQUEST / INVALID_CONDITION ✎ | unparseable body / invalid condition |
-| 404 | MODEL_NOT_FOUND | unknown model |
-| 401/403 | — | auth |
-
-**`POST /entity/{format}/{entityName}/{modelVersion}` (create)** and
-**`POST|PUT /entity/{format}` (createCollection / updateCollection)**
-
-| Status | Code | Producing scenario |
-|---|---|---|
-| 200 | — | success |
-| 400 | MALFORMED_REQUEST / INCOMPATIBLE_TYPE / POLYMORPHIC_SLOT | bad body shape ✎ / type mismatch |
-| 409 | UNIQUE_VIOLATION ✎ | composite-unique-key conflict |
-| 422 | INVALID_UNIQUE_KEY / INVALID_UNIQUE_KEY_DEFINITION ✎ | null/invalid unique-key field or definition |
-| 404 | MODEL_NOT_FOUND | unknown model (create) |
-| 401/403 | — | auth |
-
-**`PUT|PATCH /entity/{format}/{entityId}[/{transition}]` (updateSingle[WithLoopback], patchSingle[WithLoopback])**
-
-| Status | Code | Producing scenario |
-|---|---|---|
-| 200 | — | success |
-| 400 / 404 / 409 / 412 | (existing) | as documented |
-| 415 / 428 / 501 | (existing, PATCH) | as documented |
-| 422 | INVALID_UNIQUE_KEY[_DEFINITION] ✎ | unique-key violation on the save path |
+**`PUT|PATCH /entity/{format}/{entityId}[/{transition}]`** — 200; 400/404/409/412 existing;
+415/428/501 existing (PATCH); 422 INVALID_UNIQUE_KEY[_DEFINITION] ✎.
 
 **`GET /entity/{entityId}/changes` (getEntityChangesMetadata)** — response-shape fixes
 (E6/E7/E8); error table unchanged (200/404/401/403).
 
 ## 8. Coverage matrix (scenario × layer)
 
-Per `.claude/rules/test-coverage.md`. `✓` required · `—` n/a · `waive` = waived with reason.
+Per `.claude/rules/test-coverage.md`. HTTP and gRPC are **separate entry points — both
+covered** (no false waivers; the gRPC meta and delete surfaces both exist).
 
 | Scenario | Unit | Running-backend e2e | Cross-backend parity | gRPC |
 |---|---|---|---|---|
-| Conformance core: response validation both directions | ✓ | — | — | — |
-| Conformance core: error-code matrix both directions | ✓ | — | — | — |
-| E1 meta shape (fields present, no `previousTransition`, `additionalProperties:false`) | — | ✓ | ✓ (backend-agnostic) | verify gRPC GetEntity meta if it returns one; else `waive`: gRPC entity read has no meta envelope |
-| E2 conditional delete (matching subset only) | condition→ids selection ✓ | ✓ | ✓ | verify gRPC delete if present; else `waive` |
-| E2 `pointInTime` + `verbose` (ids returned) | — | ✓ | ✓ | per above |
-| E3 `getAllEntities` as-at `pointInTime` | — | ✓ | ✓ | — |
+| Error-code matrix (producible + declared), entity scope | ✓ (collector logic) | ✓ (aggregate) | — | — |
+| E1 meta shape (mirror canonical; `additionalProperties:false`; no `previousTransition`) | — | ✓ | ✓ (backend-agnostic) | ✓ — assert `buildEntityMeta` output (`internal/grpc/search.go:377,577`) matches the tightened shape |
+| E2 conditional delete (matching subset only) | condition→ids selection ✓ | ✓ | ✓ (inside tx — §6.1) | per decision D2 |
+| E2 `pointInTime` + `verbose` (ids returned) | — | ✓ | ✓ | per D2 |
+| E3 `getAllEntities` as-at (`GetAllAsAt`) | — | ✓ | ✓ | — |
 | E4 request-body shape (array-of-`{model,payload}`) | — | ✓ | ✓ | — |
-| E5 unique-key `409`/`422` codes | — | ✓ (per code) | ✓ | ✓ (gRPC error envelope: `Success`,`Error.Code`) |
-| E6/E7/E8 changes shape/enum/ordering | — | ✓ (gate-validated) | — | — |
+| E5 unique-key `409`/`422` codes | — | ✓ (per code) | ✓ | ✓ — assert envelope; note N1: gRPC `Error.Code` is a coarse CLIENT/SERVER bucket, the unique-key code is in `Error.Message` (`internal/grpc/errors.go`), matching `TestRPC_EntityCreate_UniqueViolation` (`rpc_test.go:654`) |
+| E6 `fieldsChangedCount` (per §6.2 decision) | — | ✓ | ✓ | ✓ if emitted on gRPC change path |
+| E7/E8 changes ordering/enum | — | ✓ (gate-validated) | — | — |
 
-**Concurrency:** none of the entity-slice changes need the isolated concurrency-test
-treatment. `deleteEntities` is select-then-delete over a snapshot; parity asserts the
-correct subset survives, not an interleave (per `.claude/rules/test-coverage.md`, concurrency
-tests stay out of the shared parity suite).
+**Decision D2 — gRPC conditional delete.** gRPC exposes `EntityDeleteAllRequest`
+(unconditional; `internal/grpc/entity.go:391`) and per-entity `EntityDeleteRequest`, but no
+*conditional* delete. The OpenAPI conditional-delete is an **HTTP-contract** feature; the
+gRPC/proto contract does not promise conditional delete. **Recommendation:** implement E2 on
+HTTP only; keep gRPC `DeleteAll` as-is (it conforms to its own proto contract), and add/verify
+gRPC test coverage for the existing `DeleteAll` behaviour so the gRPC entry point is covered,
+not waived. Record the HTTP-only scope in `docs/cloud-parity/`. (Confirm with Cloud that gRPC
+parity is not expected before finalizing — Gate 7 / multi-node.)
 
-**gRPC applicability** is confirmed per row during implementation; any `waive` records a
-one-line reason in the plan (no silent gaps).
-
-### 8.1 Test infrastructure notes
-- Core unit tests live beside the core (`internal/e2e/conformance/`), runnable with
-  `-short` (no Docker).
-- e2e conformance assertions run in the existing `internal/e2e` suite (Postgres testcontainer).
-- Backend-agnostic scenarios register in `e2e/parity/registry.go` (picked up by all
-  backends incl. the commercial one).
+**Concurrency:** entity-slice changes need no isolated concurrency test; `deleteEntities` is
+select-then-delete over a snapshot; parity asserts the surviving subset, not an interleave.
 
 ## 9. Documentation & gate obligations
 
-- **Gate 4:** any new error code → `cmd/cyoda/help/content/errors/<CODE>.md`
-  (`TestErrCode_Parity` enforces the bijection). E2/E5 introduce/surface
-  `INVALID_CONDITION`, `UNIQUE_VIOLATION`, `INVALID_UNIQUE_KEY[_DEFINITION]` at these
-  endpoints — ensure topics exist.
-- **Gate 7:** `docs/cloud-parity/` entry per reconciled behaviour (E1 meta shape; E2
-  conditional-delete conformance; E3 as-at list). Each states the reconciliation direction
-  and rationale.
-- `api/generated.go` is regenerated (or hand-updated, per the existing oapi-codegen/Go 1.26
-  caveat) whenever request/response models change (E1, E4).
+- **Gate 4:** new error codes → `cmd/cyoda/help/content/errors/<CODE>.md`
+  (`TestErrCode_Parity` bijection). E2/E5 surface `INVALID_CONDITION`, `UNIQUE_VIOLATION`,
+  `INVALID_UNIQUE_KEY[_DEFINITION]` at these endpoints.
+- **Gate 7:** `docs/cloud-parity/` entry per reconciled behaviour (E1 meta; E2 conditional-
+  delete + D2 gRPC scope; E3 as-at; E6 decision). Each states direction + rationale.
+- **Canonical schemas / parity mirror:** reconcile `docs/cyoda/schema/common/EntityMetadata.json`
+  (E1) and `EntityChangeMeta.json` (E6) with the OpenAPI, and update `e2e/parity/client/types.go`
+  (S5) for E1/E4 wire-shape changes.
+- **Codegen:** `api/generated.go` regenerated (or hand-updated) on model changes (E1, E4).
+  Note: tree is on **oapi-codegen v2.7.0** with a `//go:generate` directive
+  (`api/generate.go`); re-verify whether the Go 1.26 regen caveat still applies before relying
+  on `go generate`.
+- **ADR:** reference ADR 0001; no superseding ADR needed (we stay within it).
 
 ## 10. Decomposition — follow-on plans (out of scope here)
 
-Each reuses the Pillar-B loop and the Pillar-A gate:
-1. stats / audit / search (fictional 404/408, page-size default, ndjson, `pointInTime`).
-2. entity-model & workflow (missing 409/422/404 on lock/unlock/delete/import).
-3. auth / OIDC (error-envelope family decision: problem+json vs OAuth `ErrorResponseDto`).
-4. message (mis-typed bodies, v1-UUID validation, `ValueMaps`).
-5. **dead-surface decision** — implement vs remove the 22 excluded-tag ops + always-501
-   stubs from the published contract. Highest single "scale" signal; it's a contract
-   decision, so it gets its own brainstorm.
+Each reuses the Pillar-B loop and the extended validator:
+1. stats / audit / search · 2. entity-model & workflow · 3. auth / OIDC (error-envelope
+family decision) · 4. message · 5. **dead-surface decision** (implement vs remove 22
+excluded-tag ops + always-501 stubs — its own brainstorm; highest single scale signal).
 
 ## 11. Risks
 
-- **Spec precision debt:** the gate only guards what the spec declares precisely. Mitigation:
-  in-scope schemas are tightened; the matrix explicitly lists out-of-scope ops as `pending`
-  so coverage is never overstated.
-- **`deleteEntities` blast radius:** implementing conditional delete touches a
-  destructive path. Mitigation: reuse the proven `searchEntities` condition primitive,
-  backward-compatible empty-body behaviour, parity asserts the surviving subset, and the
-  data-loss failure mode is closed by construction (present conditions are honoured).
-- **`api/generated.go` regen friction** (known oapi-codegen v2.6.0 / Go 1.26 incompatibility):
-  model changes may need the same manual-edit approach used in commit `9c721b4`.
-```
+- **Spec precision debt:** the validator only guards precisely-declared schemas. Mitigation:
+  in-scope schemas tightened; matrix reuses `knownUncoveredOps` so out-of-scope coverage is
+  never overstated.
+- **`deleteEntities` blast radius:** destructive path. Mitigation: reuse the proven search
+  condition primitive, backward-compatible empty-body behaviour, parity asserts the surviving
+  subset **inside the tx** (§6.1), per-id delete loop, data-loss closed by construction.
+- **Canonical-schema coupling:** E1/E6 touch embedded, Cloud-consumed schemas; changes must
+  reconcile all mirrors (§5) and be recorded in cloud-parity — mishandling risks silent
+  cross-repo drift.
+- **Two open decisions (E6 direction, D2 gRPC scope):** recommendations given; confirm the
+  Cloud-parity facts before finalizing.

--- a/docs/superpowers/specs/2026-07-03-openapi-contract-status-and-parity-design.md
+++ b/docs/superpowers/specs/2026-07-03-openapi-contract-status-and-parity-design.md
@@ -57,8 +57,10 @@ An OpenAPI specification extension on the operation object. Two values:
   "NOT YET IMPLEMENTED in cyoda-go — planned for Trino integration"), so a human reading the
   rendered spec (Scalar UI, cyoda-docs) sees it without inspecting extensions.
 - Live operations MUST NOT carry the marker.
-- Marked operations stay excluded from codegen (`api/config.yaml`) so no client method is
-  generated for a non-live operation.
+- `x-cyoda-status` is **orthogonal to codegen exclusion.** Only the `Stream Data` and
+  `SQL-Schema` tags are excluded from codegen (`api/config.yaml`); the IAM/OIDC/account stubs
+  are generated and routed yet still `planned`. So a marked operation may or may not have a
+  generated client method — the marker records *implementation status*, not codegen state.
 
 ## 4. The coverage gate (live-or-marked)
 
@@ -68,14 +70,20 @@ Replace the two current escape hatches with one spec-derived rule.
   (`internal/e2e/e2e_test.go`): the gate now sees every published operation.
 - **Retire `knownUncoveredOps`** (`internal/e2e/zzz_openapi_conformance_test.go`): its entries
   become `x-cyoda-status` markers in the spec (§6).
-- **New rule:** for each published operation, exactly one of must hold —
-  - *exercised* — hit by ≥1 e2e (proxy for "routed and live"); or
-  - *marked* — carries `x-cyoda-status`.
-  - **Unexercised and unmarked → CI fail** (a silent 404 or a live op with no coverage).
-  - **Exercised and marked → CI fail** (a marker on an operation that is actually live —
-    contradiction).
-- The marker is read from the embedded spec (same source the validator already loads), so the
-  gate needs no second source of truth.
+- **Marker set:** built in `TestMain` (`internal/e2e/e2e_test.go`, which already iterates
+  `swagger.Paths.Map()`) by reading each operation's `x-cyoda-status` from
+  `openapi3.Operation.Extensions`, and exported as a package var (`markedOps`) alongside
+  `allOperationIds`. The gate in `zzz_openapi_conformance_test.go` reads it — no second source
+  of truth.
+- **Rule 1 (coverage):** each published operation must be *exercised* (hit by ≥1 e2e — proxy for
+  routed-and-live) **or** *marked*. Unexercised and unmarked → CI fail (a silent 404, or a live
+  op with no coverage).
+- **Rule 2 (stale-marker guard):** a *marked* operation exercised **with a 2xx success** → CI
+  fail (the marker sits on an operation that is actually live). Exercising a marked op with only
+  `501`/`4xx` does **not** trip this — so a stub's documented `501` can be covered per
+  `.claude/rules/test-coverage.md` while the marker stands. This needs the collector to record
+  whether each operation ever returned a 2xx; add that minimal per-op flag (the entity slice's
+  richer `(op, status, errorCode)` matrix builds on it).
 
 This subsumes the entity slice's earlier plan to "reuse `knownUncoveredOps`": that list no
 longer exists after this spec; the entity slice's error-code matrix builds on the marker-aware gate.
@@ -119,13 +127,14 @@ generated Go model consumed by `api/generated.go` or handlers. Verify per schema
   reachability check, not by the earlier HTTP-path-only "orphan" scan (which false-flagged the
   `StateMachine*Dto`).
 
-## 8. Embedded spec-snapshot regeneration
+## 8. Spec embedding (no regeneration step)
 
-`api/generated.go` embeds a gzip+base64 snapshot of `api/openapi.yaml` returned by
-`api.GetSwagger()` — this is the source the runtime validator loads. Any spec edit in this work
-(markers, deletions) requires re-encoding that snapshot (oapi-codegen v2.7.0 / Go 1.26 caveat may
-require the manual re-encode path used previously). A test asserts the embedded snapshot matches
-the on-disk `api/openapi.yaml` so drift between them is caught.
+`GetSwagger()` embeds `api/openapi.yaml` **verbatim** via `//go:embed` (`api/spec.go`;
+`api/config.yaml` sets `embedded-spec: false`, so oapi-codegen does not emit its own re-encoded
+copy). Editing `api/openapi.yaml` is therefore the only step — the embed picks up the new bytes at
+build time, and no embedded-vs-source drift is possible. There is nothing to regenerate and no
+drift test is needed. (An earlier audit note describing a gzip+base64 snapshot referred to a
+since-replaced `embedded-spec: true` configuration.)
 
 ## 9. Cloud-parity hand-off (design-only in this repo)
 
@@ -156,8 +165,7 @@ adds no HTTP/gRPC endpoint or error code, so coverage is at the gate/infra layer
 | Coverage gate: unexercised+unmarked → fail | ✓ (gate logic) | ✓ (suite enforces) | — | — |
 | Coverage gate: exercised+marked → fail (contradiction) | ✓ | — | — | — |
 | Every published unrouted op carries a valid `x-cyoda-status` | ✓ (spec-lint test) | — | — | — |
-| oasdiff gate: breaking edit fails, additive edit passes | ✓ (fixture) | — | — | — |
-| Embedded snapshot matches on-disk spec | ✓ | — | — | — |
+| oasdiff gate: breaking edit fails, additive edit passes | ✓ (one fixture pair) | — | — | — |
 | `fetchEntityTransitions` now exercised | — | ✓ | — | — |
 
 No new error codes or endpoints → no per-endpoint error table and no gRPC error-envelope rows.
@@ -177,9 +185,16 @@ Concurrency: n/a.
 - **Sequencing:** this spec lands first. It converts the two silent escape hatches into an
   enforced live-or-marked contract, so when the entity slice adds response-shape tightening and
   the error-code matrix, the surface is already honest and the coverage gate already marker-aware.
-- **Risk — turning on full coverage surfaces gaps.** Making the gate see every operation may fail
-  CI for a live-but-uncovered op we hadn't noticed. Mitigation: that is the point; each such op
-  gets e2e coverage (if live) or a marker (if not) in this PR — no silent suppression.
+- **Risk — turning on full coverage surfaces gaps.** Making the gate see every operation
+  (~22 excluded-tag ops added to `allOperationIds`, ~9 `knownUncoveredOps` resolved → ~30 markers
+  + 1 new e2e) may fail CI for a live-but-uncovered op we hadn't noticed. Mitigation: that is the
+  point; each such op gets e2e coverage (if live) or a marker (if not) in this PR — no silent
+  suppression. The marker additions, the coverage-gate flip, and the `knownUncoveredOps`
+  retirement must land in the **same commit** so CI never observes an intermediate red state.
+- **Task — extension round-trip.** Confirm `scalar_test.go` / help-subsystem tests assert output
+  *prefixes* (not full-document byte equality) so the added `x-cyoda-status` extensions don't
+  break them; `/openapi.json` (`scalar.go`) round-trips extensions by design, which is intended
+  (Cloud/consumers see the status).
 - **Risk — marker misuse.** A marker on a live op, or a missing marker on an unrouted op, both
   fail the gate by construction (§4), so the marker cannot drift silently.
 - **Risk — Stream Data disposition still open.** `unimplemented` is honest for "undecided"; when

--- a/docs/superpowers/specs/2026-07-03-openapi-contract-status-and-parity-design.md
+++ b/docs/superpowers/specs/2026-07-03-openapi-contract-status-and-parity-design.md
@@ -1,0 +1,187 @@
+# OpenAPI Contract Status & Cloud Parity (prerequisite to the entity slice)
+
+**Date:** 2026-07-03
+**Status:** design / awaiting review
+**Governed by:** ADR 0003 (`docs/adr/0003-openapi-contract-conformance-and-evolution.md`).
+**Reference evidence:** `docs/analysis/openapi/README.md` (drift audit).
+**Runs before:** `2026-07-02-openapi-contract-reconciliation-design.md` (entity slice) — this
+spec makes the published surface honest and enforceable so the entity slice lands on a clean base.
+
+---
+
+## 1. Problem
+
+`api/openapi.yaml` publishes ~22 operations (the `Stream Data` and `SQL-Schema` tags) that are
+excluded from codegen (`api/config.yaml` `exclude-tags`), unrouted, and therefore return 404 at
+runtime — with **no in-spec signal** that they are not live. Worse, the coverage gate skips
+excluded-tag operations entirely (`internal/e2e/e2e_test.go` drops them before building
+`allOperationIds`), so they are invisible to conformance accounting: in the spec, unrouted, and
+unmeasured. A separate list, `knownUncoveredOps` (`internal/e2e/zzz_openapi_conformance_test.go`),
+hides a second class of not-live operations (IAM/OIDC stubs, a routing wart) from the gate. An
+app-builder or LLM reading the published contract cannot distinguish a live operation from one
+that 404s — the same "silent" failure mode that motivated the whole reconciliation.
+
+The published contract must state each operation's status honestly and enforce it, so that "in
+the spec" means either **live** (implemented, routed, and tested) or **explicitly marked**
+not-live — never silently 404.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- A machine-readable operation-status marker (`x-cyoda-status`) distinguishing live from
+  planned/unimplemented, visible to consumers, cyoda-docs, and Cloud.
+- A coverage gate that enforces **exactly one of {exercised-by-e2e, marked}** per published
+  operation — retiring both `knownUncoveredOps` and the excluded-tag skip.
+- An **additive-only breaking-change gate** on `api/openapi.yaml` (ADR 0003, Decision 6).
+- Delete only genuinely-dead schemas.
+- A `docs/cloud-parity/` record handing off the Cloud-side conformance mechanism.
+
+**Non-goals**
+- Implementing SQL-Schema or Stream Data (marked, not built here).
+- The entity-group shape reconciliation (the entity slice; runs after).
+- Integrating the `StateMachine*Dto` audit-event union (audit-group follow-on).
+- Any machinery that reads or asserts against `docs/cyoda/` — that is a read-only vendored
+  reference; Cloud conforms to cyoda-go, not the reverse.
+
+## 3. The `x-cyoda-status` marker
+
+An OpenAPI specification extension on the operation object. Two values:
+
+| Value | Meaning | Lifecycle |
+|---|---|---|
+| `planned` | In the contract and **committed** to be implemented in cyoda-go (roadmap / tracked). | → becomes live (marker removed) when implemented. |
+| `unimplemented` | In the contract, **not committed**; disposition under review. | → either becomes `planned`/live, or is removed from the spec once a "won't implement" decision is final. |
+
+- Every operation that is **not** live carries exactly one `x-cyoda-status`.
+- Each marked operation's `description` also opens with a human-readable caveat (e.g.
+  "NOT YET IMPLEMENTED in cyoda-go — planned for Trino integration"), so a human reading the
+  rendered spec (Scalar UI, cyoda-docs) sees it without inspecting extensions.
+- Live operations MUST NOT carry the marker.
+- Marked operations stay excluded from codegen (`api/config.yaml`) so no client method is
+  generated for a non-live operation.
+
+## 4. The coverage gate (live-or-marked)
+
+Replace the two current escape hatches with one spec-derived rule.
+
+- **Stop skipping excluded-tag operations** when building `allOperationIds`
+  (`internal/e2e/e2e_test.go`): the gate now sees every published operation.
+- **Retire `knownUncoveredOps`** (`internal/e2e/zzz_openapi_conformance_test.go`): its entries
+  become `x-cyoda-status` markers in the spec (§6).
+- **New rule:** for each published operation, exactly one of must hold —
+  - *exercised* — hit by ≥1 e2e (proxy for "routed and live"); or
+  - *marked* — carries `x-cyoda-status`.
+  - **Unexercised and unmarked → CI fail** (a silent 404 or a live op with no coverage).
+  - **Exercised and marked → CI fail** (a marker on an operation that is actually live —
+    contradiction).
+- The marker is read from the embedded spec (same source the validator already loads), so the
+  gate needs no second source of truth.
+
+This subsumes the entity slice's earlier plan to "reuse `knownUncoveredOps`": that list no
+longer exists after this spec; the entity slice's error-code matrix builds on the marker-aware gate.
+
+## 5. The additive-only evolution gate (ADR 0003, Decision 6)
+
+A breaking-change detector (`oasdiff` or equivalent) runs as a CI merge gate, diffing the PR's
+`api/openapi.yaml` against the base branch's, and **fails on breaking edits**: sealing a
+previously-open object (`additionalProperties: false`), removing a field/operation, narrowing a
+type, adding a required request field, or removing an enum value. This is the discipline that
+lets schemas stay typed-but-open (per ADR 0003) without brittleness — precision is guarded by
+the gate, not by sealing. Adding `x-cyoda-status` to an existing operation, and removing it when
+an operation goes live, are non-breaking and pass.
+
+- Wire as a dedicated CI job (mirrors the existing `per-module-hygiene` pattern).
+- Ship a fixture test proving the gate catches a representative breaking edit and passes a
+  representative additive one, so the gate itself is trusted.
+
+## 6. Operation dispositions
+
+| Operation(s) | Disposition | `x-cyoda-status` |
+|---|---|---|
+| `Stream Data` tag (13 ops) | most likely not implemented; undecided | `unimplemented` |
+| `SQL-Schema` tag (9 ops) | committed — Trino / `trino-cyoda` connector | `planned` |
+| IAM/account + OIDC stubs (`accountSubscriptionsGet`, `registerOidcProvider`, `deleteOidcProvider`, `invalidateOidcProvider`, `reactivateOidcProvider`, `listOidcProviders`, `reloadOidcProviders`, `updateOidcProvider`) | stub-implemented, implementation tracked | `planned` |
+| `fetchEntityTransitions` | **live** — routed (mounted outside the generated `ServerInterface`), not a stub | none — add e2e coverage so it is *exercised*, not marked |
+
+`fetchEntityTransitions` moving from `knownUncoveredOps` to real coverage removes the last
+"routing wart" exemption; the marker is reserved strictly for not-live operations.
+
+## 7. Dead-schema deletion (minimal, verified)
+
+Delete a component schema only when it is **unreferenced transitively within
+`api/openapi.yaml`** (no operation and no other kept schema reaches it) **and** is not a
+generated Go model consumed by `api/generated.go` or handlers. Verify per schema before deleting.
+
+- **Exclude the `StateMachine*Dto` cluster** — the audit endpoints emit that event shape; it is
+  under-integrated, not dead, and its integrate-vs-delete decision is an audit-group follow-on.
+- Expected set is small; the leading candidate is a bare `ErrorResponse` duplicate (the audit
+  finished-event endpoint uses `ErrorResponseDto`). Each deletion is confirmed by the transitive
+  reachability check, not by the earlier HTTP-path-only "orphan" scan (which false-flagged the
+  `StateMachine*Dto`).
+
+## 8. Embedded spec-snapshot regeneration
+
+`api/generated.go` embeds a gzip+base64 snapshot of `api/openapi.yaml` returned by
+`api.GetSwagger()` — this is the source the runtime validator loads. Any spec edit in this work
+(markers, deletions) requires re-encoding that snapshot (oapi-codegen v2.7.0 / Go 1.26 caveat may
+require the manual re-encode path used previously). A test asserts the embedded snapshot matches
+the on-disk `api/openapi.yaml` so drift between them is caught.
+
+## 9. Cloud-parity hand-off (design-only in this repo)
+
+cyoda-go's responsibility ends at publishing an honest contract. The parity mechanism lives in
+cyoda-cloud:
+
+- cyoda-go **publishes** `api/openapi.yaml` (already served at `/openapi.json` and via the help
+  subsystem). The **live common ground** = operations *without* `x-cyoda-status`.
+- Cloud **consumes** that published spec and runs response-conformance validation against its own
+  live responses, asserting Cloud conforms to the live common ground and may only *extend* it
+  (add operations/fields), never diverge on it. `planned`/`unimplemented` operations are
+  shared-intent Cloud may or may not have.
+- This repo produces **one `docs/cloud-parity/` record** stating the contract expectation and the
+  tolerant-reader obligation (ADR 0003, Decision 3), plus a hand-off issue to the Cloud team. No
+  cyoda-go test or gate is built for the Cloud side.
+- **Reconcile with `docs/cyoda/cloud-divergences.md`:** that file catalogs *field-level* and
+  *semantic* deliberate divergences (e.g. `ProcessorDefinitionDto.asyncResult`); `x-cyoda-status`
+  covers *operation-level* not-live status. They stay distinct and cross-reference; no op-level
+  entries are duplicated between them.
+
+## 10. Coverage matrix (scenario × layer)
+
+Per `.claude/rules/test-coverage.md`. This spec changes contract-governance infrastructure and
+adds no HTTP/gRPC endpoint or error code, so coverage is at the gate/infra layer.
+
+| Scenario | Unit | Running-backend e2e | Cross-backend parity | gRPC |
+|---|---|---|---|---|
+| Coverage gate: unexercised+unmarked → fail | ✓ (gate logic) | ✓ (suite enforces) | — | — |
+| Coverage gate: exercised+marked → fail (contradiction) | ✓ | — | — | — |
+| Every published unrouted op carries a valid `x-cyoda-status` | ✓ (spec-lint test) | — | — | — |
+| oasdiff gate: breaking edit fails, additive edit passes | ✓ (fixture) | — | — | — |
+| Embedded snapshot matches on-disk spec | ✓ | — | — | — |
+| `fetchEntityTransitions` now exercised | — | ✓ | — | — |
+
+No new error codes or endpoints → no per-endpoint error table and no gRPC error-envelope rows.
+Concurrency: n/a.
+
+## 11. Documentation & gate obligations
+
+- **Marker convention** documented in `CONTRIBUTING.md` (and a short note where the help subsystem
+  describes the spec), so future operations are marked or covered by rule, not habit.
+- **Gate 4:** no new error codes or env vars. If the oasdiff gate is a new `make` target / CI job,
+  update `CONTRIBUTING.md` and the CI docs.
+- **Gate 7:** the `docs/cloud-parity/` record (§9).
+- **ADR:** governed by ADR 0003; no new ADR.
+
+## 12. Sequencing & risks
+
+- **Sequencing:** this spec lands first. It converts the two silent escape hatches into an
+  enforced live-or-marked contract, so when the entity slice adds response-shape tightening and
+  the error-code matrix, the surface is already honest and the coverage gate already marker-aware.
+- **Risk — turning on full coverage surfaces gaps.** Making the gate see every operation may fail
+  CI for a live-but-uncovered op we hadn't noticed. Mitigation: that is the point; each such op
+  gets e2e coverage (if live) or a marker (if not) in this PR — no silent suppression.
+- **Risk — marker misuse.** A marker on a live op, or a missing marker on an unrouted op, both
+  fail the gate by construction (§4), so the marker cannot drift silently.
+- **Risk — Stream Data disposition still open.** `unimplemented` is honest for "undecided"; when
+  the decision is final the ops are either implemented (marker removed) or removed from the spec.
+  No blocker for this spec.

--- a/docs/superpowers/specs/2026-07-03-openapi-contract-status-and-parity-design.md
+++ b/docs/superpowers/specs/2026-07-03-openapi-contract-status-and-parity-design.md
@@ -99,20 +99,33 @@ the gate, not by sealing. Adding `x-cyoda-status` to an existing operation, and 
 an operation goes live, are non-breaking and pass.
 
 - Wire as a dedicated CI job (mirrors the existing `per-module-hygiene` pattern).
-- Ship a fixture test proving the gate catches a representative breaking edit and passes a
+- Ship one fixture pair proving the gate catches a representative breaking edit and passes a
   representative additive one, so the gate itself is trusted.
+- **Interaction with §7 dead-schema deletion:** this same PR removes unreferenced component
+  schemas, and "removing a field/operation" is a breaking signal. Confirm whether the detector
+  flags removal of a genuinely *unreferenced* component (oasdiff generally does not, since no
+  operation resolves it) — if it does, allow-list the specific dead schemas being deleted, or
+  land the deletion in a separate commit ahead of the gate turning on. Resolve this before the
+  single-commit constraint (§12) so the gate does not flag its own PR.
 
 ## 6. Operation dispositions
 
 | Operation(s) | Disposition | `x-cyoda-status` |
 |---|---|---|
 | `Stream Data` tag (13 ops) | most likely not implemented; undecided | `unimplemented` |
-| `SQL-Schema` tag (9 ops) | committed — Trino / `trino-cyoda` connector | `planned` |
-| IAM/account + OIDC stubs (`accountSubscriptionsGet`, `registerOidcProvider`, `deleteOidcProvider`, `invalidateOidcProvider`, `reactivateOidcProvider`, `listOidcProviders`, `reloadOidcProviders`, `updateOidcProvider`) | stub-implemented, implementation tracked | `planned` |
+| `SQL-Schema` tag (9 ops) | committed — Trino / `trino-cyoda` connector (decision recorded in this effort) | `planned` |
+| `accountSubscriptionsGet` | genuine stub — always `501` (`internal/domain/account/handler.go:87`) | `planned` |
+| OIDC provider ops (`registerOidcProvider`, `deleteOidcProvider`, `invalidateOidcProvider`, `reactivateOidcProvider`, `listOidcProviders`, `reloadOidcProviders`, `updateOidcProvider`) | **status must be verified per op** — dispatched via `s.Account.<Op>` when wired, else `501` (`internal/api/server.go:531+`); the adapters carry real logic, so some may be live | verify then assign — see below |
 | `fetchEntityTransitions` | **live** — routed (mounted outside the generated `ServerInterface`), not a stub | none — add e2e coverage so it is *exercised*, not marked |
 
-`fetchEntityTransitions` moving from `knownUncoveredOps` to real coverage removes the last
-"routing wart" exemption; the marker is reserved strictly for not-live operations.
+**Per-op status verification (required before marking).** The `knownUncoveredOps` comment calls
+the OIDC group "stub-implemented," but the adapters carry real behaviour (e.g. duplicate →
+`400`, inactive → `409`); whether they return `501` or a real `2xx` depends on the e2e server
+wiring (`s.Account != nil`). Before assigning a marker, verify each op's **actual runtime status
+under the e2e config**: an op that returns `2xx` is **live** (cover it, do not mark — else Rule 2
+fails it); an op that returns `501` is `planned`. Do not trust the stale "stub" comment.
+`fetchEntityTransitions` moving to real coverage removes the last "routing wart" exemption; the
+marker is reserved strictly for not-live operations.
 
 ## 7. Dead-schema deletion (minimal, verified)
 

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -176,15 +176,9 @@ func TestMain(m *testing.M) {
 	srv.Config.Handler = openapivalidator.NewMiddleware(validator)(testApp.Handler())
 
 	// Capture the full operationId set so the conformance test can compute
-	// the uncovered list at end-of-suite.
-	//
-	// Build the exclude-tags set (mirrors api/config.yaml). Excluded ops aren't
-	// in cyoda-go's shipped API and shouldn't count toward coverage.
-	excludeTags := map[string]bool{
-		"Stream Data":              true,
-		"CQL Execution Statistics": true,
-		"SQL-Schema":               true,
-	}
+	// the uncovered list at end-of-suite. Every published operation is
+	// included; ops that aren't live must carry an x-cyoda-status marker
+	// (enforced by TestOpenAPIConformanceReport).
 	for _, item := range swagger.Paths.Map() {
 		for _, op := range item.Operations() {
 			if op.OperationID == "" {
@@ -192,17 +186,6 @@ func TestMain(m *testing.M) {
 			}
 			if s := readCyodaStatus(op); s != "" {
 				markedOps[op.OperationID] = s
-			}
-			// Skip ops whose tags are in the exclude list.
-			skip := false
-			for _, tag := range op.Tags {
-				if excludeTags[tag] {
-					skip = true
-					break
-				}
-			}
-			if skip {
-				continue
 			}
 			allOperationIds = append(allOperationIds, op.OperationID)
 		}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -35,8 +35,22 @@ var (
 	dbPool          *pgxpool.Pool                     // direct DB access for verification queries
 	procSvc         *localproc.LocalProcessingService // in-process processor/criteria for workflow tests
 	allOperationIds []string
-	testApp         *app.App // exposed for test-mode store seeding (e.g. cross-tenant M2M client bootstrap)
+	markedOps       = map[string]string{} // operationId → x-cyoda-status value
+	testApp         *app.App              // exposed for test-mode store seeding (e.g. cross-tenant M2M client bootstrap)
 )
+
+// readCyodaStatus returns the x-cyoda-status marker on an operation, or "".
+func readCyodaStatus(op *openapi3.Operation) string {
+	if op == nil || op.Extensions == nil {
+		return ""
+	}
+	if v, ok := op.Extensions["x-cyoda-status"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
 
 func TestMain(m *testing.M) {
 	// flag.Parse must be called before testing.Short() is valid.
@@ -175,6 +189,9 @@ func TestMain(m *testing.M) {
 		for _, op := range item.Operations() {
 			if op.OperationID == "" {
 				continue
+			}
+			if s := readCyodaStatus(op); s != "" {
+				markedOps[op.OperationID] = s
 			}
 			// Skip ops whose tags are in the exclude list.
 			skip := false

--- a/internal/e2e/entity_transitions_test.go
+++ b/internal/e2e/entity_transitions_test.go
@@ -1,0 +1,66 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// TestFetchEntityTransitions exercises operationId: fetchEntityTransitions
+// GET /platform-api/entity/fetch/transitions?entityClass=<Name>.<Version>&entityId=<uuid>
+//
+// This endpoint is routed outside the generated ServerInterface dispatch —
+// it is registered on the inner mux at /platform-api/entity/fetch/transitions
+// and is reachable as /api/platform-api/entity/fetch/transitions when the
+// app is mounted under the /api context path.
+//
+// The test registers a model+workflow, creates an entity that auto-transitions
+// from NONE to CREATED, then calls fetchEntityTransitions and asserts a 200
+// response whose body is a JSON array.
+func TestFetchEntityTransitions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+
+	const model = "e2e-fetch-tr-1"
+
+	wf := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "fetch-tr-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE":    {"transitions": [{"name": "init",    "next": "CREATED",  "manual": false}]},
+				"CREATED": {"transitions": [
+					{"name": "approve", "next": "APPROVED", "manual": true},
+					{"name": "reject",  "next": "REJECTED", "manual": true}
+				]},
+				"APPROVED": {},
+				"REJECTED": {}
+			}
+		}]
+	}`
+	setupModelWithWorkflow(t, model, wf)
+
+	entityID := createEntityE2E(t, model, 1, `{"name":"test","amount":1,"status":"draft"}`)
+	// The entity auto-transitions NONE→CREATED via the automated "init"
+	// transition; fetchEntityTransitions now returns the manual transitions
+	// available from the CREATED state (approve, reject).
+
+	entityClass := url.QueryEscape(fmt.Sprintf("%s.1", model))
+	path := fmt.Sprintf("/api/platform-api/entity/fetch/transitions?entityClass=%s&entityId=%s",
+		entityClass, entityID)
+
+	resp := doAuth(t, http.MethodGet, path, "")
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("fetchEntityTransitions: expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	// Response must be a JSON array (TransitionNameList).
+	var result []any
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		t.Fatalf("fetchEntityTransitions: expected JSON array; parse error: %v; body: %s", err, body)
+	}
+}

--- a/internal/e2e/entity_transitions_test.go
+++ b/internal/e2e/entity_transitions_test.go
@@ -58,9 +58,20 @@ func TestFetchEntityTransitions(t *testing.T) {
 		t.Fatalf("fetchEntityTransitions: expected 200, got %d: %s", resp.StatusCode, body)
 	}
 
-	// Response must be a JSON array (TransitionNameList).
-	var result []any
+	// Response is a TransitionNameList (JSON array of strings). The entity is in
+	// CREATED after the automated init; the available manual transitions are
+	// exactly "approve" and "reject".
+	var result []string
 	if err := json.Unmarshal([]byte(body), &result); err != nil {
-		t.Fatalf("fetchEntityTransitions: expected JSON array; parse error: %v; body: %s", err, body)
+		t.Fatalf("fetchEntityTransitions: expected JSON array of strings; parse error: %v; body: %s", err, body)
+	}
+	got := map[string]bool{}
+	for _, tr := range result {
+		got[tr] = true
+	}
+	for _, want := range []string{"approve", "reject"} {
+		if !got[want] {
+			t.Errorf("fetchEntityTransitions: expected transition %q in returned list %v", want, result)
+		}
 	}
 }

--- a/internal/e2e/gate_logic_test.go
+++ b/internal/e2e/gate_logic_test.go
@@ -1,0 +1,21 @@
+package e2e_test
+
+import "testing"
+
+func TestUncoveredOps_rules(t *testing.T) {
+	all := []string{"live", "liveUncovered", "planned", "staleMarked"}
+	exercised := map[string]bool{"live": true, "staleMarked": true}
+	success2xx := map[string]bool{"live": true, "staleMarked": true}
+	marked := map[string]string{"planned": "planned", "staleMarked": "planned"}
+
+	unmarked, stale := uncoveredOps(all, exercised, success2xx, marked)
+
+	// liveUncovered: neither exercised nor marked -> unmarked-uncovered
+	if len(unmarked) != 1 || unmarked[0] != "liveUncovered" {
+		t.Errorf("unmarked-uncovered = %v, want [liveUncovered]", unmarked)
+	}
+	// staleMarked: marked but returned 2xx -> stale marker
+	if len(stale) != 1 || stale[0] != "staleMarked" {
+		t.Errorf("stale = %v, want [staleMarked]", stale)
+	}
+}

--- a/internal/e2e/marker_plumbing_test.go
+++ b/internal/e2e/marker_plumbing_test.go
@@ -1,0 +1,21 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestReadCyodaStatus(t *testing.T) {
+	op := &openapi3.Operation{
+		OperationID: "foo",
+		Extensions:  map[string]any{"x-cyoda-status": "planned"},
+	}
+	if got := readCyodaStatus(op); got != "planned" {
+		t.Errorf("got %q, want planned", got)
+	}
+	bare := &openapi3.Operation{OperationID: "bar"}
+	if got := readCyodaStatus(bare); got != "" {
+		t.Errorf("unmarked op should return empty, got %q", got)
+	}
+}

--- a/internal/e2e/oidc_providers_test.go
+++ b/internal/e2e/oidc_providers_test.go
@@ -1,0 +1,163 @@
+package e2e_test
+
+// oidc_providers_test.go — exercise-level e2e coverage for the 7 OIDC
+// provider operations (operationIds: registerOidcProvider, listOidcProviders,
+// reloadOidcProviders, updateOidcProvider, invalidateOidcProvider,
+// reactivateOidcProvider, deleteOidcProvider).
+//
+// Coverage level: each op hit ≥1 time, 2xx asserted. Exhaustive error-code
+// coverage is deferred to the auth/OIDC follow-on group.
+//
+// Design notes:
+//
+//   - CYODA_OIDC_REQUIRE_HTTPS and CYODA_OIDC_ALLOW_PRIVATE_NETWORKS are set
+//     via init() (runs before TestMain) so the app starts with HTTP and
+//     private-network OIDC URIs allowed, making it possible to register fake
+//     providers without a real HTTPS endpoint.  No existing e2e test exercises
+//     OIDC SSRF/TLS enforcement (those are unit tests in internal/auth/oidc).
+//
+//   - registerOidcProvider requires a UUID-shaped tenant identifier.  The
+//     bootstrap tenant ("test-tenant") is not UUID-shaped, so this test seeds
+//     a dedicated M2M client with a real UUID tenant via createM2MClient and
+//     drives every OIDC call with that client's token.
+//
+//   - When registration succeeds the OIDC registry attempts to fetch the
+//     discovery document (reloadOne); failure there is WARN-logged and
+//     non-fatal — the provider is stored and all subsequent lifecycle ops
+//     work against the KV store, not the discovery endpoint.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+)
+
+func init() {
+	// Allow HTTP (non-HTTPS) and private-network OIDC URIs in the app under
+	// test.  Both flags are read by app.DefaultConfig() which is called from
+	// TestMain — this init() runs first, before TestMain.
+	os.Setenv("CYODA_OIDC_REQUIRE_HTTPS", "false")
+	os.Setenv("CYODA_OIDC_ALLOW_PRIVATE_NETWORKS", "true")
+}
+
+// oidcTenantUUID is the UUID-shaped tenant used exclusively by the OIDC
+// lifecycle tests.  A hardcoded value keeps the test deterministic and avoids
+// polluting the list with a random UUID on every run.
+const oidcTenantUUID = "e2e00000-0000-0000-0000-000000000001"
+
+// TestOidcProviderLifecycle exercises all 7 OIDC provider operations in a
+// single lifecycle flow:
+//
+//	registerOidcProvider → listOidcProviders → reloadOidcProviders →
+//	updateOidcProvider → invalidateOidcProvider → reactivateOidcProvider →
+//	deleteOidcProvider
+//
+// Each step asserts a 2xx response.
+func TestOidcProviderLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+
+	// Seed a client with a UUID-shaped tenant so registerOidcProvider does
+	// not fail with OIDC_INVALID_TENANT.  The roles include ROLE_ADMIN so
+	// all admin-gated OIDC ops are permitted.
+	clientID, clientSecret := createM2MClient(t, oidcTenantUUID, "oidc-e2e-user", []string{"ROLE_ADMIN", "ROLE_M2M"})
+
+	// oidcDo issues an authenticated HTTP request using the UUID-tenant client.
+	// path must NOT include the /api prefix (adminRequestAs adds it).
+	oidcDo := func(t *testing.T, method, path string, body []byte) *http.Response {
+		t.Helper()
+		resp := adminRequestAs(t, clientID, clientSecret, method, path, body)
+		return resp
+	}
+
+	// Unique fake URI so repeated runs don't collide on the duplicate check.
+	wellKnown := fmt.Sprintf("http://oidc-e2e-lifecycle-%d.local/.well-known/openid-configuration",
+		time.Now().UnixNano())
+
+	// ── Step 1: registerOidcProvider ─────────────────────────────────────────
+	registerBody := mustJSON(t, map[string]any{
+		"wellKnownConfigUri": wellKnown,
+	})
+	registerResp := oidcDo(t, http.MethodPost, "/oauth/oidc/providers", registerBody)
+	registerRaw, _ := io.ReadAll(registerResp.Body)
+	registerResp.Body.Close()
+	if registerResp.StatusCode != http.StatusOK {
+		t.Fatalf("registerOidcProvider: expected 200, got %d: %s", registerResp.StatusCode, registerRaw)
+	}
+
+	var registered struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(registerRaw, &registered); err != nil {
+		t.Fatalf("registerOidcProvider: decode response: %v; body: %s", err, registerRaw)
+	}
+	if registered.ID == "" {
+		t.Fatal("registerOidcProvider: expected non-empty id in response")
+	}
+	providerID := registered.ID
+
+	// ── Step 2: listOidcProviders ─────────────────────────────────────────────
+	listResp := oidcDo(t, http.MethodGet, "/oauth/oidc/providers", nil)
+	listRaw, _ := io.ReadAll(listResp.Body)
+	listResp.Body.Close()
+	if listResp.StatusCode != http.StatusOK {
+		t.Fatalf("listOidcProviders: expected 200, got %d: %s", listResp.StatusCode, listRaw)
+	}
+	// Response must be a JSON array.
+	var listed []map[string]any
+	if err := json.Unmarshal(listRaw, &listed); err != nil {
+		t.Fatalf("listOidcProviders: expected JSON array; parse error: %v; body: %s", err, listRaw)
+	}
+
+	// ── Step 3: reloadOidcProviders ───────────────────────────────────────────
+	reloadResp := oidcDo(t, http.MethodPost, "/oauth/oidc/providers/reload", nil)
+	reloadRaw, _ := io.ReadAll(reloadResp.Body)
+	reloadResp.Body.Close()
+	if reloadResp.StatusCode != http.StatusOK {
+		t.Fatalf("reloadOidcProviders: expected 200, got %d: %s", reloadResp.StatusCode, reloadRaw)
+	}
+
+	// ── Step 4: updateOidcProvider ────────────────────────────────────────────
+	updateBody := mustJSON(t, map[string]any{
+		"issuers": []string{"https://issuer.oidc-e2e.local"},
+	})
+	updatePath := fmt.Sprintf("/oauth/oidc/providers/%s", providerID)
+	updateResp := oidcDo(t, http.MethodPatch, updatePath, updateBody)
+	updateRaw, _ := io.ReadAll(updateResp.Body)
+	updateResp.Body.Close()
+	if updateResp.StatusCode != http.StatusOK {
+		t.Fatalf("updateOidcProvider: expected 200, got %d: %s", updateResp.StatusCode, updateRaw)
+	}
+
+	// ── Step 5: invalidateOidcProvider ────────────────────────────────────────
+	invalidatePath := fmt.Sprintf("/oauth/oidc/providers/%s/invalidate", providerID)
+	invalidateResp := oidcDo(t, http.MethodPost, invalidatePath, nil)
+	invalidateRaw, _ := io.ReadAll(invalidateResp.Body)
+	invalidateResp.Body.Close()
+	if invalidateResp.StatusCode != http.StatusOK {
+		t.Fatalf("invalidateOidcProvider: expected 200, got %d: %s", invalidateResp.StatusCode, invalidateRaw)
+	}
+
+	// ── Step 6: reactivateOidcProvider ───────────────────────────────────────
+	reactivatePath := fmt.Sprintf("/oauth/oidc/providers/%s/reactivate", providerID)
+	reactivateResp := oidcDo(t, http.MethodPost, reactivatePath, nil)
+	reactivateRaw, _ := io.ReadAll(reactivateResp.Body)
+	reactivateResp.Body.Close()
+	if reactivateResp.StatusCode != http.StatusOK {
+		t.Fatalf("reactivateOidcProvider: expected 200, got %d: %s", reactivateResp.StatusCode, reactivateRaw)
+	}
+
+	// ── Step 7: deleteOidcProvider ────────────────────────────────────────────
+	deletePath := fmt.Sprintf("/oauth/oidc/providers/%s", providerID)
+	deleteResp := oidcDo(t, http.MethodDelete, deletePath, nil)
+	deleteRaw, _ := io.ReadAll(deleteResp.Body)
+	deleteResp.Body.Close()
+	if deleteResp.StatusCode != http.StatusOK {
+		t.Fatalf("deleteOidcProvider: expected 200, got %d: %s", deleteResp.StatusCode, deleteRaw)
+	}
+}

--- a/internal/e2e/openapivalidator/collector.go
+++ b/internal/e2e/openapivalidator/collector.go
@@ -20,6 +20,7 @@ type collector struct {
 	mu         sync.Mutex
 	mismatches []Mismatch
 	exercised  map[string]struct{}
+	saw2xx     map[string]struct{}
 }
 
 // the package-level singleton used by the middleware. Tests may construct
@@ -27,7 +28,10 @@ type collector struct {
 var defaultCollector = newCollector()
 
 func newCollector() *collector {
-	return &collector{exercised: make(map[string]struct{})}
+	return &collector{
+		exercised: make(map[string]struct{}),
+		saw2xx:    make(map[string]struct{}),
+	}
 }
 
 func (c *collector) append(m Mismatch) {
@@ -41,6 +45,28 @@ func (c *collector) recordExercised(operationId string) {
 	defer c.mu.Unlock()
 	c.exercised[operationId] = struct{}{}
 }
+
+func (c *collector) recordStatus(operationId string, status int) {
+	if status < 200 || status >= 300 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.saw2xx[operationId] = struct{}{}
+}
+
+func (c *collector) success2xxSet() map[string]bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]bool, len(c.saw2xx))
+	for k := range c.saw2xx {
+		out[k] = true
+	}
+	return out
+}
+
+// Success2xxSet returns the set of operationIds that returned a 2xx during the run.
+func Success2xxSet() map[string]bool { return defaultCollector.success2xxSet() }
 
 // drain returns all accumulated mismatches and resets the slice.
 func (c *collector) drain() []Mismatch {

--- a/internal/e2e/openapivalidator/collector_test.go
+++ b/internal/e2e/openapivalidator/collector_test.go
@@ -36,6 +36,20 @@ func TestCollector_RecordExercised(t *testing.T) {
 	}
 }
 
+func TestCollector_recordStatus_tracks2xx(t *testing.T) {
+	c := newCollector()
+	c.recordStatus("opA", 200)
+	c.recordStatus("opB", 501)
+	c.recordStatus("opC", 404)
+	got := c.success2xxSet()
+	if !got["opA"] {
+		t.Errorf("opA (200) should be in the 2xx set")
+	}
+	if got["opB"] || got["opC"] {
+		t.Errorf("opB (501) / opC (404) must not be in the 2xx set: %v", got)
+	}
+}
+
 func TestCollector_ConcurrentAppend(t *testing.T) {
 	c := newCollector()
 	var wg sync.WaitGroup

--- a/internal/e2e/openapivalidator/middleware.go
+++ b/internal/e2e/openapivalidator/middleware.go
@@ -18,9 +18,9 @@ import (
 //
 // Keep this list to genuinely non-spec paths only. Customer endpoints that
 // are spec-declared but not yet implemented must NOT appear here — they should
-// go through the validator so that knownUncoveredOps (in
-// zzz_openapi_conformance_test.go) remains the single authoritative source of
-// "intentionally uncovered" operations.
+// go through the validator so the conformance gate (in
+// zzz_openapi_conformance_test.go) sees them; a not-yet-implemented op is
+// declared not-live via its `x-cyoda-status` marker in api/openapi.yaml.
 var operationalPathPrefixes = []string{
 	"/api/health",
 	"/api/docs",

--- a/internal/e2e/openapivalidator/middleware_test.go
+++ b/internal/e2e/openapivalidator/middleware_test.go
@@ -68,9 +68,9 @@ func TestMiddleware_RecordsMismatchOnDriftedResponse(t *testing.T) {
 // OAuth discovery) are not recorded as mismatches.
 //
 // Note: /api/oauth/keys/ is NOT in this list — those paths ARE declared in the
-// spec (with 501 responses for #194 stubs) and must pass through the validator.
-// knownUncoveredOps in zzz_openapi_conformance_test.go is the single source of
-// "intentionally uncovered" for spec-declared operations.
+// spec and must pass through the validator. The conformance gate in
+// zzz_openapi_conformance_test.go requires each such op to be either exercised
+// or marked not-live via `x-cyoda-status` in api/openapi.yaml.
 func TestMiddleware_SkipsOperationalPaths(t *testing.T) {
 	v := newFixtureValidator(t)
 	defaultCollector = newCollector()

--- a/internal/e2e/openapivalidator/typed_but_open_test.go
+++ b/internal/e2e/openapivalidator/typed_but_open_test.go
@@ -1,0 +1,24 @@
+package openapivalidator
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Guards the typed-but-open policy (ADR 0003): an additive/unknown member
+// validates against an open schema and is rejected by additionalProperties:false.
+func TestTypedButOpen_AdditionalPropertiesSemantics(t *testing.T) {
+	body := map[string]any{"id": "x", "extra": "y"} // "extra" = additive/unknown
+
+	open := openapi3.NewObjectSchema().WithProperty("id", openapi3.NewStringSchema())
+	if err := open.VisitJSON(body); err != nil {
+		t.Fatalf("open schema must ACCEPT an additive field: %v", err)
+	}
+
+	sealed := openapi3.NewObjectSchema().WithProperty("id", openapi3.NewStringSchema())
+	sealed.AdditionalProperties = openapi3.AdditionalProperties{Has: openapi3.BoolPtr(false)}
+	if err := sealed.VisitJSON(body); err == nil {
+		t.Fatal("additionalProperties:false must REJECT an additive field")
+	}
+}

--- a/internal/e2e/openapivalidator/validator.go
+++ b/internal/e2e/openapivalidator/validator.go
@@ -92,6 +92,7 @@ func (v *Validator) Validate(ctx context.Context, req *http.Request, resp *http.
 			// schema validation (we can't construct a full routers.Route without
 			// re-entering the broken router).
 			defaultCollector.recordExercised(opId)
+			defaultCollector.recordStatus(opId, resp.StatusCode)
 			return nil
 		}
 		// No matching route — the request hit a path the spec doesn't declare.
@@ -113,6 +114,7 @@ func (v *Validator) Validate(ctx context.Context, req *http.Request, resp *http.
 	if !v.pathParamsSatisfied(route.Operation, pathParams) {
 		if opId, op := v.fallbackFindRoute(req); op != nil {
 			defaultCollector.recordExercised(opId)
+			defaultCollector.recordStatus(opId, resp.StatusCode)
 			return nil
 		}
 		return []Mismatch{{
@@ -126,6 +128,7 @@ func (v *Validator) Validate(ctx context.Context, req *http.Request, resp *http.
 
 	opId := route.Operation.OperationID
 	defaultCollector.recordExercised(opId)
+	defaultCollector.recordStatus(opId, resp.StatusCode)
 
 	// Streaming check: if the matched operation declares
 	// application/x-ndjson for the actual status code, skip body validation.

--- a/internal/e2e/zzz_openapi_conformance_test.go
+++ b/internal/e2e/zzz_openapi_conformance_test.go
@@ -16,25 +16,23 @@ import (
 	"github.com/cyoda-platform/cyoda-go/internal/e2e/openapivalidator"
 )
 
-// knownUncoveredOps are operationIds that have no E2E coverage by design:
-// either they're stub-implemented (#194) or mounted outside the generated
-// ServerInterface dispatch (transitions handler — #21 design Section 8 noted
-// the wart). Audit table at docs/superpowers/audits/2026-04-29-openapi-
-// conformance-audit.md captures the full disposition for each.
-var knownUncoveredOps = map[string]bool{
-	// Stub IAM/account ops — implementation tracked in #194.
-	"accountSubscriptionsGet": true,
-	// OIDC provider ops — implementation tracked in #194.
-	"deleteOidcProvider":     true,
-	"invalidateOidcProvider": true,
-	"listOidcProviders":      true,
-	"reactivateOidcProvider": true,
-	"registerOidcProvider":   true,
-	"reloadOidcProviders":    true,
-	"updateOidcProvider":     true,
-	// Outside the generated ServerInterface dispatch — see #21 design
-	// Section 8, Task 5.1's Option B note. Tracked as future cleanup.
-	"fetchEntityTransitions": true,
+// uncoveredOps computes two disjoint problem sets from the full operation
+// list:
+//   - unmarkedUncovered: ops that were neither exercised by an E2E test nor
+//     carry an x-cyoda-status marker (silent 404 or untested live op).
+//   - staleMarkers: ops that carry an x-cyoda-status marker but returned a
+//     2xx response during the run (marker is stale — the op is now live).
+func uncoveredOps(all []string, exercised, success2xx map[string]bool, marked map[string]string) (unmarkedUncovered, staleMarkers []string) {
+	for _, op := range all {
+		_, isMarked := marked[op]
+		switch {
+		case !exercised[op] && !isMarked:
+			unmarkedUncovered = append(unmarkedUncovered, op) // silent 404 or untested live op
+		case isMarked && success2xx[op]:
+			staleMarkers = append(staleMarkers, op) // marker on an op that is actually live
+		}
+	}
+	return
 }
 
 // TestOpenAPIConformanceReport runs after every other E2E test, drains the
@@ -64,15 +62,12 @@ func TestOpenAPIConformanceReport(t *testing.T) {
 		// Enforce mode, no mismatches: also check coverage. Skip the
 		// coverage check when -run is set (single-test workflow).
 		if !openapivalidator.RunFilterActive() {
-			uncovered := []string{}
-			for _, op := range allOperationIds {
-				if !exercised[op] && !knownUncoveredOps[op] {
-					uncovered = append(uncovered, op)
-				}
+			unmarked, stale := uncoveredOps(allOperationIds, exercised, openapivalidator.Success2xxSet(), markedOps)
+			if len(unmarked) > 0 {
+				t.Fatalf("openapi conformance: %d published ops are neither exercised nor x-cyoda-status-marked (silent 404 or untested live op): %v", len(unmarked), unmarked)
 			}
-			if len(uncovered) > 0 {
-				t.Fatalf("openapi conformance: %d operations have no E2E coverage; see %s",
-					len(uncovered), reportPath)
+			if len(stale) > 0 {
+				t.Fatalf("openapi conformance: %d x-cyoda-status-marked ops returned 2xx (marker is stale — op is live): %v", len(stale), stale)
 			}
 		}
 		return

--- a/internal/oasdiffcheck/oasdiff_gate_test.go
+++ b/internal/oasdiffcheck/oasdiff_gate_test.go
@@ -1,0 +1,45 @@
+// Package oasdiffcheck verifies the premise of the ADR 0003 breaking-change CI
+// gate: that oasdiff correctly classifies additive response-schema changes as
+// non-breaking and sealed (additionalProperties: false) changes as breaking.
+//
+// This test is deliberately isolated from internal/e2e, whose TestMain boots a
+// Postgres container that this test does not need.
+package oasdiffcheck_test
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// testdataDir is relative to the package directory; Go test sets cwd to the
+// package being tested, so this path is stable across machines.
+const testdataDir = "testdata/oasdiff"
+
+func TestOasdiffGatePremise(t *testing.T) {
+	bin, err := exec.LookPath("oasdiff")
+	if err != nil {
+		t.Skip("oasdiff not in PATH; install with: go install github.com/oasdiff/oasdiff@latest")
+	}
+
+	base := testdataDir + "/base.yaml"
+	additive := testdataDir + "/additive.yaml"
+	breaking := testdataDir + "/breaking.yaml"
+
+	t.Run("additive_is_not_breaking", func(t *testing.T) {
+		cmd := exec.Command(bin, "breaking", base, additive, "--fail-on", "ERR")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("oasdiff breaking base→additive: expected exit 0 (no breaking change), got %v\noutput:\n%s", err, out)
+		}
+		t.Logf("oasdiff output (base→additive): %s", out)
+	})
+
+	t.Run("sealing_additionalProperties_is_breaking", func(t *testing.T) {
+		cmd := exec.Command(bin, "breaking", base, breaking, "--fail-on", "ERR")
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			t.Fatalf("oasdiff breaking base→breaking: expected non-zero exit (breaking change detected), got exit 0\noutput:\n%s", out)
+		}
+		t.Logf("oasdiff output (base→breaking): %s", out)
+	})
+}

--- a/internal/oasdiffcheck/oasdiff_gate_test.go
+++ b/internal/oasdiffcheck/oasdiff_gate_test.go
@@ -1,13 +1,24 @@
-// Package oasdiffcheck verifies the premise of the ADR 0003 breaking-change CI
-// gate: that oasdiff correctly classifies additive response-schema changes as
-// non-breaking and sealed (additionalProperties: false) changes as breaking.
+// Package oasdiffcheck verifies the ADR 0003 breaking-change CI gate.
 //
-// This test is deliberately isolated from internal/e2e, whose TestMain boots a
-// Postgres container that this test does not need.
+// TestOasdiffGatePremise checks that the pinned oasdiff classifies an additive
+// change as non-breaking and a client-breaking change (a request-parameter type
+// narrowing) as breaking — the assumption the oasdiff gate rests on.
+//
+// TestSpecHasNoSealedSchemas enforces ADR 0003's "typed-but-open" rule directly.
+// oasdiff does NOT flag sealing a response schema (additionalProperties: false)
+// as breaking — it is not client-breaking — so oasdiff alone cannot enforce the
+// never-seal rule; this direct check provides that teeth.
+//
+// This package is deliberately isolated from internal/e2e, whose TestMain boots a
+// Postgres container these tests do not need.
 package oasdiffcheck_test
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -18,7 +29,7 @@ const testdataDir = "testdata/oasdiff"
 func TestOasdiffGatePremise(t *testing.T) {
 	bin, err := exec.LookPath("oasdiff")
 	if err != nil {
-		t.Skip("oasdiff not in PATH; install with: go install github.com/oasdiff/oasdiff@latest")
+		t.Skip("oasdiff not in PATH; install with: go install github.com/oasdiff/oasdiff@v1.21.0")
 	}
 
 	base := testdataDir + "/base.yaml"
@@ -34,7 +45,7 @@ func TestOasdiffGatePremise(t *testing.T) {
 		t.Logf("oasdiff output (base→additive): %s", out)
 	})
 
-	t.Run("sealing_additionalProperties_is_breaking", func(t *testing.T) {
+	t.Run("request_param_type_change_is_breaking", func(t *testing.T) {
 		cmd := exec.Command(bin, "breaking", base, breaking, "--fail-on", "ERR")
 		out, err := cmd.CombinedOutput()
 		if err == nil {
@@ -42,4 +53,27 @@ func TestOasdiffGatePremise(t *testing.T) {
 		}
 		t.Logf("oasdiff output (base→breaking): %s", out)
 	})
+}
+
+// TestSpecHasNoSealedSchemas enforces ADR 0003 Decision 2 directly: the authored
+// api/openapi.yaml must never seal a schema with `additionalProperties: false`.
+// Because oasdiff does not catch response-sealing, this is the check with teeth
+// for the never-seal rule — and it runs in the normal `go test` suite with no
+// oasdiff binary required.
+func TestSpecHasNoSealedSchemas(t *testing.T) {
+	specPath := filepath.Join("..", "..", "api", "openapi.yaml")
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", specPath, err)
+	}
+	re := regexp.MustCompile(`(?m)additionalProperties:[ \t]*false\b`)
+	locs := re.FindAllIndex(data, -1)
+	if len(locs) == 0 {
+		return
+	}
+	var lines []int
+	for _, loc := range locs {
+		lines = append(lines, 1+strings.Count(string(data[:loc[0]]), "\n"))
+	}
+	t.Fatalf("api/openapi.yaml seals %d schema(s) with `additionalProperties: false` at line(s) %v — ADR 0003 forbids this (use typed-but-open; if a composed allOf schema must close, use `unevaluatedProperties: false`).", len(lines), lines)
 }

--- a/internal/oasdiffcheck/testdata/oasdiff/additive.yaml
+++ b/internal/oasdiffcheck/testdata/oasdiff/additive.yaml
@@ -1,0 +1,26 @@
+openapi: 3.1.0
+info:
+  title: Fixture API
+  version: 0.0.1
+paths:
+  /items/{id}:
+    get:
+      operationId: getItem
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string

--- a/internal/oasdiffcheck/testdata/oasdiff/base.yaml
+++ b/internal/oasdiffcheck/testdata/oasdiff/base.yaml
@@ -1,0 +1,24 @@
+openapi: 3.1.0
+info:
+  title: Fixture API
+  version: 0.0.1
+paths:
+  /items/{id}:
+    get:
+      operationId: getItem
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string

--- a/internal/oasdiffcheck/testdata/oasdiff/breaking.yaml
+++ b/internal/oasdiffcheck/testdata/oasdiff/breaking.yaml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: Fixture API
+  version: 0.0.1
+paths:
+  /items/{id}:
+    get:
+      operationId: getItem
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                properties:
+                  id:
+                    type: string

--- a/internal/oasdiffcheck/testdata/oasdiff/breaking.yaml
+++ b/internal/oasdiffcheck/testdata/oasdiff/breaking.yaml
@@ -11,7 +11,9 @@ paths:
           in: path
           required: true
           schema:
-            type: string
+            # BREAKING vs base.yaml: request path-parameter type narrowed
+            # string -> integer. oasdiff classifies this as a breaking change.
+            type: integer
       responses:
         "200":
           description: OK
@@ -19,7 +21,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: false
                 properties:
                   id:
                     type: string


### PR DESCRIPTION
## Summary

**Spec 1** (the prerequisite) of the OpenAPI contract reconciliation effort — Part of #369. Makes `api/openapi.yaml` honest and enforceable: every published operation is now either **live** (routed + e2e-exercised) or **explicitly marked** not-live, and schema evolution is guarded by an additive-only CI gate. Governed by **ADR 0003** (typed-but-open; supersedes ADR 0001).

## What's in this PR

**Foundation (design):**
- `docs/adr/0003-openapi-contract-conformance-and-evolution.md` (Accepted); ADR 0001 → Superseded.
- `docs/analysis/openapi/` — the 87-operation drift audit + the schema-strictness research/rubric (adversarially verified).
- `docs/superpowers/specs/` — the reviewed Spec 1 + entity-slice designs; `docs/superpowers/plans/` — the Spec 1 implementation plan.

**Spec 1 implementation:**
- `x-cyoda-status: planned|unimplemented` operation marker on all not-live ops (Stream Data → `unimplemented`; SQL-Schema → `planned` (Trino, #83); `accountSubscriptionsGet` → `planned`).
- Reworked `internal/e2e` conformance gate: **exactly-one-of {exercised, marked}** per published op (retires the `knownUncoveredOps` allowlist + the excluded-tag skip).
- e2e coverage for previously-uncovered **live** ops discovered during implementation: `fetchEntityTransitions` + the 7 OIDC provider ops (a probe found them live, so they were covered, not marked).
- Deleted a dead schema (`ErrorResponse`, duplicate of `ErrorResponseDto`).
- **oasdiff** additive-only breaking-change CI gate (`.github/workflows/openapi-breaking-change.yml`, pinned `v1.21.0`) + a local premise test.
- Docs: `CONTRIBUTING.md` convention + `docs/cloud-parity/openapi-conformance.md` (Cloud hand-off).

## Verification

Full `internal/e2e` suite green (91s) with the coverage gate active — **0 unmarked-uncovered ops, 0 stale markers**; `internal/oasdiffcheck` green; `go vet` clean. **No production code changed** (test-infra, spec YAML, CI, docs). Every task was reviewed per-task; a final whole-branch review returned READY.

## Follow-ups (not in this PR)

- The **entity slice** (typed-but-open `meta`, conditional `deleteEntities`, request bodies, unique-key codes, HTTP↔gRPC divergence reconciliation) — a separate plan, per #369.
- Deferred Cloud-fact-blocked questions recorded in `docs/cloud-parity/`: E6 (`fieldsChangedCount`) and D2 (gRPC conditional-delete parity).
- Minor: the OIDC e2e's `init()` relaxes OIDC hardening process-wide (test-only; scope later).

Part of #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
