### PR TITLE
config help: `config all` full listing (text + JSON) + `config.cluster` subtopic

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Grammar: `[@]path[:asc|desc]` — a bare dotted path sorts by a scalar entity-da
 
 Online docs at [docs.cyoda.net](https://docs.cyoda.net) mirror the `cyoda help` topic tree — the same content is available offline via `cyoda help <topic>`.
 
+Run `cyoda help config all` for the complete env-var reference (add `--format=json` for machine-readable output); `cyoda help config cluster` covers multi-node/dispatch vars.
+
 | Goal                          | Link                                              |
 |-------------------------------|---------------------------------------------------|
 | Build an app fast (Claude Code) | [github.com/cyoda/cyoda-skills](https://github.com/cyoda/cyoda-skills) — install the cyoda-skills plugin and use `/cyoda:app` to scaffold |

--- a/app/config_registry_binding_test.go
+++ b/app/config_registry_binding_test.go
@@ -1,0 +1,172 @@
+package app_test
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cyoda-platform/cyoda-go/app"
+	"github.com/cyoda-platform/cyoda-go/cmd/cyoda/help"
+)
+
+// preConfigVars are root vars that DefaultConfig() does not populate — either
+// because they are read outside it (profile loader, banner suppression) or
+// because they belong to a different binary entirely (the compute-test-client,
+// which is not part of the server's app.Config). Their table defaults can't be
+// bound to a Config field, so they are exempt from the coverage assertion.
+var preConfigVars = map[string]bool{
+	"CYODA_PROFILES":              true, // read in app/envfiles.go before DefaultConfig() runs
+	"CYODA_DEBUG":                 true, // reserved; not read anywhere yet
+	"CYODA_SUPPRESS_BANNER":       true, // read directly in cmd/cyoda/main.go
+	"CYODA_COMPUTE_GRPC_ENDPOINT": true, // compute-test-client side, not app.Config
+	"CYODA_COMPUTE_TOKEN":         true, // compute-test-client side, not app.Config
+	"CYODA_COMPUTE_HTTP_BASE":     true, // compute-test-client side, not app.Config
+}
+
+// durComponentRe splits a time.Duration.String() output into its
+// (value, unit) components, e.g. "1h0m0s" -> [{1 h} {0 m} {0 s}].
+var durComponentRe = regexp.MustCompile(`(\d+)(h|m|s|ms|us|ns)`)
+
+// renderDuration normalizes time.Duration.String() to the canonical form used
+// by the root ConfigVar table: trailing zero-value unit components are
+// dropped (e.g. "5m0s" -> "5m", "1h0m0s" -> "1h"), but a duration that isn't a
+// whole multiple of its largest unit is left as Go renders it (e.g. "1m30s").
+func renderDuration(d time.Duration) string {
+	matches := durComponentRe.FindAllStringSubmatch(d.String(), -1)
+	end := len(matches)
+	for end > 1 {
+		v, _ := strconv.Atoi(matches[end-1][1])
+		if v != 0 {
+			break
+		}
+		end--
+	}
+	var sb strings.Builder
+	for i := 0; i < end; i++ {
+		sb.WriteString(matches[i][1])
+		sb.WriteString(matches[i][2])
+	}
+	return sb.String()
+}
+
+// renderMillis renders a time.Duration stored from an integer-milliseconds
+// env var (the three CYODA_OIDC_*_TIMEOUT_MS vars) back to its millisecond
+// count, matching the table's "5000" form rather than Duration.String()'s "5s".
+func renderMillis(d time.Duration) string {
+	return strconv.FormatInt(int64(d/time.Millisecond), 10)
+}
+
+// defaultFor maps each root var to the rendered default DefaultConfig()
+// yields under an empty env. Every non-preConfig root var MUST have an
+// entry — the coverage assertion below enforces it.
+func defaultFor(c app.Config) map[string]string {
+	return map[string]string{
+		// --- server ---
+		"CYODA_HTTP_PORT":           strconv.Itoa(c.HTTPPort),
+		"CYODA_CONTEXT_PATH":        c.ContextPath,
+		"CYODA_ERROR_RESPONSE_MODE": c.ErrorResponseMode,
+		"CYODA_LOG_LEVEL":           c.LogLevel,
+		"CYODA_STARTUP_TIMEOUT":     renderDuration(c.StartupTimeout),
+		"CYODA_MAX_STATE_VISITS":    strconv.Itoa(c.MaxStateVisits),
+		"CYODA_MODEL_CACHE_LEASE":   renderDuration(c.ModelCacheLease),
+		"CYODA_STORAGE_BACKEND":     c.StorageBackend,
+
+		// --- admin ---
+		"CYODA_ADMIN_PORT":           strconv.Itoa(c.Admin.Port),
+		"CYODA_ADMIN_BIND_ADDRESS":   c.Admin.BindAddress,
+		"CYODA_METRICS_REQUIRE_AUTH": strconv.FormatBool(c.Admin.MetricsRequireAuth),
+		"CYODA_METRICS_BEARER":       "", // secret
+		"CYODA_OTEL_ENABLED":         strconv.FormatBool(c.OTelEnabled),
+
+		// --- search ---
+		"CYODA_SEARCH_SNAPSHOT_TTL":  renderDuration(c.SearchSnapshotTTL),
+		"CYODA_SEARCH_REAP_INTERVAL": renderDuration(c.SearchReapInterval),
+		"CYODA_SEARCH_MAX_SORT_KEYS": strconv.Itoa(c.SearchMaxSortKeys),
+		"CYODA_STATS_GROUP_MAX":      strconv.Itoa(c.StatsGroupMax),
+
+		// --- tx ---
+		"CYODA_TX_TTL":           renderDuration(c.Cluster.TxTTL),
+		"CYODA_TX_REAP_INTERVAL": renderDuration(c.Cluster.TxReapInterval),
+		"CYODA_TX_OUTCOME_TTL":   renderDuration(c.Cluster.OutcomeTTL),
+
+		// --- cluster ---
+		"CYODA_CLUSTER_ENABLED":          strconv.FormatBool(c.Cluster.Enabled),
+		"CYODA_NODE_ID":                  c.Cluster.NodeID,
+		"CYODA_NODE_ADDR":                c.Cluster.NodeAddr,
+		"CYODA_GRPC_NODE_ADDR":           c.Cluster.GRPCNodeAddr,
+		"CYODA_GOSSIP_ADDR":              c.Cluster.GossipAddr,
+		"CYODA_GOSSIP_STABILITY_WINDOW":  renderDuration(c.Cluster.StabilityWindow),
+		"CYODA_SEED_NODES":               strings.Join(c.Cluster.SeedNodes, ","),
+		"CYODA_HMAC_SECRET":              "", // secret
+		"CYODA_PROXY_TIMEOUT":            renderDuration(c.Cluster.ProxyTimeout),
+		"CYODA_DISPATCH_WAIT_TIMEOUT":    renderDuration(c.Cluster.DispatchWaitTimeout),
+		"CYODA_DISPATCH_FORWARD_TIMEOUT": renderDuration(c.Cluster.DispatchForwardTimeout),
+		"CYODA_TX_TOKEN_TTL":             renderDuration(c.Cluster.TxTokenTTL),
+		"CYODA_KEEPALIVE_INTERVAL":       strconv.Itoa(c.GRPC.KeepAliveInterval),
+		"CYODA_KEEPALIVE_TIMEOUT":        strconv.Itoa(c.GRPC.KeepAliveTimeout),
+
+		// --- auth ---
+		"CYODA_IAM_MODE":                             c.IAM.Mode,
+		"CYODA_IAM_MOCK_ROLES":                       strings.Join(c.IAM.MockRoles, ","),
+		"CYODA_JWT_SIGNING_KEY":                      "", // secret
+		"CYODA_JWT_ISSUER":                           c.IAM.JWTIssuer,
+		"CYODA_JWT_AUDIENCE":                         c.IAM.JWTAudience,
+		"CYODA_JWT_EXPIRY_SECONDS":                   strconv.Itoa(c.IAM.JWTExpiry),
+		"CYODA_REQUIRE_JWT":                          strconv.FormatBool(c.IAM.RequireJWT),
+		"CYODA_JWT_BOOTSTRAP_AUDIENCE":               c.IAM.BootstrapAudience,
+		"CYODA_IAM_TRUSTED_KEY_REGISTRATION_ENABLED": strconv.FormatBool(c.IAM.TrustedKeyRegistrationEnabled),
+		"CYODA_IAM_TRUSTED_KEY_MAX_PER_TENANT":       strconv.Itoa(c.IAM.TrustedKeyMaxPerTenant),
+		"CYODA_IAM_TRUSTED_KEY_MAX_VALIDITY_DAYS":    strconv.Itoa(c.IAM.TrustedKeyMaxValidityDays),
+		"CYODA_IAM_TRUSTED_KEY_MAX_JWK_PROPERTIES":   strconv.Itoa(c.IAM.TrustedKeyMaxJWKProperties),
+		"CYODA_IAM_KEYPAIR_DEFAULT_VALIDITY_DAYS":    strconv.Itoa(c.IAM.KeypairDefaultValidityDays),
+		"CYODA_IAM_M2M_ADMIN_ROLE_ENABLED":           strconv.FormatBool(c.IAM.M2MAdminRoleEnabled),
+		"CYODA_BOOTSTRAP_CLIENT_ID":                  c.Bootstrap.ClientID,
+		"CYODA_BOOTSTRAP_CLIENT_SECRET":              "", // secret
+		"CYODA_BOOTSTRAP_TENANT_ID":                  c.Bootstrap.TenantID,
+		"CYODA_BOOTSTRAP_USER_ID":                    c.Bootstrap.UserID,
+		"CYODA_BOOTSTRAP_ROLES":                      c.Bootstrap.Roles,
+		"CYODA_OIDC_REQUIRE_HTTPS":                   strconv.FormatBool(c.IAM.OIDC.RequireHTTPS),
+		"CYODA_OIDC_CONNECT_TIMEOUT_MS":              renderMillis(c.IAM.OIDC.ConnectTimeout),
+		"CYODA_OIDC_SOCKET_TIMEOUT_MS":               renderMillis(c.IAM.OIDC.SocketTimeout),
+		"CYODA_OIDC_CONNECTION_REQUEST_TIMEOUT_MS":   renderMillis(c.IAM.OIDC.ConnectionRequestTimeout),
+		"CYODA_OIDC_ALLOW_PRIVATE_NETWORKS":          strconv.FormatBool(c.IAM.OIDC.AllowPrivateNetworks),
+		"CYODA_OIDC_ROLES_CLAIM":                     c.IAM.OIDC.DefaultRolesClaim,
+
+		// --- cors ---
+		"CYODA_CORS_ENABLED":         strconv.FormatBool(c.CORS.Enabled),
+		"CYODA_CORS_ALLOWED_ORIGINS": strings.Join(c.CORS.AllowedOrigins, ","),
+
+		// --- grpc ---
+		"CYODA_GRPC_PORT": strconv.Itoa(c.GRPC.Port),
+	}
+}
+
+// TestRootConfigVars_MatchDefaults binds help.RootConfigVars()'s Default
+// strings to what app.DefaultConfig() actually produces under an empty
+// environment. A future change to a default in config.go that isn't mirrored
+// in the table fails this test.
+func TestRootConfigVars_MatchDefaults(t *testing.T) {
+	for _, v := range help.RootConfigVars() {
+		t.Setenv(v.Name, "")
+		os.Unsetenv(v.Name)
+	}
+
+	cfg := app.DefaultConfig()
+	got := defaultFor(cfg)
+	for _, v := range help.RootConfigVars() {
+		if preConfigVars[v.Name] {
+			continue
+		}
+		want, ok := got[v.Name]
+		if !ok {
+			t.Errorf("%s: no defaultFor mapping — add one", v.Name)
+			continue
+		}
+		if v.Default != want {
+			t.Errorf("%s: table default %q != DefaultConfig() %q", v.Name, v.Default, want)
+		}
+	}
+}

--- a/app/config_registry_binding_test.go
+++ b/app/config_registry_binding_test.go
@@ -28,7 +28,7 @@ var preConfigVars = map[string]bool{
 
 // durComponentRe splits a time.Duration.String() output into its
 // (value, unit) components, e.g. "1h0m0s" -> [{1 h} {0 m} {0 s}].
-var durComponentRe = regexp.MustCompile(`(\d+)(h|m|s|ms|us|ns)`)
+var durComponentRe = regexp.MustCompile(`(\d+)(h|ms|us|ns|m|s)`)
 
 // renderDuration normalizes time.Duration.String() to the canonical form used
 // by the root ConfigVar table: trailing zero-value unit components are

--- a/app/config_registry_binding_test.go
+++ b/app/config_registry_binding_test.go
@@ -28,7 +28,17 @@ var preConfigVars = map[string]bool{
 
 // durComponentRe splits a time.Duration.String() output into its
 // (value, unit) components, e.g. "1h0m0s" -> [{1 h} {0 m} {0 s}].
-var durComponentRe = regexp.MustCompile(`(\d+)(h|ms|us|ns|m|s)`)
+var durComponentRe = regexp.MustCompile(`(\d+)(h|ms|µs|ns|m|s)`)
+
+// TestRenderDuration_Microseconds guards the microsecond unit token: Go's
+// time.Duration.String() spells microseconds "µs" (U+00B5), not "us", so the
+// component regex must match "µs" or a whole-microsecond duration renders to "".
+// Latent for current config defaults (none are sub-millisecond) but correct.
+func TestRenderDuration_Microseconds(t *testing.T) {
+	if got := renderDuration(500 * time.Microsecond); got != "500µs" {
+		t.Errorf("renderDuration(500µs) = %q, want \"500µs\"", got)
+	}
+}
 
 // renderDuration normalizes time.Duration.String() to the canonical form used
 // by the root ConfigVar table: trailing zero-value unit components are

--- a/cmd/cyoda/help/actions.go
+++ b/cmd/cyoda/help/actions.go
@@ -55,6 +55,9 @@ var actionRegistry = map[string]map[string]ActionEntry{
 	"workflows.schema-version": {
 		"versions": {Handler: emitWorkflowSchemaVersions, ContentType: "application/json"},
 	},
+	"config": {
+		"all": {Handler: writeConfigAllJSON, ContentType: "application/json"},
+	},
 }
 
 // LookupAction returns the action entry for a topic, if registered.

--- a/cmd/cyoda/help/command.go
+++ b/cmd/cyoda/help/command.go
@@ -52,6 +52,18 @@ func RunHelp(tree *Tree, args []string, out io.Writer, version string, isTTY boo
 		return writeTreeSummary(tree, out, style)
 	}
 
+	// "config all" is both a registered action (HTTP, and the generic
+	// CLI action dispatch below) and a CLI special-case here — the
+	// special-case runs first so plain-text is the CLI default and
+	// --format=json is honored, which the generic action dispatch
+	// (ContentType is fixed, ignores --format) cannot do.
+	if len(positional) == 2 && positional[0] == "config" && positional[1] == "all" {
+		if resolveFormat(format, isTTY) == "json" {
+			return writeConfigAllJSONVersion(out, version)
+		}
+		return writeConfigAllText(out)
+	}
+
 	// Topic lookup.
 	topic := tree.Find(positional)
 	if topic == nil {

--- a/cmd/cyoda/help/command.go
+++ b/cmd/cyoda/help/command.go
@@ -58,10 +58,17 @@ func RunHelp(tree *Tree, args []string, out io.Writer, version string, isTTY boo
 	// --format=json is honored, which the generic action dispatch
 	// (ContentType is fixed, ignores --format) cannot do.
 	if len(positional) == 2 && positional[0] == "config" && positional[1] == "all" {
-		if resolveFormat(format, isTTY) == "json" {
+		switch format {
+		case "json":
 			return writeConfigAllJSONVersion(out, version)
+		case "auto", "", "text":
+			return writeConfigAllText(out)
+		default:
+			// markdown/yaml are valid help formats generally but meaningless
+			// for this flat listing — reject rather than silently return text.
+			fmt.Fprintf(out, "cyoda help config all: --format=%s not supported; use text or json\n", format)
+			return 2
 		}
-		return writeConfigAllText(out)
 	}
 
 	// Topic lookup.

--- a/cmd/cyoda/help/command_test.go
+++ b/cmd/cyoda/help/command_test.go
@@ -516,6 +516,22 @@ stability: stable
 	}
 }
 
+func TestRunHelp_ConfigAll_UnsupportedFormat(t *testing.T) {
+	// config all supports only text (default) and json. markdown/yaml are
+	// valid help formats generally but meaningless for this flat listing —
+	// reject them rather than silently returning the text table.
+	for _, f := range []string{"markdown", "yaml"} {
+		var buf bytes.Buffer
+		rc := RunHelp(DefaultTree, []string{"config", "all", "--format=" + f}, &buf, "v0.0.0", false, "")
+		if rc != 2 {
+			t.Errorf("config all --format=%s: rc=%d, want 2", f, rc)
+		}
+		if !strings.Contains(buf.String(), "text or json") {
+			t.Errorf("config all --format=%s: missing guidance, got %q", f, buf.String())
+		}
+	}
+}
+
 func TestRunHelp_ConfigAll(t *testing.T) {
 	var text bytes.Buffer
 	if rc := RunHelp(DefaultTree, []string{"config", "all"}, &text, "v0.0.0", false, ""); rc != 0 {

--- a/cmd/cyoda/help/command_test.go
+++ b/cmd/cyoda/help/command_test.go
@@ -524,6 +524,12 @@ func TestRunHelp_ConfigAll(t *testing.T) {
 	if !strings.Contains(text.String(), "CYODA_HTTP_PORT") {
 		t.Error("config all (text) missing vars")
 	}
+	if json.Valid(text.Bytes()) {
+		t.Error("config all (no --format) should emit the text table, not JSON")
+	}
+	if !strings.Contains(text.String(), "[server]") {
+		t.Error("config all (text) missing topic group header")
+	}
 	var js bytes.Buffer
 	if rc := RunHelp(DefaultTree, []string{"config", "all", "--format=json"}, &js, "v0.0.0", false, ""); rc != 0 {
 		t.Fatalf("json rc=%d", rc)

--- a/cmd/cyoda/help/command_test.go
+++ b/cmd/cyoda/help/command_test.go
@@ -2,6 +2,7 @@ package help
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -512,5 +513,22 @@ stability: stable
 	}
 	if !strings.Contains(s, "`cyoda help x child`") {
 		t.Errorf("markdown subtopic entry missing: %q", s)
+	}
+}
+
+func TestRunHelp_ConfigAll(t *testing.T) {
+	var text bytes.Buffer
+	if rc := RunHelp(DefaultTree, []string{"config", "all"}, &text, "v0.0.0", false, ""); rc != 0 {
+		t.Fatalf("text rc=%d", rc)
+	}
+	if !strings.Contains(text.String(), "CYODA_HTTP_PORT") {
+		t.Error("config all (text) missing vars")
+	}
+	var js bytes.Buffer
+	if rc := RunHelp(DefaultTree, []string{"config", "all", "--format=json"}, &js, "v0.0.0", false, ""); rc != 0 {
+		t.Fatalf("json rc=%d", rc)
+	}
+	if !json.Valid(js.Bytes()) {
+		t.Error("config all --format=json not valid JSON")
 	}
 }

--- a/cmd/cyoda/help/config_registry.go
+++ b/cmd/cyoda/help/config_registry.go
@@ -45,7 +45,7 @@ var rootConfigVars = []ConfigVar{
 	{Name: "CYODA_STATS_GROUP_MAX", Topic: "search", Type: "int", Default: "10000", Description: "Cardinality ceiling for grouped-stats results; also caps the request limit parameter. Values <= 0 clamp to the default."},
 
 	// --- tx ---
-	{Name: "CYODA_TX_TTL", Topic: "tx", Type: "duration", Default: "60s", Description: "Transaction TTL."},
+	{Name: "CYODA_TX_TTL", Topic: "tx", Type: "duration", Default: "1m", Description: "Transaction TTL."},
 	{Name: "CYODA_TX_REAP_INTERVAL", Topic: "tx", Type: "duration", Default: "10s", Description: "Transaction reap interval."},
 	{Name: "CYODA_TX_OUTCOME_TTL", Topic: "tx", Type: "duration", Default: "5m", Description: "Transaction outcome TTL."},
 
@@ -61,7 +61,7 @@ var rootConfigVars = []ConfigVar{
 	{Name: "CYODA_PROXY_TIMEOUT", Topic: "cluster", Type: "duration", Default: "30s", Description: "Request proxy timeout."},
 	{Name: "CYODA_DISPATCH_WAIT_TIMEOUT", Topic: "cluster", Type: "duration", Default: "5s", Description: "How long the dispatcher polls gossip for a compute member with matching tags."},
 	{Name: "CYODA_DISPATCH_FORWARD_TIMEOUT", Topic: "cluster", Type: "duration", Default: "30s", Description: "HTTP timeout for the cross-node forwarding call."},
-	{Name: "CYODA_TX_TOKEN_TTL", Topic: "cluster", Type: "duration", Default: "90s", Description: "TTL of the signed transaction routing token minted on processor/criteria dispatch."},
+	{Name: "CYODA_TX_TOKEN_TTL", Topic: "cluster", Type: "duration", Default: "1m30s", Description: "TTL of the signed transaction routing token minted on processor/criteria dispatch."},
 	{Name: "CYODA_KEEPALIVE_INTERVAL", Topic: "cluster", Type: "int", Default: "10", Description: "Keep-alive send interval in seconds."},
 	{Name: "CYODA_KEEPALIVE_TIMEOUT", Topic: "cluster", Type: "int", Default: "30", Description: "Keep-alive timeout in seconds."},
 

--- a/cmd/cyoda/help/config_registry.go
+++ b/cmd/cyoda/help/config_registry.go
@@ -1,0 +1,111 @@
+package help
+
+// ConfigVar documents one CYODA_* configuration variable for the
+// `cyoda help config all` listing. Values are never rendered — only
+// names, types, defaults, and descriptions.
+type ConfigVar struct {
+	Name        string `json:"name"`
+	Topic       string `json:"topic"`
+	Type        string `json:"type,omitempty"`     // int|duration|bool|string|csv; "" if unknown (plugin vars)
+	Default     string `json:"default,omitempty"`  // rendered default; "" for secrets/unset
+	Required    bool   `json:"required,omitempty"`
+	Description string `json:"description"`
+}
+
+// rootConfigVars is the authoritative table for app + internal/cluster
+// env vars. Plugin vars are contributed at request time via
+// spi.DescribablePlugin (see buildConfigRegistry). Kept in sync with
+// app.DefaultConfig() by TestRootConfigVars_MatchDefaults (app_test)
+// and completed by TestConfigAll_Complete (config_registry_test.go).
+var rootConfigVars = []ConfigVar{
+	// --- server ---
+	{Name: "CYODA_HTTP_PORT", Topic: "server", Type: "int", Default: "8080", Description: "HTTP listen port."},
+	{Name: "CYODA_CONTEXT_PATH", Topic: "server", Type: "string", Default: "/api", Description: "URL prefix for all routes."},
+	{Name: "CYODA_ERROR_RESPONSE_MODE", Topic: "server", Type: "string", Default: "sanitized", Description: "Error detail level: sanitized (generic message + ticket UUID for 5xx) or verbose (internal detail included; development only)."},
+	{Name: "CYODA_LOG_LEVEL", Topic: "server", Type: "string", Default: "info", Description: "Log level: debug|info|warn|error."},
+	{Name: "CYODA_SUPPRESS_BANNER", Topic: "server", Type: "bool", Default: "false", Description: "Silence startup and mock-auth banners (CI/tests only)."},
+	{Name: "CYODA_STARTUP_TIMEOUT", Topic: "server", Type: "duration", Default: "30s", Description: "Deadline for plugin init, TM init, and (cluster mode) the gossip seed-join retry loop."},
+	{Name: "CYODA_MAX_STATE_VISITS", Topic: "server", Type: "int", Default: "10", Description: "Max visits per state in workflow cascade."},
+	{Name: "CYODA_MODEL_CACHE_LEASE", Topic: "server", Type: "duration", Default: "5m", Description: "Model cache lease duration; actual expiry is jittered ±10%."},
+	{Name: "CYODA_STORAGE_BACKEND", Topic: "server", Type: "string", Default: "memory", Description: "Storage backend selection (memory|sqlite|postgres)."},
+	{Name: "CYODA_PROFILES", Topic: "server", Type: "csv", Default: "", Description: "Comma-separated profile names; loads cyoda.<name>.env files before the process's own environment is consulted."},
+	{Name: "CYODA_DEBUG", Topic: "server", Type: "bool", Default: "false", Description: "Reserved; not currently read by the server."},
+
+	// --- admin ---
+	{Name: "CYODA_ADMIN_PORT", Topic: "admin", Type: "int", Default: "9091", Description: "Admin port for health and metrics."},
+	{Name: "CYODA_ADMIN_BIND_ADDRESS", Topic: "admin", Type: "string", Default: "127.0.0.1", Description: "Admin listener bind address."},
+	{Name: "CYODA_METRICS_REQUIRE_AUTH", Topic: "admin", Type: "bool", Default: "false", Description: "Require Bearer auth on /metrics; startup fails if true and CYODA_METRICS_BEARER is empty."},
+	{Name: "CYODA_METRICS_BEARER", Topic: "admin", Type: "string", Default: "", Description: "Static Bearer token for GET /metrics. Supports _FILE suffix."},
+	{Name: "CYODA_OTEL_ENABLED", Topic: "admin", Type: "bool", Default: "false", Description: "Enable OpenTelemetry tracing and metrics."},
+
+	// --- search ---
+	{Name: "CYODA_SEARCH_SNAPSHOT_TTL", Topic: "search", Type: "duration", Default: "1h", Description: "Search snapshot TTL."},
+	{Name: "CYODA_SEARCH_REAP_INTERVAL", Topic: "search", Type: "duration", Default: "5m", Description: "Search snapshot reap interval."},
+	{Name: "CYODA_SEARCH_MAX_SORT_KEYS", Topic: "search", Type: "int", Default: "16", Description: "Maximum number of sort keys per search request; values <= 0 clamp to the default."},
+	{Name: "CYODA_STATS_GROUP_MAX", Topic: "search", Type: "int", Default: "10000", Description: "Cardinality ceiling for grouped-stats results; also caps the request limit parameter. Values <= 0 clamp to the default."},
+
+	// --- tx ---
+	{Name: "CYODA_TX_TTL", Topic: "tx", Type: "duration", Default: "60s", Description: "Transaction TTL."},
+	{Name: "CYODA_TX_REAP_INTERVAL", Topic: "tx", Type: "duration", Default: "10s", Description: "Transaction reap interval."},
+	{Name: "CYODA_TX_OUTCOME_TTL", Topic: "tx", Type: "duration", Default: "5m", Description: "Transaction outcome TTL."},
+
+	// --- cluster ---
+	{Name: "CYODA_CLUSTER_ENABLED", Topic: "cluster", Type: "bool", Default: "false", Description: "Enable multi-node clustering."},
+	{Name: "CYODA_NODE_ID", Topic: "cluster", Type: "string", Default: "", Description: "Unique node identifier; required when CYODA_CLUSTER_ENABLED=true."},
+	{Name: "CYODA_NODE_ADDR", Topic: "cluster", Type: "string", Default: "http://localhost:8080", Description: "This node's HTTP base URL; must include scheme."},
+	{Name: "CYODA_GRPC_NODE_ADDR", Topic: "cluster", Type: "string", Default: "", Description: "This node's gRPC endpoint advertised to peers (host:port, no scheme)."},
+	{Name: "CYODA_GOSSIP_ADDR", Topic: "cluster", Type: "string", Default: ":7946", Description: "Gossip protocol listen address ([host]:port)."},
+	{Name: "CYODA_GOSSIP_STABILITY_WINDOW", Topic: "cluster", Type: "duration", Default: "2s", Description: "Gossip stability window."},
+	{Name: "CYODA_SEED_NODES", Topic: "cluster", Type: "csv", Default: "", Description: "Comma-separated list of seed node addresses."},
+	{Name: "CYODA_HMAC_SECRET", Topic: "cluster", Type: "string", Default: "", Description: "Hex-encoded HMAC secret for inter-node dispatch authentication; required when CYODA_CLUSTER_ENABLED=true. Supports _FILE suffix."},
+	{Name: "CYODA_PROXY_TIMEOUT", Topic: "cluster", Type: "duration", Default: "30s", Description: "Request proxy timeout."},
+	{Name: "CYODA_DISPATCH_WAIT_TIMEOUT", Topic: "cluster", Type: "duration", Default: "5s", Description: "How long the dispatcher polls gossip for a compute member with matching tags."},
+	{Name: "CYODA_DISPATCH_FORWARD_TIMEOUT", Topic: "cluster", Type: "duration", Default: "30s", Description: "HTTP timeout for the cross-node forwarding call."},
+	{Name: "CYODA_TX_TOKEN_TTL", Topic: "cluster", Type: "duration", Default: "90s", Description: "TTL of the signed transaction routing token minted on processor/criteria dispatch."},
+	{Name: "CYODA_KEEPALIVE_INTERVAL", Topic: "cluster", Type: "int", Default: "10", Description: "Keep-alive send interval in seconds."},
+	{Name: "CYODA_KEEPALIVE_TIMEOUT", Topic: "cluster", Type: "int", Default: "30", Description: "Keep-alive timeout in seconds."},
+
+	// --- auth ---
+	{Name: "CYODA_IAM_MODE", Topic: "auth", Type: "string", Default: "mock", Description: "Authentication mode: mock or jwt."},
+	{Name: "CYODA_IAM_MOCK_ROLES", Topic: "auth", Type: "csv", Default: "ROLE_ADMIN,ROLE_M2M", Description: "Comma-separated default user roles assigned to all requests in mock mode."},
+	{Name: "CYODA_JWT_SIGNING_KEY", Topic: "auth", Type: "string", Default: "", Description: "RSA private key in PEM format; required in jwt mode. Supports _FILE suffix."},
+	{Name: "CYODA_JWT_ISSUER", Topic: "auth", Type: "string", Default: "cyoda", Description: "JWT issuer claim (iss)."},
+	{Name: "CYODA_JWT_AUDIENCE", Topic: "auth", Type: "string", Default: "", Description: "Expected JWT audience (aud); empty disables the audience check."},
+	{Name: "CYODA_JWT_EXPIRY_SECONDS", Topic: "auth", Type: "int", Default: "3600", Description: "Token lifetime in seconds."},
+	{Name: "CYODA_REQUIRE_JWT", Topic: "auth", Type: "bool", Default: "false", Description: "Production safety floor; refuses to start unless IAM mode is jwt and a signing key is set."},
+	{Name: "CYODA_JWT_BOOTSTRAP_AUDIENCE", Topic: "auth", Type: "string", Default: "client", Description: "Audience for the bootstrap signing key derived from CYODA_JWT_SIGNING_KEY; client or human."},
+	{Name: "CYODA_IAM_TRUSTED_KEY_REGISTRATION_ENABLED", Topic: "auth", Type: "bool", Default: "false", Description: "Gates the /oauth/keys/trusted/* endpoints; disabled returns 404 FEATURE_DISABLED."},
+	{Name: "CYODA_IAM_TRUSTED_KEY_MAX_PER_TENANT", Topic: "auth", Type: "int", Default: "10", Description: "Per-tenant cap on registered trusted keys; 0 means unbounded."},
+	{Name: "CYODA_IAM_TRUSTED_KEY_MAX_VALIDITY_DAYS", Topic: "auth", Type: "int", Default: "365", Description: "Default validity for trusted keys when the registration request omits validTo."},
+	{Name: "CYODA_IAM_TRUSTED_KEY_MAX_JWK_PROPERTIES", Topic: "auth", Type: "int", Default: "20", Description: "Caps the number of properties in a registered JWK."},
+	{Name: "CYODA_IAM_KEYPAIR_DEFAULT_VALIDITY_DAYS", Topic: "auth", Type: "int", Default: "365", Description: "Default validity for the bootstrap signing key and runtime-issued keypairs."},
+	{Name: "CYODA_IAM_M2M_ADMIN_ROLE_ENABLED", Topic: "auth", Type: "bool", Default: "false", Description: "Gates the withAdminRole=true query parameter on POST /clients."},
+	{Name: "CYODA_BOOTSTRAP_CLIENT_ID", Topic: "auth", Type: "string", Default: "", Description: "Bootstrap M2M client ID."},
+	{Name: "CYODA_BOOTSTRAP_CLIENT_SECRET", Topic: "auth", Type: "string", Default: "", Description: "Bootstrap M2M client secret; must be set when CYODA_BOOTSTRAP_CLIENT_ID is set. Supports _FILE suffix."},
+	{Name: "CYODA_BOOTSTRAP_TENANT_ID", Topic: "auth", Type: "string", Default: "default-tenant", Description: "Tenant for the bootstrap client."},
+	{Name: "CYODA_BOOTSTRAP_USER_ID", Topic: "auth", Type: "string", Default: "admin", Description: "User ID for the bootstrap client."},
+	{Name: "CYODA_BOOTSTRAP_ROLES", Topic: "auth", Type: "csv", Default: "ROLE_ADMIN,ROLE_M2M", Description: "Comma-separated roles granted to the bootstrap client."},
+	{Name: "CYODA_OIDC_REQUIRE_HTTPS", Topic: "auth", Type: "bool", Default: "true", Description: "Reject federated OIDC provider registration when the well-known config URI is not https."},
+	{Name: "CYODA_OIDC_CONNECT_TIMEOUT_MS", Topic: "auth", Type: "duration", Default: "5s", Description: "TCP connect timeout for OIDC discovery and JWKS endpoint fetches."},
+	{Name: "CYODA_OIDC_SOCKET_TIMEOUT_MS", Topic: "auth", Type: "duration", Default: "5s", Description: "HTTP read timeout for OIDC discovery and JWKS endpoint fetches."},
+	{Name: "CYODA_OIDC_CONNECTION_REQUEST_TIMEOUT_MS", Topic: "auth", Type: "duration", Default: "5s", Description: "Connection-pool request timeout for OIDC discovery and JWKS endpoint fetches."},
+	{Name: "CYODA_OIDC_ALLOW_PRIVATE_NETWORKS", Topic: "auth", Type: "bool", Default: "false", Description: "Bypass the SSRF blocklist so private-network OIDC providers can be registered; test/dev only, never in production."},
+	{Name: "CYODA_OIDC_ROLES_CLAIM", Topic: "auth", Type: "string", Default: "roles", Description: "JWT claim name from which role values are read for tokens issued by a federated OIDC provider."},
+
+	// --- cors ---
+	{Name: "CYODA_CORS_ENABLED", Topic: "cors", Type: "bool", Default: "true", Description: "Enable CORS middleware; false hands CORS handling to an upstream ingress."},
+	{Name: "CYODA_CORS_ALLOWED_ORIGINS", Topic: "cors", Type: "csv", Default: "", Description: "Comma-separated allowed origins, or * for wildcard mode; empty selects loopback mode."},
+
+	// --- grpc ---
+	{Name: "CYODA_GRPC_PORT", Topic: "grpc", Type: "int", Default: "9090", Description: "gRPC listen port."},
+	{Name: "CYODA_COMPUTE_GRPC_ENDPOINT", Topic: "grpc", Type: "string", Default: "", Description: "gRPC endpoint for a compute node to connect to (compute-client side)."},
+	{Name: "CYODA_COMPUTE_TOKEN", Topic: "grpc", Type: "string", Default: "", Description: "Bearer token for compute-node authentication (compute-client side)."},
+	{Name: "CYODA_COMPUTE_HTTP_BASE", Topic: "grpc", Type: "string", Default: "", Description: "HTTP base URL of the cyoda instance a compute node calls back into (compute-client side)."},
+}
+
+// RootConfigVars returns a copy of the root var table.
+func RootConfigVars() []ConfigVar {
+	out := make([]ConfigVar, len(rootConfigVars))
+	copy(out, rootConfigVars)
+	return out
+}

--- a/cmd/cyoda/help/config_registry.go
+++ b/cmd/cyoda/help/config_registry.go
@@ -1,5 +1,12 @@
 package help
 
+import (
+	"sort"
+	"strings"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
 // ConfigVar documents one CYODA_* configuration variable for the
 // `cyoda help config all` listing. Values are never rendered — only
 // names, types, defaults, and descriptions.
@@ -107,5 +114,62 @@ var rootConfigVars = []ConfigVar{
 func RootConfigVars() []ConfigVar {
 	out := make([]ConfigVar, len(rootConfigVars))
 	copy(out, rootConfigVars)
+	return out
+}
+
+// pluginVarTopic maps a plugin-contributed var to its help subtopic.
+// Schema-extension vars are shared by SQL backends; SQLite/Postgres
+// vars group under "database". Unknown prefixes fall back to the
+// plugin name so a new backend is never silently mis-grouped.
+func pluginVarTopic(varName, pluginName string) string {
+	switch {
+	case strings.HasPrefix(varName, "CYODA_SCHEMA_"):
+		return "schema"
+	case strings.HasPrefix(varName, "CYODA_SQLITE_"), strings.HasPrefix(varName, "CYODA_POSTGRES_"):
+		return "database"
+	default:
+		return pluginName
+	}
+}
+
+// buildConfigRegistry assembles the full config-var registry at call
+// time: the root table plus every registered DescribablePlugin's
+// ConfigVars(). Deduped by name (root wins). Sorted by topic, then name.
+func buildConfigRegistry() []ConfigVar {
+	out := make([]ConfigVar, 0, len(rootConfigVars))
+	seen := map[string]bool{}
+	for _, v := range rootConfigVars {
+		out = append(out, v)
+		seen[v.Name] = true
+	}
+	for _, name := range spi.RegisteredPlugins() {
+		p, ok := spi.GetPlugin(name)
+		if !ok {
+			continue
+		}
+		dp, ok := p.(spi.DescribablePlugin)
+		if !ok {
+			continue // e.g. memory — no config vars
+		}
+		for _, cv := range dp.ConfigVars() {
+			if seen[cv.Name] {
+				continue
+			}
+			seen[cv.Name] = true
+			out = append(out, ConfigVar{
+				Name:        cv.Name,
+				Topic:       pluginVarTopic(cv.Name, name),
+				Default:     cv.Default,
+				Required:    cv.Required,
+				Description: cv.Description,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Topic != out[j].Topic {
+			return out[i].Topic < out[j].Topic
+		}
+		return out[i].Name < out[j].Name
+	})
 	return out
 }

--- a/cmd/cyoda/help/config_registry.go
+++ b/cmd/cyoda/help/config_registry.go
@@ -218,7 +218,7 @@ func writeConfigAllText(w io.Writer) int {
 		if v.Required {
 			def = "(required)"
 		}
-		fmt.Fprintf(tw, "  %s\t%s\t%s\n", v.Name, def, v.Description)
+		fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n", v.Name, v.Type, def, v.Description)
 	}
 	if err := tw.Flush(); err != nil {
 		fmt.Fprintf(w, "cyoda help config all: %v\n", err)

--- a/cmd/cyoda/help/config_registry.go
+++ b/cmd/cyoda/help/config_registry.go
@@ -29,7 +29,7 @@ var rootConfigVars = []ConfigVar{
 	{Name: "CYODA_MODEL_CACHE_LEASE", Topic: "server", Type: "duration", Default: "5m", Description: "Model cache lease duration; actual expiry is jittered ±10%."},
 	{Name: "CYODA_STORAGE_BACKEND", Topic: "server", Type: "string", Default: "memory", Description: "Storage backend selection (memory|sqlite|postgres)."},
 	{Name: "CYODA_PROFILES", Topic: "server", Type: "csv", Default: "", Description: "Comma-separated profile names; loads cyoda.<name>.env files before the process's own environment is consulted."},
-	{Name: "CYODA_DEBUG", Topic: "server", Type: "bool", Default: "false", Description: "Reserved; not currently read by the server."},
+	{Name: "CYODA_DEBUG", Topic: "server", Type: "", Default: "", Description: "Reserved; not currently read by the server."},
 
 	// --- admin ---
 	{Name: "CYODA_ADMIN_PORT", Topic: "admin", Type: "int", Default: "9091", Description: "Admin port for health and metrics."},
@@ -86,9 +86,9 @@ var rootConfigVars = []ConfigVar{
 	{Name: "CYODA_BOOTSTRAP_USER_ID", Topic: "auth", Type: "string", Default: "admin", Description: "User ID for the bootstrap client."},
 	{Name: "CYODA_BOOTSTRAP_ROLES", Topic: "auth", Type: "csv", Default: "ROLE_ADMIN,ROLE_M2M", Description: "Comma-separated roles granted to the bootstrap client."},
 	{Name: "CYODA_OIDC_REQUIRE_HTTPS", Topic: "auth", Type: "bool", Default: "true", Description: "Reject federated OIDC provider registration when the well-known config URI is not https."},
-	{Name: "CYODA_OIDC_CONNECT_TIMEOUT_MS", Topic: "auth", Type: "duration", Default: "5s", Description: "TCP connect timeout for OIDC discovery and JWKS endpoint fetches."},
-	{Name: "CYODA_OIDC_SOCKET_TIMEOUT_MS", Topic: "auth", Type: "duration", Default: "5s", Description: "HTTP read timeout for OIDC discovery and JWKS endpoint fetches."},
-	{Name: "CYODA_OIDC_CONNECTION_REQUEST_TIMEOUT_MS", Topic: "auth", Type: "duration", Default: "5s", Description: "Connection-pool request timeout for OIDC discovery and JWKS endpoint fetches."},
+	{Name: "CYODA_OIDC_CONNECT_TIMEOUT_MS", Topic: "auth", Type: "int", Default: "5000", Description: "TCP connect timeout in milliseconds for OIDC discovery and JWKS endpoint fetches."},
+	{Name: "CYODA_OIDC_SOCKET_TIMEOUT_MS", Topic: "auth", Type: "int", Default: "5000", Description: "HTTP read timeout in milliseconds for OIDC discovery and JWKS endpoint fetches."},
+	{Name: "CYODA_OIDC_CONNECTION_REQUEST_TIMEOUT_MS", Topic: "auth", Type: "int", Default: "5000", Description: "Connection-pool request timeout in milliseconds for OIDC discovery and JWKS endpoint fetches."},
 	{Name: "CYODA_OIDC_ALLOW_PRIVATE_NETWORKS", Topic: "auth", Type: "bool", Default: "false", Description: "Bypass the SSRF blocklist so private-network OIDC providers can be registered; test/dev only, never in production."},
 	{Name: "CYODA_OIDC_ROLES_CLAIM", Topic: "auth", Type: "string", Default: "roles", Description: "JWT claim name from which role values are read for tokens issued by a federated OIDC provider."},
 

--- a/cmd/cyoda/help/config_registry.go
+++ b/cmd/cyoda/help/config_registry.go
@@ -1,8 +1,12 @@
 package help
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"sort"
 	"strings"
+	"text/tabwriter"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 )
@@ -172,4 +176,53 @@ func buildConfigRegistry() []ConfigVar {
 		return out[i].Name < out[j].Name
 	})
 	return out
+}
+
+// configAllEnvelope is the JSON shape for `cyoda help config all
+// --format=json` and `GET /help/config/all`.
+type configAllEnvelope struct {
+	Schema  int         `json:"schema"`
+	Version string      `json:"version"`
+	Vars    []ConfigVar `json:"vars"`
+}
+
+// writeConfigAllJSONVersion writes the config-all JSON envelope with an
+// explicit version. Used by the CLI special-case in command.go, which
+// has the real binary version in scope.
+func writeConfigAllJSONVersion(w io.Writer, version string) int {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(configAllEnvelope{Schema: 1, Version: version, Vars: buildConfigRegistry()}); err != nil {
+		fmt.Fprintf(w, "cyoda help config all: encode: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// writeConfigAllJSON is the action-registry entry (HTTP + generic CLI
+// action dispatch); version is unknown here, so it is emitted empty.
+func writeConfigAllJSON(w io.Writer) int { return writeConfigAllJSONVersion(w, "") }
+
+// writeConfigAllText renders the full config-var registry as a
+// tab-aligned table grouped by topic, for `cyoda help config all` on a
+// terminal.
+func writeConfigAllText(w io.Writer) int {
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	var topic string
+	for _, v := range buildConfigRegistry() {
+		if v.Topic != topic {
+			topic = v.Topic
+			fmt.Fprintf(tw, "\n[%s]\n", topic)
+		}
+		def := v.Default
+		if v.Required {
+			def = "(required)"
+		}
+		fmt.Fprintf(tw, "  %s\t%s\t%s\n", v.Name, def, v.Description)
+	}
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintf(w, "cyoda help config all: %v\n", err)
+		return 1
+	}
+	return 0
 }

--- a/cmd/cyoda/help/config_registry.go
+++ b/cmd/cyoda/help/config_registry.go
@@ -17,8 +17,8 @@ import (
 type ConfigVar struct {
 	Name        string `json:"name"`
 	Topic       string `json:"topic"`
-	Type        string `json:"type,omitempty"`     // int|duration|bool|string|csv; "" if unknown (plugin vars)
-	Default     string `json:"default,omitempty"`  // rendered default; "" for secrets/unset
+	Type        string `json:"type,omitempty"`    // int|duration|bool|string|csv; "" if unknown (plugin vars)
+	Default     string `json:"default,omitempty"` // rendered default; "" for secrets/unset
 	Required    bool   `json:"required,omitempty"`
 	Description string `json:"description"`
 }

--- a/cmd/cyoda/help/config_registry_test.go
+++ b/cmd/cyoda/help/config_registry_test.go
@@ -138,6 +138,26 @@ func TestWriteConfigAllJSON_Envelope(t *testing.T) {
 	}
 }
 
+func TestWriteConfigAllText_ShowsType(t *testing.T) {
+	// The text table should carry the Type column the JSON envelope has, so
+	// CLI users see int/duration/bool without switching to --format=json.
+	var buf bytes.Buffer
+	if rc := writeConfigAllText(&buf); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	s := buf.String()
+	// CYODA_HTTP_PORT is an int root var; its row must show the type.
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, "CYODA_HTTP_PORT") {
+			if !strings.Contains(line, "int") {
+				t.Errorf("CYODA_HTTP_PORT row missing type: %q", line)
+			}
+			return
+		}
+	}
+	t.Error("CYODA_HTTP_PORT row not found")
+}
+
 func TestWriteConfigAllText_ListsVars(t *testing.T) {
 	var buf bytes.Buffer
 	if rc := writeConfigAllText(&buf); rc != 0 {

--- a/cmd/cyoda/help/config_registry_test.go
+++ b/cmd/cyoda/help/config_registry_test.go
@@ -1,6 +1,12 @@
 package help
 
-import "testing"
+import (
+	"testing"
+
+	_ "github.com/cyoda-platform/cyoda-go/plugins/memory"
+	_ "github.com/cyoda-platform/cyoda-go/plugins/postgres"
+	_ "github.com/cyoda-platform/cyoda-go/plugins/sqlite"
+)
 
 func TestRootConfigVars_WellFormed(t *testing.T) {
 	vars := RootConfigVars()
@@ -31,5 +37,39 @@ func TestRootConfigVars_WellFormed(t *testing.T) {
 	// Schema/database vars are plugin-owned — must NOT be in the root table.
 	if seen["CYODA_SQLITE_PATH"] || seen["CYODA_SCHEMA_SAVEPOINT_INTERVAL"] {
 		t.Error("plugin-owned var leaked into root table")
+	}
+}
+
+func TestBuildConfigRegistry_IncludesPluginVars(t *testing.T) {
+	reg := buildConfigRegistry()
+	idx := map[string]ConfigVar{}
+	for _, v := range reg {
+		idx[v.Name] = v
+	}
+	// Plugin vars present, topic assigned.
+	if v, ok := idx["CYODA_SQLITE_PATH"]; !ok || v.Topic != "database" {
+		t.Errorf("CYODA_SQLITE_PATH: got %+v, want topic=database", v)
+	}
+	if v, ok := idx["CYODA_POSTGRES_URL"]; !ok || !v.Required {
+		t.Errorf("CYODA_POSTGRES_URL: got %+v, want Required", v)
+	}
+	// Root vars still present.
+	if _, ok := idx["CYODA_HTTP_PORT"]; !ok {
+		t.Error("root var CYODA_HTTP_PORT missing from aggregate")
+	}
+	// memory implements no ConfigVars() — must not blow up (skipped).
+}
+
+func TestPluginVarTopic(t *testing.T) {
+	cases := map[[2]string]string{
+		{"CYODA_SCHEMA_SAVEPOINT_INTERVAL", "sqlite"}: "schema",
+		{"CYODA_SQLITE_PATH", "sqlite"}:               "database",
+		{"CYODA_POSTGRES_URL", "postgres"}:            "database",
+		{"CYODA_WHATEVER", "future"}:                  "future",
+	}
+	for in, want := range cases {
+		if got := pluginVarTopic(in[0], in[1]); got != want {
+			t.Errorf("pluginVarTopic(%q,%q)=%q want %q", in[0], in[1], got, want)
+		}
 	}
 }

--- a/cmd/cyoda/help/config_registry_test.go
+++ b/cmd/cyoda/help/config_registry_test.go
@@ -1,0 +1,35 @@
+package help
+
+import "testing"
+
+func TestRootConfigVars_WellFormed(t *testing.T) {
+	vars := RootConfigVars()
+	if len(vars) < 40 {
+		t.Fatalf("expected the full root var set, got %d", len(vars))
+	}
+	seen := map[string]bool{}
+	validTopic := map[string]bool{
+		"server": true, "admin": true, "search": true, "tx": true,
+		"cluster": true, "auth": true, "cors": true, "grpc": true,
+	}
+	for _, v := range vars {
+		if v.Name == "" || v.Description == "" {
+			t.Errorf("var %+v missing name/description", v)
+		}
+		if seen[v.Name] {
+			t.Errorf("duplicate var %s", v.Name)
+		}
+		seen[v.Name] = true
+		if !validTopic[v.Topic] {
+			t.Errorf("var %s has non-root topic %q", v.Name, v.Topic)
+		}
+	}
+	// Cluster vars are root-owned (they live in DefaultConfig()).
+	if !seen["CYODA_CLUSTER_ENABLED"] || !seen["CYODA_NODE_ID"] {
+		t.Error("cluster vars missing from root table")
+	}
+	// Schema/database vars are plugin-owned — must NOT be in the root table.
+	if seen["CYODA_SQLITE_PATH"] || seen["CYODA_SCHEMA_SAVEPOINT_INTERVAL"] {
+		t.Error("plugin-owned var leaked into root table")
+	}
+}

--- a/cmd/cyoda/help/config_registry_test.go
+++ b/cmd/cyoda/help/config_registry_test.go
@@ -1,6 +1,8 @@
 package help
 
 import (
+	"sort"
+	"strings"
 	"testing"
 
 	_ "github.com/cyoda-platform/cyoda-go/plugins/memory"
@@ -58,6 +60,41 @@ func TestBuildConfigRegistry_IncludesPluginVars(t *testing.T) {
 		t.Error("root var CYODA_HTTP_PORT missing from aggregate")
 	}
 	// memory implements no ConfigVars() — must not blow up (skipped).
+}
+
+// TestConfigAll_Complete is the authoritative completeness guard: every
+// CYODA_* var referenced in source (cmd, app, plugins, internal) must
+// appear in the aggregate registry rendered by `cyoda help config all`.
+// Nothing can be added to a plugin's parseConfig without also showing up
+// here.
+func TestConfigAll_Complete(t *testing.T) {
+	root := repoRoot(t) // reuse the go.mod-walk helper from TestConfig_EnvVarCoverage
+	scanned := scanEnvVarsInGoSource(t, root, []string{"cmd", "app", "plugins", "internal"})
+
+	registry := map[string]bool{}
+	for _, v := range buildConfigRegistry() {
+		registry[v.Name] = true
+	}
+
+	var missing []string
+	for name := range scanned {
+		if isTestOnlyEnv(name) {
+			continue
+		}
+		if strings.HasSuffix(name, "_") {
+			continue // comment fragment, e.g. CYODA_POSTGRES_
+		}
+		if strings.HasSuffix(name, "_FILE") {
+			continue // derived variant of a base var
+		}
+		if !registry[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("CYODA_* vars in source but absent from `config all`:\n  %s", strings.Join(missing, "\n  "))
+	}
 }
 
 func TestPluginVarTopic(t *testing.T) {

--- a/cmd/cyoda/help/config_registry_test.go
+++ b/cmd/cyoda/help/config_registry_test.go
@@ -1,6 +1,8 @@
 package help
 
 import (
+	"bytes"
+	"encoding/json"
 	"sort"
 	"strings"
 	"testing"
@@ -107,6 +109,44 @@ func TestPluginVarTopic(t *testing.T) {
 	for in, want := range cases {
 		if got := pluginVarTopic(in[0], in[1]); got != want {
 			t.Errorf("pluginVarTopic(%q,%q)=%q want %q", in[0], in[1], got, want)
+		}
+	}
+}
+
+func TestWriteConfigAllJSON_Envelope(t *testing.T) {
+	var buf bytes.Buffer
+	if rc := writeConfigAllJSON(&buf); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	var env struct {
+		Schema  int         `json:"schema"`
+		Version string      `json:"version"`
+		Vars    []ConfigVar `json:"vars"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if env.Schema != 1 || len(env.Vars) < 40 {
+		t.Fatalf("schema=%d vars=%d", env.Schema, len(env.Vars))
+	}
+	names := map[string]bool{}
+	for _, v := range env.Vars {
+		names[v.Name] = true
+	}
+	if !names["CYODA_HTTP_PORT"] || !names["CYODA_SQLITE_PATH"] {
+		t.Error("json missing expected vars")
+	}
+}
+
+func TestWriteConfigAllText_ListsVars(t *testing.T) {
+	var buf bytes.Buffer
+	if rc := writeConfigAllText(&buf); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	s := buf.String()
+	for _, want := range []string{"CYODA_HTTP_PORT", "CYODA_CLUSTER_ENABLED", "CYODA_SQLITE_PATH", "cluster", "database"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("text output missing %q", want)
 		}
 	}
 }

--- a/cmd/cyoda/help/content/config.md
+++ b/cmd/cyoda/help/content/config.md
@@ -29,6 +29,7 @@ All configuration is environment variables prefixed with `CYODA_`. Topics group 
 - `config.grpc` — gRPC listener and compute-node credentials
 - `config.schema` — schema-extension log tuning
 - `config.cluster` — multi-node clustering, gossip, cross-node dispatch
+- `config all` — flat listing of every variable (append `--format=json` for the docs-site JSON)
 
 ## DESCRIPTION
 

--- a/cmd/cyoda/help/content/config.md
+++ b/cmd/cyoda/help/content/config.md
@@ -10,6 +10,7 @@ see_also:
   - config.database
   - config.grpc
   - config.schema
+  - config.cluster
 ---
 
 # config
@@ -27,6 +28,7 @@ All configuration is environment variables prefixed with `CYODA_`. Topics group 
 - `config.database` — storage backend selection, per-backend connection settings
 - `config.grpc` — gRPC listener and compute-node credentials
 - `config.schema` — schema-extension log tuning
+- `config.cluster` — multi-node clustering, gossip, cross-node dispatch
 
 ## DESCRIPTION
 
@@ -89,26 +91,15 @@ loads `cyoda.postgres.env` and `cyoda.otel.env` from the working directory.
 
 ### Cluster and dispatch
 
-- `CYODA_CLUSTER_ENABLED` (bool, default: `false`) — enable multi-node clustering.
-- `CYODA_NODE_ID` (string, default: unset) — unique node identifier; required when `CYODA_CLUSTER_ENABLED=true`; any non-empty string is accepted.
-- `CYODA_NODE_ADDR` (string, default: `http://localhost:8080`) — this node's HTTP base URL; must include scheme (`http://` or `https://`).
-- `CYODA_GRPC_NODE_ADDR` (string, default: unset) — this node's gRPC endpoint advertised to peers (`host:port`, no scheme). When set, peers dial this address for cross-node gRPC callback forwarding. When unset, peers derive the gRPC address from this node's HTTP host plus their own `CYODA_GRPC_PORT` (uniform-deployment default).
-- `CYODA_GOSSIP_ADDR` (string, default: `:7946`) — gossip protocol listen address; format `[host]:port` — parsed via `net.SplitHostPort`; invalid format causes startup failure.
-- `CYODA_GOSSIP_STABILITY_WINDOW` (duration, default: `2s`) — gossip stability window.
-- `CYODA_SEED_NODES` (string, default: empty) — comma-separated list of seed node addresses (e.g., `node1.example.com:7946,node2.example.com:7946`); empty means single-node or seed-discovery handled externally.
-- `CYODA_HMAC_SECRET` (string, default: unset) — hex-encoded HMAC secret for inter-node dispatch authentication; required when `CYODA_CLUSTER_ENABLED=true`. Supports `_FILE` suffix.
-- `CYODA_PROXY_TIMEOUT` (duration, default: `30s`) — request proxy timeout.
-- `CYODA_DISPATCH_WAIT_TIMEOUT` (duration, default: `5s`) — how long the dispatcher polls gossip for a compute member with matching tags.
-- `CYODA_DISPATCH_FORWARD_TIMEOUT` (duration, default: `30s`) — HTTP timeout for the cross-node forwarding call.
-- `CYODA_TX_TOKEN_TTL` (duration, default: `90s`) — TTL of the signed transaction routing token minted on processor/criteria dispatch; must be ≥ `CYODA_DISPATCH_FORWARD_TIMEOUT` so the token remains valid through the full round-trip and callback verification, including the forwarded-chain case where two budgets stack.
-- `CYODA_KEEPALIVE_INTERVAL` (int, default: `10`) — keep-alive send interval in seconds.
-- `CYODA_KEEPALIVE_TIMEOUT` (int, default: `30`) — keep-alive timeout in seconds.
+See `config.cluster` for multi-node clustering, gossip, and cross-node dispatch variables.
 
 ## SEE ALSO
 
 - cli
 - run
 - config.auth
+- config.cors
 - config.database
 - config.grpc
 - config.schema
+- config.cluster

--- a/cmd/cyoda/help/content/config/cluster.md
+++ b/cmd/cyoda/help/content/config/cluster.md
@@ -1,0 +1,36 @@
+---
+topic: config.cluster
+title: "cyoda cluster & dispatch configuration"
+stability: stable
+see_also:
+  - config
+  - run
+---
+
+# config.cluster
+
+## NAME
+
+config.cluster — multi-node clustering, gossip, and cross-node dispatch env vars.
+
+## DESCRIPTION
+
+- `CYODA_CLUSTER_ENABLED` (bool, default: `false`) — enable multi-node clustering.
+- `CYODA_NODE_ID` (string, default: unset) — unique node identifier; required when `CYODA_CLUSTER_ENABLED=true`; any non-empty string is accepted.
+- `CYODA_NODE_ADDR` (string, default: `http://localhost:8080`) — this node's HTTP base URL; must include scheme (`http://` or `https://`).
+- `CYODA_GRPC_NODE_ADDR` (string, default: unset) — this node's gRPC endpoint advertised to peers (`host:port`, no scheme). When set, peers dial this address for cross-node gRPC callback forwarding. When unset, peers derive the gRPC address from this node's HTTP host plus their own `CYODA_GRPC_PORT` (uniform-deployment default).
+- `CYODA_GOSSIP_ADDR` (string, default: `:7946`) — gossip protocol listen address; format `[host]:port` — parsed via `net.SplitHostPort`; invalid format causes startup failure.
+- `CYODA_GOSSIP_STABILITY_WINDOW` (duration, default: `2s`) — gossip stability window.
+- `CYODA_SEED_NODES` (string, default: empty) — comma-separated list of seed node addresses (e.g., `node1.example.com:7946,node2.example.com:7946`); empty means single-node or seed-discovery handled externally.
+- `CYODA_HMAC_SECRET` (string, default: unset) — hex-encoded HMAC secret for inter-node dispatch authentication; required when `CYODA_CLUSTER_ENABLED=true`. Supports `_FILE` suffix.
+- `CYODA_PROXY_TIMEOUT` (duration, default: `30s`) — request proxy timeout.
+- `CYODA_DISPATCH_WAIT_TIMEOUT` (duration, default: `5s`) — how long the dispatcher polls gossip for a compute member with matching tags.
+- `CYODA_DISPATCH_FORWARD_TIMEOUT` (duration, default: `30s`) — HTTP timeout for the cross-node forwarding call.
+- `CYODA_TX_TOKEN_TTL` (duration, default: `90s`) — TTL of the signed transaction routing token minted on processor/criteria dispatch; must be ≥ `CYODA_DISPATCH_FORWARD_TIMEOUT` so the token remains valid through the full round-trip and callback verification, including the forwarded-chain case where two budgets stack.
+- `CYODA_KEEPALIVE_INTERVAL` (int, default: `10`) — keep-alive send interval in seconds.
+- `CYODA_KEEPALIVE_TIMEOUT` (int, default: `30`) — keep-alive timeout in seconds.
+
+## SEE ALSO
+
+- config
+- run

--- a/cmd/cyoda/help/content/config/schema.md
+++ b/cmd/cyoda/help/content/config/schema.md
@@ -29,6 +29,8 @@ backends.
   backends that support native schema extension with optimistic concurrency
   (default: `8`, minimum: `1`). Increase if you observe contention under high concurrency.
 
+The prefix `CYODA_SCHEMA_` is used to namespace all schema-extension configuration variables.
+
 ## EXAMPLES
 
 **High-write workload (more frequent savepoints):**

--- a/cmd/cyoda/help/help_test.go
+++ b/cmd/cyoda/help/help_test.go
@@ -547,19 +547,7 @@ var errCodePattern = regexp.MustCompile(`ErrCode[A-Z][A-Za-z0-9]+\s*=\s*"([A-Z0-
 // TestErrCode_Parity asserts every ErrCode* in internal/common/error_codes.go
 // has a matching errors/<CODE>.md topic file, and vice versa.
 func TestErrCode_Parity(t *testing.T) {
-	wd, _ := os.Getwd()
-	root := wd
-	for {
-		if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
-			break
-		}
-		parent := filepath.Dir(root)
-		if parent == root {
-			t.Skip("cannot locate repo root")
-			return
-		}
-		root = parent
-	}
+	root := repoRoot(t)
 	src, err := os.ReadFile(filepath.Join(root, "internal/common/error_codes.go"))
 	if err != nil {
 		t.Fatalf("read error_codes.go: %v", err)
@@ -607,19 +595,7 @@ var printHelpMustAppearPhrases = []string{
 }
 
 func TestPrintHelp_ContentMigrationParity(t *testing.T) {
-	wd, _ := os.Getwd()
-	root := wd
-	for {
-		if _, err := os.Stat(filepath.Join(root, "go.mod")); err == nil {
-			break
-		}
-		parent := filepath.Dir(root)
-		if parent == root {
-			t.Skip("cannot locate repo root")
-			return
-		}
-		root = parent
-	}
+	root := repoRoot(t)
 	var combined strings.Builder
 	for _, dir := range []string{"cmd/cyoda/help/content/cli", "cmd/cyoda/help/content/config"} {
 		_ = filepath.WalkDir(filepath.Join(root, dir), func(p string, d fs.DirEntry, err error) error {

--- a/cmd/cyoda/help/help_test.go
+++ b/cmd/cyoda/help/help_test.go
@@ -461,11 +461,9 @@ func isTestOnlyEnv(v string) bool {
 	return false
 }
 
-// TestConfig_EnvVarCoverage asserts every CYODA_* env var referenced in
-// source also appears in cmd/cyoda/help/content/config/**/*.md (or
-// config.md). Scope: cmd, app, plugins, internal (excluding _test.go).
-func TestConfig_EnvVarCoverage(t *testing.T) {
-	// Walk up from getwd until we find go.mod.
+// repoRoot walks up from the current working directory until it finds
+// go.mod, returning that directory. Skips the test if no go.mod is found.
+func repoRoot(t *testing.T) string {
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("getwd: %v", err)
@@ -473,15 +471,22 @@ func TestConfig_EnvVarCoverage(t *testing.T) {
 	root := wd
 	for {
 		if _, statErr := os.Stat(filepath.Join(root, "go.mod")); statErr == nil {
-			break
+			return root
 		}
 		parent := filepath.Dir(root)
 		if parent == root {
 			t.Skip("cannot locate repo root; test skipped")
-			return
+			return ""
 		}
 		root = parent
 	}
+}
+
+// TestConfig_EnvVarCoverage asserts every CYODA_* env var referenced in
+// source also appears in cmd/cyoda/help/content/config/**/*.md (or
+// config.md). Scope: cmd, app, plugins, internal (excluding _test.go).
+func TestConfig_EnvVarCoverage(t *testing.T) {
+	root := repoRoot(t)
 
 	referenced := scanEnvVarsInGoSource(t, root, []string{"cmd", "app", "plugins", "internal"})
 	documented := scanEnvVarsInConfigDocs(t, filepath.Join(root, "cmd/cyoda/help/content"))

--- a/cmd/cyoda/help/help_test.go
+++ b/cmd/cyoda/help/help_test.go
@@ -899,3 +899,32 @@ func TestDefaultTree_AuthLandingListsAllChildren(t *testing.T) {
 		}
 	}
 }
+
+// TestDefaultTree_ConfigClusterSubtopic verifies the cluster/dispatch env
+// vars live under their own config.cluster subtopic (mirroring
+// auth/cors/database/grpc/schema) and that config.md's see_also lists both
+// config.cluster and config.cors.
+func TestDefaultTree_ConfigClusterSubtopic(t *testing.T) {
+	node := DefaultTree.Find([]string{"config", "cluster"})
+	if node == nil {
+		t.Fatal("config.cluster topic not found")
+	}
+	// The cluster/dispatch vars must now live under config.cluster, not config.
+	body := string(node.Body)
+	for _, want := range []string{"CYODA_CLUSTER_ENABLED", "CYODA_SEED_NODES", "CYODA_DISPATCH_WAIT_TIMEOUT"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("config.cluster body missing %s", want)
+		}
+	}
+	// config.md must list cluster (frontmatter see_also drives Descriptor.SeeAlso).
+	cfg := DefaultTree.Find([]string{"config"})
+	if cfg == nil {
+		t.Fatal("config topic not found")
+	}
+	joined := strings.Join(cfg.Descriptor().SeeAlso, ",")
+	for _, want := range []string{"config.cluster", "config.cors"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("config see_also missing %s (got %q)", want, joined)
+		}
+	}
+}

--- a/docs/superpowers/plans/2026-07-08-config-help-all-cluster.md
+++ b/docs/superpowers/plans/2026-07-08-config-help-all-cluster.md
@@ -1,0 +1,830 @@
+# Config help: `config all` + `config.cluster` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `cyoda help config all` (human table + `--format=json`) backed by a request-time `ConfigVar` registry, a `config.cluster` subtopic, and a completeness test that fails CI if any `CYODA_*` var is missing from the listing.
+
+**Architecture:** A Go `ConfigVar` registry is the single source of truth. Root vars (`app`+`internal/cluster`) live in a table in the `help` package; plugin vars come from the pre-existing `spi.DescribablePlugin.ConfigVars()` interface, enumerated via `spi.RegisteredPlugins()` at request time. The aggregate is rendered as text (CLI default) or JSON (CLI `--format=json`, and always over HTTP). Placement avoids the `app`→`help` import cycle: the table lives in `help` (imports `spi`, never `app`); the default-drift test lives in `app_test`.
+
+**Tech Stack:** Go 1.26, `cyoda-go-spi` v0.8.2 (`DescribablePlugin`, `ConfigVar`, `RegisteredPlugins` already present), existing `cmd/cyoda/help` embed/action framework.
+
+## Global Constraints
+
+- Go 1.26+; `log/slog` only (help CLI output uses `fmt.Fprint` to injected writers — user-facing, not logging).
+- Never emit config **values** — `config all` lists names/defaults/descriptions only (Gate 3).
+- No `cyoda-go-spi` change: the `DescribablePlugin` interface already exists and is consumed, not modified.
+- No issue IDs in shipped artefacts (code, help content, JSON) — issue refs belong in commits/PR only.
+- Env var scan regex (existing): `CYODA_[A-Z][A-Z0-9_]*`. Test-only exclusions (existing `isTestOnlyEnv`): prefixes `CYODA_TEST_`, `CYODA_MARKER`, `CYODA_DEBUG_`; suffix `_FOR_TESTING`.
+- Registry JSON envelope mirrors `renderer.HelpPayload`: `{ "schema": 1, "version": <ver>, "vars": [...] }`.
+
+---
+
+### Task 1: `config.cluster` subtopic + `config.md` fixes
+
+Moves the cluster/dispatch var block into its own subtopic (mirrors auth/cors/database/grpc/schema) and fixes the `config.cors` SEE-ALSO omission found during reconciliation.
+
+**Files:**
+- Create: `cmd/cyoda/help/content/config/cluster.md`
+- Modify: `cmd/cyoda/help/content/config.md` (remove the "### Cluster and dispatch" block; add `config.cluster` to frontmatter `see_also`, SYNOPSIS list, and the bottom `## SEE ALSO`; add `config.cors` to the bottom `## SEE ALSO`)
+- Test: `cmd/cyoda/help/help_test.go` (add `TestDefaultTree_ConfigClusterSubtopic`)
+
+**Interfaces:**
+- Consumes: existing `help.DefaultTree`, `Tree.Find`, `Topic.DottedPath`.
+- Produces: a resolvable `config.cluster` topic; no exported Go symbols.
+
+- [ ] **Step 1: Write the failing test**
+
+In `cmd/cyoda/help/help_test.go`:
+
+```go
+func TestDefaultTree_ConfigClusterSubtopic(t *testing.T) {
+	node := DefaultTree.Find([]string{"config", "cluster"})
+	if node == nil {
+		t.Fatal("config.cluster topic not found")
+	}
+	// The cluster/dispatch vars must now live under config.cluster, not config.
+	for _, want := range []string{"CYODA_CLUSTER_ENABLED", "CYODA_SEED_NODES", "CYODA_DISPATCH_WAIT_TIMEOUT"} {
+		if !strings.Contains(node.Body, want) {
+			t.Errorf("config.cluster body missing %s", want)
+		}
+	}
+	// config.md must list cluster (frontmatter see_also drives Descriptor.SeeAlso).
+	cfg := DefaultTree.Find([]string{"config"})
+	if cfg == nil {
+		t.Fatal("config topic not found")
+	}
+	joined := strings.Join(cfg.Descriptor().SeeAlso, ",")
+	for _, want := range []string{"config.cluster", "config.cors"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("config see_also missing %s (got %q)", want, joined)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/cyoda/help/ -run TestDefaultTree_ConfigClusterSubtopic -v`
+Expected: FAIL — `config.cluster topic not found`.
+
+- [ ] **Step 3: Create `content/config/cluster.md`**
+
+Frontmatter must satisfy `parseFrontMatter` (required: `topic`, `title`, `stability` ∈ stable|evolving|experimental). Transcribe the cluster/dispatch bullets verbatim from the current `config.md` "### Cluster and dispatch" section (lines beginning `CYODA_CLUSTER_ENABLED` … `CYODA_KEEPALIVE_TIMEOUT`).
+
+```markdown
+---
+topic: config.cluster
+title: "cyoda cluster & dispatch configuration"
+stability: stable
+see_also:
+  - config
+  - run
+---
+
+# config.cluster
+
+## NAME
+
+config.cluster — multi-node clustering, gossip, and cross-node dispatch env vars.
+
+## DESCRIPTION
+
+<transcribe the CYODA_CLUSTER_ENABLED … CYODA_KEEPALIVE_TIMEOUT bullets
+from config.md's "### Cluster and dispatch" section, unchanged>
+
+## SEE ALSO
+
+- config
+- run
+```
+
+- [ ] **Step 4: Edit `config.md`**
+
+Remove the entire `### Cluster and dispatch` block (the moved bullets). In its place under DESCRIPTION add a one-line pointer:
+
+```markdown
+### Cluster and dispatch
+
+See `config.cluster` for multi-node clustering, gossip, and cross-node dispatch variables.
+```
+
+Add `- config.cluster` to the frontmatter `see_also` (after `config.schema`), to the SYNOPSIS bullet list (`- \`config.cluster\` — multi-node clustering, gossip, cross-node dispatch`), and to the bottom `## SEE ALSO`. Add `- config.cors` to the bottom `## SEE ALSO` (currently missing).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./cmd/cyoda/help/ -run 'TestDefaultTree_ConfigClusterSubtopic|TestConfig_EnvVarCoverage' -v`
+Expected: PASS (coverage test still green — vars moved within the content tree, still present).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/cyoda/help/content/config/cluster.md cmd/cyoda/help/content/config.md cmd/cyoda/help/help_test.go
+git commit -m "feat(help): add config.cluster subtopic; fix config.cors see-also"
+```
+
+---
+
+### Task 2: `ConfigVar` type + root registry table
+
+Defines the aggregate type and the authoritative root-var table (all `app` + `internal/cluster` vars). Plugin vars are added in Task 4; `CYODA_SCHEMA_*` belong to plugins (Task 5).
+
+**Files:**
+- Create: `cmd/cyoda/help/config_registry.go`
+- Test: `cmd/cyoda/help/config_registry_test.go`
+
+**Interfaces:**
+- Produces:
+  - `type ConfigVar struct { Name, Topic, Type, Default string; Required bool; Description string }` (json tags: `name,topic,type,omitempty,default,omitempty,required,omitempty,description`).
+  - `var rootConfigVars []ConfigVar` (unexported) and `func RootConfigVars() []ConfigVar` (exported, returns a copy — consumed by the `app_test` binding test in Task 3).
+
+- [ ] **Step 1: Write the failing test**
+
+`cmd/cyoda/help/config_registry_test.go`:
+
+```go
+package help
+
+import "testing"
+
+func TestRootConfigVars_WellFormed(t *testing.T) {
+	vars := RootConfigVars()
+	if len(vars) < 40 {
+		t.Fatalf("expected the full root var set, got %d", len(vars))
+	}
+	seen := map[string]bool{}
+	validTopic := map[string]bool{
+		"server": true, "admin": true, "search": true, "tx": true,
+		"cluster": true, "auth": true, "cors": true, "grpc": true,
+	}
+	for _, v := range vars {
+		if v.Name == "" || v.Description == "" {
+			t.Errorf("var %+v missing name/description", v)
+		}
+		if seen[v.Name] {
+			t.Errorf("duplicate var %s", v.Name)
+		}
+		seen[v.Name] = true
+		if !validTopic[v.Topic] {
+			t.Errorf("var %s has non-root topic %q", v.Name, v.Topic)
+		}
+	}
+	// Cluster vars are root-owned (they live in DefaultConfig()).
+	if !seen["CYODA_CLUSTER_ENABLED"] || !seen["CYODA_NODE_ID"] {
+		t.Error("cluster vars missing from root table")
+	}
+	// Schema/database vars are plugin-owned — must NOT be in the root table.
+	if seen["CYODA_SQLITE_PATH"] || seen["CYODA_SCHEMA_SAVEPOINT_INTERVAL"] {
+		t.Error("plugin-owned var leaked into root table")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/cyoda/help/ -run TestRootConfigVars_WellFormed -v`
+Expected: FAIL — `RootConfigVars` undefined.
+
+- [ ] **Step 3: Create `config_registry.go` with the type and full table**
+
+Transcribe every `app` + `internal/cluster` var. Authoritative sources: `app/config.go` (names + defaults, the `envX("CYODA_…", <default>)` calls at lines ~178–272) and `content/config/*.md` + `config.md` (one-line descriptions). Topics: `server` (HTTP_PORT, CONTEXT_PATH, ERROR_RESPONSE_MODE, LOG_LEVEL, SUPPRESS_BANNER, STARTUP_TIMEOUT, MAX_STATE_VISITS, MODEL_CACHE_LEASE, PROFILES, DEBUG), `admin` (ADMIN_PORT, ADMIN_BIND_ADDRESS, METRICS_REQUIRE_AUTH, METRICS_BEARER, OTEL_ENABLED), `search` (SEARCH_SNAPSHOT_TTL, SEARCH_REAP_INTERVAL, SEARCH_MAX_SORT_KEYS), `tx` (TX_TTL, TX_REAP_INTERVAL, TX_OUTCOME_TTL), `cluster` (CLUSTER_ENABLED, NODE_ID, NODE_ADDR, GRPC_NODE_ADDR, GOSSIP_ADDR, GOSSIP_STABILITY_WINDOW, SEED_NODES, HMAC_SECRET, PROXY_TIMEOUT, DISPATCH_WAIT_TIMEOUT, DISPATCH_FORWARD_TIMEOUT, TX_TOKEN_TTL, KEEPALIVE_INTERVAL, KEEPALIVE_TIMEOUT), `auth` (IAM_MODE, IAM_MOCK_ROLES, JWT_*, REQUIRE_JWT, IAM_TRUSTED_KEY_*, IAM_KEYPAIR_DEFAULT_VALIDITY_DAYS, IAM_M2M_ADMIN_ROLE_ENABLED, JWT_BOOTSTRAP_AUDIENCE, BOOTSTRAP_*, OIDC_*, HMAC_SECRET already in cluster — HMAC is cluster), `cors` (CORS_ENABLED, CORS_ALLOWED_ORIGINS), `grpc` (GRPC_PORT, COMPUTE_GRPC_ENDPOINT, COMPUTE_HTTP_BASE, COMPUTE_TOKEN). Do **not** include `*_FILE` variants (derived) or plugin vars. The Task 5 completeness test is the backstop that every non-excluded scanned var appears here or in a plugin's `ConfigVars()`.
+
+```go
+package help
+
+// ConfigVar documents one CYODA_* configuration variable for the
+// `cyoda help config all` listing. Values are never rendered — only
+// names, types, defaults, and descriptions.
+type ConfigVar struct {
+	Name        string `json:"name"`
+	Topic       string `json:"topic"`
+	Type        string `json:"type,omitempty"`     // int|duration|bool|string|csv; "" if unknown (plugin vars)
+	Default     string `json:"default,omitempty"`  // rendered default; "" for secrets/unset
+	Required    bool   `json:"required,omitempty"`
+	Description string `json:"description"`
+}
+
+// rootConfigVars is the authoritative table for app + internal/cluster
+// env vars. Plugin vars are contributed at request time via
+// spi.DescribablePlugin (see buildConfigRegistry). Kept in sync with
+// app.DefaultConfig() by TestRootConfigVars_MatchDefaults (app_test)
+// and completed by TestConfigAll_Complete (config_registry_test.go).
+var rootConfigVars = []ConfigVar{
+	// --- server ---
+	{Name: "CYODA_HTTP_PORT", Topic: "server", Type: "int", Default: "8080", Description: "HTTP listen port."},
+	{Name: "CYODA_CONTEXT_PATH", Topic: "server", Type: "string", Default: "/api", Description: "URL prefix for all routes."},
+	// … transcribe ALL remaining server/admin/search/tx/cluster/auth/cors/grpc vars …
+}
+
+// RootConfigVars returns a copy of the root var table.
+func RootConfigVars() []ConfigVar {
+	out := make([]ConfigVar, len(rootConfigVars))
+	copy(out, rootConfigVars)
+	return out
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/cyoda/help/ -run TestRootConfigVars_WellFormed -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/cyoda/help/config_registry.go cmd/cyoda/help/config_registry_test.go
+git commit -m "feat(help): add ConfigVar type and root registry table"
+```
+
+---
+
+### Task 3: Root default-drift binding test (`app_test`)
+
+Binds the root table's `Default` strings to what `DefaultConfig()` actually produces under an empty environment, so a changed default in `config.go` fails CI. Lives in `app_test` to import both `app` and `help` without a production cycle.
+
+**Files:**
+- Create: `app/config_registry_binding_test.go` (package `app_test`)
+
+**Interfaces:**
+- Consumes: `help.RootConfigVars()`, `app.DefaultConfig()` (verify its exact name/signature in `app/config.go`; it returns the populated `Config`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package app_test
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/app"
+	"github.com/cyoda-platform/cyoda-go/cmd/cyoda/help"
+)
+
+// preConfigVars are read outside DefaultConfig() (profile loader / reserved),
+// so their defaults can't be asserted against the Config struct.
+var preConfigVars = map[string]bool{
+	"CYODA_PROFILES": true,
+	"CYODA_DEBUG":    true,
+}
+
+// defaultFor maps each root var to the rendered default DefaultConfig()
+// yields under an empty env. Every non-preConfig root var MUST have an
+// entry — the coverage assertion below enforces it.
+func defaultFor(c app.Config) map[string]string {
+	return map[string]string{
+		"CYODA_HTTP_PORT":    strconv.Itoa(c.HTTPPort),
+		"CYODA_CONTEXT_PATH": c.ContextPath,
+		// … one entry per non-preConfig root var, rendered to match the
+		//   table's Default string (durations via .String(), bools via
+		//   strconv.FormatBool, secrets to "") …
+	}
+}
+
+func TestRootConfigVars_MatchDefaults(t *testing.T) {
+	for _, k := range []string{ // ensure empty env
+		"CYODA_HTTP_PORT", "CYODA_CONTEXT_PATH",
+	} {
+		t.Setenv(k, "")
+		os.Unsetenv(k)
+	}
+	cfg := app.DefaultConfig()
+	got := defaultFor(cfg)
+	for _, v := range help.RootConfigVars() {
+		if preConfigVars[v.Name] {
+			continue
+		}
+		want, ok := got[v.Name]
+		if !ok {
+			t.Errorf("%s: no defaultFor mapping — add one", v.Name)
+			continue
+		}
+		if v.Default != want {
+			t.Errorf("%s: table default %q != DefaultConfig() %q", v.Name, v.Default, want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./app/ -run TestRootConfigVars_MatchDefaults -v`
+Expected: FAIL — mappings incomplete / mismatches until `defaultFor` covers every root var and the table matches.
+
+- [ ] **Step 3: Complete `defaultFor`**
+
+Add one entry per non-preConfig root var, rendering each field to the exact string form used in the table (`time.Duration.String()` → `"5m"`, `strconv.FormatBool`, `strconv.Itoa`, secrets → `""`). Fix any table `Default` that disagrees with `DefaultConfig()`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./app/ -run TestRootConfigVars_MatchDefaults -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/config_registry_binding_test.go cmd/cyoda/help/config_registry.go
+git commit -m "test(app): bind root ConfigVar defaults to DefaultConfig()"
+```
+
+---
+
+### Task 4: `buildConfigRegistry` — aggregate root + plugin vars
+
+Assembles the full registry at request time: root table + every registered `DescribablePlugin`'s `ConfigVars()`, with plugin topics assigned and dedup by name.
+
+**Files:**
+- Modify: `cmd/cyoda/help/config_registry.go`
+- Test: `cmd/cyoda/help/config_registry_test.go`
+
+**Interfaces:**
+- Consumes: `spi.RegisteredPlugins() []string`, `spi.GetPlugin(name) (Plugin, bool)`, `spi.DescribablePlugin`, `spi.ConfigVar{Name,Description,Default,Required}`.
+- Produces: `func buildConfigRegistry() []ConfigVar` (sorted by Topic then Name); `func pluginVarTopic(varName, pluginName string) string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `config_registry_test.go`. A blank import registers the real plugins so `spi.RegisteredPlugins()` returns them:
+
+```go
+import (
+	_ "github.com/cyoda-platform/cyoda-go/plugins/memory"
+	_ "github.com/cyoda-platform/cyoda-go/plugins/postgres"
+	_ "github.com/cyoda-platform/cyoda-go/plugins/sqlite"
+)
+
+func TestBuildConfigRegistry_IncludesPluginVars(t *testing.T) {
+	reg := buildConfigRegistry()
+	idx := map[string]ConfigVar{}
+	for _, v := range reg {
+		idx[v.Name] = v
+	}
+	// Plugin vars present, topic assigned.
+	if v, ok := idx["CYODA_SQLITE_PATH"]; !ok || v.Topic != "database" {
+		t.Errorf("CYODA_SQLITE_PATH: got %+v, want topic=database", v)
+	}
+	if v, ok := idx["CYODA_POSTGRES_URL"]; !ok || !v.Required {
+		t.Errorf("CYODA_POSTGRES_URL: got %+v, want Required", v)
+	}
+	// Root vars still present.
+	if _, ok := idx["CYODA_HTTP_PORT"]; !ok {
+		t.Error("root var CYODA_HTTP_PORT missing from aggregate")
+	}
+	// memory implements no ConfigVars() — must not blow up (skipped).
+}
+
+func TestPluginVarTopic(t *testing.T) {
+	cases := map[[2]string]string{
+		{"CYODA_SCHEMA_SAVEPOINT_INTERVAL", "sqlite"}: "schema",
+		{"CYODA_SQLITE_PATH", "sqlite"}:               "database",
+		{"CYODA_POSTGRES_URL", "postgres"}:            "database",
+		{"CYODA_WHATEVER", "future"}:                  "future",
+	}
+	for in, want := range cases {
+		if got := pluginVarTopic(in[0], in[1]); got != want {
+			t.Errorf("pluginVarTopic(%q,%q)=%q want %q", in[0], in[1], got, want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/cyoda/help/ -run 'TestBuildConfigRegistry|TestPluginVarTopic' -v`
+Expected: FAIL — `buildConfigRegistry`/`pluginVarTopic` undefined.
+
+- [ ] **Step 3: Implement in `config_registry.go`**
+
+```go
+import (
+	"sort"
+	"strings"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// pluginVarTopic maps a plugin-contributed var to its help subtopic.
+// Schema-extension vars are shared by SQL backends; SQLite/Postgres
+// vars group under "database". Unknown prefixes fall back to the
+// plugin name so a new backend is never silently mis-grouped.
+func pluginVarTopic(varName, pluginName string) string {
+	switch {
+	case strings.HasPrefix(varName, "CYODA_SCHEMA_"):
+		return "schema"
+	case strings.HasPrefix(varName, "CYODA_SQLITE_"), strings.HasPrefix(varName, "CYODA_POSTGRES_"):
+		return "database"
+	default:
+		return pluginName
+	}
+}
+
+// buildConfigRegistry assembles the full config-var registry at call
+// time: the root table plus every registered DescribablePlugin's
+// ConfigVars(). Deduped by name (root wins). Sorted by topic, then name.
+func buildConfigRegistry() []ConfigVar {
+	out := make([]ConfigVar, 0, len(rootConfigVars))
+	seen := map[string]bool{}
+	for _, v := range rootConfigVars {
+		out = append(out, v)
+		seen[v.Name] = true
+	}
+	for _, name := range spi.RegisteredPlugins() {
+		p, ok := spi.GetPlugin(name)
+		if !ok {
+			continue
+		}
+		dp, ok := p.(spi.DescribablePlugin)
+		if !ok {
+			continue // e.g. memory — no config vars
+		}
+		for _, cv := range dp.ConfigVars() {
+			if seen[cv.Name] {
+				continue
+			}
+			seen[cv.Name] = true
+			out = append(out, ConfigVar{
+				Name:        cv.Name,
+				Topic:       pluginVarTopic(cv.Name, name),
+				Default:     cv.Default,
+				Required:    cv.Required,
+				Description: cv.Description,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Topic != out[j].Topic {
+			return out[i].Topic < out[j].Topic
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/cyoda/help/ -run 'TestBuildConfigRegistry|TestPluginVarTopic' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/cyoda/help/config_registry.go cmd/cyoda/help/config_registry_test.go
+git commit -m "feat(help): aggregate root + DescribablePlugin config vars"
+```
+
+---
+
+### Task 5: Completeness test — registry ⊇ source scan (drives plugin `CYODA_SCHEMA_*` fix)
+
+The authoritative guard. Reuses the existing `scanEnvVarsInGoSource`. It goes red because sqlite/postgres parse `CYODA_SCHEMA_*` but omit them from `ConfigVars()`; the fix adds them (Topic → `schema` via `pluginVarTopic`).
+
+**Files:**
+- Modify: `cmd/cyoda/help/config_registry_test.go`
+- Modify: `plugins/sqlite/plugin.go`, `plugins/postgres/plugin.go`
+
+**Interfaces:**
+- Consumes: existing `scanEnvVarsInGoSource(t, root, dirs)`, `isTestOnlyEnv(v)`, `envVarPattern`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestConfigAll_Complete(t *testing.T) {
+	root := repoRoot(t) // reuse the go.mod-walk helper from TestConfig_EnvVarCoverage
+	scanned := scanEnvVarsInGoSource(t, root, []string{"cmd", "app", "plugins", "internal"})
+
+	registry := map[string]bool{}
+	for _, v := range buildConfigRegistry() {
+		registry[v.Name] = true
+	}
+
+	var missing []string
+	for name := range scanned {
+		if isTestOnlyEnv(name) {
+			continue
+		}
+		if strings.HasSuffix(name, "_") {
+			continue // comment fragment, e.g. CYODA_POSTGRES_
+		}
+		if strings.HasSuffix(name, "_FILE") {
+			continue // derived variant of a base var
+		}
+		if !registry[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("CYODA_* vars in source but absent from `config all`:\n  %s", strings.Join(missing, "\n  "))
+	}
+}
+```
+
+If `repoRoot`/go.mod-walk is currently inline in `TestConfig_EnvVarCoverage`, extract it to a shared helper first (pure refactor, no behavior change).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/cyoda/help/ -run TestConfigAll_Complete -v`
+Expected: FAIL — lists `CYODA_SCHEMA_EXTEND_MAX_RETRIES`, `CYODA_SCHEMA_SAVEPOINT_INTERVAL` (parsed by both SQL plugins, absent from their `ConfigVars()`).
+
+- [ ] **Step 3: Add the schema vars to both plugins' `ConfigVars()`**
+
+In `plugins/sqlite/plugin.go` and `plugins/postgres/plugin.go`, append to the returned slice (defaults match each plugin's `parseConfig`: sqlite savepoint `64` / retries `8`; verify postgres' via its `config.go`):
+
+```go
+{Name: "CYODA_SCHEMA_SAVEPOINT_INTERVAL", Description: "Rows per savepoint during schema extension", Default: "64"},
+{Name: "CYODA_SCHEMA_EXTEND_MAX_RETRIES", Description: "Max retries on concurrent schema extension", Default: "8"},
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/cyoda/help/ -run TestConfigAll_Complete -v` (root module sees plugins via go.work)
+Expected: PASS.
+
+- [ ] **Step 5: Verify plugin modules still build/test**
+
+Run: `cd plugins/sqlite && go test ./... && cd ../postgres && go test ./...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/cyoda/help/config_registry_test.go cmd/cyoda/help/help_test.go plugins/sqlite/plugin.go plugins/postgres/plugin.go
+git commit -m "feat(help): completeness test; add CYODA_SCHEMA_* to plugin ConfigVars()"
+```
+
+---
+
+### Task 6: `config all` rendering + CLI/HTTP wiring
+
+Adds the shared JSON/text emitters, registers the HTTP action, and special-cases the CLI so `cyoda help config all` prints a table and `--format=json` prints JSON.
+
+**Files:**
+- Modify: `cmd/cyoda/help/config_registry.go` (emitters)
+- Modify: `cmd/cyoda/help/actions.go` (register `config`/`all`)
+- Modify: `cmd/cyoda/help/command.go` (CLI special-case)
+- Test: `cmd/cyoda/help/config_registry_test.go`, `cmd/cyoda/help/command_test.go`
+
+**Interfaces:**
+- Produces: `func writeConfigAllJSON(w io.Writer) int`, `func writeConfigAllText(w io.Writer) int`.
+- Consumes: `buildConfigRegistry`, existing `RunHelp` dispatch, `renderer` (not required — plain `fmt`/`json`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestWriteConfigAllJSON_Envelope(t *testing.T) {
+	var buf bytes.Buffer
+	if rc := writeConfigAllJSON(&buf); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	var env struct {
+		Schema  int         `json:"schema"`
+		Version string      `json:"version"`
+		Vars    []ConfigVar `json:"vars"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if env.Schema != 1 || len(env.Vars) < 40 {
+		t.Fatalf("schema=%d vars=%d", env.Schema, len(env.Vars))
+	}
+	names := map[string]bool{}
+	for _, v := range env.Vars {
+		names[v.Name] = true
+	}
+	if !names["CYODA_HTTP_PORT"] || !names["CYODA_SQLITE_PATH"] {
+		t.Error("json missing expected vars")
+	}
+}
+
+func TestWriteConfigAllText_ListsVars(t *testing.T) {
+	var buf bytes.Buffer
+	if rc := writeConfigAllText(&buf); rc != 0 {
+		t.Fatalf("rc=%d", rc)
+	}
+	s := buf.String()
+	for _, want := range []string{"CYODA_HTTP_PORT", "CYODA_CLUSTER_ENABLED", "CYODA_SQLITE_PATH", "cluster", "database"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("text output missing %q", want)
+		}
+	}
+}
+```
+
+And in `command_test.go`, an end-to-end CLI test:
+
+```go
+func TestRunHelp_ConfigAll(t *testing.T) {
+	var text bytes.Buffer
+	if rc := RunHelp(DefaultTree, []string{"config", "all"}, &text, "v0.0.0", false, ""); rc != 0 {
+		t.Fatalf("text rc=%d", rc)
+	}
+	if !strings.Contains(text.String(), "CYODA_HTTP_PORT") {
+		t.Error("config all (text) missing vars")
+	}
+	var js bytes.Buffer
+	if rc := RunHelp(DefaultTree, []string{"config", "all", "--format=json"}, &js, "v0.0.0", false, ""); rc != 0 {
+		t.Fatalf("json rc=%d", rc)
+	}
+	if !json.Valid(js.Bytes()) {
+		t.Error("config all --format=json not valid JSON")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/cyoda/help/ -run 'ConfigAll|WriteConfigAll' -v`
+Expected: FAIL — emitters undefined; `RunHelp` treats `config all` as unknown.
+
+- [ ] **Step 3: Implement emitters (`config_registry.go`)**
+
+`version` isn't in scope inside an `ActionFunc`; use the build version the help package already exposes, or omit and let the CLI/HTTP layer not require it — simplest is a package var mirror. Here, read it from the same source `writeFullTreeJSON` uses (pass-through not available to actions, so emit `version` as the binary's version via `renderer`-independent constant is wrong). Instead, keep the envelope's `version` empty in the action and populate it only on the CLI path where `RunHelp` has `version`. Concretely, split:
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+)
+
+type configAllEnvelope struct {
+	Schema  int         `json:"schema"`
+	Version string      `json:"version"`
+	Vars    []ConfigVar `json:"vars"`
+}
+
+func writeConfigAllJSONVersion(w io.Writer, version string) int {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(configAllEnvelope{Schema: 1, Version: version, Vars: buildConfigRegistry()}); err != nil {
+		fmt.Fprintf(w, "cyoda help config all: encode: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// writeConfigAllJSON is the action-registry entry (HTTP + generic CLI
+// action dispatch); version is unknown here, so it is emitted empty.
+func writeConfigAllJSON(w io.Writer) int { return writeConfigAllJSONVersion(w, "") }
+
+func writeConfigAllText(w io.Writer) int {
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	var topic string
+	for _, v := range buildConfigRegistry() {
+		if v.Topic != topic {
+			topic = v.Topic
+			fmt.Fprintf(tw, "\n[%s]\n", topic)
+		}
+		def := v.Default
+		if v.Required {
+			def = "(required)"
+		}
+		fmt.Fprintf(tw, "  %s\t%s\t%s\n", v.Name, def, v.Description)
+	}
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintf(w, "cyoda help config all: %v\n", err)
+		return 1
+	}
+	return 0
+}
+```
+
+- [ ] **Step 4: Register the HTTP action (`actions.go`)**
+
+Add to `actionRegistry`:
+
+```go
+	"config": {
+		"all": {Handler: writeConfigAllJSON, ContentType: "application/json"},
+	},
+```
+
+- [ ] **Step 5: CLI special-case (`command.go`)**
+
+Before the generic topic/action dispatch (after `positional` is built and `format` validated), add:
+
+```go
+	if len(positional) == 2 && positional[0] == "config" && positional[1] == "all" {
+		if resolveFormat(format, isTTY) == "json" {
+			return writeConfigAllJSONVersion(out, version)
+		}
+		return writeConfigAllText(out)
+	}
+```
+
+This runs before `tree.Find`, so the JSON path carries the real `version`; HTTP uses the registered action (version empty, consistent with action semantics).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./cmd/cyoda/help/ -run 'ConfigAll|WriteConfigAll' -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/cyoda/help/config_registry.go cmd/cyoda/help/actions.go cmd/cyoda/help/command.go cmd/cyoda/help/config_registry_test.go cmd/cyoda/help/command_test.go
+git commit -m "feat(help): render config all as text (CLI) and JSON (CLI+HTTP)"
+```
+
+---
+
+### Task 7: HTTP endpoint coverage
+
+Verifies `GET /help/config/all` over the real HTTP stack: 200 + `application/json` for GET, 405 for non-GET (existing help-route behavior).
+
+**Files:**
+- Create: `internal/api/help_configall_test.go`
+
+**Interfaces:**
+- Consumes: existing `RegisterHelpRoutes(mux, help.DefaultTree, "", version)` test setup pattern (mirror `internal/api/help_action_test.go`).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func TestHTTP_ConfigAll_JSON(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterHelpRoutes(mux, help.DefaultTree, "", "v0.0.0")
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/help/config/all")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type=%q", ct)
+	}
+	var env struct{ Vars []map[string]any `json:"vars"` }
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil || len(env.Vars) == 0 {
+		t.Fatalf("decode/vars: %v len=%d", err, len(env.Vars))
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/help/config/all", nil)
+	pr, _ := http.DefaultClient.Do(req)
+	if pr.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("POST status=%d want 405", pr.StatusCode)
+	}
+	pr.Body.Close()
+}
+```
+
+Note: the HTTP help server binary registers plugins via blank import at startup; this in-process test does not, so the JSON here reflects root vars only — assert `len(Vars) > 0`, not plugin-specific names (those are covered by `TestBuildConfigRegistry` and `TestConfigAll_Complete`).
+
+- [ ] **Step 2: Run test to verify it fails, then passes**
+
+Run: `go test ./internal/api/ -run TestHTTP_ConfigAll_JSON -v`
+Expected: FAIL first if action not wired (it is, from Task 6) → should PASS. If 200-but-wrong-shape, fix envelope.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/api/help_configall_test.go
+git commit -m "test(api): cover GET /help/config/all (200 json, 405 non-GET)"
+```
+
+---
+
+### Task 8: Gate-4 docs + full verification
+
+**Files:**
+- Modify: `README.md` (config reference: mention `cyoda help config all` / `--format=json` and the `config cluster` subtopic)
+- Modify: `cmd/cyoda/help/content/config.md` (SYNOPSIS: add a line noting `config all` lists every var; JSON via `--format=json`)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Update README**
+
+In the configuration section, add: “Run `cyoda help config all` for the complete env-var reference (add `--format=json` for machine-readable output); `cyoda help config cluster` covers multi-node/dispatch vars.” Keep it to 1–2 lines (compact-prose rule).
+
+- [ ] **Step 2: Update `config.md` SYNOPSIS**
+
+Add a bullet: `` - `config all` — flat listing of every variable (append `--format=json` for the docs-site JSON). ``
+
+- [ ] **Step 3: Full verification**
+
+Run: `go test ./... && (cd plugins/sqlite && go test ./...) && (cd plugins/postgres && go test ./...) && (cd plugins/memory && go test ./...)`
+Run: `go vet ./...`
+Run: `go build -o /tmp/cyoda ./cmd/cyoda && /tmp/cyoda help config all && /tmp/cyoda help config all --format=json | head -20 && /tmp/cyoda help config cluster | head`
+Expected: all green; the three commands render the table, valid JSON, and the cluster subtopic.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md cmd/cyoda/help/content/config.md
+git commit -m "docs: reference config all + config cluster (Gate 4)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** registry single-source (T2/T4) ✓; `spi.DescribablePlugin` consumption, request-time, CLI+HTTP (T4/T6/T7) ✓; root default-drift binding, pre-config exemption (T3) ✓; completeness test with fragment/`_FILE`/test-only special-cases + memory-skip + plugin-scope caveat (T5) ✓; `config all` text+JSON, HTTP always JSON (T6/T7) ✓; `config.cluster` subtopic + `config.cors` fix (T1) ✓; Gate-4 docs (T8) ✓. In-tree plugin `CYODA_SCHEMA_*` drift fixed as a consequence (T5) ✓. No new error codes → no `errors/*.md` (spec-confirmed). No cross-backend parity scenario (host behavior; plugin participation covered by completeness test) — matches spec.
+
+**Placeholders:** the root table (T2) and `defaultFor` map (T3) are transcription-from-source *data*, not logic — the authoritative sources (`app/config.go`, `config.md`) are named, and the T3 binding test + T5 completeness test together fail CI until every row is present and correct. All logic steps carry complete code.
+
+**Type consistency:** `ConfigVar{Name,Topic,Type,Default,Required,Description}` used identically in T2/T4/T6; `RootConfigVars()`/`buildConfigRegistry()`/`writeConfigAllJSONVersion`/`writeConfigAllText`/`pluginVarTopic` names consistent across tasks; `spi.ConfigVar{Name,Description,Default,Required}` fields match the SPI (verified).

--- a/docs/superpowers/specs/2026-07-08-config-help-all-cluster-design.md
+++ b/docs/superpowers/specs/2026-07-08-config-help-all-cluster-design.md
@@ -1,0 +1,99 @@
+# Config help: `config all` full listing + `config.cluster` subtopic
+
+Issue: cyoda-go#395 (milestone v0.8.3). Cross-repo: Cyoda/cyoda-go-cassandra#60 (mirror, not implemented here).
+
+## Motivation
+
+`cyoda help config` documents 100% of `CYODA_*` vars (enforced by `TestConfig_EnvVarCoverage`), but:
+
+1. The subtopic tree breaks out only `auth`, `cors`, `database`, `grpc`, `schema`. Cluster/dispatch, server, admin/metrics, and search/transaction vars live only in prose in the parent `config.md`. Multi-node is the primary target — cluster/dispatch config should be a first-class subtopic.
+2. No single command authoritatively lists **all** vars, and there is no machine-consumable form for the docs site.
+
+## Design
+
+### Source of truth — a `ConfigVar` registry, assembled at request time
+
+The listing is rendered from a Go registry, never from parsing markdown. Two contributors, aggregated on each request so runtime-registered plugins are visible:
+
+- **Plugin vars** come from the SPI's existing optional interface. `cyoda-go-spi` already defines `DescribablePlugin { Plugin; ConfigVars() []ConfigVar }`; postgres, sqlite, and the commercial backend already implement it (memory deliberately does not). The root **consumes** it — `spi.RegisteredPlugins()` → `spi.GetPlugin(name)` → type-assert `DescribablePlugin` → `ConfigVars()`. This is **not** an SPI change (the interface pre-exists, unused by the root). It is reachable identically from the CLI (`cmd/cyoda`) and the HTTP help routes (`app/app.go`), and surfaces the out-of-tree commercial plugin with zero root import.
+- **Root vars** (`app` + `internal/cluster`, which no plugin owns) come from a root-side table.
+
+Aggregate type (richer than `spi.ConfigVar`, which is only `{Name, Description, Default, Required}`):
+
+```go
+type ConfigVar struct {
+    Name        string // "CYODA_HTTP_PORT"
+    Topic       string // server|admin|search|tx|cluster|auth|cors|database|grpc|schema|<plugin-name>
+    Type        string // int|duration|bool|string|csv — best-effort; "" for plugin vars (SPI has no Type)
+    Default     string // rendered default; "" for secrets/unset
+    Description string
+    FileSuffix  bool   // supports the CYODA_*_FILE variant
+    Secret      bool   // root-known secrets; not load-bearing (values are never emitted)
+}
+```
+
+Folding `spi.ConfigVar` → aggregate: `Name`/`Default`/`Description` map over; `Topic` = plugin name; `Type` = `""`. Dedup by `Name` (shared vars like `CYODA_SCHEMA_EXTEND_MAX_RETRIES` may appear in both a plugin's list and the scan) — first writer wins, root table before plugins.
+
+### Placement (avoids an import cycle)
+
+`app` imports `help` (`help.DefaultTree`), so `help` must **not** import `app`.
+
+- The **root `ConfigVar` table** and `buildConfigRegistry()` live in the `help` package. `help` imports `spi` (a leaf module — no cycle) to enumerate plugins. No import of `app`.
+- The **default-drift binding test** lives in an external `app_test` package: it imports both `app` (for `DefaultConfig()`) and `help` (for the exported root table). Test-only cross-import, no production cycle.
+- The **completeness test** lives in the `help` package and blank-imports the plugins (root `go.mod` already requires them) so `spi.RegisteredPlugins()` returns them during the test.
+
+### Command surface
+
+- `cyoda help config all` — human-readable table grouped by topic (CLI default).
+- `cyoda help config all --format=json` — JSON envelope `{schema:1, version, vars:[…]}`, mirroring the existing `HelpPayload` shape.
+- `GET /help/config/all` — always `application/json` (consistent with all HTTP help, which is JSON by design).
+
+Wiring (no action-framework change; openapi special-case untouched):
+
+- Shared: `writeConfigAllJSON(w)` / `writeConfigAllText(w)`, both over `buildConfigRegistry()`.
+- HTTP: register `config`/`all` in `actionRegistry` with `ContentType: application/json`, handler `writeConfigAllJSON`. Served by the existing action-mirror.
+- CLI: `command.go` special-cases positional `["config","all"]` — `--format=json` → `writeConfigAllJSON`, otherwise → `writeConfigAllText`. Mirrors branches `command.go` already has.
+
+### `config.cluster` subtopic
+
+- New `content/config/cluster.md`; move the cluster/dispatch var block out of `config.md`'s prose into it, mirroring the existing subtopic structure. `config.md` keeps its synopsis bullet + SEE ALSO entry.
+- Fold in the `config.cors` SEE-ALSO fix (present in frontmatter/synopsis, missing from the bottom list).
+
+### Completeness test
+
+Assert `names(buildConfigRegistry()) ⊇ scanEnvVarsInGoSource(root + plugins)`, reusing the existing scan. Special-cases:
+
+- Strip trailing-underscore comment fragments (`CYODA_POSTGRES_`, `CYODA_SQLITE_`).
+- Exclude `CYODA_*_FILE` from the scan — a derived variant, represented as `FileSuffix` on the base var, not a separate entry.
+- Keep `isTestOnlyEnv` exclusions (`CYODA_TEST_*`, `CYODA_MARKER*`, `CYODA_DEBUG_*`, `*_FOR_TESTING`).
+- Tolerate a registered plugin that does not implement `DescribablePlugin` (memory) — type-assert and skip.
+- **Scope caveat**: the scan cannot see the out-of-tree commercial plugin, so this test is authoritative for the OSS build only. The commercial backend enforces its own completeness (Cyoda/cyoda-go-cassandra#60).
+
+## Test plan
+
+| Scenario | Layer |
+|---|---|
+| `config all` text lists every registry var, grouped by topic | help unit |
+| `config all --format=json` emits valid envelope, all vars, stable field set | help unit |
+| Registry names ⊇ source scan (root + plugins) — completeness | help unit (blank-imports plugins) |
+| Root table defaults == `DefaultConfig()` under empty env; exempt pre-config vars (`CYODA_PROFILES`) | `app_test` |
+| Plugin not implementing `DescribablePlugin` (memory) is skipped, not fatal | help unit |
+| `GET /help/config/all` → 200 `application/json`, parseable envelope | `internal/api` |
+| `GET /help/config/all` non-GET → 405 (existing help-route behavior) | `internal/api` |
+| `cyoda help config cluster` resolves and renders the moved vars | help unit |
+| `config.md` SEE ALSO includes all six subtopics incl. `config.cors` | help unit (existing SEE-ALSO test if present) |
+
+No new error codes → no `errors/*.md` topic. No cross-backend parity scenario (help/config is host behavior, not a storage contract; plugin participation is covered by the completeness test + the SPI interface).
+
+## Gate 4 docs
+
+- `README.md` config reference: mention `cyoda help config all` / `--format=json` and the new `config cluster` subtopic.
+- `content/config/*.md`: new `cluster.md`; `config.md` synopsis + SEE ALSO updated.
+- No `cyoda-go-spi` pin bump, no chart/appVersion change, no binary release in this change → COMPATIBILITY.md untouched.
+
+## Non-goals
+
+- No implementation in the commercial backend (tracked in #60; it already implements `DescribablePlugin` but lacks a completeness/binding test and has already drifted by 5 vars).
+- No generalization of the action framework for format negotiation — HTTP help is JSON by design, so it is unnecessary.
+- No retirement of the openapi tag-resolver special-case.
+- No migration of the existing hand-authored subtopic prose to generated content — the registry backs `config all`; the rich per-topic prose stays.

--- a/internal/api/help_configall_test.go
+++ b/internal/api/help_configall_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/cmd/cyoda/help"
+)
+
+// TestHTTP_ConfigAll_JSON verifies GET /help/config/all over the real
+// HTTP help-route stack: 200 + application/json with a non-empty vars
+// list for GET, and 405 for non-GET.
+//
+// This in-process test does not blank-import the storage plugins, so
+// spi.RegisteredPlugins() returns only whatever the internal/api test
+// binary happens to register — likely just root vars. Assert only
+// len(vars) > 0 and the presence of a root var (CYODA_HTTP_PORT); do
+// not assert plugin-specific names here (covered by the help-package
+// tests: TestBuildConfigRegistry, TestConfigAll_Complete).
+func TestHTTP_ConfigAll_JSON(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterHelpRoutes(mux, help.DefaultTree, "", "v0.0.0")
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/help/config/all")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type=%q", ct)
+	}
+	var env struct {
+		Vars []map[string]any `json:"vars"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil || len(env.Vars) == 0 {
+		t.Fatalf("decode/vars: %v len=%d", err, len(env.Vars))
+	}
+	found := false
+	for _, v := range env.Vars {
+		if v["name"] == "CYODA_HTTP_PORT" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected root var CYODA_HTTP_PORT in vars: %v", env.Vars)
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/help/config/all", nil)
+	pr, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pr.Body.Close()
+	if pr.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("POST status=%d want 405", pr.StatusCode)
+	}
+}

--- a/plugins/postgres/plugin.go
+++ b/plugins/postgres/plugin.go
@@ -20,6 +20,7 @@ func (p *plugin) ConfigVars() []spi.ConfigVar {
 		{Name: "CYODA_POSTGRES_MIN_CONNS", Description: "Min pool connections", Default: "5"},
 		{Name: "CYODA_POSTGRES_MAX_CONN_IDLE_TIME", Description: "Max idle time before closing connection", Default: "5m"},
 		{Name: "CYODA_POSTGRES_AUTO_MIGRATE", Description: "Run embedded SQL migrations on startup", Default: "true"},
+		{Name: "CYODA_SCHEMA_SAVEPOINT_INTERVAL", Description: "Rows per savepoint during schema extension", Default: "64"},
 	}
 }
 

--- a/plugins/sqlite/plugin.go
+++ b/plugins/sqlite/plugin.go
@@ -20,6 +20,8 @@ func (p *plugin) ConfigVars() []spi.ConfigVar {
 		{Name: "CYODA_SQLITE_BUSY_TIMEOUT", Description: "Wait time for write lock", Default: "5s"},
 		{Name: "CYODA_SQLITE_CACHE_SIZE", Description: "Page cache in KiB", Default: "64000"},
 		{Name: "CYODA_SQLITE_SEARCH_SCAN_LIMIT", Description: "Max rows examined per search with residual filter", Default: "100000"},
+		{Name: "CYODA_SCHEMA_SAVEPOINT_INTERVAL", Description: "Rows per savepoint during schema extension", Default: "64"},
+		{Name: "CYODA_SCHEMA_EXTEND_MAX_RETRIES", Description: "Max retries on concurrent schema extension", Default: "8"},
 	}
 }
 


### PR DESCRIPTION
Closes #395

## What

Adds an authoritative, machine-consumable listing of every `CYODA_*` configuration variable, plus a dedicated cluster/dispatch subtopic.

- **`cyoda help config all`** — human-readable table of every config var, grouped by topic.
- **`cyoda help config all --format=json`** — JSON envelope `{schema, version, vars[]}` for automated consumption (docs site).
- **`GET /help/config/all`** — always `application/json`, consistent with the rest of HTTP help.
- **`cyoda help config cluster`** — new subtopic; the cluster/dispatch vars moved out of `config.md` prose into a first-class topic (multi-node is the primary target).

## How

Single source of truth is a request-time `ConfigVar` registry:
- **Root vars** (`app` + `internal/cluster`) live in a table in the `help` package.
- **Plugin vars** come from the pre-existing `spi.DescribablePlugin.ConfigVars()` interface (postgres/sqlite/commercial already implement it; memory deliberately doesn't). This is **not** an SPI change — the interface pre-existed, unused by the root — and it's reached identically from the CLI and the HTTP help routes via `spi.RegisteredPlugins()`, surfacing the out-of-tree commercial plugin with zero root import.

Placement avoids the `app`→`help` import cycle: the table lives in `help` (imports `spi`, never `app`); the default-drift binding test lives in `app_test`.

## Guarantees (tests)

- **`TestConfigAll_Complete`** — every `CYODA_*` var referenced in source (root + plugins) appears in the listing, or CI fails. Excludes test-only vars, trailing-`_` comment fragments, and derived `_FILE` variants. (OSS-scope: cannot see the out-of-tree commercial plugin, which enforces its own — tracked separately.)
- **`TestRootConfigVars_MatchDefaults`** (`app_test`) — root table defaults are bound to `DefaultConfig()`; a changed default fails CI.
- HTTP endpoint covered (200 JSON / 405 non-GET); CLI text-vs-JSON routing covered.

This surfaced and fixed a pre-existing in-tree drift: sqlite/postgres omitted `CYODA_SCHEMA_*` from their `ConfigVars()` (postgres correctly lists only the savepoint var it actually reads). Also fixed the `config.cors` SEE-ALSO omission found during reconciliation.

## Security

Read-only, GET-only endpoint. The registry emits only var names/types/defaults/descriptions — **never resolved values**; secret vars carry empty defaults. Verified against a running binary with sentinel-valued secrets (zero leakage). No `go.mod`/SPI changes.

Full suite green (incl. Docker e2e); `make race` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)