### PR TITLE
chore(ci): bump azure/setup-helm v5.0.0 → v5.0.1

### DIFF
--- a/.github/workflows/helm-chart-ci.yml
+++ b/.github/workflows/helm-chart-ci.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: azure/setup-helm@v5.0.0
+      - uses: azure/setup-helm@v5.0.1
         with:
           version: v4.1.4
 
@@ -239,7 +239,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: azure/setup-helm@v5.0.0
+      - uses: azure/setup-helm@v5.0.1
         with:
           version: v4.1.4
 

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -50,7 +50,7 @@ jobs:
             exit 1
           fi
 
-      - uses: azure/setup-helm@v5.0.0
+      - uses: azure/setup-helm@v5.0.1
         with:
           version: v4.1.4
 


### PR DESCRIPTION
Trivial patch bump of `azure/setup-helm` (5.0.0 → 5.0.1) across the two chart workflows (`helm-chart-ci.yml` ×2, `release-chart.yml` ×1).

Applied directly to `release/v0.8.2` rather than retargeting the Dependabot PR #336 (which targets `main`; retargeting would drag in main/staging divergence). Supersedes #336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)