### PR TITLE
feat(openapi): stats/audit/search reconciliation — unknown-model 404 unification, fictional-surface removal, limit-cap coherence

### DIFF
--- a/.github/oasdiff-err-ignore.txt
+++ b/.github/oasdiff-err-ignore.txt
@@ -13,3 +13,24 @@
 # stale documentation the server never honoured (a bare object is rejected with 400). Correcting
 # the schema to the real shape is the reconciliation this PR performs (E4).
 error at api/openapi.yaml, in API POST /entity/{format} the request's body `type/format` changed from `object/json` to `array<object>` [request-body-type-changed].
+
+# stats/audit/search slice (ADR 0003 Decision 7 — spec-to-reality reconciliation; prior spec never matched server):
+#
+# getStateMachineFinishedEvent (GET /audit/…/finished): prior 401/403/404/500 responses used
+# ErrorResponseDto (error, error_description, error_uri) — a prototype-era schema.  Server has
+# always returned ProblemDetail (RFC 9457).  Correcting the schema removes these fields.
+error at api/openapi.yaml, in API GET /audit/entity/{entityId}/workflow/{transactionId}/finished removed the required property `error` from the response with the `401` status [response-required-property-removed].
+error at api/openapi.yaml, in API GET /audit/entity/{entityId}/workflow/{transactionId}/finished removed the required property `error` from the response with the `403` status [response-required-property-removed].
+error at api/openapi.yaml, in API GET /audit/entity/{entityId}/workflow/{transactionId}/finished removed the required property `error` from the response with the `404` status [response-required-property-removed].
+error at api/openapi.yaml, in API GET /audit/entity/{entityId}/workflow/{transactionId}/finished removed the required property `error` from the response with the `500` status [response-required-property-removed].
+error at api/openapi.yaml, in API GET /audit/entity/{entityId}/workflow/{transactionId}/finished removed the required property `error_description` from the response with the `401` status [response-required-property-removed].
+error at api/openapi.yaml, in API GET /audit/entity/{entityId}/workflow/{transactionId}/finished removed the required property `error_description` from the response with the `403` status [response-required-property-removed].
+error at api/openapi.yaml, in API GET /audit/entity/{entityId}/workflow/{transactionId}/finished removed the required property `error_description` from the response with the `404` status [response-required-property-removed].
+error at api/openapi.yaml, in API GET /audit/entity/{entityId}/workflow/{transactionId}/finished removed the required property `error_description` from the response with the `500` status [response-required-property-removed].
+#
+# searchEntities (POST /search/direct/…): prior 200 listed application/json (wrong — server
+# streams NDJSON); prior 400/404 listed application/x-ndjson (wrong — server returns
+# ProblemDetail JSON for errors).  Correcting both removes these media-type entries.
+error at api/openapi.yaml, in API POST /search/direct/{entityName}/{modelVersion} removed the media type `application/json` for the response with the status `200` [response-media-type-removed].
+error at api/openapi.yaml, in API POST /search/direct/{entityName}/{modelVersion} removed the media type `application/x-ndjson` for the response with the status `400` [response-media-type-removed].
+error at api/openapi.yaml, in API POST /search/direct/{entityName}/{modelVersion} removed the media type `application/x-ndjson` for the response with the status `404` [response-media-type-removed].

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run shellcheck
-        run: shellcheck scripts/install.sh scripts/dev/run-docker-dev.sh scripts/check-spi-pin-sync.sh scripts/check-spi-pin-sync_test.sh
+        run: shellcheck scripts/install.sh scripts/dev/run-docker-dev.sh scripts/check-spi-pin-sync.sh scripts/check-spi-pin-sync_test.sh scripts/check-generated-in-sync.sh
 
   # Continuous security gates (issue #67):
   #   - govulncheck scans the call graph for exploitable stdlib and third-party CVEs,
@@ -155,3 +155,19 @@ jobs:
 
       - name: Verify SPI pin sync
         run: ./scripts/check-spi-pin-sync.sh
