### PR TITLE
docs: correct entity-search endpoint paths across reference docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,9 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   New error codes: `UNIQUE_VIOLATION` (409), `INVALID_UNIQUE_KEY` (422),
   `COMPOSITE_KEY_UNSUPPORTED` (422), `INVALID_UNIQUE_KEY_DEFINITION` (422).
 
-- **Search result sorting** — both search endpoints (`POST /api/entity/{entityName}/{modelVersion}/search`
-  and the async variant) now accept one or more `sort` query parameters (HTTP) or a structured
+- **Search result sorting** — both search endpoints (`POST /api/search/direct/{entityName}/{modelVersion}`
+  and the async variant `POST /api/search/async/{entityName}/{modelVersion}`) now accept one or more
+  `sort` query parameters (HTTP) or a structured
   `orderBy` array (gRPC) to control result order. HTTP grammar: `[@]path[:asc|desc]` — bare
   dotted path for scalar data fields; `@`-prefixed name for meta fields (`state`, `creationDate`,
   `lastUpdateTime`, `transitionForLatestSave`, `transactionId`, `id`). Ordering is canonical

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ This call is idempotent — it replaces the model's entire key list. The keys ar
 Search endpoints accept one or more `sort` query parameters to order results by scalar data or meta fields:
 
 ```
-GET /api/entity/{entityName}/{modelVersion}/search?sort=price:asc&sort=@creationDate:desc
+POST /api/search/direct/{entityName}/{modelVersion}?sort=price:asc&sort=@creationDate:desc
 ```
 
 Grammar: `[@]path[:asc|desc]` — a bare dotted path sorts by a scalar entity-data field; the `@` prefix sorts by a meta field. Direction defaults to `asc`. Repetition order is sort precedence; `entity_id` is always the final tiebreaker. Absent/null values sort last.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -228,12 +228,13 @@ Each entity follows a workflow — a directed graph of states connected by trans
 | Type | Trigger | Gating |
 |------|---------|--------|
 | **Automated** | Fires on state entry when criteria are met | Criteria evaluation |
-| **Manual** | Explicit API call (`POST /entity/{entityId}/{transition}`) | Criteria evaluation |
+| **Manual** | Explicit API call (`PUT /entity/{format}/{entityId}/{transition}`) | Criteria evaluation |
 
 #### Loopback
 
 Loopback is an operation, not a transition type. A client can invoke
