### PR TITLE
fix(postgres): boolean search condition no longer 500s (encode-to-text)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,16 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **Boolean search conditions on postgres no longer 500** — a `simple` search
+  condition comparing a JSON path to a boolean (`{"operatorType":"EQUALS","value":true}`)
+  returned `500 SERVER_ERROR` (`unable to encode true into text format for text (OID 25):
+  cannot find encode plan`) on the postgres backend. The query planner bound a raw Go
+  `bool` against the text-typed `doc->>'path'` extraction, which pgx cannot encode; the
+  operand is now rendered as its text form (`"true"`/`"false"`), matching the lexicographic
+  text comparison already used for strings and the memory/sqlite backends. Affected normal
+  searches and grouped-stats queries alike (shared query planner); memory and sqlite were
+  never affected. ([#399](https://github.com/Cyoda-platform/cyoda-go/issues/399))
+
 - **OIDC / admin op error envelope** — the 7 OIDC provider ops and
   `searchEntityAuditEvents` now declare `application/problem+json` `ProblemDetail`
   errors in the spec, matching the server. `getTechnicalUserToken` retains the

--- a/e2e/parity/grouped_stats.go
+++ b/e2e/parity/grouped_stats.go
@@ -54,6 +54,7 @@ const statsModelSampleDoc = `{
 	"price": 1.5,
 	"qty": 1,
 	"region": "EU",
+	"eligible": true,
 	"meta": {"source": "parity"},
 	"tags": ["a","b"]
 }`
@@ -403,6 +404,53 @@ func RunParityGroupedStats_WithCondition(t *testing.T, fixture BackendFixture) {
 	}
 	if b := findBucketByGroupKey(buckets, []client.GroupKeyEntry{{Path: "$.variantId", Value: stringValue("v2")}}); b == nil || b.Count != 1 {
 		t.Errorf("v2 bucket (filtered): got %+v, want count=1", b)
+	}
+}
+
+// RunParityGroupedStats_BoolCondition is the reported-bug guard: group-by a
+// data field, filtered by a JSON boolean data condition ($.eligible EQUALS
+// true). On postgres this previously 500'd ("cannot find encode plan" — a raw
+// Go bool bound against the text-typed doc->>'path' extraction); memory and
+// sqlite always answered it. Every backend must now return the same buckets.
+func RunParityGroupedStats_BoolCondition(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "parity-stats-bool-cond"
+	const modelVersion = 1
+	setupStatsModel(t, c, modelName, modelVersion)
+
+	if _, err := c.CreateEntity(t, modelName, modelVersion, `{"variantId":"v1","price":10,"eligible":true}`); err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	if _, err := c.CreateEntity(t, modelName, modelVersion, `{"variantId":"v1","price":20,"eligible":false}`); err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+	if _, err := c.CreateEntity(t, modelName, modelVersion, `{"variantId":"v2","price":30,"eligible":true}`); err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	// Data condition: $.eligible EQUALS a JSON boolean true.
+	buckets, err := c.QueryGroupedStats(t, modelName, modelVersion, client.GroupedStatsRequest{
+		GroupBy: []string{"$.variantId"},
+		Condition: &client.AggregationCond{
+			"type":         "simple",
+			"jsonPath":     "$.eligible",
+			"operatorType": "EQUALS",
+			"value":        true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("QueryGroupedStats (eligible EQUALS true): %v", err)
+	}
+	if len(buckets) != 2 {
+		t.Fatalf("expected 2 buckets (v1 eligible + v2 eligible), got %d: %+v", len(buckets), buckets)
+	}
+	if b := findBucketByGroupKey(buckets, []client.GroupKeyEntry{{Path: "$.variantId", Value: stringValue("v1")}}); b == nil || b.Count != 1 {
+		t.Errorf("v1 bucket (eligible=true): got %+v, want count=1", b)
+	}
+	if b := findBucketByGroupKey(buckets, []client.GroupKeyEntry{{Path: "$.variantId", Value: stringValue("v2")}}); b == nil || b.Count != 1 {
+		t.Errorf("v2 bucket (eligible=true): got %+v, want count=1", b)
 	}
 }
 

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 169
+// Total parity scenarios: 171
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
 // distributed-safety contracts + schema extensions + Phase 9.2 OIDC CRUD/authz
 // + Phase 9.3 OIDC JWT validation + Phase 9.4 OIDC divergences
@@ -99,6 +99,7 @@ var allTests = []NamedTest{
 
 	// Phase 4b — search scenarios (Task 4b.6-8)
 	{"SearchSimpleCondition", RunSearchSimpleCondition},
+	{"SearchBoolCondition", RunSearchBoolCondition},
 	{"SearchLifecycleCondition", RunSearchLifecycleCondition},
 	{"SearchGroupCondition", RunSearchGroupCondition},
 	{"SearchNoMatches", RunSearchNoMatches},
@@ -325,6 +326,7 @@ var allTests = []NamedTest{
 	{"GroupedStats_CountByDataField", RunParityGroupedStats_CountByDataField},
 	{"GroupedStats_MultiDimGroupBy", RunParityGroupedStats_MultiDimGroupBy},
 	{"GroupedStats_WithCondition", RunParityGroupedStats_WithCondition},
+	{"GroupedStats_BoolCondition", RunParityGroupedStats_BoolCondition},
 	{"GroupedStats_PointInTime", RunParityGroupedStats_PointInTime},
 	{"GroupedStats_AggregationsTier1", RunParityGroupedStats_AggregationsTier1},
 	{"GroupedStats_StdevLowVarianceHighMean", RunParityGroupedStats_StdevLowVarianceHighMean},

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,9 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 171
+// Total parity scenarios: 196 (guarded by TestParityScenarioCount — bump
+// wantParityScenarioCount in registry_count_test.go when adding/removing an
+// entry, or the test fails).
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
 // distributed-safety contracts + schema extensions + Phase 9.2 OIDC CRUD/authz
 // + Phase 9.3 OIDC JWT validation + Phase 9.4 OIDC divergences

--- a/e2e/parity/registry_count_test.go
+++ b/e2e/parity/registry_count_test.go
@@ -1,0 +1,30 @@
+package parity
+
+import "testing"
+
+// wantParityScenarioCount is the number of entries in allTests. The count in
+// the registry.go header comment drifted silently for many PRs because nothing
+// asserted it; this test converts that drift into a failure. Bump this constant
+// (and the header comment) in the same change that adds or removes a scenario.
+const wantParityScenarioCount = 196
+
+// TestParityScenarioCount guards the documented scenario count against silent
+// drift.
+func TestParityScenarioCount(t *testing.T) {
+	if got := len(allTests); got != wantParityScenarioCount {
+		t.Errorf("parity scenario count = %d, want %d; update wantParityScenarioCount and the registry.go header comment together", got, wantParityScenarioCount)
+	}
+}
+
+// TestParityScenarioNamesUnique guards against copy-paste duplicate scenario
+// names — two entries sharing a Name collide as subtests and one silently
+// shadows the other in test output.
+func TestParityScenarioNamesUnique(t *testing.T) {
+	seen := make(map[string]int, len(allTests))
+	for i, tc := range allTests {
+		if prev, dup := seen[tc.Name]; dup {
+			t.Errorf("duplicate parity scenario name %q at indices %d and %d", tc.Name, prev, i)
+		}
+		seen[tc.Name] = i
+	}
+}

--- a/e2e/parity/search.go
+++ b/e2e/parity/search.go
@@ -60,6 +60,60 @@ func RunSearchSimpleCondition(t *testing.T, fixture BackendFixture) {
 	}
 }
 
+// RunSearchBoolCondition creates 3 entities with a boolean field and searches
+// with a JSON boolean value (EQUALS true, then NOT_EQUALS true). Guards the
+// postgres bool->text encode bug: a raw Go bool bound against the text-typed
+// doc->>'path' extraction failed to encode ("cannot find encode plan"), 500ing
+// the search. Memory and sqlite always handled it; this asserts all backends agree.
+func RunSearchBoolCondition(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "parity-search-bool"
+	const modelVersion = 1
+	// Own model import so the schema declares the boolean `active` field
+	// (the shared search model has no bool field).
+	if err := c.ImportModel(t, modelName, modelVersion, `{"name":"Sample","active":true}`); err != nil {
+		t.Fatalf("ImportModel: %v", err)
+	}
+	if err := c.LockModel(t, modelName, modelVersion); err != nil {
+		t.Fatalf("LockModel: %v", err)
+	}
+	if err := c.ImportWorkflow(t, modelName, modelVersion, searchWorkflowJSON); err != nil {
+		t.Fatalf("ImportWorkflow: %v", err)
+	}
+
+	if _, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Alice","active":true}`); err != nil {
+		t.Fatalf("CreateEntity Alice: %v", err)
+	}
+	if _, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Bob","active":false}`); err != nil {
+		t.Fatalf("CreateEntity Bob: %v", err)
+	}
+	if _, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"Carol","active":true}`); err != nil {
+		t.Fatalf("CreateEntity Carol: %v", err)
+	}
+
+	// EQUALS a JSON boolean true -> Alice, Carol.
+	eqCond := `{"type":"simple","jsonPath":"$.active","operatorType":"EQUALS","value":true}`
+	eqResults, err := c.SyncSearch(t, modelName, modelVersion, eqCond)
+	if err != nil {
+		t.Fatalf("SyncSearch (EQUALS true): %v", err)
+	}
+	if len(eqResults) != 2 {
+		t.Errorf("EQUALS true: expected 2 results (Alice, Carol), got %d", len(eqResults))
+	}
+
+	// NOT_EQUALS a JSON boolean true -> Bob (same text-branch encode path).
+	neCond := `{"type":"simple","jsonPath":"$.active","operatorType":"NOT_EQUAL","value":true}`
+	neResults, err := c.SyncSearch(t, modelName, modelVersion, neCond)
+	if err != nil {
+		t.Fatalf("SyncSearch (NOT_EQUAL true): %v", err)
+	}
+	if len(neResults) != 1 {
+		t.Errorf("NOT_EQUAL true: expected 1 result (Bob), got %d", len(neResults))
+	}
+}
+
 // RunSearchLifecycleCondition creates 2 entities, fires a manual transition
 // on one to move it to APPROVED, then searches by lifecycle state==APPROVED
 // and asserts 1 result.

--- a/plugins/postgres/query_planner.go
+++ b/plugins/postgres/query_planner.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
@@ -243,6 +244,19 @@ func isNumericValue(v any) bool {
 	return false
 }
 
+// textArg normalizes an operand for binding against a text-typed doc->>'path'
+// extraction. A Go bool cannot be encoded into text (OID 25) by pgx — it has no
+// bool->text encode plan — so a boolean operand is rendered as its text form
+// ("true"/"false"), which is exactly how doc->>'path' renders a stored JSON
+// boolean. This mirrors the lexicographic text comparison used for strings and
+// the memory/sqlite backends. Non-bool values pass through unchanged.
+func textArg(v any) any {
+	if b, ok := v.(bool); ok {
+		return strconv.FormatBool(b)
+	}
+	return v
+}
+
 // orderExpr returns the SQL expression used as the LHS of an ordering
 // comparison (Gt/Lt/Gte/Lte/Between). For numeric values it wraps the field
 // in cyoda_try_float8(...) so overflow/non-numeric content returns NULL
@@ -296,7 +310,7 @@ func leafToSQL(f spi.Filter, counter *int) (string, []any) {
 		}
 		col := fieldExpr(f)
 		p := nextPlaceholder(counter)
-		return fmt.Sprintf("(%s IS NOT NULL AND %s = %s)", col, col, p), []any{f.Value}
+		return fmt.Sprintf("(%s IS NOT NULL AND %s = %s)", col, col, p), []any{textArg(f.Value)}
 	case spi.FilterNe:
 		if isNumericValue(f.Value) {
 			col := orderExpr(f, true)
@@ -305,7 +319,7 @@ func leafToSQL(f spi.Filter, counter *int) (string, []any) {
 		}
 		col := fieldExpr(f)
 		p := nextPlaceholder(counter)
-		return fmt.Sprintf("(%s IS NULL OR %s != %s)", col, col, p), []any{f.Value}
+		return fmt.Sprintf("(%s IS NULL OR %s != %s)", col, col, p), []any{textArg(f.Value)}
 	case spi.FilterGt:
 		return orderingOp(f, ">", counter)
 	case spi.FilterLt:
@@ -351,7 +365,7 @@ func leafToSQL(f spi.Filter, counter *int) (string, []any) {
 					col, col, p1, p2), []any{f.Values[0], f.Values[1]}
 			}
 			return fmt.Sprintf("(%s IS NOT NULL AND %s BETWEEN %s AND %s)",
-				col, col, p1, p2), []any{f.Values[0], f.Values[1]}
+				col, col, p1, p2), []any{textArg(f.Values[0]), textArg(f.Values[1])}
 		}
 		return "1=1", nil
 	}
@@ -368,7 +382,7 @@ func orderingOp(f spi.Filter, sqlOp string, counter *int) (string, []any) {
 	if numeric {
 		return fmt.Sprintf("(%s IS NOT NULL AND %s %s %s::float8)", col, col, sqlOp, p), []any{f.Value}
 	}
-	return fmt.Sprintf("(%s IS NOT NULL AND %s %s %s)", col, col, sqlOp, p), []any{f.Value}
+	return fmt.Sprintf("(%s IS NOT NULL AND %s %s %s)", col, col, sqlOp, p), []any{textArg(f.Value)}
 }
 
 // escapeLike escapes LIKE wildcards (%, _, \) in a user-provided value

--- a/plugins/postgres/query_planner.go
+++ b/plugins/postgres/query_planner.go
@@ -295,7 +295,9 @@ func nextPlaceholder(counter *int) string {
 // content returns NULL rather than raising 22003, and so a numeric operand is
 // compared numerically against the text-typed doc->>'path' extraction (a raw
 // numeric bind against a text column fails to encode) — the regex+EXCEPTION
-// helper is defined in migration 000002. String values keep text comparison.
+// helper is defined in migration 000002. String values keep text comparison;
+// boolean operands are rendered to their text form ("true"/"false") via textArg
+// so they encode against the text-typed extraction (see textArg).
 func leafToSQL(f spi.Filter, counter *int) (string, []any) {
 	switch f.Op {
 	case spi.FilterEq:

--- a/plugins/postgres/query_planner_bool_test.go
+++ b/plugins/postgres/query_planner_bool_test.go
@@ -1,0 +1,51 @@
+package postgres
+
+import (
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// TestPlanQuery_BoolEqNe guards against the pgx "cannot find encode plan"
+// failure: a boolean operand must be bound as its text form ("true"/"false")
+// so it encodes against the text-typed doc->>'path' extraction, matching the
+// lexicographic text comparison used for strings and the memory/sqlite backends.
+func TestPlanQuery_BoolEqNe(t *testing.T) {
+	tests := []struct {
+		name    string
+		op      spi.FilterOp
+		value   bool
+		wantSQL string
+		wantArg string
+	}{
+		{"eq_true", spi.FilterEq, true, "(doc->>'active' IS NOT NULL AND doc->>'active' = $1)", "true"},
+		{"eq_false", spi.FilterEq, false, "(doc->>'active' IS NOT NULL AND doc->>'active' = $1)", "false"},
+		{"ne_true", spi.FilterNe, true, "(doc->>'active' IS NULL OR doc->>'active' != $1)", "true"},
+		{"ne_false", spi.FilterNe, false, "(doc->>'active' IS NULL OR doc->>'active' != $1)", "false"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := spi.Filter{
+				Op:     tt.op,
+				Path:   "active",
+				Source: spi.SourceData,
+				Value:  tt.value,
+			}
+			plan := planQuery(f)
+			if plan.where != tt.wantSQL {
+				t.Errorf("where:\n  got  %s\n  want %s", plan.where, tt.wantSQL)
+			}
+			if len(plan.args) != 1 {
+				t.Fatalf("args = %v, want 1 element", plan.args)
+			}
+			// The arg must be the text form of the bool, never a raw Go bool
+			// (pgx cannot encode bool into text OID 25).
+			if _, isBool := plan.args[0].(bool); isBool {
+				t.Errorf("arg is a raw bool %v; must be bound as text to avoid pgx encode failure", plan.args[0])
+			}
+			if plan.args[0] != tt.wantArg {
+				t.Errorf("args[0] = %#v, want %q", plan.args[0], tt.wantArg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A `simple` search condition comparing a JSON path to a **boolean** value returned `500 SERVER_ERROR` on the **postgres** backend:

```json
{ "type": "simple", "jsonPath": "$.eligibility.included", "operatorType": "EQUALS", "value": true }
```
```
search query: failed to encode args[3]: unable to encode true into text format for text (OID 25): cannot find encode plan
```

## Root cause

`plugins/postgres/query_planner.go` `leafToSQL` bound a raw Go `bool` as a query arg against the text-typed `doc->>'path'` extraction. pgx has no `bool → text` encode plan. Numeric operands take a `::float8` cast branch and strings encode natively; `isNumericValue` excludes `bool`, so booleans fell through the text branch with a raw bool arg and blew up.

**Scope:** shared query planner → affected normal searches (`Search`), grouped-stats iterate, and grouped-stats aggregation alike. Postgres-only: memory (`"true"=="true"`) and sqlite (`json_extract` → integer, driver binds bool natively) were never affected — a backend-divergence bug with postgres as the outlier.

## Fix

Render a boolean operand as its text form (`"true"`/`"false"`) in the text-comparison branches (eq/ne/ordering/between), exactly how `doc->>'path'` renders a stored JSON boolean, and consistent with the lexicographic text comparison already used for strings and the memory/sqlite semantics.

## Workaround (pre-fix)

Send the value as the string `"true"` instead of the JSON boolean `true`.

## Tests (red/green TDD)

- **Unit** — `query_planner_bool_test.go`: bool eq/ne bind text `"true"`/`"false"`, never a raw bool. Fails before, passes after.
- **Cross-backend parity** — `SearchBoolCondition` (EQUALS + NOT_EQUAL, data-field bool) and `GroupedStats_BoolCondition` (the reported endpoint) registered in `registry.go`; run against memory/sqlite/postgres (and picked up by the commercial backend on its next dependency update).
- Reverting only the planner fix reproduces the **exact** reported error (`args[3]`, OID 25, 500) on postgres; restoring it passes. All parity suites green across all three backends.

Closes #399