### PR TITLE
fix(messaging)!: rename edge-message request field meta-data → metaData; add help topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,14 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   emitted by the server (the endpoint is auth-only, not admin-only); the spec entry
   is removed.
 
+- **Edge-message request metadata field renamed `meta-data` → `metaData`** — the
+  `POST /api/message/new/{subject}` request envelope now carries its optional metadata map
+  under `metaData` (camelCase), symmetric with the `getMessage` response and consistent with
+  the rest of the API's JSON naming. The former kebab-case `meta-data` key is no longer honored;
+  its contents are ignored. Breaking input change, shipped in a patch because edge messages have
+  no known consumers. A new `cyoda help messages` topic documents the full edge-message API.
+  ([#386](https://github.com/Cyoda-platform/cyoda-go/issues/386))
+
 ### Removed
 
 - **`pointInTime` param on `getAsyncSearchResults`** — the point-in-time is

--- a/api/generated.go
+++ b/api/generated.go
@@ -1759,7 +1759,7 @@ type EdgeMessageDto struct {
 	Content *EdgeMessagePayload `json:"content,omitempty"`
 	Header  EdgeMessageHeader   `json:"header"`
 
-	// MetaData Flat map of the message's metadata key-value pairs, symmetric with the `meta-data` supplied at creation. All values are indexed for search.
+	// MetaData Flat map of the message's metadata key-value pairs, symmetric with the `metaData` supplied at creation. All values are indexed for search.
 	MetaData EdgeMessageMetaData `json:"metaData"`
 }
 
@@ -1778,7 +1778,7 @@ type EdgeMessageHeader struct {
 	UserId        *string `json:"userId,omitempty"`
 }
 
-// EdgeMessageMetaData Flat map of the message's metadata key-value pairs, symmetric with the `meta-data` supplied at creation. All values are indexed for search.
+// EdgeMessageMetaData Flat map of the message's metadata key-value pairs, symmetric with the `metaData` supplied at creation. All values are indexed for search.
 type EdgeMessageMetaData map[string]interface{}
 
 // EdgeMessagePayload Polymorphic by intent — accepts any JSON value. The contentType field
@@ -2421,7 +2421,7 @@ type ModelStatsDto struct {
 // NewMessageRequest A single JSON object carrying the message payload and optional flat metadata.
 type NewMessageRequest struct {
 	// MetaData Optional flat key→value map; indexed to enable search by metadata.
-	MetaData *map[string]interface{} `json:"meta-data,omitempty"`
+	MetaData *map[string]interface{} `json:"metaData,omitempty"`
 
 	// Payload The message payload — any JSON value (object, array, string, number, …). Non-JSON content (e.g. binary) must be stringified (e.g. base64) and sent as a JSON string; see the EdgeMessagePayload note.
 	Payload EdgeMessagePayload `json:"payload"`

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3483,17 +3483,17 @@ paths:
       requestBody:
         description: >
           A single JSON object. It must contain a `payload` field (any valid JSON
-          value) and may include an optional flat `meta-data` map of key-value pairs.
-          The meta-data is indexed to enable fast search by meta-data.
+          value) and may include an optional flat `metaData` map of key-value pairs.
+          The metaData is indexed to enable fast search by metadata.
         content:
           application/json:
             schema:
               $ref: "#/components/schemas/NewMessageRequest"
             examples:
-              Nobel Prize Announcement (with payload and meta-data):
-                description: Nobel Prize Announcement (with payload and meta-data)
+              Nobel Prize Announcement (with payload and metaData):
+                description: Nobel Prize Announcement (with payload and metaData)
                 value:
-                  meta-data:
+                  metaData:
                     eventType: nobel.prize.announced
                     timestamp: 2024-10-09T12:00:00Z
                   payload:
@@ -3512,8 +3512,8 @@ paths:
                         motivation: for foundational discoveries and inventions that enable machine
                           learning with artificial neural networks
                         share: "2"
-              Nobel Prize Announcement (with payload but without meta-data):
-                description: Nobel Prize Announcement (with payload but without meta-data)
+              Nobel Prize Announcement (with payload but without metaData):
+                description: Nobel Prize Announcement (with payload but without metaData)
                 value:
                   payload:
                     category: physics
@@ -10360,7 +10360,7 @@ components:
       additionalProperties: true
       description: >
         Flat map of the message's metadata key-value pairs, symmetric with the
-        `meta-data` supplied at creation. All values are indexed for search.
+        `metaData` supplied at creation. All values are indexed for search.
     EdgeMessagePayload:
       description: |
         Polymorphic by intent — accepts any JSON value. The contentType field
@@ -10380,7 +10380,7 @@ components:
             The message payload — any JSON value (object, array, string, number, …).
             Non-JSON content (e.g. binary) must be stringified (e.g. base64) and sent
             as a JSON string; see the EdgeMessagePayload note.
-        meta-data:
+        metaData:
           type: object
           additionalProperties: true
           description: Optional flat key→value map; indexed to enable search by metadata.

--- a/cmd/cyoda/help/content/crud.md
+++ b/cmd/cyoda/help/content/crud.md
@@ -17,6 +17,7 @@ see_also:
   - errors.TRANSITION_NOT_FOUND
   - errors.UNIQUE_VIOLATION
   - errors.INVALID_UNIQUE_KEY
+  - messages
   - openapi
 ---
 
@@ -793,4 +794,5 @@ curl -s -X POST \
 - errors.UNIQUE_VIOLATION
 - errors.INVALID_UNIQUE_KEY
 - errors.TRANSITION_NOT_FOUND
+- messages
 - openapi

--- a/cmd/cyoda/help/content/messages.md
+++ b/cmd/cyoda/help/content/messages.md
@@ -1,0 +1,209 @@
+---
+topic: messages
+title: "messages — edge message store API"
+stability: stable
+see_also:
+  - crud
+  - cloudevents
+  - openapi
+  - errors.ENTITY_NOT_FOUND
+  - errors.BAD_REQUEST
+---
+
+# messages
+
+## NAME
+
+messages — edge message create, read, and delete REST API.
+
+## SYNOPSIS
+
+```
+POST   /api/message/new/{subject}
+GET    /api/message/{messageId}
+DELETE /api/message/{messageId}
+DELETE /api/message
+```
+
+Context path prefix is `CYODA_CONTEXT_PATH` (default `/api`). All endpoints require `Authorization: Bearer <token>` except when `CYODA_IAM_MODE=mock`. No role is required beyond a valid token.
+
+## DESCRIPTION
+
+An edge message is an arbitrary JSON payload stored under a server-generated time-UUID together with a fixed set of AMQP-aligned headers and an optional flat metadata map. The store is standalone: a message is not an entity, and creating one does not touch the workflow engine — no transition fires, no processor or criterion runs. Edge messaging is a durable, tenant-scoped staging buffer at the platform edge, a peer of the entity store rather than part of it.
+
+The surface is HTTP-only; there is no gRPC message service.
+
+Messages are keyed by `(tenant, messageId)`. The tenant is derived from the authenticated caller, never from a request parameter, so a message ID only resolves within the tenant that created it (see TENANT ISOLATION).
+
+Body size limit on all write endpoints: 10 MiB.
+
+## MESSAGE SHAPE
+
+The create request and the read response are different shapes: you POST a payload plus metadata, and you GET back the same payload and metadata wrapped alongside the stored header. The metadata values round-trip unchanged — a flat map in, the same flat map out.
+
+**Create request** — a single JSON object:
+
+- `payload` (required): any valid JSON value — object, array, string, number, boolean, or `null`. It is stored verbatim (whitespace is compacted). `Content-Type` is informational only; the store does not parse the payload against it. Non-JSON content must be stringified by the client (for example base64) and sent as a JSON string.
+- `metaData` (optional): a flat map of string keys to JSON values, stored alongside the message and returned verbatim on read. There is no message-query endpoint — messages are retrieved by ID, not searched by metadata.
+
+**Read response** (`EdgeMessageDto`) — three top-level fields:
+
+- `header`: the stored `EdgeMessageHeader` (below); empty optional fields are omitted.
+- `metaData`: the metadata map, returned flat and unchanged — the same `metaData` supplied at creation.
+- `content`: the payload, echoed back verbatim as it was stored.
+
+**Header** (`EdgeMessageHeader`) — AMQP-aligned:
+
+- `subject` (string): taken from the `{subject}` path segment on create.
+- `contentType` (string): from the `Content-Type` request header; informational.
+- `contentLength` (int64): from the `Content-Length` request header.
+- `contentEncoding` (string): from the `Content-Encoding` request header (default `UTF-8`).
+- `messageId`, `userId`, `recipient`, `replyTo`, `correlationId` (all optional strings): from the `X-Message-ID`, `X-User-ID`, `X-Recipient`, `X-Reply-To`, `X-Correlation-ID` request headers respectively. These are caller-supplied envelope fields and are distinct from the server-generated store ID in the URL.
+
+## ENDPOINTS
+
+**POST /api/message/new/{subject}** — Create and store a message
+
+- `subject` (path): string matching `^[a-zA-Z0-9._-]{1,256}$`
+- `Content-Type` (header, required): MIME type of the payload (informational)
+- `Content-Length` (header, required): payload size in bytes
+- `Content-Encoding` (header, optional): default `UTF-8`
+- `X-Message-ID`, `X-User-ID`, `X-Recipient`, `X-Reply-To`, `X-Correlation-ID` (headers, optional): AMQP envelope fields, each 1..1024 chars
+- `transactionTimeoutMillis` (query, optional): int64, default `10000` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.
+
+Request body: a `NewMessageRequest` object `{ payload, metaData }` as described in MESSAGE SHAPE. Missing `payload` returns `400 BAD_REQUEST`.
+
+The server generates a time-UUID for the message and a separate time-UUID for the transaction. Response: `200 OK`, `application/json`, an `EntityTransactionResponse` array with a single element:
+
+```json
+[{
+  "entityIds": ["8824c480-c166-11ee-bf9f-ae468cd3ed16"],
+  "transactionId": "9f3a0000-c166-11ee-bf9f-ae468cd3ed16"
+}]
+```
+
+**GET /api/message/{messageId}** — Retrieve a message by ID
+
+- `messageId` (path): UUID
+
+Response: `200 OK`, `application/json`, an `EdgeMessageDto`:
+
+```json
+{
+  "header": {
+    "subject": "nobel.prize.events",
+    "contentType": "application/json",
+    "contentLength": 1024,
+    "contentEncoding": "UTF-8",
+    "messageId": "msg-nobel-2024-physics",
+    "userId": "nobel-committee",
+    "recipient": "scientific-community",
+    "replyTo": "announcements@nobelprize.org",
+    "correlationId": "nobel-2024-physics-announcement"
+  },
+  "metaData": {
+    "eventType": "nobel.prize.announced",
+    "timestamp": "2024-10-09T12:00:00Z"
+  },
+  "content": { "category": "physics", "year": "2024" }
+}
+```
+
+A malformed `messageId` returns `400 BAD_REQUEST`; a well-formed UUID that does not exist for the calling tenant returns `404 ENTITY_NOT_FOUND`.
+
+**DELETE /api/message/{messageId}** — Delete a single message
+
+- `messageId` (path): UUID
+
+Deletes the message and its payload blob. Returns `404 ENTITY_NOT_FOUND` if the ID does not exist for the tenant. Response: `200 OK`, `application/json`, a `MessageDeleteResponse`:
+
+```json
+{ "entityIds": ["8824c480-c166-11ee-bf9f-ae468cd3ed16"] }
+```
+
+Message delete is not transactional in the same sense as entity create/update.
+
+**DELETE /api/message** — Delete multiple messages by ID
+
+- `transactionSize` (query, optional): int32, default `1000` — accepted for Cyoda Cloud parity; parsed but currently has no behavioural effect in cyoda-go.
+
+Request body: a JSON array of UUID strings. Every element must parse as a UUID; otherwise `400 BAD_REQUEST`. Response: `200 OK`, `application/json`, a `MessageDeleteBatchResponse` array:
+
+```json
+[{
+  "entityIds": [
+    "8824c480-c166-11ee-9cc7-ae468cd3ed16",
+    "31134900-d9cb-11ee-9cc7-ae468cd3ed16"
+  ],
+  "success": true
+}]
+```
+
+## TENANT ISOLATION
+
+Every operation is scoped to the authenticated caller's tenant. The tenant is resolved from the user context, and each backend keys and filters messages by `(tenant, messageId)`:
+
+- postgres / sqlite — the primary key is `(tenant_id, message_id)` and every query filters on `tenant_id`.
+- memory — metadata is held per tenant and each payload blob lives under a per-tenant directory.
+
+A message ID is an unguessable time-UUID and is only ever retrievable or deletable by the tenant that created it. A cross-tenant read or delete resolves to `404 ENTITY_NOT_FOUND`, not a leak.
+
+## ERRORS
+
+Errors are RFC 9457 `application/problem+json` with `properties.errorCode` set to the machine-readable code:
+
+- `errors.BAD_REQUEST` — `400` — invalid JSON, missing `payload`, malformed `messageId`, or a delete body that is not a JSON array of UUID strings
+- `errors.ENTITY_NOT_FOUND` — `404` — no message with this ID exists for the calling tenant (get and single-delete)
+- `413` — request body exceeds the 10 MiB limit (create and batch-delete)
+- `401` — missing or invalid Bearer token
+- `403` — authenticated but not authorized
+- `500` — internal error; generic message plus a ticket UUID, full detail logged server-side
+
+## EXAMPLES
+
+**Create a message:**
+
+```
+curl -s -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "X-Correlation-ID: nobel-2024-physics" \
+  -d '{
+    "metaData": { "eventType": "nobel.prize.announced" },
+    "payload":   { "category": "physics", "year": "2024" }
+  }' \
+  "http://localhost:8080/api/message/new/nobel.prize.events"
+```
+
+**Retrieve a message:**
+
+```
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8080/api/message/8824c480-c166-11ee-bf9f-ae468cd3ed16"
+```
+
+**Delete a single message:**
+
+```
+curl -s -X DELETE \
+  -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8080/api/message/8824c480-c166-11ee-bf9f-ae468cd3ed16"
+```
+
+**Delete several messages by ID:**
+
+```
+curl -s -X DELETE \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '["8824c480-c166-11ee-9cc7-ae468cd3ed16","31134900-d9cb-11ee-9cc7-ae468cd3ed16"]' \
+  "http://localhost:8080/api/message"
+```
+
+## SEE ALSO
+
+- crud
+- cloudevents
+- openapi
+- errors.ENTITY_NOT_FOUND
+- errors.BAD_REQUEST

--- a/docs/cloud-parity/openapi-conformance.md
+++ b/docs/cloud-parity/openapi-conformance.md
@@ -166,7 +166,8 @@ Per-finding contract decisions from the Edge-message reconciliation slice.
 
 - **M1 — request body shapes corrected.** `newMessage` body is a JSON object envelope
   `{payload (any JSON value, required), meta-data (optional flat map)}` — not a bare `string`;
-  a top-level array is rejected (single object only). `deleteMessages` body is a JSON `array` of
+  a top-level array is rejected (single object only). (The `meta-data` request field was
+  subsequently renamed `metaData` — see M5.) `deleteMessages` body is a JSON `array` of
   uuid strings — not a single `string`. Direction: spec-incomplete (closed). Cloud's documented
   request contract must match these shapes.
 - **M2 — fictional v1-UUID `400` removed; `messageId` typed `uuid`.** `getMessage` / `deleteMessage`
@@ -185,7 +186,8 @@ Per-finding contract decisions from the Edge-message reconciliation slice.
   The bucketed `metaData: {values, indexedValues}` split and the injected `typeReferences: {}` were
   cyoda-cloud indexing workarounds. In cyoda-go, `values` was always empty (all client `meta-data`
   routes to indexed storage) and `typeReferences` was an always-empty placeholder. cyoda-go now
-  emits a **single flat map** — what a client PUTs in `meta-data` it GETs back in `metaData`. The
+  emits a **single flat map** — what a client PUTs in `meta-data` it GETs back in `metaData` (the
+  request field was subsequently renamed `meta-data` → `metaData`; see M5). The
   `ValueMaps` / `LocalTime` schemas are deleted. This is a response-shape change only (no SPI /
   storage / indexing change). Direction: **cyoda-go leads — Cloud MUST conform**: emit the flat
   `metaData` map and drop `values` / `indexedValues` / `typeReferences` from the read response.
@@ -193,6 +195,15 @@ Per-finding contract decisions from the Edge-message reconciliation slice.
   `metaData.indexedValues.strings`) must be updated to the flat shape.
 - **M4 — `deleteMessages` `413` on oversized body (runtime change).** A >10 MB batch-delete body now
   returns `413` (was `500`), matching `newMessage`. Direction: server-gap (closed, Gate-6 parity fix).
+- **M5 — request metadata field renamed `meta-data` → `metaData` (camelCase alignment).** The
+  `newMessage` request envelope carried its metadata under `meta-data` — the only kebab-case JSON
+  property in the API, while every other body field (including the `getMessage` response's own
+  `metaData`) is camelCase. cyoda-go now accepts the metadata map under `metaData` on the create
+  request, so the field name is symmetric with the response and consistent with the project-wide
+  convention. The legacy `meta-data` key is no longer honored (its contents are ignored) — a
+  breaking input change, taken on a patch release because edge messages have no known consumers.
+  Supersedes the `meta-data` request-field spelling in M1 and M3. Direction: **cyoda-go leads —
+  Cloud MUST conform**: accept `metaData` (not `meta-data`) on the `newMessage` request body.
 - **Deferred (out of this slice).** Honoring `transactionTimeoutMillis` / `transactionSize` uniformly
   → **#379** (supersedes #372). Native non-JSON / content-type payloads (binary without base64
   wrapping) → **#193**. The message contract documents current JSON-envelope behavior.

--- a/e2e/parity/client/create_message_with_headers_test.go
+++ b/e2e/parity/client/create_message_with_headers_test.go
@@ -77,7 +77,7 @@ func TestCreateMessageWithHeaders_SetsXHeaders(t *testing.T) {
 		t.Errorf("Content-Encoding: got %q, want utf-8", got)
 	}
 
-	// Body envelope: {"payload": ..., "meta-data": {"source": "parity"}}
+	// Body envelope: {"payload": ..., "metaData": {"source": "parity"}}
 	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(gotBody, &envelope); err != nil {
 		t.Fatalf("body not valid JSON: %v", err)
@@ -85,8 +85,8 @@ func TestCreateMessageWithHeaders_SetsXHeaders(t *testing.T) {
 	if _, ok := envelope["payload"]; !ok {
 		t.Error("body missing 'payload' field")
 	}
-	if _, ok := envelope["meta-data"]; !ok {
-		t.Error("body missing 'meta-data' field")
+	if _, ok := envelope["metaData"]; !ok {
+		t.Error("body missing 'metaData' field")
 	}
 }
 

--- a/e2e/parity/client/http.go
+++ b/e2e/parity/client/http.go
@@ -909,13 +909,13 @@ func (c *Client) doRawWithHeaders(t *testing.T, method, path, body string, extra
 }
 
 // CreateMessage issues POST /api/message/new/{subject} with the given
-// payload wrapped in the edge-message envelope {payload, meta-data}.
+// payload wrapped in the edge-message envelope {payload, metaData}.
 // Returns the message ID.
 // Canonical: docs/cyoda/openapi.yml:2401.
 func (c *Client) CreateMessage(t *testing.T, subject, payload string) (string, error) {
 	t.Helper()
 	path := "/api/message/new/" + subject
-	body := fmt.Sprintf(`{"payload": %s, "meta-data": {"source": "parity"}}`, payload)
+	body := fmt.Sprintf(`{"payload": %s, "metaData": {"source": "parity"}}`, payload)
 	raw, err := c.doRaw(t, http.MethodPost, path, body)
 	if err != nil {
 		return "", err
@@ -937,7 +937,7 @@ func (c *Client) CreateMessage(t *testing.T, subject, payload string) (string, e
 // It sends the fields in MessageHeaderInput as HTTP request headers so
 // cyoda-go's generated handler reads them via NewMessageParams. The body
 // envelope is identical to CreateMessage: {"payload": <payload>,
-// "meta-data": {"source": "parity"}}.
+// "metaData": {"source": "parity"}}.
 //
 // If header.ContentType is empty it defaults to "application/json".
 // Empty fields in header are omitted from the request.
@@ -945,7 +945,7 @@ func (c *Client) CreateMessage(t *testing.T, subject, payload string) (string, e
 func (c *Client) CreateMessageWithHeaders(t *testing.T, subject, payload string, header MessageHeaderInput) (string, error) {
 	t.Helper()
 	path := "/api/message/new/" + subject
-	body := fmt.Sprintf(`{"payload": %s, "meta-data": {"source": "parity"}}`, payload)
+	body := fmt.Sprintf(`{"payload": %s, "metaData": {"source": "parity"}}`, payload)
 
 	h := make(http.Header)
 	ct := header.ContentType

--- a/e2e/parity/message.go
+++ b/e2e/parity/message.go
@@ -78,13 +78,13 @@ func RunMessageDelete(t *testing.T, fixture BackendFixture) {
 
 // RunMessageRoundTrip exercises the edge-message new->get->delete cycle and
 // asserts the backend-agnostic response shape: metaData is a single FLAT map
-// (symmetric with the submitted meta-data), carrying the user's key and NONE of
+// (symmetric with the submitted metaData), carrying the user's key and NONE of
 // the retired cyoda-cloud indexing artifacts (values/indexedValues/typeReferences).
 func RunMessageRoundTrip(t *testing.T, fixture BackendFixture) {
 	tenant := fixture.NewTenant(t)
 	c := client.NewClient(fixture.BaseURL(), tenant.Token)
 
-	// the parity client's CreateMessage hardcodes meta-data {"source":"parity"}.
+	// the parity client's CreateMessage hardcodes metaData {"source":"parity"}.
 	id, err := c.CreateMessage(t, "parity-roundtrip", `{"hello":"world"}`)
 	if err != nil {
 		t.Fatalf("CreateMessage: %v", err)

--- a/internal/domain/messaging/handler.go
+++ b/internal/domain/messaging/handler.go
@@ -45,7 +45,7 @@ func (h *Handler) NewMessage(w http.ResponseWriter, r *http.Request, subject str
 
 	var envelope struct {
 		Payload  json.RawMessage `json:"payload"`
-		MetaData map[string]any  `json:"meta-data"`
+		MetaData map[string]any  `json:"metaData"`
 	}
 	if err := json.Unmarshal(rawBody, &envelope); err != nil {
 		common.WriteError(w, r, common.Operational(http.StatusBadRequest, common.ErrCodeBadRequest, "invalid JSON: expected an object with a 'payload' field"))
@@ -164,12 +164,12 @@ func (h *Handler) GetMessage(w http.ResponseWriter, r *http.Request, messageId u
 		respHeader["correlationId"] = header.CorrelationID
 	}
 
-	// Flat metadata map — symmetric with the submitted `meta-data`. The
+	// Flat metadata map — symmetric with the submitted `metaData`. The
 	// values/indexedValues split and the injected typeReferences were
 	// cyoda-cloud indexing artifacts, not part of the cyoda-go contract.
 	metaMap := map[string]any{}
 	// IndexedValues is merged last, so it wins on a key collision — which is
-	// currently impossible: cyoda-go routes all client meta-data to IndexedValues,
+	// currently impossible: cyoda-go routes all client metaData to IndexedValues,
 	// leaving Values empty.
 	for k, v := range metaData.Values {
 		metaMap[k] = v

--- a/internal/domain/messaging/handler_test.go
+++ b/internal/domain/messaging/handler_test.go
@@ -131,7 +131,7 @@ func TestNewMessageAndGet(t *testing.T) {
 	srv := newTestServer(t)
 
 	// POST a new message
-	body := `{"payload": {"name": "Alice", "age": 30}, "meta-data": {"eventType": "test.event"}}`
+	body := `{"payload": {"name": "Alice", "age": 30}, "metaData": {"eventType": "test.event"}}`
 	resp := postMessage(t, srv.URL, "test.subject", body)
 	expectStatus(t, resp, http.StatusOK)
 	msgID := extractMessageID(t, resp)
@@ -179,7 +179,7 @@ func TestNewMessageWithIndexedMetadata(t *testing.T) {
 	srv := newTestServer(t)
 
 	// POST message with indexed metadata
-	body := `{"payload": {"data": "test"}, "meta-data": {"eventType": "nobel.prize.announced", "timestamp": "2024-10-09T12:00:00Z", "category": "physics"}}`
+	body := `{"payload": {"data": "test"}, "metaData": {"eventType": "nobel.prize.announced", "timestamp": "2024-10-09T12:00:00Z", "category": "physics"}}`
 	resp := postMessage(t, srv.URL, "events.nobel", body)
 	expectStatus(t, resp, http.StatusOK)
 	msgID := extractMessageID(t, resp)
@@ -194,7 +194,7 @@ func TestNewMessageWithIndexedMetadata(t *testing.T) {
 		t.Fatalf("failed to parse GET response: %v", err)
 	}
 
-	// Verify metaData is a flat map — symmetric with submitted meta-data.
+	// Verify metaData is a flat map — symmetric with submitted metaData.
 	metaData, ok := msg["metaData"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected metaData flat map, got %v", msg["metaData"])
@@ -222,11 +222,56 @@ func TestNewMessageWithIndexedMetadata(t *testing.T) {
 	}
 }
 
+func TestNewMessageMetaDataFieldIsCamelCase(t *testing.T) {
+	srv := newTestServer(t)
+
+	// The request metadata field is `metaData` (camelCase) — symmetric with
+	// the `metaData` field on the read response and consistent with the rest
+	// of the API's JSON naming.
+	body := `{"payload": {"data": "test"}, "metaData": {"eventType": "nobel.prize.announced"}}`
+	resp := postMessage(t, srv.URL, "events.camel", body)
+	expectStatus(t, resp, http.StatusOK)
+	msgID := extractMessageID(t, resp)
+
+	resp = getMessage(t, srv.URL, msgID)
+	expectStatus(t, resp, http.StatusOK)
+	var msg map[string]any
+	if err := json.Unmarshal(readBody(t, resp), &msg); err != nil {
+		t.Fatalf("failed to parse GET response: %v", err)
+	}
+	metaData, ok := msg["metaData"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected metaData flat map, got %v", msg["metaData"])
+	}
+	if metaData["eventType"] != "nobel.prize.announced" {
+		t.Errorf("expected metaData.eventType round-tripped from camelCase request field, got %v", metaData["eventType"])
+	}
+
+	// The legacy kebab-case `meta-data` request field is no longer honored
+	// (breaking rename). Sending it must not populate metadata.
+	legacy := `{"payload": {"data": "test"}, "meta-data": {"eventType": "should.be.ignored"}}`
+	resp = postMessage(t, srv.URL, "events.legacy", legacy)
+	expectStatus(t, resp, http.StatusOK)
+	legacyID := extractMessageID(t, resp)
+
+	resp = getMessage(t, srv.URL, legacyID)
+	expectStatus(t, resp, http.StatusOK)
+	var legacyMsg map[string]any
+	if err := json.Unmarshal(readBody(t, resp), &legacyMsg); err != nil {
+		t.Fatalf("failed to parse GET response: %v", err)
+	}
+	if md, ok := legacyMsg["metaData"].(map[string]any); ok {
+		if _, present := md["eventType"]; present {
+			t.Errorf("legacy `meta-data` field must be ignored, but eventType leaked into metaData: %v", md)
+		}
+	}
+}
+
 func TestMetadataPreservesJsonTypes(t *testing.T) {
 	srv := newTestServer(t)
 
 	// POST message with mixed-type metadata: string, number, boolean, null
-	body := `{"payload": {"x": 1}, "meta-data": {"name": "Alice", "age": 30, "active": true, "score": 99.5, "tags": ["a","b"]}}`
+	body := `{"payload": {"x": 1}, "metaData": {"name": "Alice", "age": 30, "active": true, "score": 99.5, "tags": ["a","b"]}}`
 	resp := postMessage(t, srv.URL, "typed.meta", body)
 	expectStatus(t, resp, http.StatusOK)
 	msgID := extractMessageID(t, resp)
@@ -241,7 +286,7 @@ func TestMetadataPreservesJsonTypes(t *testing.T) {
 		t.Fatalf("failed to parse GET response: %v", err)
 	}
 
-	// metaData is a flat map — symmetric with submitted meta-data.
+	// metaData is a flat map — symmetric with submitted metaData.
 	indexed, ok := msg["metaData"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected metaData flat map, got %v (%T)", msg["metaData"], msg["metaData"])
@@ -424,7 +469,7 @@ func TestDeleteMessagesInvalidBody(t *testing.T) {
 func TestNewMessageWithOptionalHeaders(t *testing.T) {
 	srv := newTestServer(t)
 
-	body := `{"payload": {"data": "value"}, "meta-data": {"key1": "val1"}}`
+	body := `{"payload": {"data": "value"}, "metaData": {"key1": "val1"}}`
 	resp := postMessage(t, srv.URL, "headers.test", body)
 	expectStatus(t, resp, http.StatusOK)
 	msgID := extractMessageID(t, resp)

--- a/internal/e2e/message_test.go
+++ b/internal/e2e/message_test.go
@@ -12,7 +12,7 @@ import (
 func createMessageE2E(t *testing.T, subject string, payload string) string {
 	t.Helper()
 	path := fmt.Sprintf("/api/message/new/%s", subject)
-	body := fmt.Sprintf(`{"payload": %s, "meta-data": {"source": "e2e"}}`, payload)
+	body := fmt.Sprintf(`{"payload": %s, "metaData": {"source": "e2e"}}`, payload)
 	resp := doAuth(t, http.MethodPost, path, body)
 	respBody := readBody(t, resp)
 	if resp.StatusCode != http.StatusOK {
@@ -135,7 +135,7 @@ func TestMessage_DeleteMessages_Shape(t *testing.T) {
 // TestMessage_NewMessage_Shape verifies that NewMessage returns an array with entityIds,
 // not a bare string — the spec was wrong (type:string).
 func TestMessage_NewMessage_Shape(t *testing.T) {
-	body := `{"payload": {"k": "v"}, "meta-data": {}}`
+	body := `{"payload": {"k": "v"}, "metaData": {}}`
 	resp := doAuth(t, http.MethodPost, "/api/message/new/test-new-shape", body)
 	respBody := readBody(t, resp)
 	if resp.StatusCode != http.StatusOK {
@@ -285,9 +285,9 @@ func TestMessage_MetaDataFlatShape(t *testing.T) {
 }
 
 // TestMessage_NewMessage_ObjectEnvelope characterizes the real body contract:
-// an object {payload, meta-data}; missing payload -> 400; a top-level array -> 400.
+// an object {payload, metaData}; missing payload -> 400; a top-level array -> 400.
 func TestMessage_NewMessage_ObjectEnvelope(t *testing.T) {
-	ok := doAuth(t, http.MethodPost, "/api/message/new/env-ok", `{"payload":{"a":1},"meta-data":{"k":"v"}}`)
+	ok := doAuth(t, http.MethodPost, "/api/message/new/env-ok", `{"payload":{"a":1},"metaData":{"k":"v"}}`)
 	defer ok.Body.Close()
 	if ok.StatusCode != http.StatusOK {
 		t.Fatalf("object envelope: status=%d, want 200", ok.StatusCode)
@@ -300,7 +300,7 @@ func TestMessage_NewMessage_ObjectEnvelope(t *testing.T) {
 		t.Fatalf("string payload: status=%d, want 200", strp.StatusCode)
 	}
 
-	missing := doAuth(t, http.MethodPost, "/api/message/new/env-missing", `{"meta-data":{}}`)
+	missing := doAuth(t, http.MethodPost, "/api/message/new/env-missing", `{"metaData":{}}`)
 	defer missing.Body.Close()
 	if missing.StatusCode != http.StatusBadRequest {
 		t.Fatalf("missing payload: status=%d, want 400", missing.StatusCode)


### PR DESCRIPTION
## Summary

Two things, one deliverable (issue #386):

1. **Adds the missing `cyoda help messages` topic** — edge messaging was the only user-facing API surface with no `cyoda help` entry (the OpenAPI spec was the sole doc). Covers `newMessage`/`getMessage`/`deleteMessage`/`deleteMessages`, request/response shapes, AMQP-aligned headers, error table, tenant isolation, examples; adds a reciprocal `see_also` from `crud`.

2. **Fixes an accidental naming inconsistency (breaking, patch-safe).** The `newMessage` request carried its metadata under `meta-data` — the *only* kebab-case JSON property in the entire API — while the `getMessage` response already returned `metaData` (camelCase, the project-wide convention). The M3 cloud-parity change made the metadata *values* symmetric but left the field *names* mismatched by accident. This renames the **request** field `meta-data` → `metaData`. The legacy key is no longer honored (contents ignored). Breaking input change, taken on a patch because **edge messages have no known consumers**.

The real decode point is a *local* envelope struct in the handler, not the generated DTO — that tag is the behavioural change; the spec + regenerated `generated.go` keep the contract in lock-step.

## Changes

- `internal/domain/messaging/handler.go` — request envelope decodes `metaData`
- `api/openapi.yaml` — `NewMessageRequest.metaData` property + examples + descriptions; `api/generated.go` regenerated (clean 3-line diff)
- `cmd/cyoda/help/content/messages.md` (new) + `crud.md` see_also
- `docs/cloud-parity/openapi-conformance.md` — **M5** (cyoda-go leads; Cloud MUST accept `metaData`, supersedes M1/M3 spelling)
- `CHANGELOG.md` — breaking-change entry

## Testing

- **TDD**: new `TestNewMessageMetaDataFieldIsCamelCase` (asserts `metaData` honored + legacy `meta-data` ignored) — watched it fail, then pass
- messaging unit, `api`, help, parity-client unit ✓
- E2E full-stack message tests (Postgres + openapivalidator — proves spec & handler agree) ✓
- Cross-backend parity `MessageRoundTrip` on memory/sqlite/postgres ✓
- module-wide `go build` / `go vet` / `go test -short ./...` ✓
- `make race` — running as final pre-merge gate

Done on a dedicated worktree off `release/v0.8.2`, kept out of unrelated feature branches.

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)