+
+  # Guards against api/generated.go drifting from api/openapi.yaml — an edit to
+  # the spec that isn't followed by `go generate ./api/...`. This drift went
+  # undetected across several PRs (the spec changed; generated.go did not), so
+  # this gate regenerates and fails on any diff.
+  codegen-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Verify api/generated.go is in sync with api/openapi.yaml
+        run: make check-codegen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,41 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   did this; the memory backend keeps filtering in memory by design.
   ([#37](https://github.com/Cyoda-platform/cyoda-go/issues/37))
 
+- **Unknown model → `404 MODEL_NOT_FOUND` (uniform)** — all model-scoped read
+  operations (`getAllEntities`, `getEntityStatisticsForModel`,
+  `getEntityStatisticsByStateForModel`, `searchEntities`, `submitAsyncSearchJob`,
+  `queryGroupedEntityStatisticsForModel`) now return `404 MODEL_NOT_FOUND` when
+  the requested model is not registered for the calling tenant. Previously these
+  paths returned empty results silently; the ad-hoc `UNKNOWN_MODEL` code used by
+  grouped-stats is retired.
+
+- **`searchEntities` limit enforcement** — `limit > 10000` is now rejected with
+  `400 BAD_REQUEST` across synchronous search (HTTP), gRPC direct search, and
+  async search submission. Previously the spec documented this as a silent clamp.
+
+- **`searchEntities` content type** — the synchronous search endpoint responds
+  with `application/x-ndjson` only; the previously-listed `application/json`
+  variant is removed from the contract.
+
+### Removed
+
+- **`pointInTime` param on `getAsyncSearchResults`** — the point-in-time is
+  fixed at job submission; the param was a no-op and is removed from the contract.
+
+- **`timeoutMillis` param and `408` on `searchEntities`** — these were fictional
+  contract surface not backed by an implementation; both are removed. Actual
+  per-request timeout support is tracked separately.
+
+- **Fictional time-based-UUID `400` on `getStateMachineFinishedEvent`** — any
+  valid UUID is accepted; the fictional constraint is removed from the spec.
+
 ### Fixed
+
+- **`getStateMachineFinishedEvent` error envelope** — error responses now use
+  `application/problem+json` (`ProblemDetail`), matching the rest of the API.
+
+- **`getAsyncSearchResults` documented default page size** — corrected from 10
+  to 1000 in the spec; the implementation was already using 1000.
 
 - Point-in-time ("as at T") reads now apply one canonical rule across all
   storage engines and read paths: inclusive of the requested instant (`<=`),

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev-up dev-down dev-ps dev-logs dev-run dev-test build test test-all test-short-all race clean docker-build docker-push todos check-spi-pin-sync
+.PHONY: dev-up dev-down dev-ps dev-logs dev-run dev-test build test test-all test-short-all race clean docker-build docker-push todos check-spi-pin-sync check-codegen
 
 # Plugin submodules: each has its own go.mod, so `go test ./...` from the
 # repo root does not recurse into them. The aggregator targets below close
@@ -99,6 +99,9 @@ clean:                 ## Remove build artifacts
 
 check-spi-pin-sync:    ## Verify cyoda-go-spi is pinned to the same version across root and all plugin go.mods
 	@./scripts/check-spi-pin-sync.sh
+
+check-codegen:         ## Verify api/generated.go is in sync with api/openapi.yaml (go generate is up to date)
+	@./scripts/check-generated-in-sync.sh
 
 help:                  ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'

--- a/api/generated.go
+++ b/api/generated.go
@@ -339,19 +339,19 @@ func (e CancelAsyncSearchDtoCurrentSearchJobStatus) Valid() bool {
 
 // Defines values for EntityChangeAuditEventDtoChangeType.
 const (
-	EntityChangeAuditEventDtoChangeTypeCREATED EntityChangeAuditEventDtoChangeType = "CREATED"
-	EntityChangeAuditEventDtoChangeTypeDELETED EntityChangeAuditEventDtoChangeType = "DELETED"
-	EntityChangeAuditEventDtoChangeTypeUPDATED EntityChangeAuditEventDtoChangeType = "UPDATED"
+	EntityChangeAuditEventDtoChangeTypeCREATE EntityChangeAuditEventDtoChangeType = "CREATE"
+	EntityChangeAuditEventDtoChangeTypeDELETE EntityChangeAuditEventDtoChangeType = "DELETE"
+	EntityChangeAuditEventDtoChangeTypeUPDATE EntityChangeAuditEventDtoChangeType = "UPDATE"
 )
 
 // Valid indicates whether the value is a known member of the EntityChangeAuditEventDtoChangeType enum.
 func (e EntityChangeAuditEventDtoChangeType) Valid() bool {
 	switch e {
-	case EntityChangeAuditEventDtoChangeTypeCREATED:
+	case EntityChangeAuditEventDtoChangeTypeCREATE:
 		return true
-	case EntityChangeAuditEventDtoChangeTypeDELETED:
+	case EntityChangeAuditEventDtoChangeTypeDELETE:
 		return true
-	case EntityChangeAuditEventDtoChangeTypeUPDATED:
+	case EntityChangeAuditEventDtoChangeTypeUPDATE:
 		return true
 	default:
 		return false
@@ -384,19 +384,19 @@ func (e EntityChangeAuditEventDtoSeverity) Valid() bool {
 
 // Defines values for EntityChangeMetaChangeType.
 const (
-	EntityChangeMetaChangeTypeCREATED EntityChangeMetaChangeType = "CREATED"
-	EntityChangeMetaChangeTypeDELETED EntityChangeMetaChangeType = "DELETED"
-	EntityChangeMetaChangeTypeUPDATED EntityChangeMetaChangeType = "UPDATED"
+	EntityChangeMetaChangeTypeCREATE EntityChangeMetaChangeType = "CREATE"
+	EntityChangeMetaChangeTypeDELETE EntityChangeMetaChangeType = "DELETE"
+	EntityChangeMetaChangeTypeUPDATE EntityChangeMetaChangeType = "UPDATE"
 )
 
 // Valid indicates whether the value is a known member of the EntityChangeMetaChangeType enum.
 func (e EntityChangeMetaChangeType) Valid() bool {
 	switch e {
-	case EntityChangeMetaChangeTypeCREATED:
+	case EntityChangeMetaChangeTypeCREATE:
 		return true
-	case EntityChangeMetaChangeTypeDELETED:
+	case EntityChangeMetaChangeTypeDELETE:
 		return true
-	case EntityChangeMetaChangeTypeUPDATED:
+	case EntityChangeMetaChangeTypeUPDATE:
 		return true
 	default:
 		return false
@@ -1940,7 +1940,7 @@ type EntityChangeAuditEventDto struct {
 	Actor          *AuditActorInfoDto `json:"actor,omitempty"`
 	AuditEventType string             `json:"auditEventType"`
 
-	// ChangeType Type of change that occurred
+	// ChangeType Type of change that occurred (canonical wire spelling; CREATE/UPDATE/DELETE)
 	ChangeType *EntityChangeAuditEventDtoChangeType `json:"changeType,omitempty"`
 
 	// Changes Changes made to the entity
@@ -1974,7 +1974,7 @@ type EntityChangeAuditEventDto struct {
 	UtcTime time.Time `json:"utcTime"`
 }
 
-// EntityChangeAuditEventDtoChangeType Type of change that occurred
+// EntityChangeAuditEventDtoChangeType Type of change that occurred (canonical wire spelling; CREATE/UPDATE/DELETE)
 type EntityChangeAuditEventDtoChangeType string
 
 // EntityChangeAuditEventDtoSeverity Severity level of the event
@@ -1999,6 +1999,36 @@ type EntityChangesDto struct {
 
 	// Before Entity before changes
 	Before *JsonNode `json:"before,omitempty"`
+}
+
+// EntityMetadata System-managed entity metadata. Mirrors the canonical
+// docs/cyoda/schema/common/EntityMetadata.json. Typed-but-open: known
+// fields are enumerated and validated; the object is not sealed, so
+// additive fields remain non-breaking.
+type EntityMetadata struct {
+	CreationDate time.Time `json:"creationDate"`
+
+	// Id Entity id (invariant against point-in-time).
+	Id openapi_types.UUID `json:"id"`
+
+	// LastUpdateTime Last update as-at the point-in-time; equals creationDate if never updated.
+	LastUpdateTime time.Time `json:"lastUpdateTime"`
+
+	// ModelKey Model of the entity. Present on single-entity reads.
+	ModelKey *struct {
+		Name    *string `json:"name,omitempty"`
+		Version *int32  `json:"version,omitempty"`
+	} `json:"modelKey,omitempty"`
+
+	// PointInTime The as-at point-in-time for which the entity was retrieved, when supplied.
+	PointInTime *time.Time `json:"pointInTime,omitempty"`
+
+	// State Entity state at the given point-in-time.
+	State         string              `json:"state"`
+	TransactionId *openapi_types.UUID `json:"transactionId,omitempty"`
+
+	// TransitionForLatestSave Transition applied when the entity was last saved as-at the point-in-time.
+	TransitionForLatestSave *string `json:"transitionForLatestSave,omitempty"`
 }
 
 // EntityMetadataDto System-managed metadata returned for each entity in search results.
@@ -2141,8 +2171,11 @@ type Envelope struct {
 	// Exact fields depend on the entity model.
 	Data map[string]interface{} `json:"data"`
 
-	// Meta System-managed metadata: id, state, creationDate, previousTransition, etc.
-	Meta map[string]interface{} `json:"meta"`
+	// Meta System-managed entity metadata. Mirrors the canonical
+	// docs/cyoda/schema/common/EntityMetadata.json. Typed-but-open: known
+	// fields are enumerated and validated; the object is not sealed, so
+	// additive fields remain non-breaking.
+	Meta EntityMetadata `json:"meta"`
 
 	// Type Entity type discriminator (e.g. "ENTITY").
 	Type string `json:"type"`
@@ -3408,7 +3441,13 @@ type GetAllEntitiesParams struct {
 }
 
 // CreateCollectionJSONBody defines parameters for CreateCollection.
-type CreateCollectionJSONBody = map[string]interface{}
+type CreateCollectionJSONBody = []struct {
+	Model struct {
+		Name    string `json:"name"`
+		Version int32  `json:"version"`
+	} `json:"model"`
+	Payload string `json:"payload"`
+}
 
 // CreateCollectionParams defines parameters for CreateCollection.
 type CreateCollectionParams struct {
@@ -3612,7 +3651,9 @@ type UpdateSingleParams struct {
 type UpdateSingleParamsFormat string
 
 // CreateJSONBody defines parameters for Create.
-type CreateJSONBody = map[string]interface{}
+type CreateJSONBody struct {
+	union json.RawMessage
+}
 
 // CreateParams defines parameters for Create.
 type CreateParams struct {
@@ -3643,6 +3684,12 @@ type CreateParams struct {
 
 // CreateParamsFormat defines parameters for Create.
 type CreateParamsFormat string
+
+// CreateJSONBody0 defines parameters for Create.
+type CreateJSONBody0 map[string]interface{}
+
+// CreateJSONBody1 defines parameters for Create.
+type CreateJSONBody1 = []map[string]interface{}
 
 // DeleteMessagesJSONBody defines parameters for DeleteMessages.
 type DeleteMessagesJSONBody = openapi_types.UUID
@@ -3771,9 +3818,6 @@ type GetAsyncSearchResultsParams struct {
 
 	// PageNumber Zero-based page number
 	PageNumber *string `form:"pageNumber,omitempty" json:"pageNumber,omitempty"`
-
-	// PointInTime The point-in-time for loading the entities, in ISO 8601 format (e.g., '2035-01-01T12:00:00Z'). Defaults to the point-in-time of the report if not provided.
-	PointInTime *time.Time `form:"pointInTime,omitempty" json:"pointInTime,omitempty"`
 }
 
 // SearchEntitiesJSONBody defines parameters for SearchEntities.
@@ -3827,7 +3871,7 @@ type PatchSingleApplicationMergePatchPlusJSONRequestBody = PatchSingleApplicatio
 type UpdateSingleJSONRequestBody = UpdateSingleJSONBody
 
 // CreateJSONRequestBody defines body for Create for application/json ContentType.
-type CreateJSONRequestBody = CreateJSONBody
+type CreateJSONRequestBody CreateJSONBody
 
 // DeleteMessagesJSONRequestBody defines body for DeleteMessages for application/json ContentType.
 type DeleteMessagesJSONRequestBody = DeleteMessagesJSONBody
@@ -4568,6 +4612,68 @@ func (t WorkflowConfigurationDto_Criterion) MarshalJSON() ([]byte, error) {
 }
 
 func (t *WorkflowConfigurationDto_Criterion) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsCreateJSONBody0 returns the union data inside the CreateJSONBody as a CreateJSONBody0
+func (t CreateJSONBody) AsCreateJSONBody0() (CreateJSONBody0, error) {
+	var body CreateJSONBody0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateJSONBody0 overwrites any union data inside the CreateJSONBody as the provided CreateJSONBody0
+func (t *CreateJSONBody) FromCreateJSONBody0(v CreateJSONBody0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateJSONBody0 performs a merge with any union data inside the CreateJSONBody, using the provided CreateJSONBody0
+func (t *CreateJSONBody) MergeCreateJSONBody0(v CreateJSONBody0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsCreateJSONBody1 returns the union data inside the CreateJSONBody as a CreateJSONBody1
+func (t CreateJSONBody) AsCreateJSONBody1() (CreateJSONBody1, error) {
+	var body CreateJSONBody1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromCreateJSONBody1 overwrites any union data inside the CreateJSONBody as the provided CreateJSONBody1
+func (t *CreateJSONBody) FromCreateJSONBody1(v CreateJSONBody1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeCreateJSONBody1 performs a merge with any union data inside the CreateJSONBody, using the provided CreateJSONBody1
+func (t *CreateJSONBody) MergeCreateJSONBody1(v CreateJSONBody1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t CreateJSONBody) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *CreateJSONBody) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -8131,19 +8237,6 @@ func (siw *ServerInterfaceWrapper) GetAsyncSearchResults(w http.ResponseWriter, 
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "pageNumber"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "pageNumber", Err: err})
-		}
-		return
-	}
-
-	// ------------- Optional query parameter "pointInTime" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "pointInTime", r.URL.Query(), &params.PointInTime, runtime.BindQueryParameterOptions{Type: "string", Format: "date-time"})
-	if err != nil {
-		var requiredError *runtime.RequiredParameterError
-		if errors.As(err, &requiredError) {
-			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "pointInTime"})
-		} else {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "pointInTime", Err: err})
 		}
 		return
 	}

--- a/api/generated.go
+++ b/api/generated.go
@@ -3833,9 +3833,6 @@ type SearchEntitiesParams struct {
 	// Limit The maximum number of rows to return. You can specify a limit of up to 10000 and defaults to 1000 if not provided.
 	Limit *string `form:"limit,omitempty" json:"limit,omitempty"`
 
-	// TimeoutMillis The maximum time to wait for the query to complete, in milliseconds, and defaults to 60000 if not provided.
-	TimeoutMillis *string `form:"timeoutMillis,omitempty" json:"timeoutMillis,omitempty"`
-
 	// Sort Repeatable sort key. Grammar: [@]path[:asc|desc], direction defaults to asc. A bare path sorts by a scalar entity-data field; a leading '@' selects a meta field (state, creationDate, lastUpdateTime, transitionForLatestSave, transactionId, id). Repetition order is sort precedence; entity id is the final tiebreaker. Absent/null values sort last.
 	Sort *[]string `form:"sort,omitempty" json:"sort,omitempty"`
 }
@@ -8371,19 +8368,6 @@ func (siw *ServerInterfaceWrapper) SearchEntities(w http.ResponseWriter, r *http
 			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
 		} else {
 			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
-		}
-		return
-	}
-
-	// ------------- Optional query parameter "timeoutMillis" -------------
-
-	err = runtime.BindQueryParameterWithOptions("form", true, false, "timeoutMillis", r.URL.Query(), &params.TimeoutMillis, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
-	if err != nil {
-		var requiredError *runtime.RequiredParameterError
-		if errors.As(err, &requiredError) {
-			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "timeoutMillis"})
-		} else {
-			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "timeoutMillis", Err: err})
 		}
 		return
 	}

--- a/api/generated.go
+++ b/api/generated.go
@@ -3830,7 +3830,7 @@ type SearchEntitiesParams struct {
 	// PointInTime The point-in-time for searching the entities, in ISO 8601 format. Defaults to the consistency time of the system if not provided.
 	PointInTime *time.Time `form:"pointInTime,omitempty" json:"pointInTime,omitempty"`
 
-	// Limit The maximum number of rows to return. You can specify a limit of up to 10000 and defaults to 1000 if not provided.
+	// Limit The maximum number of rows to return. Defaults to 1000 if not provided. Values above 10000 are rejected with 400.
 	Limit *string `form:"limit,omitempty" json:"limit,omitempty"`
 
 	// Sort Repeatable sort key. Grammar: [@]path[:asc|desc], direction defaults to asc. A bare path sorts by a scalar entity-data field; a leading '@' selects a meta field (state, creationDate, lastUpdateTime, transitionForLatestSave, transactionId, id). Repetition order is sort precedence; entity id is the final tiebreaker. Absent/null values sort last.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6468,7 +6468,7 @@ paths:
 
         The results are returned in a paginated format, with:
 
-        - Configurable page size (default: 10)
+        - Configurable page size (default: 1000)
 
         - Zero-based page numbering
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1127,7 +1127,7 @@ paths:
 
         Error responses use RFC 9457 problem+json with the cyoda-go
         `properties.errorCode` extension carrying the stable machine-readable
-        code (`MALFORMED_REQUEST`, `INVALID_CONDITION`, `UNKNOWN_MODEL`,
+        code (`MALFORMED_REQUEST`, `INVALID_CONDITION`,
         `GROUP_CARDINALITY_EXCEEDED`, `NOT_IMPLEMENTED_BY_BACKEND`).
       operationId: queryGroupedEntityStatisticsForModel
       parameters:
@@ -1202,8 +1202,7 @@ paths:
           description: >-
             Bad request — malformed JSON body, validation failure (empty
             `groupBy`, unknown aggregation `op`, `limit` out of range, invalid
-            JSONPath, etc.), invalid Condition DSL predicate, or unknown
-            model for the calling tenant.
+            JSONPath, etc.), or invalid Condition DSL predicate.
           content:
             application/problem+json:
               schema:
@@ -1212,6 +1211,12 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         "403":
           $ref: '#/components/responses/Forbidden'
+        "404":
+          description: Entity model not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
         "413":
           description: Request body exceeds the 10 MiB maximum
           content:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -89,7 +89,6 @@ info:
        - Designed for small to medium datasets
        - Limited by maximum result set size (default: 1000, max: 10000)
        - Non-distributed (executes on single node)
-       - Configurable timeout and result limits
        - Returns immediate streaming results
 
     All endpoints support:
@@ -295,7 +294,6 @@ tags:
          - Designed for small to medium datasets
          - Limited by maximum result set size (default: 1000, max: 10000)
          - Non-distributed (executes on single node)
-         - Configurable timeout and result limits
          - Returns immediate streaming results
 
       All endpoints support:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -497,24 +497,18 @@ paths:
         transaction without needing to
 
         search through all audit events.
-
-
-        Both entityId and transactionId must be valid time-based UUIDs (version
-        1).
       operationId: getStateMachineFinishedEvent
       parameters:
         - name: entityId
           in: path
-          description: "Identifier of the entity. Must be a valid time-based UUID (version
-            1). "
+          description: Identifier of the entity.
           required: true
           schema:
             type: string
             format: uuid
         - name: transactionId
           in: path
-          description: "Identifier of the transaction. Must be a valid time-based UUID
-            (version 1). "
+          description: Identifier of the transaction.
           required: true
           schema:
             type: string
@@ -526,36 +520,30 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/StateMachineAuditEventDto"
-        "400":
-          description: Invalid request - UUID is not time-based
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponseDto"
         "401":
-          description: Error response
+          description: Unauthorized - Authentication is required
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorResponseDto"
+                $ref: "#/components/schemas/ProblemDetail"
         "403":
-          description: Error response
+          description: Forbidden - Insufficient permissions
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorResponseDto"
+                $ref: "#/components/schemas/ProblemDetail"
         "404":
           description: Entity or transaction not found
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorResponseDto"
+                $ref: "#/components/schemas/ProblemDetail"
         "500":
-          description: Error response
+          description: Internal server error
           content:
-            application/json:
+            application/problem+json:
               schema:
-                $ref: "#/components/schemas/ErrorResponseDto"
+                $ref: "#/components/schemas/ProblemDetail"
       security:
         - bearerAuth: []
   /clients:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6506,15 +6506,6 @@ paths:
           required: false
           schema:
             type: string
-        - name: pointInTime
-          in: query
-          description: "The point-in-time for loading the entities, in ISO 8601 format
-            (e.g., '2035-01-01T12:00:00Z'). Defaults to the point-in-time of the
-            report if not provided. "
-          required: false
-          schema:
-            type: string
-            format: date-time
       responses:
         "200":
           description: Successfully retrieved page of results
@@ -6523,8 +6514,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/PagedEntityResultsDto"
         "400":
-          description: Invalid parameters (malformed point-in-time or invalid page
-            parameters)
+          description: Invalid parameters (invalid page parameters)
           content:
             application/problem+json:
               schema:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6688,8 +6688,8 @@ paths:
             format: date-time
         - name: limit
           in: query
-          description: "The maximum number of rows to return. You can specify a limit of
-            up to 10000 and defaults to 1000 if not provided. "
+          description: "The maximum number of rows to return. Defaults to 1000 if not
+            provided. Values above 10000 are rejected with 400."
           required: false
           schema:
             type: string
@@ -6729,26 +6729,15 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/EntityResultDto"
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/EntityResultDto"
         "400":
-          description: Invalid search parameters
+          description: Invalid search parameters (e.g. limit exceeds 10000)
           content:
-            application/x-ndjson:
-              schema:
-                $ref: "#/components/schemas/ProblemDetailDto"
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetailDto"
         "404":
           description: Entity model not found
           content:
-            application/x-ndjson:
-              schema:
-                $ref: "#/components/schemas/ProblemDetailDto"
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetailDto"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6636,8 +6636,6 @@ paths:
 
         - Is optimized for smaller result sets
 
-        - Has configurable timeout and result limits
-
         - Supports point-in-time querying
 
 
@@ -6665,8 +6663,6 @@ paths:
         result to 10000)
 
         - Default result limit: 1000 entities
-
-        - Default timeout: 60000 milliseconds
       operationId: searchEntities
       parameters:
         - name: entityName
@@ -6698,13 +6694,6 @@ paths:
           schema:
             type: string
             maximum: 10000
-        - name: timeoutMillis
-          in: query
-          description: "The maximum time to wait for the query to complete, in
-            milliseconds, and defaults to 60000 if not provided. "
-          required: false
-          schema:
-            type: string
         - name: sort
           in: query
           description: >
@@ -6756,15 +6745,6 @@ paths:
                 $ref: "#/components/schemas/ProblemDetailDto"
         "404":
           description: Entity model not found
-          content:
-            application/x-ndjson:
-              schema:
-                $ref: "#/components/schemas/ProblemDetailDto"
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ProblemDetailDto"
-        "408":
-          description: Search timeout exceeded
           content:
             application/x-ndjson:
               schema:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1212,7 +1212,7 @@ paths:
         "403":
           $ref: '#/components/responses/Forbidden'
         "404":
-          description: Entity model not found
+          description: Entity model not found (MODEL_NOT_FOUND)
           content:
             application/problem+json:
               schema:

--- a/app/app.go
+++ b/app/app.go
@@ -611,8 +611,9 @@ func New(cfg Config) *App {
 	// the service layer) and a validated ModelRef for the calling tenant.
 	// The resolver returns ok=false when the model is not registered (after
 	// one bounded cache refresh — closing the multi-node stale-cache race);
-	// the handler maps that to 404 MODEL_NOT_FOUND. Every other storage
-	// error surfaces via the 500-with-ticket path.
+	// the handler maps that to 404 MODEL_NOT_FOUND. Genuine store errors
+	// (non-ErrNotFound from Get or RefreshAndGet) surface as Internal(500)
+	// and are propagated to the 500-with-ticket path.
 	storeFactory := a.storeFactory
 	groupedStatsResolver := func(r *http.Request, entityName, modelVersion string) (any, spi.ModelRef, bool, error) {
 		ctx := r.Context()
@@ -622,9 +623,12 @@ func New(cfg Config) *App {
 		}
 		ref := spi.ModelRef{EntityName: entityName, ModelVersion: modelVersion}
 		if appErr := common.EnsureModelRegistered(ctx, modelStore, ref); appErr != nil {
-			// Not registered (after one bounded refresh) → resolver reports
-			// ok=false; the handler maps that to 404 MODEL_NOT_FOUND.
-			return nil, ref, false, nil
+			if appErr.Status == http.StatusNotFound {
+				// Not registered after one bounded refresh → handler emits 404 MODEL_NOT_FOUND.
+				return nil, ref, false, nil
+			}
+			// Genuine store error → propagate to 500-with-ticket path.
+			return nil, ref, false, appErr
 		}
 		entityStore, err := storeFactory.EntityStore(ctx)
 		if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -610,9 +609,10 @@ func New(cfg Config) *App {
 	// the closure can capture a.storeFactory directly — the handler needs
 	// the EntityStore as `any` (capability detection via type assertion in
 	// the service layer) and a validated ModelRef for the calling tenant.
-	// The resolver returns ok=false for spi.ErrNotFound (mapped by the
-	// handler to 400 UNKNOWN_MODEL per spec §3) and surfaces every other
-	// storage error to the 500-with-ticket path.
+	// The resolver returns ok=false when the model is not registered (after
+	// one bounded cache refresh — closing the multi-node stale-cache race);
+	// the handler maps that to 404 MODEL_NOT_FOUND. Every other storage
+	// error surfaces via the 500-with-ticket path.
 	storeFactory := a.storeFactory
 	groupedStatsResolver := func(r *http.Request, entityName, modelVersion string) (any, spi.ModelRef, bool, error) {
 		ctx := r.Context()
@@ -621,11 +621,10 @@ func New(cfg Config) *App {
 			return nil, spi.ModelRef{}, false, err
 		}
 		ref := spi.ModelRef{EntityName: entityName, ModelVersion: modelVersion}
-		if _, gerr := modelStore.Get(ctx, ref); gerr != nil {
-			if errors.Is(gerr, spi.ErrNotFound) {
-				return nil, ref, false, nil
-			}
-			return nil, ref, false, gerr
+		if appErr := common.EnsureModelRegistered(ctx, modelStore, ref); appErr != nil {
+			// Not registered (after one bounded refresh) → resolver reports
+			// ok=false; the handler maps that to 404 MODEL_NOT_FOUND.
+			return nil, ref, false, nil
 		}
 		entityStore, err := storeFactory.EntityStore(ctx)
 		if err != nil {

--- a/cmd/cyoda/help/content/crud.md
+++ b/cmd/cyoda/help/content/crud.md
@@ -532,8 +532,8 @@ ON entities (json_extract(data, '$.variantId'));
 
 Error codes (response carries RFC 9457 problem+json with `properties.errorCode` set to the machine-readable code below):
 
+- `MODEL_NOT_FOUND` — `404` — model not registered for the calling tenant
 - `MALFORMED_REQUEST` — `400` — JSON parse failed
-- `UNKNOWN_MODEL` — `400` — path does not resolve for the calling tenant
 - `MISSING_GROUP_BY` — `400` — `groupBy` empty or missing
 - `INVALID_GROUP_BY_PATH` — `400` — empty entry, or array projection in a `groupBy` JSONPath
 - `DUPLICATE_GROUP_BY` — `400` — duplicate entries after normalization
@@ -618,7 +618,7 @@ See `cyoda help errors ENTITY_MODIFIED` for the recovery flow on a `412`.
 - `errors.IDEMPOTENCY_CONFLICT` — `409` — reserved; not yet implemented. Future contract: returned on collection create/update when the `Idempotency-Key` header is re-used with a different payload body
 - `errors.TRANSITION_NOT_FOUND` — `404` — named transition does not exist in the workflow
 - `errors.BAD_REQUEST` — `400` — malformed request, invalid UUID, conflicting query parameters, states filter exceeds 1000 entries
-- Grouped-stats query (`POST /api/entity/stats/{entityName}/{modelVersion}/query`) — `400` for validation failures (`MALFORMED_REQUEST`, `UNKNOWN_MODEL`, `MISSING_GROUP_BY`, `INVALID_GROUP_BY_PATH`, `DUPLICATE_GROUP_BY`, `INVALID_AGGREGATION_OP`, `INVALID_AGGREGATION_FIELD`, `DUPLICATE_AGGREGATION_ALIAS`, `INVALID_POINT_IN_TIME`, `INVALID_LIMIT`); `400` propagated from the search-condition validator (`INVALID_OPERATOR`, `INVALID_CONDITION`, `INVALID_FIELD_PATH`, `CONDITION_TYPE_MISMATCH`); `422 GROUP_CARDINALITY_EXCEEDED` when distinct buckets would exceed `CYODA_STATS_GROUP_MAX`; `501 NOT_IMPLEMENTED_BY_BACKEND` when the storage backend implements neither `Iterable` nor `GroupedAggregator`. The full enumeration with descriptions is in the grouped-stats endpoint section above.
+- Grouped-stats query (`POST /api/entity/stats/{entityName}/{modelVersion}/query`) — `404 MODEL_NOT_FOUND` when the model is not registered for the calling tenant; `400` for validation failures (`MALFORMED_REQUEST`, `MISSING_GROUP_BY`, `INVALID_GROUP_BY_PATH`, `DUPLICATE_GROUP_BY`, `INVALID_AGGREGATION_OP`, `INVALID_AGGREGATION_FIELD`, `DUPLICATE_AGGREGATION_ALIAS`, `INVALID_POINT_IN_TIME`, `INVALID_LIMIT`); `400` propagated from the search-condition validator (`INVALID_OPERATOR`, `INVALID_CONDITION`, `INVALID_FIELD_PATH`, `CONDITION_TYPE_MISMATCH`); `422 GROUP_CARDINALITY_EXCEEDED` when distinct buckets would exceed `CYODA_STATS_GROUP_MAX`; `501 NOT_IMPLEMENTED_BY_BACKEND` when the storage backend implements neither `Iterable` nor `GroupedAggregator`. The full enumeration with descriptions is in the grouped-stats endpoint section above.
 
 ## EXAMPLES
 

--- a/cmd/cyoda/help/content/crud.md
+++ b/cmd/cyoda/help/content/crud.md
@@ -340,7 +340,7 @@ Response: `200 OK`, `application/json`:
 - `pageSize` (query, optional): int32, default `20`
 - `pageNumber` (query, optional): int32, default `0`
 
-Response: `200 OK`, `application/json`, array of entity envelopes (same shape as single-entity GET).
+Response: `200 OK`, `application/json`, array of entity envelopes (same shape as single-entity GET). Returns `404 MODEL_NOT_FOUND` when the model is not registered for the calling tenant.
 
 **GET /api/entity/{entityId}/changes** — Get entity change history metadata
 
@@ -415,7 +415,7 @@ Response: `200 OK`, `application/json`:
 - `entityName` (path): string
 - `modelVersion` (path): int32
 
-Response: `200 OK`, `application/json`, single `ModelStatsDto`.
+Response: `200 OK`, `application/json`, single `ModelStatsDto`. Returns `404 MODEL_NOT_FOUND` when the model is not registered for the calling tenant.
 
 **GET /api/entity/stats/states/{entityName}/{modelVersion}** — Entity count by state for a specific model
 
@@ -423,7 +423,7 @@ Response: `200 OK`, `application/json`, single `ModelStatsDto`.
 - `modelVersion` (path): int32
 - `states` (query, optional): list of state names to filter by; maximum 1000 entries
 
-Response: `200 OK`, `application/json`, array of `ModelStateStatsDto`.
+Response: `200 OK`, `application/json`, array of `ModelStateStatsDto`. Returns `404 MODEL_NOT_FOUND` when the model is not registered for the calling tenant.
 
 **POST /api/entity/stats/{entityName}/{modelVersion}/query** — Grouped statistics with optional aggregations
 

--- a/cmd/cyoda/help/content/search.md
+++ b/cmd/cyoda/help/content/search.md
@@ -6,6 +6,7 @@ see_also:
   - crud
   - models
   - analytics
+  - errors.MODEL_NOT_FOUND
   - errors.SEARCH_JOB_NOT_FOUND
   - errors.SEARCH_JOB_ALREADY_TERMINAL
   - errors.SEARCH_RESULT_LIMIT
@@ -37,7 +38,7 @@ Context path prefix is `CYODA_CONTEXT_PATH` (default `/api`). All endpoints requ
 
 Search operates against a specific entity model `(entityName, modelVersion)`. Two modes are supported:
 
-**Synchronous (direct) search**: `POST /search/direct/{entityName}/{modelVersion}`. Executes inline within the HTTP request. The response is an NDJSON stream (`application/x-ndjson`), one entity envelope per line. The default result limit is 1000 entities per request; the maximum is 10000 (values above 10000 are clamped to 10000).
+**Synchronous (direct) search**: `POST /search/direct/{entityName}/{modelVersion}`. Executes inline within the HTTP request. The response is an NDJSON stream (`application/x-ndjson`), one entity envelope per line. The default result limit is 1000 entities per request; the maximum is 10000 — values above 10000 are rejected with `400 BAD_REQUEST`.
 
 **Asynchronous search**: `POST /search/async/{entityName}/{modelVersion}`. Submits a search job and returns a job UUID immediately. The search executes in a background goroutine (or in the plugin's own executor for `SelfExecutingSearchStore` plugins). Results are retrieved by polling status and then fetching pages.
 
@@ -177,7 +178,7 @@ The function is dispatched as `EntityCriteriaCalculationRequest` to the matching
 - `pointInTime` (query, optional): RFC 3339 date-time — search against entity state at this instant.
   Point-in-time search uses the canonical inclusive (`<=`, no rounding) bound —
   see `cyoda help crud` ("Point-in-time semantics").
-- `limit` (query, optional): string-encoded integer, clamped to maximum 10000; default 1000
+- `limit` (query, optional): string-encoded integer, maximum 10000 (values above 10000 are rejected with `400 BAD_REQUEST`); default 1000
 
 Request body: `Condition` JSON document.
 
@@ -324,10 +325,11 @@ Both sync and async search accept one or more `sort` query parameters. Repeat th
 
 Async search results use page-number pagination: `pageNumber=0` is the first page, `offset = pageNumber * pageSize`. `pageNumber` and `pageSize` are both string-encoded integers in query parameters.
 
-Synchronous search does not paginate; use the `limit` parameter (max 10000) to bound results. For large datasets, use async search with page retrieval.
+Synchronous search does not paginate; use the `limit` parameter (maximum 10000; above rejects `400`) to bound results. For large datasets, use async search with page retrieval.
 
 ## ERRORS
 
+- `errors.MODEL_NOT_FOUND` — `404` — model not registered for the calling tenant (search, async submit)
 - `errors.SEARCH_JOB_NOT_FOUND` — `404` — async job UUID does not exist.
 - `errors.SEARCH_JOB_ALREADY_TERMINAL` — `400` — cancel attempted on a job that is already `SUCCESSFUL`, `FAILED`, or `CANCELLED`; error code in response is `BAD_REQUEST`
 - `errors.SEARCH_RESULT_LIMIT` — result set exceeds configured limit
@@ -422,6 +424,7 @@ curl -s -X PUT \
 - crud
 - models
 - analytics
+- errors.MODEL_NOT_FOUND
 - errors.SEARCH_JOB_NOT_FOUND
 - errors.SEARCH_JOB_ALREADY_TERMINAL
 - errors.SEARCH_RESULT_LIMIT

--- a/docs/cloud-parity/openapi-conformance.md
+++ b/docs/cloud-parity/openapi-conformance.md
@@ -87,6 +87,31 @@ ADR 0003). Each states the direction and what Cloud must mirror.
   canonical field was the higher-risk alternative). Cloud MUST emit `CREATE/UPDATE/DELETE`
   on all these surfaces.
 
+## Stats/audit/search reconciliations (2026-07)
+
+Per-finding contract decisions from the stats/audit/search reconciliation slice.
+
+- **S1 — unknown model → `404 MODEL_NOT_FOUND` (uniform).** All model-scoped read
+  operations (`getAllEntities`, `getEntityStatisticsForModel`,
+  `getEntityStatisticsByStateForModel`, `searchEntities`, `submitAsyncSearchJob`,
+  `queryGroupedEntityStatisticsForModel`) now return `404 MODEL_NOT_FOUND` when the
+  requested `(entityName, modelVersion)` is not registered for the calling tenant.
+  Direction: spec-stale + server-gap (closed). Previous Cloud behaviour: list/stats/search
+  silently returned empty; grouped-stats returned `400 UNKNOWN_MODEL`. The ad-hoc
+  `UNKNOWN_MODEL` code is retired. Cloud MUST return `404 MODEL_NOT_FOUND` on all
+  these paths for unregistered models.
+- **S2 — `searchEntityAuditEvents.changes` diff (documented gap).** The
+  `EntityAuditEventDto.changes` before/after diff field is declared in the schema but
+  not emitted by cyoda-go (nor populated server-side). This is a deferred feature, not
+  a spec contradiction. Direction: server-gap (open; tracked separately). Cloud behaviour
+  is authoritative for now; cyoda-go will close the gap when the feature is implemented.
+- **S3 — `NOT_FOUND` async search-job status (retained).** The `searchJobStatus` field
+  in `GET /api/search/async/{jobId}/status` responses may carry the value `NOT_FOUND`.
+  This is retained in the contract because the commercial self-executing search store
+  emits it. Direction: needs-decision → retained (commercial store compatibility). Cloud
+  MUST continue to emit `NOT_FOUND` where applicable; cyoda-go tolerates it on inbound
+  status payloads.
+
 ## Open questions (Cloud-fact-blocked)
 
 Decided once the Cloud facts are gathered (Gate 7):

--- a/docs/superpowers/plans/2026-07-04-openapi-stats-audit-search-plan.md
+++ b/docs/superpowers/plans/2026-07-04-openapi-stats-audit-search-plan.md
@@ -19,6 +19,11 @@
 - TDD: red → green → commit per step. `go vet ./...` after signature changes (a plain `go build` skips test files). `make race` once before PR.
 - No issue IDs in shipped artefacts (code/spec/help/response bodies); issue IDs only in commits/PR/plan/spec docs.
 - Spec source of truth: `docs/superpowers/specs/2026-07-04-openapi-stats-audit-search-design.md`.
+- **gRPC envelope assertion (Tasks 2-7):** cyoda-go maps operational (4xx) `AppError`s to
+  `Error.Code == "CLIENT_ERROR"` with the domain code in `Error.Message` (`"MODEL_NOT_FOUND: detail"`),
+  uniformly (`internal/grpc/errors.go` `buildErrorFields`). gRPC tests assert `Error.Code == "CLIENT_ERROR"`
+  AND `Error.Message` contains `"MODEL_NOT_FOUND"` — NOT `Error.Code == "MODEL_NOT_FOUND"`. Do not change
+  the envelope wrapper (issue #342 territory, out of scope).
 
 ---
 

--- a/docs/superpowers/plans/2026-07-04-openapi-stats-audit-search-plan.md
+++ b/docs/superpowers/plans/2026-07-04-openapi-stats-audit-search-plan.md
@@ -1,0 +1,925 @@
+# OpenAPI stats/audit/search reconciliation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reconcile the Stats/Audit/Search area of `api/openapi.yaml` with the running server: one canonical `404 MODEL_NOT_FOUND` for unknown models, remove fictional/misplaced surface, fix mechanical spec-stale drift, and document intentionally-retained enums — with no dead code left behind.
+
+**Architecture:** A single shared `common.EnsureModelRegistered` helper (bounded, multi-node-safe registry check) is applied at six model-scoped entry points. HTTP and gRPC inherit the fix through shared service methods; grouped-stats is fixed in its `app.go` resolver closure (also closing a latent multi-node bug). The rest is spec edits + targeted code-comment/dead-branch cleanup, each driven by a test.
+
+**Tech Stack:** Go 1.26+, `log/slog`, testcontainers-go (Postgres e2e), kin-openapi enforce-mode validator, oasdiff CI gate.
+
+## Global Constraints
+
+- Go 1.26+; `log/slog` only (never `log.Printf`/`fmt.Printf`); wrap errors `fmt.Errorf("...: %w", err)`; `uuid.UUID` not `string`.
+- 4xx = full domain detail + error code; 5xx = generic message + ticket UUID. `retryable:true` only for 409 tx-conflict.
+- Schema policy: **typed-but-open** — never `additionalProperties:false`.
+- Contract = cyoda-go leads; every Cloud-facing behaviour change → a `docs/cloud-parity/openapi-conformance.md` note.
+- Multi-node is primary: the model-existence check must not falsely 404 a model just registered on a peer.
+- No zombies: every removal cleans spec + code + comments + help topics + tests.
+- TDD: red → green → commit per step. `go vet ./...` after signature changes (a plain `go build` skips test files). `make race` once before PR.
+- No issue IDs in shipped artefacts (code/spec/help/response bodies); issue IDs only in commits/PR/plan/spec docs.
+- Spec source of truth: `docs/superpowers/specs/2026-07-04-openapi-stats-audit-search-design.md`.
+
+---
+
+## File structure
+
+- **Create:** `internal/common/model_registration.go` (+ `_test.go`) — the shared helper.
+- **Modify (guards):** `internal/domain/entity/service.go` (ListEntities, GetStatisticsForModel, GetStatisticsByStateForModel); `internal/domain/search/service.go` (Search, SubmitAsync + admit-branch/comment cleanup); `app/app.go` (grouped-stats resolver); `internal/domain/entity/grouped_stats_handler.go` (404 mapping).
+- **Modify (spec):** `api/openapi.yaml` — grouped-stats 404, stats/list 404, searchEntities (drop application/json + timeoutMillis + 408 + timeout prose, document limit>10000 400), getAsyncSearchResults (drop pointInTime, page-size prose), getStateMachineFinishedEvent (drop v1-UUID prose + 400, ProblemDetail).
+- **Modify (comments/docs):** `internal/domain/search/service.go:57`, `internal/domain/audit/handler.go:30` (do-not-remove notes); `cmd/cyoda/help/content/crud.md`; `docs/cloud-parity/openapi-conformance.md`; `CHANGELOG.md`.
+- **Tests:** new e2e in `internal/e2e/`, gRPC envelope in `internal/grpc/`, one parity scenario in `e2e/parity/` + registry, isolated cluster test, matrix rows in `internal/e2e/zzz_errorcode_matrix_test.go`.
+
+---
+
+## Task 1: Shared `EnsureModelRegistered` helper
+
+**Files:**
+- Create: `internal/common/model_registration.go`
+- Test: `internal/common/model_registration_test.go`
+
+**Interfaces:**
+- Consumes: `spi.ModelStore`, `spi.ModelRef`, `spi.ErrNotFound`, `common.AppError`, `common.Operational`, `common.Internal`, `common.ErrCodeModelNotFound`.
+- Produces: `func EnsureModelRegistered(ctx context.Context, ms spi.ModelStore, ref spi.ModelRef) *AppError` — returns nil if registered (possibly after one bounded refresh), `Operational(404, MODEL_NOT_FOUND)` if not, `Internal(...)` on a non-NotFound store error.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/common/model_registration_test.go`. Use a small fake `spi.ModelStore` (only `Get` matters; other methods can panic/return zero). Add a second fake embedding the first plus a `RefreshAndGet` method to exercise the bounded-refresh path.
+
+```go
+package common
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+type fakeModelStore struct {
+	spi.ModelStore // embed for unused methods; nil is fine (never called)
+	getErr         error
+}
+
+func (f fakeModelStore) Get(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return &spi.ModelDescriptor{}, nil
+}
+
+type refreshingStore struct {
+	fakeModelStore
+	refreshErr error
+}
+
+func (r refreshingStore) RefreshAndGet(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	if r.refreshErr != nil {
+		return nil, r.refreshErr
+	}
+	return &spi.ModelDescriptor{}, nil
+}
+
+func TestEnsureModelRegistered(t *testing.T) {
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	if err := EnsureModelRegistered(context.Background(), fakeModelStore{}, ref); err != nil {
+		t.Fatalf("registered model: want nil, got %v", err)
+	}
+
+	// Not found, no refresh capability → 404.
+	err := EnsureModelRegistered(context.Background(), fakeModelStore{getErr: spi.ErrNotFound}, ref)
+	if err == nil || err.Status != http.StatusNotFound || err.Code != ErrCodeModelNotFound {
+		t.Fatalf("unknown model: want 404 MODEL_NOT_FOUND, got %v", err)
+	}
+
+	// Not found in cache but refresh finds it → nil (multi-node peer registration).
+	if err := EnsureModelRegistered(context.Background(), refreshingStore{fakeModelStore: fakeModelStore{getErr: spi.ErrNotFound}}, ref); err != nil {
+		t.Fatalf("peer-registered model: want nil after refresh, got %v", err)
+	}
+
+	// Not found in cache and refresh also not found → 404.
+	err = EnsureModelRegistered(context.Background(), refreshingStore{fakeModelStore: fakeModelStore{getErr: spi.ErrNotFound}, refreshErr: spi.ErrNotFound}, ref)
+	if err == nil || err.Status != http.StatusNotFound {
+		t.Fatalf("refresh-miss: want 404, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/common/ -run TestEnsureModelRegistered -v`
+Expected: FAIL — `EnsureModelRegistered` undefined.
+
+- [ ] **Step 3: Write the helper**
+
+Create `internal/common/model_registration.go`:
+
+```go
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// EnsureModelRegistered returns a 404 MODEL_NOT_FOUND AppError when ref names a
+// model that is not registered for the caller's tenant, and nil otherwise.
+//
+// It performs at most one bounded RefreshAndGet (singleflight-collapsed and
+// negative-cached inside the caching model store) so a model just registered on
+// a peer node is not falsely rejected — mirroring the write path's
+// ValidateWithRefresh and the search path-validator's one-shot refresh. When the
+// store has no RefreshAndGet (single-node / memory), the cached Get is
+// authoritative.
+func EnsureModelRegistered(ctx context.Context, ms spi.ModelStore, ref spi.ModelRef) *AppError {
+	_, err := ms.Get(ctx, ref)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, spi.ErrNotFound) {
+		return Internal("failed to check model registration", err)
+	}
+
+	if refresher, ok := ms.(interface {
+		RefreshAndGet(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error)
+	}); ok {
+		if _, rerr := refresher.RefreshAndGet(ctx, ref); rerr == nil {
+			return nil
+		}
+	}
+
+	return Operational(http.StatusNotFound, ErrCodeModelNotFound,
+		fmt.Sprintf("model %s/%s not found", ref.EntityName, ref.ModelVersion))
+}
+```
+
+Note: confirm `AppError` exposes `Status` and `Code` fields as used in the test; if the field names differ (check `internal/common/errors.go`), align the test assertions to the real field names.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/common/ -run TestEnsureModelRegistered -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/common/model_registration.go internal/common/model_registration_test.go
+git commit -m "feat(common): EnsureModelRegistered — bounded multi-node-safe model existence check
+
+Refs #369"
+```
+
+---
+
+## Task 2: getAllEntities → 404 on unknown model
+
+**Files:**
+- Modify: `internal/domain/entity/service.go` (`ListEntities`, ~957)
+- Test: `internal/e2e/entity_list_unknown_model_test.go` (create), `internal/grpc/search_test.go` (add gRPC case)
+
+**Interfaces:**
+- Consumes: `common.EnsureModelRegistered` (Task 1); `h.factory.ModelStore(ctx)`.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+Mirror the assertion style of `internal/e2e/entity_delete_conditional_test.go:79` (`commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")`). Create `internal/e2e/entity_list_unknown_model_test.go`:
+
+```go
+func TestGetAllEntities_UnknownModel_404(t *testing.T) {
+	h := newHarness(t) // use the package's standard harness constructor; see existing tests
+	resp := h.GET(t, "/entity/DoesNotExist/1")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
+}
+```
+
+Use the exact harness/helper names the neighbouring e2e tests use (open `entity_delete_conditional_test.go` for the request+assert helpers; do not invent new ones).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/e2e/ -run TestGetAllEntities_UnknownModel_404 -v`
+Expected: FAIL — returns 200 with an empty list.
+
+- [ ] **Step 3: Add the guard**
+
+In `ListEntities` (`internal/domain/entity/service.go:957`), after obtaining the `ModelStore` and building `ref`, before the `entityStore.GetAll`/`GetAllAsAt` call:
+
+```go
+	modelStore, err := h.factory.ModelStore(ctx)
+	if err != nil {
+		return nil, common.Internal("failed to access model store", err)
+	}
+	if appErr := common.EnsureModelRegistered(ctx, modelStore, ref); appErr != nil {
+		return nil, appErr
+	}
+```
+
+(Place after `ref` is constructed at ~972-975. `ListEntities` currently obtains only the entity store; add the model-store fetch.)
+
+- [ ] **Step 4: Run e2e + vet**
+
+Run: `go test ./internal/e2e/ -run TestGetAllEntities_UnknownModel_404 -v && go vet ./internal/domain/entity/...`
+Expected: PASS; vet clean.
+
+- [ ] **Step 5: Add the gRPC envelope case**
+
+In `internal/grpc/search_test.go`, mirror an existing envelope assertion (search for `resp.Error` / `Error.Code`). Add a case: list via the gRPC `EntitySearchRequest`/list path for `DoesNotExist/1`, assert the CloudEvent envelope `Error.Code == "MODEL_NOT_FOUND"`.
+
+- [ ] **Step 6: Run gRPC test**
+
+Run: `go test ./internal/grpc/ -run Test... -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/domain/entity/service.go internal/e2e/entity_list_unknown_model_test.go internal/grpc/search_test.go
+git commit -m "feat(entity): getAllEntities returns 404 MODEL_NOT_FOUND on unknown model
+
+Refs #369"
+```
+
+---
+
+## Task 3: getEntityStatisticsForModel → 404
+
+**Files:**
+- Modify: `internal/domain/entity/service.go` (`GetStatisticsForModel`, 594)
+- Test: `internal/e2e/entity_stats_unknown_model_test.go` (create), `internal/grpc/search_test.go`
+
+**Interfaces:** Consumes `common.EnsureModelRegistered`, `h.factory.ModelStore(ctx)`.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+```go
+func TestGetStatisticsForModel_UnknownModel_404(t *testing.T) {
+	h := newHarness(t)
+	resp := h.GET(t, "/entity/stats/DoesNotExist/1")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/e2e/ -run TestGetStatisticsForModel_UnknownModel_404 -v`
+Expected: FAIL — returns 200 `{count:0}`.
+
+- [ ] **Step 3: Add the guard**
+
+In `GetStatisticsForModel` (`service.go:594`), after building `ref` and before `entityStore.Count`:
+
+```go
+	modelStore, err := h.factory.ModelStore(ctx)
+	if err != nil {
+		return nil, common.Internal("failed to access model store", err)
+	}
+	if appErr := common.EnsureModelRegistered(ctx, modelStore, ref); appErr != nil {
+		return nil, appErr
+	}
+```
+
+- [ ] **Step 4: Run e2e**
+
+Run: `go test ./internal/e2e/ -run TestGetStatisticsForModel_UnknownModel_404 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Add gRPC envelope case** for `EntityStatsGetRequest` on `DoesNotExist/1` → `Error.Code == "MODEL_NOT_FOUND"` (mirror `search.go:397` path).
+
+- [ ] **Step 6: Run gRPC test** — Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/domain/entity/service.go internal/e2e/entity_stats_unknown_model_test.go internal/grpc/search_test.go
+git commit -m "feat(entity): getEntityStatisticsForModel returns 404 on unknown model
+
+Refs #369"
+```
+
+---
+
+## Task 4: getEntityStatisticsByStateForModel → 404
+
+**Files:**
+- Modify: `internal/domain/entity/service.go` (`GetStatisticsByStateForModel`, 556)
+- Test: append to `internal/e2e/entity_stats_unknown_model_test.go`, `internal/grpc/search_test.go`
+
+**Interfaces:** Consumes `common.EnsureModelRegistered`.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+```go
+func TestGetStatisticsByStateForModel_UnknownModel_404(t *testing.T) {
+	h := newHarness(t)
+	resp := h.GET(t, "/entity/stats/states/DoesNotExist/1")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — Expected: FAIL (200 `[]`).
+
+- [ ] **Step 3: Add the guard** in `GetStatisticsByStateForModel` (`service.go:556`), after `ref`, before `entityStore.CountByState` (same 4-line block as Task 3).
+
+- [ ] **Step 4: Run e2e** — Expected: PASS.
+
+- [ ] **Step 5: Add gRPC case** for `EntityStatsByStateGetRequest` (mirror `search.go:471`).
+
+- [ ] **Step 6: Run gRPC test** — Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/domain/entity/service.go internal/e2e/entity_stats_unknown_model_test.go internal/grpc/search_test.go
+git commit -m "feat(entity): getEntityStatisticsByStateForModel returns 404 on unknown model
+
+Refs #369"
+```
+
+---
+
+## Task 5: searchEntities → 404 + remove the dead admit-branch
+
+**Files:**
+- Modify: `internal/domain/search/service.go` (`Search` ~122; delete admit-branch at `:529-532`; fix comment `:496-500`, `:128-131`)
+- Test: `internal/e2e/search_unknown_model_test.go` (create), `internal/grpc/search_test.go`
+
+**Interfaces:** Consumes `common.EnsureModelRegistered`, `s.factory.ModelStore(ctx)`.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+```go
+func TestSearchEntities_UnknownModel_404(t *testing.T) {
+	h := newHarness(t)
+	resp := h.POST(t, "/search/direct/DoesNotExist/1", `{"type":"group","operator":"AND","conditions":[]}`)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
+}
+```
+
+Use the exact empty/valid condition body the neighbouring search e2e tests use.
+
+- [ ] **Step 2: Run to verify it fails** — Expected: FAIL (200, empty ndjson stream).
+
+- [ ] **Step 3: Add the guard at the top of `Search`**
+
+In `SearchService.Search` (`service.go:122`), as the first step (before `validateConditionPaths`):
+
+```go
+	modelStore, err := s.factory.ModelStore(ctx)
+	if err != nil {
+		return nil, common.Internal("failed to access model store", err)
+	}
+	if appErr := common.EnsureModelRegistered(ctx, modelStore, modelRef); appErr != nil {
+		return nil, appErr
+	}
+```
+
+- [ ] **Step 4: Delete the now-dead admit-branch and fix stale comments**
+
+In `validateConditionPaths` (`service.go:527-541`), the `errors.Is(err, spi.ErrNotFound) { return nil }` branch is unreachable for the unregistered case (existence is gated up front). Remove that branch, keeping the schema-decode-failure fallback:
+
+```go
+	fields, err := loadFieldsMap(ctx, modelStore, modelRef)
+	if err != nil {
+		// Model existence is guaranteed by EnsureModelRegistered before we
+		// reach here; a schema-decode failure is upstream — log and proceed
+		// so the matcher's own error path can still surface a useful error.
+		slog.Debug("failed to load schema for pre-execution validation",
+			"pkg", "search",
+			"entityName", modelRef.EntityName,
+			"modelVersion", modelRef.ModelVersion,
+			"error", err)
+		return nil
+	}
+```
+
+Update the function doc (`service.go:496-500`) to drop the "model has not been registered … search must preserve that behaviour" clause. Also fix the `loadFieldsMap` doc (`path_validate.go:128-131`) — it no longer needs to "preserve" unregistered-admit at the search boundary (the refresh path can still legitimately return ErrNotFound on a deleted-mid-flight model, so keep that handling, just drop the "admit" framing).
+
+- [ ] **Step 5: Run e2e + full search unit tests + vet**
+
+Run: `go test ./internal/domain/search/... ./internal/e2e/ -run 'Search' -v && go vet ./internal/domain/search/...`
+Expected: PASS; vet clean. (Confirm no existing search unit test asserted "unknown model admitted / empty result" — if one does, it encodes the old contract and must be updated to expect 404. Search for it: `grep -rn "unregistered\|unknown model\|admit" internal/domain/search/*_test.go`.)
+
+- [ ] **Step 6: Add gRPC envelope case** — direct search (`EntitySearchRequest`) on `DoesNotExist/1` → `Error.Code == "MODEL_NOT_FOUND"`.
+
+- [ ] **Step 7: Run gRPC test** — Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/domain/search/service.go internal/domain/search/path_validate.go internal/e2e/search_unknown_model_test.go internal/grpc/search_test.go
+git commit -m "feat(search): searchEntities returns 404 on unknown model; drop dead admit-branch
+
+Refs #369"
+```
+
+---
+
+## Task 6: submitAsyncSearchJob → 404
+
+**Files:**
+- Modify: `internal/domain/search/service.go` (`SubmitAsync` ~214)
+- Test: append to `internal/e2e/search_unknown_model_test.go`, `internal/grpc/search_test.go`
+
+**Interfaces:** Consumes `common.EnsureModelRegistered`.
+
+- [ ] **Step 1: Write the failing e2e test**
+
+```go
+func TestSubmitAsyncSearchJob_UnknownModel_404(t *testing.T) {
+	h := newHarness(t)
+	resp := h.POST(t, "/search/async/DoesNotExist/1", `{"type":"group","operator":"AND","conditions":[]}`)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — Expected: FAIL (200 with a jobId).
+
+- [ ] **Step 3: Add the guard at the top of `SubmitAsync`**
+
+In `SubmitAsync` (`service.go:214`), after the user-context check (`:215-218`) and before `validateConditionPaths`:
+
+```go
+	modelStore, err := s.factory.ModelStore(ctx)
+	if err != nil {
+		return "", common.Internal("failed to access model store", err)
+	}
+	if appErr := common.EnsureModelRegistered(ctx, modelStore, modelRef); appErr != nil {
+		return "", appErr
+	}
+```
+
+(`SubmitAsync` returns `(string, error)`; return `""` with the AppError.)
+
+- [ ] **Step 4: Run e2e** — Expected: PASS.
+
+- [ ] **Step 5: Add gRPC case** — async submit (`EntitySnapshotSearchRequest`, `search.go:161`) on `DoesNotExist/1` → `Error.Code == "MODEL_NOT_FOUND"`.
+
+- [ ] **Step 6: Run gRPC test** — Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/domain/search/service.go internal/e2e/search_unknown_model_test.go internal/grpc/search_test.go
+git commit -m "feat(search): submitAsyncSearchJob returns 404 on unknown model
+
+Refs #369"
+```
+
+---
+
+## Task 7: grouped-stats → 404 MODEL_NOT_FOUND; retire UNKNOWN_MODEL
+
+**Files:**
+- Modify: `app/app.go` (resolver closure ~618-637), `internal/domain/entity/grouped_stats_handler.go` (~137), `cmd/cyoda/help/content/crud.md` (536, 621), `api/openapi.yaml` (grouped-stats op ~1132: add 404, drop UNKNOWN_MODEL from 400 enum at ~1130)
+- Test: `internal/domain/entity/grouped_stats_handler_test.go:108` (flip), `internal/e2e/grouped_stats_test.go` (add/confirm 404 case)
+
+**Interfaces:** Consumes `common.EnsureModelRegistered`.
+
+- [ ] **Step 1: Flip the failing unit test**
+
+In `grouped_stats_handler_test.go:108-109`, change the expectation:
+
+```go
+	if got := decodeProblemErrorCode(t, rec.Body.Bytes()); got != "MODEL_NOT_FOUND" {
+		t.Fatalf("errorCode=%s, want MODEL_NOT_FOUND (body: %s)", got, rec.Body.String())
+	}
+```
+
+Also update the asserted status in that test to `http.StatusNotFound` (find the `rec.Code`/status assertion in the same test function and change `400` → `404`).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/domain/entity/ -run TestGroupedStats -v` (use the exact test name)
+Expected: FAIL — still gets `UNKNOWN_MODEL`/400.
+
+- [ ] **Step 3: Add bounded refresh in the resolver**
+
+In `app/app.go`, replace the `modelStore.Get` + `ErrNotFound` block in `groupedStatsResolver` (~628-633) with the shared helper:
+
+```go
+		ref := spi.ModelRef{EntityName: entityName, ModelVersion: modelVersion}
+		if appErr := common.EnsureModelRegistered(ctx, modelStore, ref); appErr != nil {
+			// Not registered (after one bounded refresh) → resolver reports
+			// ok=false; the handler maps that to 404 MODEL_NOT_FOUND.
+			return nil, ref, false, nil
+		}
+```
+
+Update the closure's doc comment (~611-617) to say the handler maps `ok=false` to `404 MODEL_NOT_FOUND` (not `400 UNKNOWN_MODEL`), and note the refresh closes the multi-node stale-cache race.
+
+- [ ] **Step 4: Change the handler mapping**
+
+In `grouped_stats_handler.go:137-141`:
+
+```go
+	if !ok {
+		common.WriteError(w, r, common.Operational(
+			http.StatusNotFound, common.ErrCodeModelNotFound,
+			"model not found",
+		))
+		return
+	}
+```
+
+Update the comment at `grouped_stats_handler.go:24` (`400 UNKNOWN_MODEL` → `404 MODEL_NOT_FOUND`).
+
+- [ ] **Step 5: Run unit + vet**
+
+Run: `go test ./internal/domain/entity/ -run TestGroupedStats -v && go vet ./app/... ./internal/domain/entity/...`
+Expected: PASS; vet clean.
+
+- [ ] **Step 6: Update spec + help doc**
+
+`api/openapi.yaml`: in the grouped-stats operation (`queryGroupedEntityStatisticsForModel`, ~1132), (a) remove `UNKNOWN_MODEL` from the `400` error-code enumeration prose (~1130), (b) add a `404` response block referencing `ProblemDetail` (description "Entity model not found"). `cmd/cyoda/help/content/crud.md`: remove `UNKNOWN_MODEL` at :536 and :621, adding a `404 MODEL_NOT_FOUND` note for the grouped-stats endpoint.
+
+- [ ] **Step 7: Add/confirm the e2e 404 case**
+
+In `internal/e2e/grouped_stats_test.go`, add:
+
+```go
+func TestGroupedStats_UnknownModel_404(t *testing.T) {
+	h := newHarness(t)
+	resp := h.POST(t, "/entity/stats/DoesNotExist/1/query", `{"groupBy":["x"]}`)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
+}
+```
+
+Use the minimal valid grouped-stats body the existing tests use.
+
+- [ ] **Step 8: Run e2e + confirm UNKNOWN_MODEL is fully gone**
+
+Run: `go test ./internal/e2e/ -run TestGroupedStats -v && grep -rn "UNKNOWN_MODEL" internal/ app/ api/openapi.yaml cmd/cyoda/help/content/ | grep -v docs/`
+Expected: PASS; grep returns **no** matches outside historical `docs/`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/app.go internal/domain/entity/grouped_stats_handler.go internal/domain/entity/grouped_stats_handler_test.go internal/e2e/grouped_stats_test.go cmd/cyoda/help/content/crud.md api/openapi.yaml
+git commit -m "feat(stats): grouped-stats returns 404 MODEL_NOT_FOUND; retire UNKNOWN_MODEL; fix latent multi-node race
+
+Refs #369"
+```
+
+---
+
+## Task 8: cross-backend parity + isolated multi-node bounded-refresh test
+
+**Files:**
+- Create: `e2e/parity/unknown_model_test.go` + register in `e2e/parity/registry.go`
+- Create: an isolated cluster test (place with the existing cluster/multi-node e2e; e.g. `internal/e2e/multinode_unknown_model_test.go`)
+
+**Interfaces:** Uses the parity harness (see a neighbouring `e2e/parity/*_test.go` for the backend-parameterised runner + `registry.go` registration).
+
+- [ ] **Step 1: Write the parity scenario**
+
+One backend-agnostic scenario asserting the unknown-model rule on a representative op (e.g. `GET /entity/stats/DoesNotExist/1` → 404 MODEL_NOT_FOUND), following the exact shape of an existing parity test. Register it in `registry.go` so memory/sqlite/postgres/commercial all run it.
+
+- [ ] **Step 2: Run parity** — `go test ./e2e/parity/ -run UnknownModel -v` (per the suite's invocation) — Expected: PASS on all registered backends.
+
+- [ ] **Step 3: Write the isolated multi-node test**
+
+Scenario: register a model on node A; issue a model-scoped data op (e.g. searchEntities) against node B whose cache is cold → `EnsureModelRegistered`'s bounded `RefreshAndGet` must make it succeed (no false 404). Mirror the existing multi-node/cluster test harness (search `internal/e2e` for `TestMultiNode`/two-node setups). Assert the op succeeds (not 404). This is NOT added to the parity suite.
+
+- [ ] **Step 4: Run the cluster test** — Expected: PASS (op succeeds; no false 404).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/parity/unknown_model_test.go e2e/parity/registry.go internal/e2e/multinode_unknown_model_test.go
+git commit -m "test(search): cross-backend parity + isolated multi-node bounded-refresh for unknown-model 404
+
+Refs #369"
+```
+
+---
+
+## Task 9: Error-code matrix rows
+
+**Files:**
+- Modify: `internal/e2e/zzz_errorcode_matrix_test.go`
+
+**Interfaces:** The matrix is the declared-vs-produced checklist (entity-slice learning: per-op completeness; run the WHOLE e2e suite to validate; exempt non-deterministic codes).
+
+- [ ] **Step 1: Add the ops + rows**
+
+Add matrix entries for the newly-declared `404 MODEL_NOT_FOUND` on getAllEntities, getEntityStatisticsForModel, getEntityStatisticsByStateForModel, searchEntities, submitAsyncSearchJob, and queryGroupedEntityStatisticsForModel — following the existing `{Status: 404, Code: "MODEL_NOT_FOUND"}` row shape (`zzz_errorcode_matrix_test.go:37`). Ensure each added op declares its FULL emitted error surface (per-op completeness); CONFLICT / non-deterministic codes stay exempt from the `declared` check.
+
+- [ ] **Step 2: Run the WHOLE e2e suite**
+
+Run: `go test ./internal/e2e/ -v`
+Expected: PASS — the matrix has no undeclared/unproduced gaps for the touched ops.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/e2e/zzz_errorcode_matrix_test.go
+git commit -m "test(e2e): declare 404 MODEL_NOT_FOUND in the error-code matrix for stats/search/list ops
+
+Refs #369"
+```
+
+---
+
+## Task 10: Remove `pointInTime` param from getAsyncSearchResults
+
+**Files:**
+- Modify: `api/openapi.yaml` (getAsyncSearchResults, `GET /search/async/{jobId}`)
+
+**Interfaces:** none (spec-only; handler never reads it).
+
+- [ ] **Step 1: Confirm no code reads it**
+
+Run: `grep -rn "PointInTime" internal/domain/search/handler.go`
+Expected: matches only at `:128`, `:220` (sync search + submit) — NOT in `GetAsyncSearchResults` (`:274-352`). If a `params.PointInTime` reference exists in the paging handler, stop and reassess.
+
+- [ ] **Step 2: Remove the param from the spec**
+
+In `api/openapi.yaml`, delete the `pointInTime` query parameter block from the `getAsyncSearchResults` operation only. Leave `pointInTime` on searchEntities and submitAsyncSearchJob untouched.
+
+- [ ] **Step 3: Regenerate + build + validate**
+
+Run: `go generate ./... 2>/dev/null; go build ./... && go test ./internal/e2e/ -run 'Async' -v`
+Expected: builds; the generated `GetAsyncSearchResultsParams` no longer carries `PointInTime`; async tests pass. (`api/openapi.yaml` is `//go:embed`'d — no snapshot to regenerate; if codegen is wired, the params struct updates.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/openapi.yaml api/generated.go
+git commit -m "fix(openapi): drop pointInTime from getAsyncSearchResults — captured at submit, ignored on paging
+
+Refs #369"
+```
+
+---
+
+## Task 11: getStateMachineFinishedEvent — remove fictional v1-UUID 400; ProblemDetail envelope
+
+**Files:**
+- Modify: `api/openapi.yaml` (getStateMachineFinishedEvent, ~487-560)
+- Test: `internal/e2e/audit_finished_event_test.go` (create or extend)
+
+**Interfaces:** none (handler already accepts any UUID; spec-only + a proving test).
+
+- [ ] **Step 1: Write the proving e2e test**
+
+Assert a well-formed **non-v1** UUID is accepted (not rejected with 400) — it yields 404 (no matching finished event) or 200, never 400:
+
+```go
+func TestGetStateMachineFinishedEvent_NonV1UUID_NotRejected(t *testing.T) {
+	h := newHarness(t)
+	// random v4 UUIDs (not time-based)
+	resp := h.GET(t, "/audit/entity/00000000-0000-4000-8000-000000000000/workflow/00000000-0000-4000-8000-000000000001/finished")
+	if resp.StatusCode == http.StatusBadRequest {
+		t.Fatalf("non-v1 UUID rejected with 400; want 404/200 (handler does no version check)")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify current behaviour** — Expected: PASS already (handler does no v1 check). This test is a regression guard proving the spec's `400` is fictional; it does not require code change.
+
+- [ ] **Step 3: Fix the spec**
+
+In `api/openapi.yaml` (getStateMachineFinishedEvent): remove the "must be a valid time-based UUID (version 1)" prose (description ~502-503 and both param descriptions ~508-509, ~516-517); delete the `400` response block (~529-534); change this operation's remaining error responses (`401/403/404/500`) from `ErrorResponseDto` to `ProblemDetail` (`#/components/schemas/ProblemDetail`).
+
+- [ ] **Step 4: Validate spec + e2e**
+
+Run: `go test ./internal/e2e/ -run 'FinishedEvent|StateMachine' -v`
+Expected: PASS; the enforce-mode validator accepts the ProblemDetail bodies.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add api/openapi.yaml internal/e2e/audit_finished_event_test.go
+git commit -m "fix(openapi): getStateMachineFinishedEvent — drop fictional v1-UUID 400; ProblemDetail envelope
+
+Refs #369"
+```
+
+---
+
+## Task 12: searchEntities — remove fictional timeoutMillis / 408 / timeout prose
+
+**Files:**
+- Modify: `api/openapi.yaml` (searchEntities: params ~6718-6724, response ~6783-6790, prose ~6656, ~6686)
+
+**Interfaces:** none (spec-only; the impl is tracked in #372).
+
+- [ ] **Step 1: Remove the fictional surface**
+
+In `api/openapi.yaml` (searchEntities): delete the `timeoutMillis` query parameter (~6718-6724); delete the `408` response block (~6783-6790); remove the timeout prose bullets ("Has configurable timeout…" ~6656, "Default timeout: 60000 milliseconds" ~6686). Leave `404` and the unknown-model semantics (Task 5) intact.
+
+- [ ] **Step 2: Build + validate**
+
+Run: `go build ./... && go test ./internal/e2e/ -run 'Search' -v`
+Expected: PASS; the generated `SearchEntitiesParams` no longer carries `TimeoutMillis` (confirm nothing referenced it: `grep -rn "TimeoutMillis" internal/` → no matches).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/openapi.yaml api/generated.go
+git commit -m "fix(openapi): remove fictional timeoutMillis/408 from searchEntities (impl tracked in #372)
+
+Refs #369, #372"
+```
+
+---
+
+## Task 13: searchEntities — x-ndjson only + document limit>10000 400
+
+**Files:**
+- Modify: `api/openapi.yaml` (searchEntities 200 content ~6752-6764; limit prose ~6681-6682; error content ~6767-6773)
+- Test: `internal/e2e/search_content_type_test.go` (create)
+
+**Interfaces:** none (server already correct).
+
+- [ ] **Step 1: Write the failing/confirming e2e tests**
+
+```go
+func TestSearchEntities_ContentTypeIsNdjson(t *testing.T) {
+	h := newHarness(t)
+	// register a model + import so the search is valid; reuse existing helpers
+	resp := h.POST(t, "/search/direct/"+model+"/1", `{"type":"group","operator":"AND","conditions":[]}`)
+	if ct := resp.Header.Get("Content-Type"); ct != "application/x-ndjson" {
+		t.Fatalf("Content-Type = %q, want application/x-ndjson", ct)
+	}
+}
+
+func TestSearchEntities_LimitOver10000_400(t *testing.T) {
+	h := newHarness(t)
+	resp := h.POST(t, "/search/direct/"+model+"/1?limit=10001", `{"type":"group","operator":"AND","conditions":[]}`)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+```
+
+- [ ] **Step 2: Run** — Expected: PASS already (server streams ndjson; rejects limit>10000 at `handler.go:150`). These pin the real behaviour before the spec edit.
+
+- [ ] **Step 3: Fix the spec**
+
+In `api/openapi.yaml` (searchEntities): remove the `application/json` variant from the `200` response (keep only `application/x-ndjson`); remove `application/x-ndjson` from the error responses (errors are `problem+json` only); replace the "silently limit the result to 10000" prose (~6681-6682) with a statement that `limit>10000` is rejected with `400`.
+
+- [ ] **Step 4: Verify gRPC limit-cap parity (open item from the spec)**
+
+Run: `grep -rn "MaxPageSize\|limit\|Limit" internal/grpc/search.go`
+Determine whether gRPC direct search enforces the same `limit>10000` cap. If it does NOT, add a task-local fix so the cap lives at the service layer (both entry points), or record the asymmetry explicitly in the spec's cloud-parity note — do not leave it silently divergent (coherence mandate).
+
+- [ ] **Step 5: Validate** — `go test ./internal/e2e/ -run 'Search' -v` — Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/openapi.yaml internal/e2e/search_content_type_test.go
+git commit -m "fix(openapi): searchEntities is x-ndjson only; document limit>10000 400
+
+Refs #369"
+```
+
+---
+
+## Task 14: getAsyncSearchResults — page-size prose 10 → 1000
+
+**Files:**
+- Modify: `api/openapi.yaml` (getAsyncSearchResults `pageSize` description)
+
+- [ ] **Step 1: Fix the prose**
+
+In `api/openapi.yaml`, change the `getAsyncSearchResults` `pageSize` default from `10` to `1000` (matches `handler.go:277`).
+
+- [ ] **Step 2: Build/validate** — `go build ./...` — Expected: OK.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/openapi.yaml
+git commit -m "docs(openapi): getAsyncSearchResults default page size 10 -> 1000
+
+Refs #369"
+```
+
+---
+
+## Task 15: Document intentionally-retained enums in code
+
+**Files:**
+- Modify: `internal/domain/search/service.go:57`, `internal/domain/audit/handler.go:30`
+
+**Interfaces:** none (comments only).
+
+- [ ] **Step 1: Add the do-not-remove notes**
+
+`search/service.go:57` (`SearchJobStatus.Status` field doc): expand to note `NOT_FOUND` is emitted by the commercial self-executing search store on snapshot-expiry races (documented in the spec) and is intentionally retained — do not remove from the contract even though OSS never sets it.
+
+`audit/handler.go:30`: expand the `System` comment to note `System` is a reserved/commercial audit source retained in the contract — do not remove from the `eventType` enum even though OSS never emits it.
+
+- [ ] **Step 2: Build** — `go build ./...` — Expected: OK.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/domain/search/service.go internal/domain/audit/handler.go
+git commit -m "docs(search,audit): mark NOT_FOUND/System as intentionally-retained commercial enum values
+
+Refs #369"
+```
+
+---
+
+## Task 16: Cloud-parity + Gate-4 docs
+
+**Files:**
+- Modify: `docs/cloud-parity/openapi-conformance.md`, `cmd/cyoda/help/content/crud.md`, `CHANGELOG.md`
+
+- [ ] **Step 1: Cloud-parity note**
+
+Append to `docs/cloud-parity/openapi-conformance.md`: (a) unknown-model → `404 MODEL_NOT_FOUND` is the canonical contract across list/stats/search/grouped-stats (Cloud mirrors; was divergent — silent-empty and `400 UNKNOWN_MODEL`); (b) `searchEntityAuditEvents.changes` before/after diff is a documented gap (deferred feature); (c) `NOT_FOUND` search-job status retained because the commercial store emits it.
+
+- [ ] **Step 2: Help-topic hygiene**
+
+Confirm `cmd/cyoda/help/content/crud.md` reflects the new `404 MODEL_NOT_FOUND` for the stats/search/list endpoints and no longer mentions `UNKNOWN_MODEL` (already edited in Task 7 — verify here). Note the deferred message-op v1-UUID cleanup as a follow-on so the doc is internally consistent.
+
+- [ ] **Step 3: CHANGELOG**
+
+Add an entry under the current release section summarising: unknown-model unification to `404 MODEL_NOT_FOUND`; removal of fictional `timeoutMillis`/`408` (→ #372), `pointInTime` on async results, and the finished-event v1-UUID `400`; searchEntities `x-ndjson`-only.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/cloud-parity/openapi-conformance.md cmd/cyoda/help/content/crud.md CHANGELOG.md
+git commit -m "docs: cloud-parity + changelog for stats/audit/search reconciliation
+
+Refs #369"
+```
+
+---
+
+## Task 17: oasdiff gate + final verification
+
+**Files:**
+- Modify (if needed): `.github/oasdiff-err-ignore.txt`
+
+- [ ] **Step 1: Run the oasdiff gate locally**
+
+Run the same oasdiff check CI runs (see `.github/workflows` for the exact invocation comparing against the base spec). For each edit flagged breaking — `application/json` removal on searchEntities 200, `timeoutMillis`/`pointInTime` param removals, `408`/finished-event `400` response removals — add a surgical entry to `.github/oasdiff-err-ignore.txt` with a one-line rationale (fail-closed; the E4 pattern). Additive changes (new 404s) need no entry.
+
+- [ ] **Step 2: Full verification sweep**
+
+Run:
+```bash
+go test ./... -v            # root incl. e2e (Docker up)
+go vet ./...
+make test-short-all         # plugin submodules
+make race                   # once, CI-parity scope
+```
+Expected: all green; vet clean.
+
+- [ ] **Step 3: Dead-code sweep confirmation**
+
+Run:
+```bash
+grep -rn "UNKNOWN_MODEL" internal/ app/ api/openapi.yaml cmd/ | grep -v docs/     # empty
+grep -rn "TimeoutMillis" internal/                                                # empty
+grep -rn "timeoutMillis\|Default timeout\|configurable timeout" api/openapi.yaml  # empty (searchEntities)
+```
+Expected: no matches (all removals cleaned both sides).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/oasdiff-err-ignore.txt
+git commit -m "ci(oasdiff): document reconciliation removals for the additive-only gate
+
+Refs #369"
+```
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** §2 → Tasks 1-9; §3 → Tasks 10-12; §4 → Tasks 13-14; §5 → Task 15; §6 → Task 16; §7 error table → Tasks 2-7,11-13; §8 matrix → Tasks 2-9; §9 oasdiff → Task 17; §10 cloud-parity → Task 16; §11 sweep → Tasks 7,12,17.
+- **No new error codes** (MODEL_NOT_FOUND exists; UNKNOWN_MODEL retired) — so no `errors/<CODE>.md` task; `TestErrCode_Parity` unaffected (verified: UNKNOWN_MODEL has no topic).
+- **Type consistency:** `common.EnsureModelRegistered(ctx, spi.ModelStore, spi.ModelRef) *common.AppError` used identically in Tasks 2-7.
+- **Open verify items surfaced, not buried:** gRPC `limit>10000` cap (Task 13 Step 4); `AppError` field names (Task 1 Step 3).

--- a/docs/superpowers/specs/2026-07-04-openapi-stats-audit-search-design.md
+++ b/docs/superpowers/specs/2026-07-04-openapi-stats-audit-search-design.md
@@ -185,6 +185,14 @@ audit-by-id ops (`404 ENTITY_NOT_FOUND`).
 Layers: **U** unit · **E** running-backend e2e (real Postgres) · **P** cross-backend parity
 (memory/sqlite/postgres/commercial) · **G** gRPC envelope (`Error.Code`).
 
+**gRPC envelope-assertion convention:** cyoda-go's gRPC error envelope (`buildErrorFields`,
+`internal/grpc/errors.go`) maps every operational (4xx) `AppError` to `Error.Code == "CLIENT_ERROR"`
+with the domain code carried in `Error.Message` as `"MODEL_NOT_FOUND: <detail>"` (internal errors →
+`"SERVER_ERROR"` + ticket). This is uniform across all builders. So a "gRPC envelope Error.Code"
+cell asserts **`Error.Code == "CLIENT_ERROR"` AND `Error.Message` contains `"MODEL_NOT_FOUND"`** —
+not `Error.Code == "MODEL_NOT_FOUND"`. Exposing domain codes in `Error.Code` is a separate envelope
+question (issue #342), out of scope here; do not diverge one op from the uniform contract.
+
 | Scenario | U | E | P | G |
 |---|---|---|---|---|
 | getAllEntities unknown model → 404 | ✓ | ✓ | (shared P below) | ✓ (grpc ListEntities) |

--- a/docs/superpowers/specs/2026-07-04-openapi-stats-audit-search-design.md
+++ b/docs/superpowers/specs/2026-07-04-openapi-stats-audit-search-design.md
@@ -1,0 +1,255 @@
+# OpenAPI stats / audit / search reconciliation — design
+
+**Date:** 2026-07-04
+**Umbrella:** #369 (OpenAPI contract reconciliation)
+**Base:** `release/v0.8.2` @ `05e87d1` (entity slice merged)
+**Governing policy:** typed-but-open schemas (never `additionalProperties:false`); cyoda-go
+**defines** the contract (Cloud follows); cyoda-go is **primarily multi-node**; Gate 6 (resolve
+divergence, don't defer); no zombies (every removal cleans both sides).
+
+This is one slice/PR reconciling the `Stats / Audit / Search` area of `api/openapi.yaml`
+(audit source: `docs/analysis/openapi/README.md` §6B) with the running server. It reuses the
+entity-slice machinery: the error-code matrix, typed-but-open schemas, and the exercised-or-marked
+coverage gate (Spec 1).
+
+## 1. Scope
+
+**In scope** — three sub-areas, one PR:
+
+- **Unknown-model unification** (search + stats + list): one canonical `404 MODEL_NOT_FOUND` rule.
+- **Fictional / misplaced surface removal** (search + audit).
+- **Mechanical spec-stale fixes** (search).
+- **Enum retention with documented rationale** (search + audit).
+- **Deferred documented gap** (audit `changes` diff → cloud-parity).
+
+**Out of scope — explicitly named, not missed:**
+
+- **`timeoutMillis` implementation** on `searchEntities` — split to bug **#372**. Only item adding
+  runtime behaviour + a new error path; the fictional param/`408` are *removed* here and re-added
+  with the implementation in #372.
+- **Message-op fictional v1-UUID `400` prose** (`deleteMessages`/`getMessage`/`deleteMessage`) —
+  handled in the message slice (follow-on group 4). Named here so fixing only the finished-event
+  copies reads as intentional.
+
+## 2. Design area 1 — Unknown-model unification
+
+### 2.1 Canonical rule
+
+**Any model-scoped data operation on an unregistered model returns `404 MODEL_NOT_FOUND`.**
+No silent-empty, no ad-hoc `400 UNKNOWN_MODEL`. One predictable behaviour across the surface.
+
+This is coherent and leaks nothing: `create`/`update`/`patch`/`delete` already 404 on an
+unregistered model (`internal/domain/entity/service.go:212,780,889,1062`), so no unregistered model
+can hold entities via the API — `404` cannot hide present data. `modelStore.Get` is tenant-scoped, so
+another tenant's model returns `ErrNotFound` → `404`, identical to truly-absent (no cross-tenant
+existence leak).
+
+### 2.2 Shared helper
+
+```go
+// ensureModelRegistered returns a 404 MODEL_NOT_FOUND AppError when ref names a
+// model that is not registered for the caller's tenant. It performs at most one
+// bounded RefreshAndGet (singleflight-collapsed, negative-cached) so a model just
+// registered on a peer node is not falsely rejected — mirroring the write path's
+// ValidateWithRefresh and the search path-validator. Degrades gracefully when the
+// store has no RefreshAndGet (single-node / memory).
+func ensureModelRegistered(ctx context.Context, ms spi.ModelStore, ref spi.ModelRef) *common.AppError
+```
+
+- **Home:** a package importable by `app`, `internal/domain/entity`, and `internal/domain/search`
+  (the grouped-stats resolver lives in `app/app.go`). Candidate: `internal/domain/model` or a small
+  `internal/common` helper. Decided at implementation; must not create an import cycle.
+- **Multi-node:** confirmed the `RefreshAndGet` machinery exists and is safe
+  (`internal/cluster/modelcache/cache.go:129` singleflight; used by `search/service.go:558`,
+  `search/path_validate.go:151`, `entity/handler.go:233-253`). No SPI/storage change — `ModelStore`
+  is a separate interface from `EntityStore` and its `Get` already returns `spi.ErrNotFound` on every
+  backend (`persistence.go:67`; memory/sqlite/postgres `model_store.go`).
+
+### 2.3 Application points (6)
+
+| Endpoint | Op | Where the guard goes | Today → After |
+|---|---|---|---|
+| `GET /entity/{entityName}/{modelVersion}` | getAllEntities | `entity.Handler.ListEntities` (`service.go:957`) | 200 `[]` → 404 |
+| `GET /entity/stats/{entityName}/{modelVersion}` | getEntityStatisticsForModel | `entity.Handler.GetStatisticsForModel` (`service.go:594`) | 200 `{count:0}` → 404 |
+| `GET /entity/stats/states/{entityName}/{modelVersion}` | getEntityStatisticsByStateForModel | `entity.Handler.GetStatisticsByStateForModel` (`service.go:556`) | 200 `[]` → 404 |
+| `POST /search/direct/{entityName}/{modelVersion}` | searchEntities | `search.SearchService.Search` (`service.go:122`) | 200 empty stream → 404 |
+| `POST /search/async/{entityName}/{modelVersion}` | submitAsyncSearchJob | `search.SearchService.SubmitAsync` (`service.go:214`) | jobId over empty → 404 |
+| `POST /entity/stats/{entityName}/{modelVersion}/query` | queryGroupedEntityStatisticsForModel | `app.go` resolver closure (`app.go:614-637`) | **400 UNKNOWN_MODEL** → 404 MODEL_NOT_FOUND |
+
+HTTP **and** gRPC inherit the fix for the first five (both entry points call the same service method:
+`internal/grpc/search.go:161,346,397,471`). **grouped-stats is HTTP-only** and its model check is a
+plain `modelStore.Get` in the `app.go` resolver closure with **no** bounded refresh — so it *already*
+carries the multi-node racy-false-negative bug. The fix upgrades that closure to
+`ensureModelRegistered`, closing the latent bug (Gate-6 bonus).
+
+The all-models stats ops (`getEntityStatistics`, `getEntityStatisticsByState`) enumerate the registry
+and cannot encounter an unknown model — **unchanged**. Entity-ID-keyed ops (`getOneEntity`,
+update/patch/delete-single, transitions, audit-by-id) are **unchanged** (unknown *entity* → 404).
+
+### 2.4 grouped-stats: retire `UNKNOWN_MODEL`
+
+`UNKNOWN_MODEL` is a bare unregistered string (not in `error_codes.go`, no `errors/UNKNOWN_MODEL.md`).
+Retire it entirely in favour of the registered `MODEL_NOT_FOUND`:
+
+- Emission: `grouped_stats_handler.go:137` → `ensureModelRegistered` / `Operational(404, ModelNotFound)`.
+- Comments: `app.go:614`, `grouped_stats_handler.go:24`.
+- Help doc: `cmd/cyoda/help/content/crud.md:536` and `:621`.
+- Spec: `api/openapi.yaml:1130` (drop from the `400` code-list) + add a `404` response block to the
+  grouped-stats operation (it has none today — **additive**, oasdiff-safe).
+- Test: flip `grouped_stats_handler_test.go:108` (`UNKNOWN_MODEL` → `MODEL_NOT_FOUND`, `400` → `404`).
+
+`MODEL_NOT_FOUND` code + `errors/MODEL_NOT_FOUND.md` already exist — `TestErrCode_Parity` unaffected.
+
+### 2.5 Gate-6 zombie cleanup created by the 404 change
+
+Once `Search`/`SubmitAsync` call `ensureModelRegistered` up front, the search path-validator's
+"admit unregistered model" branch is unreachable for the unregistered case:
+
+- Remove/reconcile the `ErrNotFound → return nil` admit-branch (`search/service.go:529-532`).
+- Remove/reconcile the stale comment (`search/service.go:496-500`) claiming search must preserve
+  "memory admits entity writes without a prior model" — no longer true at the search boundary.
+
+## 3. Design area 2 — Fictional / misplaced surface removal
+
+- **`getAsyncSearchResults` (`GET /search/async/{jobId}`): remove the `pointInTime` param.** PIT is
+  captured and persisted at submit (`SubmitAsync` defaults nil→now and stores `job.PointInTime`,
+  `service.go:235-273`; `GetAsyncResults` reads `job.PointInTime`, `service.go:399`). The paging
+  handler never reads `params.PointInTime` (`handler.go:274-352`). Nothing reads it — safe removal.
+- **`getStateMachineFinishedEvent` (`GET /audit/entity/{entityId}/workflow/{transactionId}/finished`):
+  remove the fictional "must be a valid time-based UUID (version 1)" prose** (openapi.yaml:502-503,
+  508-509, 516-517) **and the `400 "UUID is not time-based"` response** (openapi.yaml:529-534). The
+  handler does no version check (`audit/handler.go:231-270`); it accepts any valid UUID and `404`s on
+  no-match. Implementing v1-validation instead would make this op an incoherent outlier vs every other
+  ID-keyed op (none validate UUID version). **Also** swap this op's error refs `ErrorResponseDto` →
+  `ProblemDetail` (the platform emits `problem+json`; the sibling `/clients` op already uses it).
+- **`searchEntities`: remove the fictional `timeoutMillis` param + `408` response + "configurable
+  timeout" / "Default timeout: 60000 ms" prose** (openapi.yaml:6656, 6686, 6718-6724, 6783-6790).
+  Advertised but unimplemented; tracked for reimplementation in **#372**. The `404` (unknown model)
+  **stays** — it becomes real via §2.
+
+## 4. Design area 3 — Mechanical spec-stale fixes (server already correct)
+
+- **`searchEntities` `200`:** drop `application/json`, keep only `application/x-ndjson` (handler always
+  streams ndjson, `handler.go:178`).
+- **`searchEntities` `limit`:** drop "silently limited to 10000" prose; **document the `400`** on
+  `limit>10000` — the server deliberately rejects rather than clamps (`handler.go:150-153`,
+  rationale comment in code). Drop the ndjson variant from error bodies (errors are `problem+json`).
+- **`getAsyncSearchResults`:** page-size default prose `10` → `1000` (real default, `handler.go:277`).
+
+## 5. Design area 4 — Enum retention with documented rationale
+
+**Do NOT remove `NOT_FOUND` (searchJobStatus / `CancelAsyncSearchDto.currentSearchJobStatus`) or
+`System` (audit `eventType`).** OSS never *sets* them, but:
+
+- `NOT_FOUND` is emitted by the **commercial self-executing search store** on snapshot-expiry races —
+  the spec's own prose says so (openapi.yaml:6595-6612). Removing it would break the Cloud contract.
+- `System` is not provably dead contract-wide (only OSS-dead).
+- Typed-but-open policy keeps evolving value-sets' documented values, including commercial-only ones.
+
+Instead, **document the rationale in code** so this is never re-litigated (Paul's explicit ask):
+
+- `search/service.go:57` (`SearchJobStatus` type doc): note `NOT_FOUND` is emitted by the commercial
+  self-executing store on snapshot-expiry races and is intentionally retained — **do not remove**.
+- `audit/handler.go:30` (the `System` filter comment): note `System` is a reserved/commercial audit
+  source retained in the contract — **do not remove**.
+
+## 6. Design area 5 — Deferred documented gap
+
+**`searchEntityAuditEvents.changes` before/after diff never emitted** (`audit/handler.go:70-97` builds
+only metadata). Emitting it is real feature work (per-version diff materialization). Deferred: a
+`docs/cloud-parity/openapi-conformance.md` note (mirrors the E6 `fieldsChangedCount` deferral). Not
+implemented this slice. The `changes` field stays in the schema (typed-but-open; optional).
+
+## 7. Per-endpoint error / status-code table
+
+Only rows this slice adds or changes. "✚" = added this slice; "→" = changed.
+
+| Endpoint | Status | Code | Notes |
+|---|---|---|---|
+| `GET /entity/{entityName}/{modelVersion}` | ✚ 404 | MODEL_NOT_FOUND | unknown model |
+| `GET /entity/stats/{entityName}/{modelVersion}` | ✚ 404 | MODEL_NOT_FOUND | unknown model |
+| `GET /entity/stats/states/{entityName}/{modelVersion}` | ✚ 404 | MODEL_NOT_FOUND | unknown model |
+| `POST /search/direct/{entityName}/{modelVersion}` | 404 | MODEL_NOT_FOUND | now real (was fictional-empty); already in spec |
+| `POST /search/direct/{entityName}/{modelVersion}` | 400 | BAD_REQUEST | `limit>10000` (newly documented; already emitted) |
+| `POST /search/direct/{entityName}/{modelVersion}` | ✖ 408 | — | removed (fictional → #372) |
+| `POST /search/async/{entityName}/{modelVersion}` | ✚ 404 | MODEL_NOT_FOUND | unknown model |
+| `POST /entity/stats/{entityName}/{modelVersion}/query` | → 404 | MODEL_NOT_FOUND | was `400 UNKNOWN_MODEL` |
+| `GET /audit/entity/{entityId}/workflow/{transactionId}/finished` | ✖ 400 | — | removed fictional v1-UUID 400; envelope → ProblemDetail |
+| `GET /search/async/{jobId}` (results) | — | — | `pointInTime` param removed (no status change) |
+
+Unchanged-but-relevant: `getAsyncSearchStatus`/`cancelAsyncSearch` (job-ID keyed, `404 SEARCH_JOB_NOT_FOUND`);
+audit-by-id ops (`404 ENTITY_NOT_FOUND`).
+
+## 8. Coverage matrix (scenario × layer)
+
+Layers: **U** unit · **E** running-backend e2e (real Postgres) · **P** cross-backend parity
+(memory/sqlite/postgres/commercial) · **G** gRPC envelope (`Error.Code`).
+
+| Scenario | U | E | P | G |
+|---|---|---|---|---|
+| getAllEntities unknown model → 404 | ✓ | ✓ | (shared P below) | ✓ (grpc ListEntities) |
+| getEntityStatisticsForModel unknown model → 404 | ✓ | ✓ | (shared P) | ✓ |
+| getEntityStatisticsByStateForModel unknown model → 404 | ✓ | ✓ | (shared P) | ✓ |
+| searchEntities unknown model → 404 | ✓ | ✓ | (shared P) | ✓ (grpc direct search) |
+| submitAsyncSearchJob unknown model → 404 | ✓ | ✓ | (shared P) | ✓ (grpc async submit) |
+| queryGroupedEntityStatisticsForModel unknown model → 404 | ✓ | ✓ | (shared P) | N/A — HTTP-only (**waived**) |
+| **Unknown-model rule → 404** (one representative op per layer) | — | — | ✓ **one parity scenario** | — |
+| **Multi-node**: model registered on peer, stale node → refresh → op succeeds (no false 404) | — | — | — | isolated **cluster** test (not parity) |
+| searchEntities `limit>10000` → 400 | ✓ | ✓ | — | ⚠ verify |
+| searchEntities 200 is `x-ndjson` (content-type) | — | ✓ | — | — |
+| getStateMachineFinishedEvent accepts non-v1 UUID → 200/404 (no 400) | ✓ | ✓ | — | — |
+| grouped-stats error-flip regression (`MODEL_NOT_FOUND`, not `UNKNOWN_MODEL`) | ✓ | ✓ | — | — |
+
+Notes:
+- One **shared parity scenario** covers the backend-agnostic unknown-model→404 rule; per-op parity
+  rows are not duplicated (the rule is uniform).
+- The **multi-node bounded-refresh** cell is mandatory (primarily-multi-node rule) and lives as an
+  isolated cluster test — never folded into the shared parity suite.
+- No concurrency/race scenario in this slice; if one arises it goes isolated, not in parity.
+- ⚠ The `limit>10000` reject lives in the HTTP handler (`handler.go:150-153`), not the service —
+  planning must verify whether gRPC direct search enforces the same cap. If it does not, that is an
+  HTTP/gRPC divergence to reconcile (make the cap a service-layer concern) per the coherence mandate;
+  if out of proportion, record explicitly rather than silently leave asymmetric.
+
+## 9. oasdiff dispositions
+
+Enum removals are dropped (§5), eliminating the request-enum-narrowing break. Remaining edits:
+
+| Edit | oasdiff verdict | Action |
+|---|---|---|
+| Add `404` to 3 stats/list ops + grouped-stats | additive | none |
+| searchEntities `404` already present; now exercised | none | none |
+| Remove searchEntities `200` `application/json` variant | response content narrowing (non-client-breaking) | verify; ignore-entry if flagged |
+| Remove searchEntities `408` + `timeoutMillis` param | response/param removal | verify; ignore-entry if flagged (documented; #372 re-adds) |
+| Remove `pointInTime` param from getAsyncSearchResults | optional param removal | verify; ignore-entry if flagged |
+| Remove finished-event `400` | response removal (non-client-breaking) | none/verify |
+
+Any required ignore lives in `.github/oasdiff-err-ignore.txt` with a one-line rationale (the E4
+pattern) — fail-closed, cannot mask other breaks.
+
+## 10. Cloud-parity notes (`docs/cloud-parity/openapi-conformance.md`)
+
+- Unknown-model → `404 MODEL_NOT_FOUND` is the canonical contract; Cloud mirrors it (was divergent:
+  silent-empty on some ops, `400 UNKNOWN_MODEL` on grouped-stats).
+- `searchEntityAuditEvents.changes` before/after diff = documented gap (deferred feature).
+- `NOT_FOUND` search-job status is retained specifically because the commercial store emits it.
+
+## 11. Dead-code / zombie sweep checklist
+
+Every removal cleans both sides:
+
+- [ ] `UNKNOWN_MODEL` string fully gone (emission, comments, crud.md ×2, openapi.yaml enum).
+- [ ] searchEntities "configurable timeout" / "Default timeout" prose (openapi.yaml:6656,6686) gone
+      with the `timeoutMillis`/`408` removal.
+- [ ] finished-event v1-UUID prose (×3) + `400` gone; envelope refs → `ProblemDetail`.
+- [ ] search "admit unregistered model" branch (`service.go:529-532`) + comment (`:496-500`) removed.
+- [ ] `pointInTime` param gone from getAsyncSearchResults; no dangling `ResultOptions` field.
+- [ ] `NOT_FOUND`/`System` **retained** with explicit "do-not-remove" code comments (§5).
+- [ ] `go vet ./...` clean (catches call-site breaks a plain `go build` misses).
+
+## 12. Verification gates
+
+`go test ./... -v` (incl. e2e) green; `go vet ./...`; per-plugin submodule tests; `make race` once
+before PR. Full `internal/e2e` suite run to validate the error-code matrix per-op completeness
+(CONFLICT and other non-deterministic codes exempted from the `declared` check, per entity-slice
+learnings).

--- a/e2e/parity/multinode/unknown_model_coldcache.go
+++ b/e2e/parity/multinode/unknown_model_coldcache.go
@@ -1,0 +1,88 @@
+package multinode
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
+)
+
+func init() {
+	Register(
+		NamedTest{
+			Name: "UnknownModel_BoundedRefresh_ColdCacheSucceeds",
+			Fn:   RunUnknownModel_BoundedRefresh_ColdCacheSucceeds,
+		},
+	)
+}
+
+// RunUnknownModel_BoundedRefresh_ColdCacheSucceeds proves that
+// EnsureModelRegistered's bounded RefreshAndGet prevents a false 404 when a
+// model-scoped operation reaches a node whose model cache is cold.
+//
+// Scenario:
+//  1. Register (import + lock) the model on node A.
+//  2. Issue GET /api/entity/stats/{model}/{version} on node B, which has never
+//     seen this tenant's model (cold in-process cache).
+//  3. Assert the op succeeds (200) — NOT 404 MODEL_NOT_FOUND.
+//
+// If the bounded refresh were removed (or EnsureModelRegistered only consulted
+// its in-process cache), node B would return 404 because the model was written
+// to the authoritative store via node A, not via node B. The test would fail on
+// the MODEL_NOT_FOUND guard below.
+//
+// Not in the main parity registry — this is an isolated cluster test exercising
+// the cluster-specific cold-cache→refresh path, not a cross-backend contract.
+func RunUnknownModel_BoundedRefresh_ColdCacheSucceeds(t *testing.T, fixture MultiNodeFixture) {
+	t.Helper()
+	urls := fixture.BaseURLs()
+	if len(urls) < 2 {
+		t.Fatalf("need at least 2 nodes for cold-cache test, got %d", len(urls))
+	}
+	tenant := fixture.NewTenant(t)
+
+	// Fresh tenant means this model name is unique within the test run;
+	// no UUID suffix needed because tenant isolation provides the namespace.
+	const modelName = "cold-cache-refresh"
+	const modelVersion = 1
+
+	// Step 1: register and lock the model on node A (index 0).
+	cA := client.NewClient(urls[0], tenant.Token)
+	if err := cA.ImportModel(t, modelName, modelVersion, `{"k":1}`); err != nil {
+		t.Fatalf("node A ImportModel: %v", err)
+	}
+	if err := cA.LockModel(t, modelName, modelVersion); err != nil {
+		t.Fatalf("node A LockModel: %v", err)
+	}
+
+	// Step 2: issue GET /api/entity/stats/{model}/{version} on node B (index 1).
+	// Node B has no in-process knowledge of this tenant's model yet (cold cache).
+	// EnsureModelRegistered must perform a bounded RefreshAndGet against the
+	// shared authoritative store (postgres) and find the model registered via A.
+	cB := client.NewClient(urls[1], tenant.Token)
+	statsPath := fmt.Sprintf("/api/entity/stats/%s/%d", modelName, modelVersion)
+	status, body, err := cB.DoJSONBodyRaw(t, http.MethodGet, statsPath, nil)
+	if err != nil && status == 0 {
+		t.Fatalf("node B transport error: %v", err)
+	}
+
+	// Step 3: must NOT be a false 404 (cold-cache regression guard).
+	if status == http.StatusNotFound {
+		var envelope struct {
+			Properties struct {
+				ErrorCode string `json:"errorCode"`
+			} `json:"properties"`
+		}
+		_ = json.Unmarshal(body, &envelope)
+		if envelope.Properties.ErrorCode == "MODEL_NOT_FOUND" {
+			t.Fatalf("cold-cache false-404: node B returned MODEL_NOT_FOUND for a model registered on node A; "+
+				"EnsureModelRegistered's bounded RefreshAndGet did not consult the authoritative store (body: %s)", string(body))
+		}
+		t.Fatalf("node B returned 404 (body: %s)", string(body))
+	}
+	if status != http.StatusOK {
+		t.Fatalf("node B: status = %d (want 200); body: %s", status, string(body))
+	}
+}

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -7,7 +7,7 @@ import "testing"
 // distributed-safety contracts + schema extensions + Phase 9.2 OIDC CRUD/authz
 // + Phase 9.3 OIDC JWT validation + Phase 9.4 OIDC divergences
 // + Phase 9.5 OIDC SSRF/D19/D20/D23/D25/D21/I9/state/E2E
-// + Phase 9.6 Audit fixes + grouped stats).
+// + Phase 9.6 Audit fixes + grouped stats + unknown-model 404 contract).
 // ExternalAPI scenarios registered via parity.Register() in e2e/parity/externalapi/
 // are additional to this count.
 //
@@ -329,8 +329,9 @@ var allTests = []NamedTest{
 	{"GroupedStats_CardinalityExceeded", RunParityGroupedStats_CardinalityExceeded},
 
 	// Unknown-model contract — unified 404 MODEL_NOT_FOUND (stats/audit/search slice).
-	// One representative op (grouped-stats query) suffices: every backend must
-	// reject an unknown model before doing any query work.
+	// One representative op (GET stats query) suffices: every backend must reject
+	// an unknown model before doing any query work. (The GET stats endpoint runs
+	// the model-existence check first; grouped-stats validates groupBy beforehand.)
 	{"UnknownModel404", RunUnknownModel404},
 }
 

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 167
+// Total parity scenarios: 168
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
 // distributed-safety contracts + schema extensions + Phase 9.2 OIDC CRUD/authz
 // + Phase 9.3 OIDC JWT validation + Phase 9.4 OIDC divergences
@@ -327,6 +327,11 @@ var allTests = []NamedTest{
 	{"GroupedStats_NonNumericSkipped", RunParityGroupedStats_NonNumericSkipped},
 	{"GroupedStats_NonScalarCoercesToNull", RunParityGroupedStats_NonScalarCoercesToNull},
 	{"GroupedStats_CardinalityExceeded", RunParityGroupedStats_CardinalityExceeded},
+
+	// Unknown-model contract — unified 404 MODEL_NOT_FOUND (stats/audit/search slice).
+	// One representative op (grouped-stats query) suffices: every backend must
+	// reject an unknown model before doing any query work.
+	{"UnknownModel404", RunUnknownModel404},
 }
 
 // Register appends additional NamedTests to the canonical list at init time.

--- a/e2e/parity/unknown_model.go
+++ b/e2e/parity/unknown_model.go
@@ -1,0 +1,37 @@
+package parity
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
+)
+
+// RunUnknownModel404 asserts that a model-scoped operation against a model
+// that has never been registered returns 404 MODEL_NOT_FOUND on every
+// backend. Uses GET /api/entity/stats/{name}/{version} as the representative
+// operation because it requires no request body and is gated by
+// common.EnsureModelRegistered — guaranteeing the model check runs before
+// any query work. Every backend (memory / sqlite / postgres / commercial)
+// must return 404 MODEL_NOT_FOUND for a model name that was never imported.
+func RunUnknownModel404(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	// UUID suffix guarantees the model name has never been imported in any
+	// prior test on this backend, even on a shared long-running instance.
+	unknownModel := "never-registered-" + uuid.NewString()
+	path := fmt.Sprintf("/api/entity/stats/%s/1", unknownModel)
+
+	status, body, err := c.DoJSONBodyRaw(t, http.MethodGet, path, nil)
+	if err != nil && status == 0 {
+		t.Fatalf("transport error: %v", err)
+	}
+	if status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body: %s", status, string(body))
+	}
+	assertErrCode(t, body, "MODEL_NOT_FOUND")
+}

--- a/internal/common/model_registration.go
+++ b/internal/common/model_registration.go
@@ -10,7 +10,8 @@ import (
 )
 
 // EnsureModelRegistered returns a 404 MODEL_NOT_FOUND AppError when ref names a
-// model that is not registered for the caller's tenant, and nil otherwise.
+// model that is not registered for the caller's tenant, nil when it is registered,
+// and an Internal(500) AppError when the store returns a non-not-found error.
 //
 // It performs at most one bounded RefreshAndGet (singleflight-collapsed and
 // negative-cached inside the caching model store) so a model just registered on
@@ -18,6 +19,14 @@ import (
 // ValidateWithRefresh and the search path-validator's one-shot refresh. When the
 // store has no RefreshAndGet (single-node / memory), the cached Get is
 // authoritative.
+//
+// Decision tree:
+//   - Get succeeds → nil (registered)
+//   - Get fails with non-ErrNotFound → Internal(500) (store failure)
+//   - Get fails with ErrNotFound, no RefreshAndGet → 404 MODEL_NOT_FOUND
+//   - RefreshAndGet succeeds → nil (registered on peer)
+//   - RefreshAndGet fails with ErrNotFound → 404 MODEL_NOT_FOUND
+//   - RefreshAndGet fails with non-ErrNotFound → Internal(500) (store failure)
 func EnsureModelRegistered(ctx context.Context, ms spi.ModelStore, ref spi.ModelRef) *AppError {
 	_, err := ms.Get(ctx, ref)
 	if err == nil {
@@ -30,8 +39,12 @@ func EnsureModelRegistered(ctx context.Context, ms spi.ModelStore, ref spi.Model
 	if refresher, ok := ms.(interface {
 		RefreshAndGet(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error)
 	}); ok {
-		if _, rerr := refresher.RefreshAndGet(ctx, ref); rerr == nil {
+		_, rerr := refresher.RefreshAndGet(ctx, ref)
+		if rerr == nil {
 			return nil
+		}
+		if !errors.Is(rerr, spi.ErrNotFound) {
+			return Internal("failed to refresh model registration", rerr)
 		}
 	}
 

--- a/internal/common/model_registration.go
+++ b/internal/common/model_registration.go
@@ -1,0 +1,40 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// EnsureModelRegistered returns a 404 MODEL_NOT_FOUND AppError when ref names a
+// model that is not registered for the caller's tenant, and nil otherwise.
+//
+// It performs at most one bounded RefreshAndGet (singleflight-collapsed and
+// negative-cached inside the caching model store) so a model just registered on
+// a peer node is not falsely rejected — mirroring the write path's
+// ValidateWithRefresh and the search path-validator's one-shot refresh. When the
+// store has no RefreshAndGet (single-node / memory), the cached Get is
+// authoritative.
+func EnsureModelRegistered(ctx context.Context, ms spi.ModelStore, ref spi.ModelRef) *AppError {
+	_, err := ms.Get(ctx, ref)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, spi.ErrNotFound) {
+		return Internal("failed to check model registration", err)
+	}
+
+	if refresher, ok := ms.(interface {
+		RefreshAndGet(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error)
+	}); ok {
+		if _, rerr := refresher.RefreshAndGet(ctx, ref); rerr == nil {
+			return nil
+		}
+	}
+
+	return Operational(http.StatusNotFound, ErrCodeModelNotFound,
+		fmt.Sprintf("model %s/%s not found", ref.EntityName, ref.ModelVersion))
+}

--- a/internal/common/model_registration_test.go
+++ b/internal/common/model_registration_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -50,9 +51,16 @@ func TestEnsureModelRegistered(t *testing.T) {
 		t.Fatalf("peer-registered model: want nil after refresh, got %v", err)
 	}
 
-	// Not found in cache and refresh also not found → 404.
+	// Not found in cache and refresh also not found → 404 MODEL_NOT_FOUND.
 	err = EnsureModelRegistered(context.Background(), refreshingStore{fakeModelStore: fakeModelStore{getErr: spi.ErrNotFound}, refreshErr: spi.ErrNotFound}, ref)
-	if err == nil || err.Status != http.StatusNotFound {
-		t.Fatalf("refresh-miss: want 404, got %v", err)
+	if err == nil || err.Status != http.StatusNotFound || err.Code != ErrCodeModelNotFound {
+		t.Fatalf("refresh-miss: want 404 MODEL_NOT_FOUND, got %v", err)
+	}
+
+	// RefreshAndGet returns a non-ErrNotFound error (store failure) → Internal/500, NOT 404.
+	storeErr := errors.New("boom")
+	err = EnsureModelRegistered(context.Background(), refreshingStore{fakeModelStore: fakeModelStore{getErr: spi.ErrNotFound}, refreshErr: storeErr}, ref)
+	if err == nil || err.Status != http.StatusInternalServerError {
+		t.Fatalf("refresh-store-error: want 500 Internal, got %v", err)
 	}
 }

--- a/internal/common/model_registration_test.go
+++ b/internal/common/model_registration_test.go
@@ -1,0 +1,58 @@
+package common
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+type fakeModelStore struct {
+	spi.ModelStore // embed for unused methods; nil is fine (never called)
+	getErr         error
+}
+
+func (f fakeModelStore) Get(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return &spi.ModelDescriptor{}, nil
+}
+
+type refreshingStore struct {
+	fakeModelStore
+	refreshErr error
+}
+
+func (r refreshingStore) RefreshAndGet(context.Context, spi.ModelRef) (*spi.ModelDescriptor, error) {
+	if r.refreshErr != nil {
+		return nil, r.refreshErr
+	}
+	return &spi.ModelDescriptor{}, nil
+}
+
+func TestEnsureModelRegistered(t *testing.T) {
+	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+
+	if err := EnsureModelRegistered(context.Background(), fakeModelStore{}, ref); err != nil {
+		t.Fatalf("registered model: want nil, got %v", err)
+	}
+
+	// Not found, no refresh capability → 404.
+	err := EnsureModelRegistered(context.Background(), fakeModelStore{getErr: spi.ErrNotFound}, ref)
+	if err == nil || err.Status != http.StatusNotFound || err.Code != ErrCodeModelNotFound {
+		t.Fatalf("unknown model: want 404 MODEL_NOT_FOUND, got %v", err)
+	}
+
+	// Not found in cache but refresh finds it → nil (multi-node peer registration).
+	if err := EnsureModelRegistered(context.Background(), refreshingStore{fakeModelStore: fakeModelStore{getErr: spi.ErrNotFound}}, ref); err != nil {
+		t.Fatalf("peer-registered model: want nil after refresh, got %v", err)
+	}
+
+	// Not found in cache and refresh also not found → 404.
+	err = EnsureModelRegistered(context.Background(), refreshingStore{fakeModelStore: fakeModelStore{getErr: spi.ErrNotFound}, refreshErr: spi.ErrNotFound}, ref)
+	if err == nil || err.Status != http.StatusNotFound {
+		t.Fatalf("refresh-miss: want 404, got %v", err)
+	}
+}

--- a/internal/domain/audit/handler.go
+++ b/internal/domain/audit/handler.go
@@ -28,6 +28,9 @@ func (h *Handler) SearchEntityAuditEvents(w http.ResponseWriter, r *http.Request
 
 	// Determine which event types to include.
 	// Default (no filter): include EntityChange and StateMachine but NOT System.
+	// System is a reserved/commercial audit source retained in the eventType
+	// enum contract — do NOT remove it from the OpenAPI spec even though OSS
+	// backends never emit it.
 	includeEntityChange := true
 	includeStateMachine := true
 	if params.EventType != nil {

--- a/internal/domain/entity/grouped_stats_handler.go
+++ b/internal/domain/entity/grouped_stats_handler.go
@@ -21,7 +21,7 @@ const maxGroupedStatsBodySize = 10 * 1024 * 1024
 // detection happens via type assertion inside the service) and the
 // resolved ModelRef for the given entity name and model version. The ok
 // return is false when the model is not found for the calling tenant —
-// the handler maps that to 400 UNKNOWN_MODEL per spec §3.
+// the handler maps that to 404 MODEL_NOT_FOUND.
 //
 // The handler holds a StoreResolver rather than (factory, modelStore)
 // directly so it can be unit-tested in isolation: tests inject a
@@ -135,8 +135,8 @@ func (h *GroupedStatsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	}
 	if !ok {
 		common.WriteError(w, r, common.Operational(
-			http.StatusBadRequest, "UNKNOWN_MODEL",
-			"model not found for tenant",
+			http.StatusNotFound, common.ErrCodeModelNotFound,
+			"model not found",
 		))
 		return
 	}

--- a/internal/domain/entity/grouped_stats_handler_test.go
+++ b/internal/domain/entity/grouped_stats_handler_test.go
@@ -91,7 +91,7 @@ func TestGroupedStatsHandler_RejectsUnknownTopLevelField(t *testing.T) {
 	}
 }
 
-func TestGroupedStatsHandler_Returns400OnUnknownModel(t *testing.T) {
+func TestGroupedStatsHandler_Returns404OnUnknownModel(t *testing.T) {
 	resolver := func(_ *http.Request, _, _ string) (any, spi.ModelRef, bool, error) {
 		return nil, spi.ModelRef{}, false, nil
 	}
@@ -102,11 +102,11 @@ func TestGroupedStatsHandler_Returns400OnUnknownModel(t *testing.T) {
 	req.SetPathValue("modelVersion", "1")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("status %d, want 400 (body: %s)", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status %d, want 404 (body: %s)", rec.Code, rec.Body.String())
 	}
-	if got := decodeProblemErrorCode(t, rec.Body.Bytes()); got != "UNKNOWN_MODEL" {
-		t.Fatalf("errorCode=%s, want UNKNOWN_MODEL (body: %s)", got, rec.Body.String())
+	if got := decodeProblemErrorCode(t, rec.Body.Bytes()); got != "MODEL_NOT_FOUND" {
+		t.Fatalf("errorCode=%s, want MODEL_NOT_FOUND (body: %s)", got, rec.Body.String())
 	}
 }
 

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -974,6 +974,14 @@ func (h *Handler) ListEntities(ctx context.Context, entityName string, modelVers
 		ModelVersion: modelVersion,
 	}
 
+	modelStore, err := h.factory.ModelStore(ctx)
+	if err != nil {
+		return nil, common.Internal("failed to access model store", err)
+	}
+	if appErr := common.EnsureModelRegistered(ctx, modelStore, ref); appErr != nil {
+		return nil, appErr
+	}
+
 	var entities []*spi.Entity
 	if pointInTime != nil {
 		entities, err = entityStore.GetAllAsAt(ctx, ref, *pointInTime)

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -602,6 +602,14 @@ func (h *Handler) GetStatisticsForModel(ctx context.Context, entityName string, 
 		ModelVersion: modelVersion,
 	}
 
+	modelStore, err := h.factory.ModelStore(ctx)
+	if err != nil {
+		return nil, common.Internal("failed to access model store", err)
+	}
+	if appErr := common.EnsureModelRegistered(ctx, modelStore, ref); appErr != nil {
+		return nil, appErr
+	}
+
 	count, err := entityStore.Count(ctx, ref)
 	if err != nil {
 		return nil, common.Internal("failed to count entities", err)

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -564,6 +564,14 @@ func (h *Handler) GetStatisticsByStateForModel(ctx context.Context, entityName s
 		ModelVersion: modelVersion,
 	}
 
+	modelStore, err := h.factory.ModelStore(ctx)
+	if err != nil {
+		return nil, common.Internal("failed to access model store", err)
+	}
+	if appErr := common.EnsureModelRegistered(ctx, modelStore, ref); appErr != nil {
+		return nil, appErr
+	}
+
 	// Dereference the optional filter. Distinguish nil-pointer (no filter)
 	// from pointer-to-empty-slice — per the SPI contract, the latter yields
 	// an empty map without a storage call.

--- a/internal/domain/entity/service_test.go
+++ b/internal/domain/entity/service_test.go
@@ -280,6 +280,15 @@ func TestGetStatisticsByStateForModel_UsesCountByState(t *testing.T) {
 
 	mref := spi.ModelRef{EntityName: "model-m", ModelVersion: "1"}
 
+	// Register the model so the model-existence guard passes.
+	mstore, err := factory.ModelStore(ctx)
+	if err != nil {
+		t.Fatalf("ModelStore: %v", err)
+	}
+	if err := mstore.Save(ctx, &spi.ModelDescriptor{Ref: mref, State: spi.ModelLocked}); err != nil {
+		t.Fatalf("ModelStore.Save: %v", err)
+	}
+
 	es, err := factory.EntityStore(ctx)
 	if err != nil {
 		t.Fatalf("EntityStore: %v", err)

--- a/internal/domain/search/path_validate.go
+++ b/internal/domain/search/path_validate.go
@@ -125,10 +125,9 @@ func isPathKnown(p string, fields map[string]schema.FieldDescriptor) bool {
 // loadFieldsMap fetches and parses the cached schema for ref, returning
 // the path → FieldDescriptor view used by pre-execution validation.
 //
-// Returns (nil, nil) when the model has not been registered (the memory
-// plugin admits entity writes without a prior model, so search must
-// preserve that behaviour). Other errors propagate so the caller can
-// log and skip validation rather than mistakenly reject the search.
+// Returns (nil, nil) when the descriptor has no schema bound. Other errors
+// propagate so the caller can log and skip validation rather than
+// mistakenly reject the search.
 func loadFieldsMap(ctx context.Context, store spi.ModelStore, ref spi.ModelRef) (map[string]schema.FieldDescriptor, error) {
 	desc, err := store.Get(ctx, ref)
 	if err != nil {

--- a/internal/domain/search/path_validate_test.go
+++ b/internal/domain/search/path_validate_test.go
@@ -125,7 +125,8 @@ func TestSearch_StaleSchema_RefreshesOnceAndSucceeds(t *testing.T) {
 	stale := buildSearchDescriptor(t, ref, "a")
 	fresh := buildSearchDescriptor(t, ref, "a", "z")
 	ms := &refreshingModelStore{
-		getQueue:     []*spi.ModelDescriptor{stale},
+		// EnsureModelRegistered consumes the first Get; loadFieldsMap gets the second.
+		getQueue:     []*spi.ModelDescriptor{stale, stale},
 		refreshQueue: []*spi.ModelDescriptor{fresh},
 	}
 	factory := &modelStoreFactory{StoreFactory: base, modelStore: ms}
@@ -166,7 +167,8 @@ func TestSearch_TrulyMissingPath_FourxxAfterOneRefresh(t *testing.T) {
 	stale := buildSearchDescriptor(t, ref, "a")
 	stillStale := buildSearchDescriptor(t, ref, "a")
 	ms := &refreshingModelStore{
-		getQueue:     []*spi.ModelDescriptor{stale},
+		// EnsureModelRegistered consumes the first Get; loadFieldsMap gets the second.
+		getQueue:     []*spi.ModelDescriptor{stale, stale},
 		refreshQueue: []*spi.ModelDescriptor{stillStale},
 	}
 	factory := &modelStoreFactory{StoreFactory: base, modelStore: ms}

--- a/internal/domain/search/path_validate_test.go
+++ b/internal/domain/search/path_validate_test.go
@@ -54,12 +54,14 @@ func (s *refreshingModelStore) RefreshAndGet(_ context.Context, _ spi.ModelRef) 
 	return d, nil
 }
 
-func (s *refreshingModelStore) Save(context.Context, *spi.ModelDescriptor) error     { return nil }
-func (s *refreshingModelStore) GetAll(context.Context) ([]spi.ModelRef, error)       { return nil, nil }
-func (s *refreshingModelStore) Delete(context.Context, spi.ModelRef) error           { return nil }
-func (s *refreshingModelStore) Lock(context.Context, spi.ModelRef) error             { return nil }
-func (s *refreshingModelStore) Unlock(context.Context, spi.ModelRef) error           { return nil }
-func (s *refreshingModelStore) IsLocked(context.Context, spi.ModelRef) (bool, error) { return true, nil }
+func (s *refreshingModelStore) Save(context.Context, *spi.ModelDescriptor) error { return nil }
+func (s *refreshingModelStore) GetAll(context.Context) ([]spi.ModelRef, error)   { return nil, nil }
+func (s *refreshingModelStore) Delete(context.Context, spi.ModelRef) error       { return nil }
+func (s *refreshingModelStore) Lock(context.Context, spi.ModelRef) error         { return nil }
+func (s *refreshingModelStore) Unlock(context.Context, spi.ModelRef) error       { return nil }
+func (s *refreshingModelStore) IsLocked(context.Context, spi.ModelRef) (bool, error) {
+	return true, nil
+}
 func (s *refreshingModelStore) SetChangeLevel(context.Context, spi.ModelRef, spi.ChangeLevel) error {
 	return nil
 }

--- a/internal/domain/search/path_validation_cache_test.go
+++ b/internal/domain/search/path_validation_cache_test.go
@@ -55,10 +55,12 @@ var _ spi.ModelStore = (*countingModelStore)(nil)
 
 // TestSearch_NegativeCache_CollapsesSerialFloodForUnknownPath asserts that
 // a serial flood of validation requests for the same unknown field path
-// hits the inner ModelStore at most once for the initial Get and once for
-// the bounded RefreshAndGet. Without the negative cache every request
-// would fire its own Get + RefreshAndGet pair, amplifying client error
-// into a denial-of-service vector against the schema cache.
+// hits the path-validation inner store at most once for the initial Get and
+// once for the bounded RefreshAndGet. EnsureModelRegistered fires one Get
+// per Search call (it is not cached), so the total Get count is
+// reqCount+1. Without the negative cache every request would fire its own
+// Get+RefreshAndGet pair for path validation, amplifying client error into
+// a denial-of-service vector against the schema cache.
 func TestSearch_NegativeCache_CollapsesSerialFloodForUnknownPath(t *testing.T) {
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 	desc := buildSearchDescriptor(t, ref, "a")
@@ -90,8 +92,10 @@ func TestSearch_NegativeCache_CollapsesSerialFloodForUnknownPath(t *testing.T) {
 		}
 	}
 
-	if got := ms.getCount.Load(); got > 2 {
-		t.Errorf("inner Get count: want <=2 (cached negative), got %d", got)
+	// EnsureModelRegistered fires 1 Get per call; path validation fires 1 Get
+	// only on the first call (then the negative cache short-circuits it).
+	if got := ms.getCount.Load(); got > int64(reqCount)+1 {
+		t.Errorf("inner Get count: want <=%d (EnsureModelRegistered per call + 1 path-validation load), got %d", reqCount+1, got)
 	}
 	if got := ms.refreshCount.Load(); got > 1 {
 		t.Errorf("inner RefreshAndGet count: want <=1 (bounded), got %d", got)
@@ -141,12 +145,13 @@ func TestSearch_NegativeCache_InvalidatedOnSchemaChange(t *testing.T) {
 	getsBefore := ms.getCount.Load()
 	refreshesBefore := ms.refreshCount.Load()
 
-	// Second request hits the negative cache (no inner store calls).
+	// Second request: EnsureModelRegistered fires one Get, but path validation
+	// should hit the negative cache (no additional inner store calls).
 	if _, err := svc.Search(ctx, ref, cond, search.SearchOptions{}); err == nil {
 		t.Fatalf("expected error on second call")
 	}
-	if ms.getCount.Load() != getsBefore || ms.refreshCount.Load() != refreshesBefore {
-		t.Fatalf("expected no inner store calls between warmup and invalidation, got Δgets=%d Δrefreshes=%d",
+	if ms.getCount.Load() > getsBefore+1 || ms.refreshCount.Load() != refreshesBefore {
+		t.Fatalf("expected only EnsureModelRegistered's Get (no path-validation calls) between warmup and invalidation, got Δgets=%d Δrefreshes=%d",
 			ms.getCount.Load()-getsBefore, ms.refreshCount.Load()-refreshesBefore)
 	}
 

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -14,6 +14,7 @@ import (
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 	"github.com/cyoda-platform/cyoda-go/internal/common"
+	"github.com/cyoda-platform/cyoda-go/internal/domain/pagination"
 	"github.com/cyoda-platform/cyoda-go/internal/match"
 
 	"github.com/cyoda-platform/cyoda-go-spi/predicate"
@@ -118,6 +119,15 @@ func (s *SearchService) WithMaxSortKeys(n int) *SearchService {
 // authoritative read. Truly-unknown paths surface as 4xx BAD_REQUEST.
 // Unregistered models surface as 404 MODEL_NOT_FOUND.
 func (s *SearchService) Search(ctx context.Context, modelRef spi.ModelRef, cond predicate.Condition, opts SearchOptions) ([]*spi.Entity, error) {
+	// Defense-in-depth: enforce the limit cap at the service layer so every
+	// entry point (HTTP, gRPC, future transports) sees the same rejection.
+	// The HTTP handler checks this already; gRPC does not — placing the check
+	// here closes that gap without altering the unbounded (limit<0) semantics.
+	if opts.Limit > pagination.MaxPageSize {
+		return nil, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest,
+			fmt.Sprintf("limit exceeds maximum %d", pagination.MaxPageSize))
+	}
+
 	modelStore, err := s.factory.ModelStore(ctx)
 	if err != nil {
 		return nil, common.Internal("failed to access model store", err)

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -54,8 +54,13 @@ type SearchJobStatus struct {
 
 // SnapshotStatus is a transport-friendly summary of an async search job's state.
 type SnapshotStatus struct {
-	SnapshotID    string
-	Status        string // RUNNING, SUCCESSFUL, FAILED, CANCELLED, NOT_FOUND
+	SnapshotID string
+	// Status is one of: RUNNING, SUCCESSFUL, FAILED, CANCELLED, NOT_FOUND.
+	// NOT_FOUND is emitted by the commercial self-executing search store on
+	// snapshot-expiry races (documented in the getAsyncSearchStatus spec); it
+	// is intentionally retained in the contract — do NOT remove this value
+	// even though OSS backends never set it.
+	Status        string
 	EntitiesCount int
 }
 

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -228,6 +228,13 @@ func (s *SearchService) Search(ctx context.Context, modelRef spi.ModelRef, cond 
 // know about returns a 4xx without ever creating a job, sparing the
 // client a round-trip through the polling endpoint.
 func (s *SearchService) SubmitAsync(ctx context.Context, modelRef spi.ModelRef, cond predicate.Condition, opts SearchOptions) (string, error) {
+	// Defense-in-depth: same cap as Search so the async path also fails fast
+	// rather than creating a job that will fail in the background.
+	if opts.Limit > pagination.MaxPageSize {
+		return "", common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest,
+			fmt.Sprintf("limit exceeds maximum %d", pagination.MaxPageSize))
+	}
+
 	uc := spi.GetUserContext(ctx)
 	if uc == nil {
 		return "", fmt.Errorf("no user context — cannot determine tenant")

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -223,6 +223,14 @@ func (s *SearchService) SubmitAsync(ctx context.Context, modelRef spi.ModelRef, 
 		return "", fmt.Errorf("no user context — cannot determine tenant")
 	}
 
+	modelStore, err := s.factory.ModelStore(ctx)
+	if err != nil {
+		return "", common.Internal("failed to access model store", err)
+	}
+	if appErr := common.EnsureModelRegistered(ctx, modelStore, modelRef); appErr != nil {
+		return "", appErr
+	}
+
 	if vErr := s.validateConditionPaths(ctx, modelRef, cond); vErr != nil {
 		return "", vErr
 	}

--- a/internal/domain/search/service.go
+++ b/internal/domain/search/service.go
@@ -116,10 +116,16 @@ func (s *SearchService) WithMaxSortKeys(n int) *SearchService {
 // entity.Handler.ValidateWithRefresh's bounded-retry contract) so a
 // search referencing a peer's freshly-extended path succeeds after one
 // authoritative read. Truly-unknown paths surface as 4xx BAD_REQUEST.
-// Models that have never been registered are admitted unchanged —
-// pre-execution validation is best-effort and only applies once the
-// model exists. See issue #77.
+// Unregistered models surface as 404 MODEL_NOT_FOUND.
 func (s *SearchService) Search(ctx context.Context, modelRef spi.ModelRef, cond predicate.Condition, opts SearchOptions) ([]*spi.Entity, error) {
+	modelStore, err := s.factory.ModelStore(ctx)
+	if err != nil {
+		return nil, common.Internal("failed to access model store", err)
+	}
+	if appErr := common.EnsureModelRegistered(ctx, modelStore, modelRef); appErr != nil {
+		return nil, appErr
+	}
+
 	if vErr := s.validateConditionPaths(ctx, modelRef, cond); vErr != nil {
 		return nil, vErr
 	}
@@ -493,11 +499,9 @@ func (s *SearchService) CancelAsyncSearch(ctx context.Context, snapshotID string
 // a peer's freshly-extended path succeeds after one bounded refresh,
 // and a truly-unknown path surfaces as 4xx without a refresh loop.
 //
-// Returns nil when validation passes, when no data-field paths are
-// addressed (lifecycle-only conditions), or when the model has not been
-// registered (the memory plugin admits entity writes without a prior
-// model, and search must preserve that behaviour). Validator failures
-// surface as a 4xx common.AppError with the missing paths listed.
+// Returns nil when validation passes or when no data-field paths are
+// addressed (lifecycle-only conditions). Validator failures surface as a
+// 4xx common.AppError with the missing paths listed.
 func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi.ModelRef, cond predicate.Condition) error {
 	paths := extractFieldPaths(cond)
 	if len(paths) == 0 {
@@ -526,12 +530,9 @@ func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi
 
 	fields, err := loadFieldsMap(ctx, modelStore, modelRef)
 	if err != nil {
-		if errors.Is(err, spi.ErrNotFound) {
-			// Unregistered model — nothing to validate against.
-			return nil
-		}
-		// Decoding-the-schema failures are upstream: log and continue so
-		// search can still proceed via the matcher's own error path.
+		// Model existence is guaranteed by EnsureModelRegistered before we
+		// reach here; a schema-decode failure is upstream — log and proceed
+		// so the matcher's own error path can still surface a useful error.
 		slog.Debug("failed to load schema for pre-execution validation",
 			"pkg", "search",
 			"entityName", modelRef.EntityName,
@@ -540,8 +541,7 @@ func (s *SearchService) validateConditionPaths(ctx context.Context, modelRef spi
 		return nil
 	}
 	if fields == nil {
-		// Descriptor returned nil (no schema bound) — treat as
-		// unregistered and admit the search.
+		// Descriptor returned nil — no schema bound to validate against.
 		return nil
 	}
 

--- a/internal/domain/search/service_test.go
+++ b/internal/domain/search/service_test.go
@@ -1319,3 +1319,55 @@ func TestSearch_LimitExceedsMax(t *testing.T) {
 		}
 	})
 }
+
+// TestSubmitAsync_LimitExceedsMax mirrors TestSearch_LimitExceedsMax for the
+// async submit path: limit > MaxPageSize must be rejected synchronously (before
+// any job is created), unbounded (limit<0) and boundary (limit==MaxPageSize)
+// must be allowed.
+func TestSubmitAsync_LimitExceedsMax(t *testing.T) {
+	factory := memory.NewStoreFactory()
+	defer factory.Close()
+	uuids := common.NewTestUUIDGenerator()
+	searchStore, _ := factory.AsyncSearchStore(context.Background())
+	svc := search.NewSearchService(factory, uuids, searchStore)
+
+	ctx := tenantCtx("tenant-async-cap")
+	ref := spi.ModelRef{EntityName: "async-cap-model", ModelVersion: "1"}
+	saveMinimalModel(t, ctx, factory, ref)
+
+	cond := &predicate.GroupCondition{Operator: "AND", Conditions: []predicate.Condition{}}
+
+	t.Run("limit above max rejected synchronously", func(t *testing.T) {
+		jobID, err := svc.SubmitAsync(ctx, ref, cond, search.SearchOptions{Limit: 10001})
+		if err == nil {
+			t.Fatalf("expected error for limit=10001, got nil (jobID=%s)", jobID)
+		}
+		if jobID != "" {
+			t.Errorf("expected empty job ID on rejection, got %q", jobID)
+		}
+		var appErr *common.AppError
+		if !errors.As(err, &appErr) {
+			t.Fatalf("expected *common.AppError, got %T: %v", err, err)
+		}
+		if appErr.Status != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", appErr.Status)
+		}
+		if appErr.Code != common.ErrCodeBadRequest {
+			t.Errorf("code = %q, want %q", appErr.Code, common.ErrCodeBadRequest)
+		}
+	})
+
+	t.Run("limit at max accepted", func(t *testing.T) {
+		_, err := svc.SubmitAsync(ctx, ref, cond, search.SearchOptions{Limit: 10000})
+		if err != nil {
+			t.Fatalf("expected success for limit=10000, got: %v", err)
+		}
+	})
+
+	t.Run("unbounded limit (negative) accepted", func(t *testing.T) {
+		_, err := svc.SubmitAsync(ctx, ref, cond, search.SearchOptions{Limit: -1})
+		if err != nil {
+			t.Fatalf("expected success for unbounded limit=-1, got: %v", err)
+		}
+	})
+}

--- a/internal/domain/search/service_test.go
+++ b/internal/domain/search/service_test.go
@@ -1271,3 +1271,51 @@ func TestAsyncSuccessfulWhenNotCancelled(t *testing.T) {
 		t.Fatalf("expected SUCCESSFUL, got %s", status.Status)
 	}
 }
+
+// TestSearch_LimitExceedsMax verifies the service-layer defense-in-depth cap:
+// limit > MaxPageSize is rejected with a 400 BAD_REQUEST AppError before any
+// store access, and the unbounded case (limit < 0) is NOT rejected.
+func TestSearch_LimitExceedsMax(t *testing.T) {
+	factory := memory.NewStoreFactory()
+	defer factory.Close()
+	uuids := common.NewTestUUIDGenerator()
+	searchStore, _ := factory.AsyncSearchStore(context.Background())
+	svc := search.NewSearchService(factory, uuids, searchStore)
+
+	ctx := tenantCtx("tenant-cap")
+	ref := spi.ModelRef{EntityName: "cap-model", ModelVersion: "1"}
+	saveMinimalModel(t, ctx, factory, ref)
+
+	cond := &predicate.GroupCondition{Operator: "AND", Conditions: []predicate.Condition{}}
+
+	t.Run("limit above max rejected", func(t *testing.T) {
+		_, err := svc.Search(ctx, ref, cond, search.SearchOptions{Limit: 10001})
+		if err == nil {
+			t.Fatal("expected error for limit=10001, got nil")
+		}
+		var appErr *common.AppError
+		if !errors.As(err, &appErr) {
+			t.Fatalf("expected *common.AppError, got %T: %v", err, err)
+		}
+		if appErr.Status != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", appErr.Status)
+		}
+		if appErr.Code != common.ErrCodeBadRequest {
+			t.Errorf("code = %q, want %q", appErr.Code, common.ErrCodeBadRequest)
+		}
+	})
+
+	t.Run("limit at max accepted", func(t *testing.T) {
+		_, err := svc.Search(ctx, ref, cond, search.SearchOptions{Limit: 10000})
+		if err != nil {
+			t.Fatalf("expected success for limit=10000, got: %v", err)
+		}
+	})
+
+	t.Run("unbounded limit (negative) accepted", func(t *testing.T) {
+		_, err := svc.Search(ctx, ref, cond, search.SearchOptions{Limit: -1})
+		if err != nil {
+			t.Fatalf("expected success for unbounded limit=-1, got: %v", err)
+		}
+	})
+}

--- a/internal/domain/search/service_test.go
+++ b/internal/domain/search/service_test.go
@@ -313,6 +313,7 @@ func TestAsyncCancel(t *testing.T) {
 
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+	saveMinimalModel(t, ctx, factory, ref)
 
 	// Create many entities to increase chance the goroutine is still running
 	for i := 0; i < 100; i++ {
@@ -370,6 +371,7 @@ func TestAsyncTenantIsolation(t *testing.T) {
 	ctxA := tenantCtx("tenant-A")
 	ctxB := tenantCtx("tenant-B")
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+	saveMinimalModel(t, ctxA, factory, ref)
 
 	saveEntity(t, ctxA, factory, ref, "e1", []byte(`{"name":"Alice"}`))
 
@@ -421,6 +423,7 @@ func TestSubmitAsyncPopulatesSearchOpts(t *testing.T) {
 
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+	saveMinimalModel(t, ctx, factory, ref)
 
 	saveEntity(t, ctx, factory, ref, "e1", []byte(`{"name":"Alice"}`))
 
@@ -602,6 +605,7 @@ func TestSubmitAsync_SelfExecutingStore_SkipsGoroutine(t *testing.T) {
 
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "Order", ModelVersion: "1"}
+	saveMinimalModel(t, ctx, factory, ref)
 	cond := &predicate.SimpleCondition{
 		JsonPath:     "$.x",
 		OperatorType: "EQUALS",
@@ -1136,6 +1140,7 @@ func TestSubmitAsync_SortKeyCap_ReturnsError(t *testing.T) {
 
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "item", ModelVersion: "1"}
+	saveMinimalModel(t, ctx, factory, ref)
 
 	orderBy := []search.OrderKey{
 		{Path: "a", Source: spi.SourceData},

--- a/internal/domain/search/service_test.go
+++ b/internal/domain/search/service_test.go
@@ -30,6 +30,18 @@ func tenantCtx(tenantID string) context.Context {
 	})
 }
 
+// helper: register a minimal model descriptor so EnsureModelRegistered passes.
+func saveMinimalModel(t *testing.T, ctx context.Context, factory *memory.StoreFactory, ref spi.ModelRef) {
+	t.Helper()
+	ms, err := factory.ModelStore(ctx)
+	if err != nil {
+		t.Fatalf("ModelStore: %v", err)
+	}
+	if err := ms.Save(ctx, &spi.ModelDescriptor{Ref: ref}); err != nil {
+		t.Fatalf("Save model: %v", err)
+	}
+}
+
 // helper: save an entity with JSON data, return its ID.
 func saveEntity(t *testing.T, ctx context.Context, factory *memory.StoreFactory, modelRef spi.ModelRef, id string, data []byte) {
 	t.Helper()
@@ -60,6 +72,7 @@ func TestDirectSearchSimpleEquals(t *testing.T) {
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 
+	saveMinimalModel(t, ctx, factory, ref)
 	saveEntity(t, ctx, factory, ref, "e1", []byte(`{"name":"Alice","age":30}`))
 	saveEntity(t, ctx, factory, ref, "e2", []byte(`{"name":"Bob","age":25}`))
 	saveEntity(t, ctx, factory, ref, "e3", []byte(`{"name":"Alice","age":40}`))
@@ -95,6 +108,7 @@ func TestDirectSearchNoMatches(t *testing.T) {
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 
+	saveMinimalModel(t, ctx, factory, ref)
 	saveEntity(t, ctx, factory, ref, "e1", []byte(`{"name":"Alice"}`))
 
 	cond := &predicate.SimpleCondition{
@@ -122,6 +136,7 @@ func TestDirectSearchPointInTime(t *testing.T) {
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 
+	saveMinimalModel(t, ctx, factory, ref)
 	// Save original
 	saveEntity(t, ctx, factory, ref, "e1", []byte(`{"name":"Alice"}`))
 
@@ -183,6 +198,7 @@ func TestDirectSearchPagination(t *testing.T) {
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "item", ModelVersion: "1"}
 
+	saveMinimalModel(t, ctx, factory, ref)
 	for i := 0; i < 5; i++ {
 		saveEntity(t, ctx, factory, ref,
 			fmt.Sprintf("e%d", i),
@@ -235,6 +251,7 @@ func TestAsyncLifecycle(t *testing.T) {
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 
+	saveMinimalModel(t, ctx, factory, ref)
 	saveEntity(t, ctx, factory, ref, "e1", []byte(`{"name":"Alice"}`))
 	saveEntity(t, ctx, factory, ref, "e2", []byte(`{"name":"Bob"}`))
 
@@ -471,6 +488,10 @@ func TestCancelRaceDoesNotOverwriteCancelled(t *testing.T) {
 	uuids := common.NewTestUUIDGenerator()
 	realStore, _ := factory.AsyncSearchStore(context.Background())
 
+	ctx := tenantCtx("tenant-1")
+	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
+	saveMinimalModel(t, ctx, factory, ref)
+
 	gate := make(chan struct{})
 	blockedStore := &blockingSearchStore{
 		AsyncSearchStore: realStore,
@@ -478,9 +499,6 @@ func TestCancelRaceDoesNotOverwriteCancelled(t *testing.T) {
 	}
 
 	svc := search.NewSearchService(factory, uuids, blockedStore)
-
-	ctx := tenantCtx("tenant-1")
-	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 
 	saveEntity(t, ctx, factory, ref, "e1", []byte(`{"name":"Alice"}`))
 
@@ -647,6 +665,7 @@ func TestSearchDelegatesToSearcher(t *testing.T) {
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 
+	saveMinimalModel(t, ctx, base, ref)
 	// Save entities to the real store for fallback verification.
 	saveEntity(t, ctx, base, ref, "e1", []byte(`{"name":"Alice"}`))
 
@@ -699,6 +718,7 @@ func TestSearchFallsBackWhenNotSearcher(t *testing.T) {
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 
+	saveMinimalModel(t, ctx, factory, ref)
 	saveEntity(t, ctx, factory, ref, "e1", []byte(`{"name":"Alice"}`))
 
 	cond := &predicate.SimpleCondition{
@@ -723,6 +743,7 @@ func TestSearchFallsBackWhenInTransaction(t *testing.T) {
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 
+	saveMinimalModel(t, ctx, base, ref)
 	saveEntity(t, ctx, base, ref, "e1", []byte(`{"name":"Alice"}`))
 
 	realStore, _ := base.EntityStore(ctx)
@@ -802,8 +823,9 @@ func TestSearch_SortByDataField_PushesOrderSpecToSearcher(t *testing.T) {
 	// Model declares "surname" as a String field.
 	desc := buildSearchDescriptor(t, ref, "surname")
 	ms := &refreshingModelStore{
-		// validateConditionPaths (for $.surname) + resolveSortKeys each call Get once.
-		getQueue: []*spi.ModelDescriptor{desc, desc},
+		// EnsureModelRegistered + validateConditionPaths (for $.surname) + resolveSortKeys
+		// each call Get once.
+		getQueue: []*spi.ModelDescriptor{desc, desc, desc},
 	}
 
 	var capturedOpts spi.SearchOptions
@@ -1060,8 +1082,8 @@ func TestSubmitAsync_OrderBy_PersistsTypedSpecs(t *testing.T) {
 
 // TestSearch_SortKeyCap_ReturnsError verifies that Search returns a 400
 // INVALID_FIELD_PATH AppError when the number of sort keys exceeds the
-// configured cap. The cap check must fire before the model store is
-// consulted so the model need not be registered.
+// configured cap. The cap check fires inside resolveSortKeys, before the
+// model schema is consulted for sort-key typing.
 func TestSearch_SortKeyCap_ReturnsError(t *testing.T) {
 	factory := memory.NewStoreFactory()
 	defer factory.Close()
@@ -1072,6 +1094,7 @@ func TestSearch_SortKeyCap_ReturnsError(t *testing.T) {
 
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "item", ModelVersion: "1"}
+	saveMinimalModel(t, ctx, factory, ref)
 
 	orderBy := []search.OrderKey{
 		{Path: "a", Source: spi.SourceData},
@@ -1212,6 +1235,7 @@ func TestAsyncSuccessfulWhenNotCancelled(t *testing.T) {
 	ctx := tenantCtx("tenant-1")
 	ref := spi.ModelRef{EntityName: "person", ModelVersion: "1"}
 
+	saveMinimalModel(t, ctx, factory, ref)
 	saveEntity(t, ctx, factory, ref, "e1", []byte(`{"name":"Alice"}`))
 
 	cond := &predicate.SimpleCondition{

--- a/internal/e2e/audit_finished_event_test.go
+++ b/internal/e2e/audit_finished_event_test.go
@@ -1,0 +1,24 @@
+package e2e_test
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestGetStateMachineFinishedEvent_NonV1UUID_NotRejected is a proving test:
+// it asserts that a well-formed non-v1 (v4) UUID in entityId/transactionId
+// is NOT rejected with 400. The spec previously claimed both IDs "must be a
+// valid time-based UUID (version 1)" and documented a 400 for that check, but
+// the handler performs no version check. This test guards that the fictional
+// 400 stays absent.
+func TestGetStateMachineFinishedEvent_NonV1UUID_NotRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+	// v4 UUIDs — not time-based (version 1).
+	resp := doAuth(t, http.MethodGet, "/api/audit/entity/00000000-0000-4000-8000-000000000000/workflow/00000000-0000-4000-8000-000000000001/finished", "")
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusBadRequest {
+		t.Fatalf("non-v1 UUID rejected with 400; want 404/200 (handler does no version check)")
+	}
+}

--- a/internal/e2e/entity_list_unknown_model_test.go
+++ b/internal/e2e/entity_list_unknown_model_test.go
@@ -1,0 +1,22 @@
+package e2e_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common/commontest"
+	"github.com/google/uuid"
+)
+
+// TestGetAllEntities_UnknownModel_404 asserts that GET /api/entity/{model}/{version}
+// returns 404 MODEL_NOT_FOUND when the model has never been registered.
+func TestGetAllEntities_UnknownModel_404(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+	resp := doAuth(t, http.MethodGet, "/api/entity/never-registered-"+uuid.NewString()+"/1", "")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
+}

--- a/internal/e2e/entity_stats_unknown_model_test.go
+++ b/internal/e2e/entity_stats_unknown_model_test.go
@@ -20,3 +20,17 @@ func TestGetStatisticsForModel_UnknownModel_404(t *testing.T) {
 	}
 	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
 }
+
+// TestGetStatisticsByStateForModel_UnknownModel_404 asserts that
+// GET /api/entity/stats/states/{model}/{version} returns 404 MODEL_NOT_FOUND
+// when the model has never been registered.
+func TestGetStatisticsByStateForModel_UnknownModel_404(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+	resp := doAuth(t, http.MethodGet, "/api/entity/stats/states/never-registered-"+uuid.NewString()+"/1", "")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
+}

--- a/internal/e2e/entity_stats_unknown_model_test.go
+++ b/internal/e2e/entity_stats_unknown_model_test.go
@@ -1,0 +1,22 @@
+package e2e_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common/commontest"
+	"github.com/google/uuid"
+)
+
+// TestGetStatisticsForModel_UnknownModel_404 asserts that GET /api/entity/stats/{model}/{version}
+// returns 404 MODEL_NOT_FOUND when the model has never been registered.
+func TestGetStatisticsForModel_UnknownModel_404(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+	resp := doAuth(t, http.MethodGet, "/api/entity/stats/never-registered-"+uuid.NewString()+"/1", "")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
+}

--- a/internal/e2e/grouped_stats_test.go
+++ b/internal/e2e/grouped_stats_test.go
@@ -16,6 +16,9 @@ import (
 	"math"
 	"net/http"
 	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common/commontest"
+	"github.com/google/uuid"
 )
 
 // statsWorkflowJSON is the same canonical workflow used by the search tests:
@@ -211,6 +214,21 @@ func TestGroupedStats_E2E_Aggregations(t *testing.T) {
 		t.Errorf("stdev s: got %.17g, want %.17g (rel diff %.3e)",
 			gotStdev, wantStdev, math.Abs(gotStdev-wantStdev)/wantStdev)
 	}
+}
+
+// TestGroupedStats_UnknownModel_404 asserts that a grouped-stats query for a
+// model that was never registered returns 404 MODEL_NOT_FOUND.
+func TestGroupedStats_UnknownModel_404(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+	model := "never-registered-" + uuid.NewString()
+	path := fmt.Sprintf("/api/entity/stats/%s/1/query", model)
+	resp := doAuth(t, http.MethodPost, path, `{"groupBy":["state"]}`)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
 }
 
 // TestGroupedStats_E2E_ValidationError verifies the validation-error wire

--- a/internal/e2e/search_content_type_test.go
+++ b/internal/e2e/search_content_type_test.go
@@ -1,0 +1,53 @@
+package e2e_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// TestSearchEntities_ContentTypeIsNdjson verifies that a valid synchronous
+// entity search returns Content-Type: application/x-ndjson. The spec now
+// documents x-ndjson as the only response content type for the 200 case;
+// this test pins that server behaviour before the spec edit so regressions
+// are caught immediately.
+func TestSearchEntities_ContentTypeIsNdjson(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+	const model = "e2e-ct-ndjson"
+	setupSearchModel(t, model)
+
+	path := fmt.Sprintf("/api/search/direct/%s/1", model)
+	resp := doAuth(t, http.MethodPost, path, `{"type":"group","operator":"AND","conditions":[]}`)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body := readBody(t, resp)
+		t.Fatalf("expected 200, got %d; body: %s", resp.StatusCode, body)
+	}
+	ct := resp.Header.Get("Content-Type")
+	if ct != "application/x-ndjson" {
+		t.Errorf("Content-Type = %q, want application/x-ndjson", ct)
+	}
+}
+
+// TestSearchEntities_LimitOver10000_Returns400 verifies that a synchronous
+// entity search with limit > MaxPageSize (10000) is rejected with HTTP 400.
+// The spec documents this as an explicit rejection (not silent clamping).
+func TestSearchEntities_LimitOver10000_Returns400(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+	const model = "e2e-ct-limit"
+	setupSearchModel(t, model)
+
+	path := fmt.Sprintf("/api/search/direct/%s/1?limit=10001", model)
+	resp := doAuth(t, http.MethodPost, path, `{"type":"group","operator":"AND","conditions":[]}`)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		body := readBody(t, resp)
+		t.Fatalf("expected 400, got %d; body: %s", resp.StatusCode, body)
+	}
+}

--- a/internal/e2e/search_unknown_model_test.go
+++ b/internal/e2e/search_unknown_model_test.go
@@ -22,3 +22,18 @@ func TestSearchEntities_UnknownModel_404(t *testing.T) {
 	}
 	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
 }
+
+// TestSubmitAsyncSearchJob_UnknownModel_404 asserts that POST /api/search/async/{model}/{version}
+// returns 404 MODEL_NOT_FOUND immediately at submit time when the model has never been registered.
+func TestSubmitAsyncSearchJob_UnknownModel_404(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+	model := "never-registered-" + uuid.NewString()
+	resp := doAuth(t, http.MethodPost, "/api/search/async/"+model+"/1",
+		`{"type":"group","operator":"AND","conditions":[]}`)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
+}

--- a/internal/e2e/search_unknown_model_test.go
+++ b/internal/e2e/search_unknown_model_test.go
@@ -1,0 +1,24 @@
+package e2e_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/internal/common/commontest"
+	"github.com/google/uuid"
+)
+
+// TestSearchEntities_UnknownModel_404 asserts that POST /api/search/direct/{model}/{version}
+// returns 404 MODEL_NOT_FOUND when the model has never been registered.
+func TestSearchEntities_UnknownModel_404(t *testing.T) {
+	if testing.Short() {
+		t.Skip("e2e: requires Docker + PostgreSQL")
+	}
+	model := "never-registered-" + uuid.NewString()
+	resp := doAuth(t, http.MethodPost, "/api/search/direct/"+model+"/1",
+		`{"type":"group","operator":"AND","conditions":[]}`)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	commontest.ExpectErrorCode(t, resp, "MODEL_NOT_FOUND")
+}

--- a/internal/e2e/zzz_errorcode_matrix_test.go
+++ b/internal/e2e/zzz_errorcode_matrix_test.go
@@ -36,7 +36,7 @@ var EntityErrorCodeMatrix = map[string][]codeCell{
 		{Status: 400, Code: "INVALID_CONDITION"},
 		{Status: 404, Code: "MODEL_NOT_FOUND"},
 	},
-		// Stats / list / search ops (stats-audit-search slice, §7). Three read ops
+	// Stats / list / search ops (stats-audit-search slice, §7). Three read ops
 	// have a bounded, bidirectionally-checkable error surface — only
 	// 404 MODEL_NOT_FOUND in the current suite — and are tracked as full keys:
 	//   {getAllEntities, getEntityStatisticsForModel, getEntityStatisticsByStateForModel}.

--- a/internal/e2e/zzz_errorcode_matrix_test.go
+++ b/internal/e2e/zzz_errorcode_matrix_test.go
@@ -36,6 +36,31 @@ var EntityErrorCodeMatrix = map[string][]codeCell{
 		{Status: 400, Code: "INVALID_CONDITION"},
 		{Status: 404, Code: "MODEL_NOT_FOUND"},
 	},
+		// Stats / list / search ops (stats-audit-search slice, §7). Three read ops
+	// have a bounded, bidirectionally-checkable error surface — only
+	// 404 MODEL_NOT_FOUND in the current suite — and are tracked as full keys:
+	//   {getAllEntities, getEntityStatisticsForModel, getEntityStatisticsByStateForModel}.
+	// Three further ops are deliberately NOT matrix keys because their full error
+	// surface is large or partially out of scope for this slice:
+	//   searchEntities: 404 MODEL_NOT_FOUND proven by TestSearchEntities_UnknownModel_404
+	//     (search_unknown_model_test.go); 400 INVALID_FIELD_PATH has 8+ sub-cases
+	//     (condition + sort variants); full surface out of scope.
+	//   submitAsyncSearchJob: 404 MODEL_NOT_FOUND proven by
+	//     TestSubmitAsyncSearchJob_UnknownModel_404; same INVALID_FIELD_PATH family;
+	//     full surface out of scope.
+	//   queryGroupedEntityStatisticsForModel: 404 MODEL_NOT_FOUND proven by
+	//     TestGroupedStats_UnknownModel_404 (grouped_stats_test.go); full surface
+	//     (MISSING_GROUP_BY, GROUP_CARDINALITY_EXCEEDED, NOT_IMPLEMENTED_BY_BACKEND)
+	//     out of scope for this slice.
+	"getAllEntities": {
+		{Status: 404, Code: "MODEL_NOT_FOUND"}, // TestGetAllEntities_UnknownModel_404
+	},
+	"getEntityStatisticsForModel": {
+		{Status: 404, Code: "MODEL_NOT_FOUND"}, // TestGetStatisticsForModel_UnknownModel_404
+	},
+	"getEntityStatisticsByStateForModel": {
+		{Status: 404, Code: "MODEL_NOT_FOUND"}, // TestGetStatisticsByStateForModel_UnknownModel_404
+	},
 	// Entity write operations (E5). The matrix tracks the ops with a bounded,
 	// bidirectionally-checkable error surface:
 	//   {getOneEntity, deleteEntities, create, createCollection, updateSingle,

--- a/internal/grpc/search_test.go
+++ b/internal/grpc/search_test.go
@@ -8,6 +8,39 @@ import (
 	events "github.com/cyoda-platform/cyoda-go/api/grpc/events"
 )
 
+// TestEntityStatsByStateGet_UnknownModel_ModelNotFound verifies that
+// EntityStatsByStateGetRequest for an unregistered model returns a CLIENT_ERROR
+// envelope response with MODEL_NOT_FOUND in the message, not a zero-count success.
+func TestEntityStatsByStateGet_UnknownModel_ModelNotFound(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+
+	ce := makeCE(EntityStatsByStateGetRequest, map[string]any{
+		"id":    "stats-state-unknown",
+		"model": map[string]any{"name": "does-not-exist", "version": 1},
+	})
+	stream := &mockEntityStream{ctx: ctx}
+	if err := svc.EntitySearchCollection(ce, stream); err != nil {
+		t.Fatalf("unexpected stream-level error (errors should be envelope responses): %v", err)
+	}
+	if len(stream.sent) == 0 {
+		t.Fatal("expected an error response on the stream, got empty stream")
+	}
+	var typed events.EntityStatsByStateResponseJson
+	validateResponse(t, stream.sent[0], &typed)
+	if typed.Success {
+		t.Fatal("expected success=false for unknown model")
+	}
+	if typed.Error == nil {
+		t.Fatal("expected error block in response")
+	}
+	if typed.Error.Code != "CLIENT_ERROR" {
+		t.Errorf("expected code=CLIENT_ERROR, got %q", typed.Error.Code)
+	}
+	if !strings.Contains(typed.Error.Message, "MODEL_NOT_FOUND") {
+		t.Errorf("expected MODEL_NOT_FOUND in message, got %q", typed.Error.Message)
+	}
+}
+
 // TestEntityStatsGet_UnknownModel_ModelNotFound verifies that EntityStatsGetRequest
 // for an unregistered model returns a CLIENT_ERROR envelope response with
 // MODEL_NOT_FOUND in the message, not a zero-count success.

--- a/internal/grpc/search_test.go
+++ b/internal/grpc/search_test.go
@@ -8,6 +8,39 @@ import (
 	events "github.com/cyoda-platform/cyoda-go/api/grpc/events"
 )
 
+// TestEntityGetAll_UnknownModel_ModelNotFound verifies that EntityGetAllRequest
+// for an unregistered model returns a CLIENT_ERROR envelope response with
+// MODEL_NOT_FOUND in the message, not an empty stream.
+func TestEntityGetAll_UnknownModel_ModelNotFound(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+
+	ce := makeCE(EntityGetAllRequest, map[string]any{
+		"id":    "getall-unknown",
+		"model": map[string]any{"name": "does-not-exist", "version": 1},
+	})
+	stream := &mockEntityStream{ctx: ctx}
+	if err := svc.EntitySearchCollection(ce, stream); err != nil {
+		t.Fatalf("unexpected stream-level error (errors should be envelope responses): %v", err)
+	}
+	if len(stream.sent) == 0 {
+		t.Fatal("expected an error response on the stream, got empty stream")
+	}
+	var typed events.EntityResponseJson
+	validateResponse(t, stream.sent[0], &typed)
+	if typed.Success {
+		t.Fatal("expected success=false for unknown model")
+	}
+	if typed.Error == nil {
+		t.Fatal("expected error block in response")
+	}
+	if typed.Error.Code != "CLIENT_ERROR" {
+		t.Errorf("expected code=CLIENT_ERROR, got %q", typed.Error.Code)
+	}
+	if !strings.Contains(typed.Error.Message, "MODEL_NOT_FOUND") {
+		t.Errorf("expected MODEL_NOT_FOUND in message, got %q", typed.Error.Message)
+	}
+}
+
 // TestEntitySearch_DirectSearch_OrderBy_SourceMeta verifies that a direct search
 // with source:"meta" on the canonical meta field "creationDate" succeeds,
 // exercising the SourceMeta mapping branch in handleDirectSearchRequest.

--- a/internal/grpc/search_test.go
+++ b/internal/grpc/search_test.go
@@ -547,6 +547,47 @@ func TestEntitySearch_SnapshotSearch_UnknownModel_ModelNotFound(t *testing.T) {
 	}
 }
 
+// TestEntitySearch_DirectSearch_LimitExceedsMax verifies that a direct search
+// with limit > 10000 (MaxPageSize) is rejected by the service layer and
+// surfaces as CLIENT_ERROR in the gRPC envelope. This closes the HTTP/gRPC
+// parity gap: the HTTP handler already rejects oversized limits; the service
+// cap ensures gRPC inherits the same constraint.
+func TestEntitySearch_DirectSearch_LimitExceedsMax(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+	importAndLockModel(t, svc, ctx, "caplimit", "1", map[string]any{"val": "x"})
+
+	overLimit := 10001
+	ce := makeCE(EntitySearchRequest, map[string]any{
+		"id":    "s-caplimit-1",
+		"model": map[string]any{"name": "caplimit", "version": 1},
+		"condition": map[string]any{
+			"type": "group", "operator": "AND", "conditions": []any{},
+		},
+		"limit": overLimit,
+	})
+	stream := &mockEntityStream{ctx: ctx}
+	if err := svc.EntitySearchCollection(ce, stream); err != nil {
+		t.Fatalf("unexpected stream-level error (errors should be envelope responses): %v", err)
+	}
+	if len(stream.sent) == 0 {
+		t.Fatal("expected an error response on the stream, got empty stream")
+	}
+	var typed events.EntityResponseJson
+	validateResponse(t, stream.sent[0], &typed)
+	if typed.Success {
+		t.Fatal("expected success=false for limit exceeding max")
+	}
+	if typed.Error == nil {
+		t.Fatal("expected error block in response")
+	}
+	if typed.Error.Code != "CLIENT_ERROR" {
+		t.Errorf("expected code=CLIENT_ERROR, got %q", typed.Error.Code)
+	}
+	if !strings.Contains(typed.Error.Message, "BAD_REQUEST") {
+		t.Errorf("expected BAD_REQUEST in message, got %q", typed.Error.Message)
+	}
+}
+
 // TestEntitySearch_SnapshotSearch_OrderBy_InvalidField verifies that an async
 // snapshot search with an unknown sort path is rejected synchronously at submit,
 // surfaces CLIENT_ERROR / INVALID_FIELD_PATH, and issues no snapshot ID.

--- a/internal/grpc/search_test.go
+++ b/internal/grpc/search_test.go
@@ -472,6 +472,43 @@ func TestEntitySearch_SnapshotSearch_OrderBy_ExceedsCap(t *testing.T) {
 	}
 }
 
+// TestEntitySearch_DirectSearch_UnknownModel_ModelNotFound verifies that
+// EntitySearchRequest for an unregistered model returns a CLIENT_ERROR
+// envelope response with MODEL_NOT_FOUND in the message, not an empty
+// stream.
+func TestEntitySearch_DirectSearch_UnknownModel_ModelNotFound(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+
+	ce := makeCE(EntitySearchRequest, map[string]any{
+		"id":    "search-unknown",
+		"model": map[string]any{"name": "does-not-exist", "version": 1},
+		"condition": map[string]any{
+			"type": "group", "operator": "AND", "conditions": []any{},
+		},
+	})
+	stream := &mockEntityStream{ctx: ctx}
+	if err := svc.EntitySearchCollection(ce, stream); err != nil {
+		t.Fatalf("unexpected stream-level error (errors should be envelope responses): %v", err)
+	}
+	if len(stream.sent) == 0 {
+		t.Fatal("expected an error response on the stream, got empty stream")
+	}
+	var typed events.EntityResponseJson
+	validateResponse(t, stream.sent[0], &typed)
+	if typed.Success {
+		t.Fatal("expected success=false for unknown model")
+	}
+	if typed.Error == nil {
+		t.Fatal("expected error block in response")
+	}
+	if typed.Error.Code != "CLIENT_ERROR" {
+		t.Errorf("expected code=CLIENT_ERROR, got %q", typed.Error.Code)
+	}
+	if !strings.Contains(typed.Error.Message, "MODEL_NOT_FOUND") {
+		t.Errorf("expected MODEL_NOT_FOUND in message, got %q", typed.Error.Message)
+	}
+}
+
 // TestEntitySearch_SnapshotSearch_OrderBy_InvalidField verifies that an async
 // snapshot search with an unknown sort path is rejected synchronously at submit,
 // surfaces CLIENT_ERROR / INVALID_FIELD_PATH, and issues no snapshot ID.

--- a/internal/grpc/search_test.go
+++ b/internal/grpc/search_test.go
@@ -8,6 +8,39 @@ import (
 	events "github.com/cyoda-platform/cyoda-go/api/grpc/events"
 )
 
+// TestEntityStatsGet_UnknownModel_ModelNotFound verifies that EntityStatsGetRequest
+// for an unregistered model returns a CLIENT_ERROR envelope response with
+// MODEL_NOT_FOUND in the message, not a zero-count success.
+func TestEntityStatsGet_UnknownModel_ModelNotFound(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+
+	ce := makeCE(EntityStatsGetRequest, map[string]any{
+		"id":    "stats-unknown",
+		"model": map[string]any{"name": "does-not-exist", "version": 1},
+	})
+	stream := &mockEntityStream{ctx: ctx}
+	if err := svc.EntitySearchCollection(ce, stream); err != nil {
+		t.Fatalf("unexpected stream-level error (errors should be envelope responses): %v", err)
+	}
+	if len(stream.sent) == 0 {
+		t.Fatal("expected an error response on the stream, got empty stream")
+	}
+	var typed events.EntityStatsResponseJson
+	validateResponse(t, stream.sent[0], &typed)
+	if typed.Success {
+		t.Fatal("expected success=false for unknown model")
+	}
+	if typed.Error == nil {
+		t.Fatal("expected error block in response")
+	}
+	if typed.Error.Code != "CLIENT_ERROR" {
+		t.Errorf("expected code=CLIENT_ERROR, got %q", typed.Error.Code)
+	}
+	if !strings.Contains(typed.Error.Message, "MODEL_NOT_FOUND") {
+		t.Errorf("expected MODEL_NOT_FOUND in message, got %q", typed.Error.Message)
+	}
+}
+
 // TestEntityGetAll_UnknownModel_ModelNotFound verifies that EntityGetAllRequest
 // for an unregistered model returns a CLIENT_ERROR envelope response with
 // MODEL_NOT_FOUND in the message, not an empty stream.

--- a/internal/grpc/search_test.go
+++ b/internal/grpc/search_test.go
@@ -509,6 +509,44 @@ func TestEntitySearch_DirectSearch_UnknownModel_ModelNotFound(t *testing.T) {
 	}
 }
 
+// TestEntitySearch_SnapshotSearch_UnknownModel_ModelNotFound verifies that
+// EntitySnapshotSearchRequest for an unregistered model returns a CLIENT_ERROR
+// envelope response with MODEL_NOT_FOUND in the message at submit time,
+// and issues no snapshot ID.
+func TestEntitySearch_SnapshotSearch_UnknownModel_ModelNotFound(t *testing.T) {
+	svc, ctx := newTestEnv(t)
+
+	ce := makeCE(EntitySnapshotSearchRequest, map[string]any{
+		"id":    "snap-unknown",
+		"model": map[string]any{"name": "does-not-exist", "version": 1},
+		"condition": map[string]any{
+			"type": "group", "operator": "AND", "conditions": []any{},
+		},
+	})
+	resp, err := svc.EntitySearch(ctx, ce)
+	if err != nil {
+		t.Fatalf("unexpected transport error (errors should be envelope responses): %v", err)
+	}
+	var typed events.EntitySnapshotSearchResponseJson
+	validateResponse(t, resp, &typed)
+	if typed.Success {
+		t.Fatal("expected success=false for unknown model")
+	}
+	if typed.Error == nil {
+		t.Fatal("expected error block in response")
+	}
+	if typed.Error.Code != "CLIENT_ERROR" {
+		t.Errorf("expected code=CLIENT_ERROR, got %q", typed.Error.Code)
+	}
+	if !strings.Contains(typed.Error.Message, "MODEL_NOT_FOUND") {
+		t.Errorf("expected MODEL_NOT_FOUND in message, got %q", typed.Error.Message)
+	}
+	// No snapshot ID must be issued when submit fails.
+	if typed.Status.SnapshotID != nilUUID {
+		t.Errorf("expected nilUUID for failed submit, got %q", typed.Status.SnapshotID)
+	}
+}
+
 // TestEntitySearch_SnapshotSearch_OrderBy_InvalidField verifies that an async
 // snapshot search with an unknown sort path is rejected synchronously at submit,
 // surfaces CLIENT_ERROR / INVALID_FIELD_PATH, and issues no snapshot ID.

--- a/scripts/check-generated-in-sync.sh
+++ b/scripts/check-generated-in-sync.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Verifies api/generated.go is in sync with api/openapi.yaml — i.e. that
+# `go generate ./api/...` produces no change relative to the committed file.
+#
+# Exits 0 if in sync.
+# Exits 1 if regeneration changes generated.go, with a readable diff, so an
+# edit to api/openapi.yaml that was not followed by `go generate ./api/...`
+# cannot merge.
+#
+# Used as a CI gate to prevent the generated.go drift that accumulated across
+# several PRs (spec edited, generated.go not regenerated) from recurring.
+# Compatible with bash 3.2+ (macOS system bash).
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "$repo_root"
+
+echo "Regenerating api/generated.go from api/openapi.yaml..."
+go generate ./api/...
+
+if git diff --quiet -- api/generated.go; then
+	echo "OK: api/generated.go is in sync with api/openapi.yaml."
+	exit 0
+fi
+
+cat >&2 <<'EOF'
+ERROR: api/generated.go is out of sync with api/openapi.yaml.
+
+An edit to api/openapi.yaml was not followed by regeneration. Run:
+
+    go generate ./api/...
+
+and commit the updated api/generated.go. Diff:
+EOF
+git --no-pager diff -- api/generated.go >&2
+exit 1


### PR DESCRIPTION
## Summary

Reconciles the **Stats / Audit / Search** area of `api/openapi.yaml` with the running server
(audit source: `docs/analysis/openapi/README.md` §6B). Part of the OpenAPI contract-reconciliation
effort (#369).

Design: `docs/superpowers/specs/2026-07-04-openapi-stats-audit-search-design.md` ·
Plan: `docs/superpowers/plans/2026-07-04-openapi-stats-audit-search-plan.md`

### What changed

**1. Unknown-model → `404 MODEL_NOT_FOUND`, unified.** One canonical rule across all six model-scoped
data operations — `getAllEntities`, `getEntityStatisticsForModel`, `getEntityStatisticsByStateForModel`,
`searchEntities`, `submitAsyncSearchJob`, `queryGroupedEntityStatisticsForModel` — via a shared
`common.EnsureModelRegistered` helper that does one **bounded, multi-node-safe** `RefreshAndGet` (so a
model just registered on a peer node is not falsely rejected). Previously the read/query ops silently
returned empty and grouped-stats returned an ad-hoc `400 UNKNOWN_MODEL`; that unregistered code is
**retired**. HTTP and gRPC both inherit the rule; grouped-stats' fix also closes a pre-existing latent
multi-node race in its resolver. Covered by per-op e2e, gRPC-envelope tests, a cross-backend parity
scenario, and an isolated 3-node cluster test proving the cold-cache refresh.

**2. `searchEntities` limit + content-type.** Response is `application/x-ndjson` only; `limit>10000` is
**rejected with `400`** (was documented as "silently limited"). The cap is enforced in the service
layer, closing an HTTP/gRPC divergence — HTTP, gRPC direct search, and async submit now all reject
oversized limits (unbounded `limit<0` still allowed).

**3. Removed fictional / misplaced surface.** `pointInTime` param on `getAsyncSearchResults` (PIT is
fixed at submit); `timeoutMillis` param + `408` on `searchEntities` (the real timeout impl is tracked
in **#372**); the fictional "must be a time-based UUID" `400` on `getStateMachineFinishedEvent` (any
valid UUID is accepted). `getStateMachineFinishedEvent` error responses now use RFC-9457
`application/problem+json ProblemDetail`. `getAsyncSearchResults` documented default page size corrected
10 → 1000.

**4. Retained + deferred.** `NOT_FOUND` (async-search-job status) and `System` (audit `eventType`) are
kept — they are commercial/cross-backend contract values — with explicit do-not-remove code comments.
The `searchEntityAuditEvents.changes` before/after diff is a documented gap (deferred feature), recorded
in `docs/cloud-parity/`.

### Testing & gates

Full verification green: `go build`, `go vet ./...`, `go test ./...` (root + e2e), `make test-short-all`
(plugin submodules), `make race` (no races). Error-code matrix extended (bounded ops as keys; large-surface
ops waived with explicit e2e references). oasdiff additive-only gate: 11 ERR reconciliations covered by
surgical, fail-closed `.github/oasdiff-err-ignore.txt` entries (ADR-0003 Decision 7); `TestSpecHasNoSealedSchemas`
passes (no `additionalProperties:false` introduced — typed-but-open preserved). Docs updated (CHANGELOG,
cloud-parity, help topics).

### Note on the `api/generated.go` diff

The `generated.go` hunks are larger than this slice's `openapi.yaml` change because `generated.go` was
**stale since #347** — PRs #370/#371 edited the spec without regenerating it. This branch's `go generate`
resynced it (typed `EntityMetadata`/`Envelope.Meta`, the `changeType` CREATE/UPDATE/DELETE constants from
#371's E8, and the `Create*` body unions). It matches the current spec and the wire output is unchanged
(the server is hand-wired against the `//go:embed`'d spec), validated by the full e2e run.

### Recurrence guard (added in this PR)

To stop this drift from recurring, this PR adds a **`codegen-sync` CI gate** (`scripts/check-generated-in-sync.sh`
+ `make check-codegen`, mirroring the existing `check-spi-pin-sync` precedent): it regenerates `api/generated.go`
and fails on any diff, so a spec edit that isn't followed by `go generate ./api/...` cannot merge. Verified it
passes on the synced tree and fails with a diff on a stale `generated.go`.

### Suggested follow-up (not in this PR)

- The repo has pre-existing gofmt-dirty files unrelated to this slice; there is no gofmt CI gate.

Refs #369, #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
