### PR TITLE
fix(help): config all JSON self-reports version (CLI/HTTP parity)

### DIFF
--- a/cmd/cyoda/help/command.go
+++ b/cmd/cyoda/help/command.go
@@ -60,7 +60,7 @@ func RunHelp(tree *Tree, args []string, out io.Writer, version string, isTTY boo
 	if len(positional) == 2 && positional[0] == "config" && positional[1] == "all" {
 		switch format {
 		case "json":
-			return writeConfigAllJSONVersion(out, version)
+			return writeConfigAllJSON(out)
 		case "auto", "", "text":
 			return writeConfigAllText(out)
 		default:

--- a/cmd/cyoda/help/command_test.go
+++ b/cmd/cyoda/help/command_test.go
@@ -553,4 +553,12 @@ func TestRunHelp_ConfigAll(t *testing.T) {
 	if !json.Valid(js.Bytes()) {
 		t.Error("config all --format=json not valid JSON")
 	}
+	// CLI --format=json and the HTTP action must emit identical bytes — same
+	// registry, same self-reported version — so the resource doesn't differ
+	// by entry point.
+	var action bytes.Buffer
+	writeConfigAllJSON(&action)
+	if js.String() != action.String() {
+		t.Error("config all --format=json (CLI) differs from the HTTP action output; must be identical")
+	}
 }

--- a/cmd/cyoda/help/config_registry.go
+++ b/cmd/cyoda/help/config_registry.go
@@ -186,22 +186,19 @@ type configAllEnvelope struct {
 	Vars    []ConfigVar `json:"vars"`
 }
 
-// writeConfigAllJSONVersion writes the config-all JSON envelope with an
-// explicit version. Used by the CLI special-case in command.go, which
-// has the real binary version in scope.
-func writeConfigAllJSONVersion(w io.Writer, version string) int {
+// writeConfigAllJSON writes the config-all JSON envelope. The cyoda build
+// version is self-reported via binaryVersion() (the same helper cloudevents
+// json uses), so the output is identical whether reached from the CLI
+// (--format=json) or over HTTP (GET /help/config/all) — no entry-point drift.
+func writeConfigAllJSON(w io.Writer) int {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	if err := enc.Encode(configAllEnvelope{Schema: 1, Version: version, Vars: buildConfigRegistry()}); err != nil {
+	if err := enc.Encode(configAllEnvelope{Schema: 1, Version: binaryVersion(), Vars: buildConfigRegistry()}); err != nil {
 		fmt.Fprintf(w, "cyoda help config all: encode: %v\n", err)
 		return 1
 	}
 	return 0
 }
-
-// writeConfigAllJSON is the action-registry entry (HTTP + generic CLI
-// action dispatch); version is unknown here, so it is emitted empty.
-func writeConfigAllJSON(w io.Writer) int { return writeConfigAllJSONVersion(w, "") }
 
 // writeConfigAllText renders the full config-var registry as a
 // tab-aligned table grouped by topic, for `cyoda help config all` on a

--- a/cmd/cyoda/help/config_registry_test.go
+++ b/cmd/cyoda/help/config_registry_test.go
@@ -129,6 +129,11 @@ func TestWriteConfigAllJSON_Envelope(t *testing.T) {
 	if env.Schema != 1 || len(env.Vars) < 40 {
 		t.Fatalf("schema=%d vars=%d", env.Schema, len(env.Vars))
 	}
+	// version is self-reported via binaryVersion() (same helper cloudevents
+	// json uses), so it is populated over HTTP too — never empty.
+	if env.Version == "" || env.Version != binaryVersion() {
+		t.Errorf("version = %q, want binaryVersion() = %q", env.Version, binaryVersion())
+	}
 	names := map[string]bool{}
 	for _, v := range env.Vars {
 		names[v.Name] = true


### PR DESCRIPTION
Follow-up to #396 (config `all` listing), before v0.8.3 ships.

## Problem

The `config all` JSON envelope took the cyoda build version as a passed-in value, which was left blank on the HTTP action path. Result: `GET /help/config/all` returned `"version": ""` while the CLI `--format=json` stamped the real version — the same resource differing by entry point.

## Fix

Use `binaryVersion()` — the exact helper `cloudevents json` already uses to self-report the build version — inside the single `writeConfigAllJSON` emitter. Now:
- CLI `--format=json` and HTTP `GET /help/config/all` emit **identical bytes**, both carrying the real build version.
- Consistent with the `cloudevents json` sibling (which also carries a self-reported version).
- Collapses the `writeConfigAllJSON` / `writeConfigAllJSONVersion` split into one function.

## Tests
- Envelope test asserts `version == binaryVersion()` (never empty).
- CLI-vs-HTTP-action byte-identity assertion added.

Discovered while deciding whether to keep or drop the field: populating it consistently turned out to be a one-liner via the existing `binaryVersion()` helper, not the framework change it first appeared to be.