-`PUT /entity/{id}?loopback` to re-evaluate the entity's automated
+`PUT /entity/{format}/{entityId}` (an update carrying a virtual loopback
+transition) to re-evaluate the entity's automated
 transitions from its current state without forcing a manual transition.
 Useful for retriggering workflow logic after the entity's data has
 changed via a non-workflow path (e.g. an external processor's
@@ -272,13 +273,13 @@ Processors may create or mutate other entities, triggering further workflow trav
 
 ### Audit Trail
 
-12 event types track the full state machine narrative:
+14 event types track the full state machine narrative:
 
-- Workflow selection (selected, not found)
-- Transition attempts (attempted, made, denied, failed)
-- Processor execution (dispatched, succeeded, failed)
-- Criteria evaluation results
-- Cancellation events
+- Machine lifecycle — `STATE_MACHINE_START`, `STATE_MACHINE_FINISH`
+- Workflow selection — `WORKFLOW_FOUND`, `WORKFLOW_NOT_FOUND`, `WORKFLOW_SKIP`
+- Transitions — `TRANSITION_MAKE`, `TRANSITION_NOT_FOUND`, `TRANSITION_NOT_MATCH_CRITERION`, `TRANSITION_ABORTED`
+- Processing — `PROCESS_NOT_MATCH_CRITERION`, `PAUSE_FOR_PROCESSING`, `STATE_PROCESS_RESULT`
+- Manual overrides — `CANCEL`, `FORCE_SUCCESS`
 
 Filterable by event type, severity, time range, transaction ID. Cursor-based pagination.
 
@@ -400,22 +401,22 @@ Calculation members (external compute nodes) are scoped to their authenticating 
 
 ### Synchronous (Direct) Search
 
-`POST /search/{entityName}/{modelVersion}` — Evaluates predicate conditions against entity data and returns results immediately.
+`POST /search/direct/{entityName}/{modelVersion}` — Evaluates predicate conditions against entity data and returns results immediately.
 
-### Asynchronous (Snapshot) Search
+### Asynchronous Search
 
-Snapshot search provides a job-based lifecycle for longer-running queries:
+Async search provides a job-based lifecycle for longer-running queries:
 
 ```
-SUBMIT ──► RUNNING ──► SUCCESSFUL ──► (retrieve results) ──► DELETE
+SUBMIT ──► RUNNING ──► SUCCESSFUL ──► (retrieve results)
                   │
                   └──► FAILED / CANCELLED
 ```
 
-- `POST /search/snapshot` — Submit search, receive job ID
-- `GET /search/async/{jobId}` — Poll status
-- Retrieve results with pagination
-- `DELETE /search/async/{jobId}` — Cancel/cleanup
+- `POST /search/async/{entityName}/{modelVersion}` — Submit search, receive job ID
+- `GET /search/async/{jobId}/status` — Poll status
+- `GET /search/async/{jobId}` — Retrieve results with pagination
+- `PUT /search/async/{jobId}/cancel` — Cancel a running job
 
 **Multi-node persistence:** In PostgreSQL mode, snapshot jobs and results are stored in `search_jobs` and `search_job_results` tables. Any node can create or retrieve snapshots. In memory mode, snapshots are node-local.
 
@@ -536,9 +537,9 @@ for mode-specific semantics.
 | **Token issuance** | `POST /oauth/token` | `client_credentials` grant |
 | **OBO exchange** | `POST /oauth/token` | RFC 8693 token exchange — a service acting on behalf of a user |
 | **JWKS** | `GET /.well-known/jwks.json` | Public key discovery for token verification |
-| **M2M clients** | `POST/DELETE /auth/m2m/...` | Create, delete, reset secret for machine-to-machine clients |
-| **Key management** | `POST/DELETE /auth/keys/...` | Issue, invalidate, reactivate, delete signing key pairs |
-| **Trusted keys** | `POST/DELETE /auth/trusted/...` | Register external signing keys for cross-system trust |
+| **M2M clients** | `GET/POST /clients`, `DELETE /clients/{clientId}`, `PUT /clients/{clientId}/secret` | Create, delete, reset secret for machine-to-machine clients |
+| **Key management** | `POST/GET/DELETE /oauth/keys/keypair/...` | Issue, invalidate, reactivate, delete signing key pairs |
+| **Trusted keys** | `POST/GET/DELETE /oauth/keys/trusted/...` | Register external signing keys for cross-system trust |
 | **Bootstrap client** | `CYODA_BOOTSTRAP_CLIENT_ID` | Pre-configured M2M client at startup (solves chicken-and-egg) |
 
 ### Token Claims
@@ -565,7 +566,7 @@ In JWT mode, each tenant can register one or more external Identity Providers (I
 **What you can do with OIDC providers:**
 
 - **Register** a provider by supplying its URL, accepted issuer values, expected audiences, and (optionally) a custom roles claim name.
-- **List, get, update, delete** providers through the `/oauth/oidc/providers` REST surface (7 endpoints, `ROLE_ADMIN` required).
+- **List, register, update, delete** providers through the `/oauth/oidc/providers` REST surface (7 endpoints, `ROLE_ADMIN` required).
 - **Invalidate** a provider to suspend JWT acceptance without removing the record; **reactivate** to restore it.
 - **Reload** to force a fresh JWKS fetch and evict the node-local cache — useful after an IdP rotates its signing keys outside the normal TTL window.
 
@@ -687,12 +688,12 @@ In a multi-node cluster, a calculation member's gRPC stream terminates at one no
 | **Entity Stats** | `GET /entity/stats/...` | Count, state distribution per model |
 | **Model Management** | `POST/GET/DELETE /model/...` | Import, export, lock, unlock, delete, validate, changeLevel |
 | **Workflow** | `GET/POST /model/.../workflow/{export,import}` | Import/export workflow definitions |
-| **Search** | `POST /search/{direct,async}/...` | Synchronous and snapshot search |
+| **Search** | `POST /search/{direct,async}/...` | Synchronous and async search |
 | **Audit** | `GET /audit/entity/{entityId}` | Entity change history, SM audit trail |
 | **Messaging** | `POST/GET/DELETE /message/...` | Edge message store |
 | **Auth** | `POST /oauth/token`, `GET /.well-known/jwks.json`, key/trusted/M2M management | Authentication and key management |
 | **Account** | `GET /account` | Account info, subscriptions |
-| **Cluster** | `GET /cluster/members/calculation/...` | Connected member registry |
+| **Cluster** | _(not exposed over REST)_ | Connected calculation-member registry is internal-only (`contract.ClusterService`) |
 | **Admin** | `GET/POST /admin/log-level` | Runtime log level control |
 
 All REST responses follow RFC 9457 (Problem Details) for errors.

--- a/docs/cloud-parity/search-sort.md
+++ b/docs/cloud-parity/search-sort.md
@@ -10,8 +10,8 @@ spec and implemented code.
 ### Endpoints
 
 ```
-POST /api/entity/{entityName}/{modelVersion}/search
-POST /api/entity/{entityName}/{modelVersion}/search/async
+POST /api/search/direct/{entityName}/{modelVersion}
+POST /api/search/async/{entityName}/{modelVersion}
 ```
 
 Both endpoints accept the same `sort` query parameter — repeatable, in

--- a/docs/release-notes/v0-8-2.md
+++ b/docs/release-notes/v0-8-2.md
@@ -35,7 +35,8 @@ transaction that dispatched them.
 ### 🔎 Search: sorting and pushdown
 
 Both search endpoints
-(`POST /api/entity/{entityName}/{modelVersion}/search` and the async variant)
+(`POST /api/search/direct/{entityName}/{modelVersion}` and the async variant
+`POST /api/search/async/{entityName}/{modelVersion}`)
 now accept `sort` query parameters (HTTP) or a structured `orderBy` array
 (gRPC). The HTTP grammar is `[@]path[:asc|desc]` — a bare dotted path for a
 scalar data field, an `@`-prefixed name for a meta field (`state`,


### PR DESCRIPTION
## Summary

The entity-search endpoints were documented with a path shape that **does not exist**: `POST /api/entity/{entityName}/{modelVersion}/search`. The real routes are:

- **Sync:** `POST /api/search/direct/{entityName}/{modelVersion}` (ndjson stream)
- **Async:** `POST /api/search/async/{entityName}/{modelVersion}` (submit → paged retrieval)

Originated in a release-notes line; the same wrong shape had propagated into several docs. Fixed everywhere, then a full accuracy audit of `docs/PRD.md` (the baseline reference doc) turned up more drift, corrected in the same PR.

## Changes

**Search-path fix (5 docs):** `docs/release-notes/v0-8-2.md`, `CHANGELOG.md`, `README.md` (also had wrong method `GET`→`POST`), `docs/cloud-parity/search-sort.md` (the Cloud twin-alignment contract), `docs/PRD.md`.

**Full PRD audit** — verified against `api/openapi.yaml` + the generated route table:
- Manual transition `POST /entity/{entityId}/{transition}` → `PUT /entity/{format}/{entityId}/{transition}`
- Loopback: fictional `?loopback` query param → `PUT /entity/{format}/{entityId}` (virtual loopback transition)
- Async search lifecycle: submit/status/results/cancel routes + state diagram (`/search/snapshot`, `DELETE /search/async/{jobId}` never existed)
- Auth mgmt: `/auth/{m2m,keys,trusted}/...` (nonexistent) → `/clients...`, `/oauth/keys/{keypair,trusted}/...`
- OIDC surface: "get" verb corrected (no single-provider GET)
- Cluster: removed fictional `GET /cluster/...` REST route (registry is internal-only, `contract.ClusterService`)
- Audit event types: 12 → **14**, reconciled to real `StateMachineEventType` constants (independently re-counted: 13 SPI + local `TRANSITION_ABORTED`)
- Normalized async-search "snapshot" naming → "async" (kept "Snapshot Isolation" transaction-level term untouched)

## Verification

Doc-only change; no code touched. Endpoint claims cross-checked against `api/openapi.yaml` and `api/generated.go`; the event-type count re-derived from the pinned `cyoda-go-spi@v0.8.2` `types.go` plus `internal/domain/workflow/transition_aborted.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)