### PR TITLE
chore(security): bump goldmark v1.7.13 → v1.7.17 (govulncheck GO-2026-5320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,14 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   different read paths within one backend, could disagree at sub-millisecond
   boundaries. ([#349](https://github.com/Cyoda-platform/cyoda-go/issues/349))
 
+### Security
+
+- Bumped the indirect `github.com/yuin/goldmark` dependency `v1.7.13` → `v1.7.17`
+  to clear govulncheck advisory GO-2026-5320 (XSS in goldmark HTML rendering,
+  reached via `glamour` in the `cyoda help` renderer). The renderer only formats
+  first-party help content embedded in the binary, so the advisory was not
+  reachable with attacker-controlled input; the bump keeps the security scan clean.
+
 ## [0.8.1] — 2026-06-23
 
 > No `v0.8.0` release. The `cyoda-go-spi v0.8.0` tag was poisoned by a premature

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/speakeasy-api/openapi v1.19.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	github.com/yuin/goldmark v1.7.13 // indirect
+	github.com/yuin/goldmark v1.7.17 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
-github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.7.17 h1:p36OVWwRb246iHxA/U4p8OPEpOTESm4n+g+8t0EE5uA=
+github.com/yuin/goldmark v1.7.17/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9HTHs=
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=


### PR DESCRIPTION
## Summary

Clears the `security` job (govulncheck) on the `release/v0.8.2` staging line. govulncheck flags **GO-2026-5320** — XSS in `github.com/yuin/goldmark` HTML rendering — reached transitively via `glamour` in the `cyoda help` renderer (`cmd/cyoda/help/renderer`).

- goldmark is an **indirect** dependency of the **root module only** (no plugin uses it).
- The renderer only formats **first-party help content embedded in the binary**, so the advisory is not reachable with attacker-controlled input — but the bump keeps the staging security scan clean.
- Only `go.mod` / `go.sum` change.

## Verification

- `govulncheck ./...` → **No vulnerabilities found** (was 1 before the bump)
- `go test ./cmd/cyoda/help/...` green (renderer behaviour unchanged under 1.7.17)
- `go build ./...` clean

Part of clearing staging to green alongside #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)