### PR TITLE
fix(grpc): callback transaction-join now covers the search RPCs (entitySearch / entitySearchCollection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,23 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **Compute-node callback transaction-join now covers the gRPC search RPCs** — a
+  processor/criteria callback that presented a valid `tx-token` on `EntitySearch` /
+  `EntitySearchCollection` had the token silently ignored: the joining
+  `txRouteInterceptor` was wired only for the write RPCs (`EntityManage` /
+  `EntityManageCollection`), so a callback's searches ran unjoined against
+  last-committed state while its writes joined the originating transaction `T`.
+  Read-your-own-writes was therefore asymmetric — a processor could not search for
+  entities it created or transitioned earlier in the same still-open transaction
+  (silent stale results, no error). The interceptor now routes the search RPCs
+  through the same join / peer-forward path: a local-owner token joins `T` for the
+  read; a peer-owner token forwards the search to the owner (B→A), mirroring the
+  write path. Routing/join failures on a search return the search-shaped error
+  envelope (`EntityResponse`, `Success=false`) rather than a raw gRPC status, and
+  a token-less search is unchanged (no join). The HTTP entity API already joined
+  reads (route-agnostic `X-Tx-Token` middleware) and was unaffected.
+  ([#402](https://github.com/Cyoda-platform/cyoda-go/issues/402))
+
 - **Boolean search conditions on postgres no longer 500** — a `simple` search
   condition comparing a JSON path to a boolean (`{"operatorType":"EQUALS","value":true}`)
   returned `500 SERVER_ERROR` (`unable to encode true into text format for text (OID 25):

--- a/cmd/compute-test-client/callback.go
+++ b/cmd/compute-test-client/callback.go
@@ -290,6 +290,39 @@ func newCallbackCatalog(gcb *grpcCallbackClient) (map[string]callbackProcessorFu
 			return withData(entity, data)
 		},
 
+		// cb-grpc-search-forward — the cross-node counterpart of
+		// cb-grpc-search-read-your-writes: creates a secondary via a joined gRPC
+		// callback (B→A forwarded to the owner, written into T there), then SEARCHES
+		// for it via a joined gRPC EntitySearchCollection callback. When this member
+		// is a non-owner for T, the search call forwards B→A to the owner and joins T
+		// there, so it observes the uncommitted secondary. Without the search-RPC
+		// routing the call would run locally (non-owner, no T) and match nothing.
+		// Records the joined match count + lineage into the primary's data.
+		"cb-grpc-search-forward": func(ctx context.Context, entity *Entity, cfg cbConfig, token string, cb *callbackClient) (*Entity, error) {
+			if gcb == nil {
+				return nil, fmt.Errorf("gRPC callback client unavailable: CYODA_COMPUTE_GRPC_ENDPOINT not set")
+			}
+			created, err := gcb.createSecondary(ctx, cfg, token, cfg.Marker)
+			if err != nil {
+				return nil, fmt.Errorf("grpc callback create: %w", err)
+			}
+			if !created.Success {
+				return nil, fmt.Errorf("grpc callback create failed: code=%s msg=%s", created.ErrorCode, created.ErrorMsg)
+			}
+			joined, err := gcb.searchSecondary(ctx, cfg, token, cfg.Marker)
+			if err != nil {
+				return nil, fmt.Errorf("grpc forwarded search: %w", err)
+			}
+			data, err := decodeData(entity)
+			if err != nil {
+				return nil, err
+			}
+			data["grpcForwardSearchCount"] = float64(joined)
+			data["secondaryId"] = created.EntityID
+			data["tokenWasEmpty"] = token == ""
+			return withData(entity, data)
+		},
+
 		// cb-grpc-create-then-fail — creates a secondary via a joined gRPC callback,
 		// then deliberately fails so T rolls back (cross-node atomicity proof).
 		"cb-grpc-create-then-fail": func(ctx context.Context, entity *Entity, cfg cbConfig, token string, cb *callbackClient) (*Entity, error) {
@@ -304,6 +337,44 @@ func newCallbackCatalog(gcb *grpcCallbackClient) (map[string]callbackProcessorFu
 				return nil, fmt.Errorf("grpc callback create failed: code=%s msg=%s", res.ErrorCode, res.ErrorMsg)
 			}
 			return nil, fmt.Errorf("processor deliberately fails after gRPC callback write")
+		},
+
+		// cb-grpc-search-read-your-writes — creates a secondary inside T
+		// (uncommitted) via the HTTP join path, then SEARCHES for it over the gRPC
+		// EntitySearchCollection RPC both WITH the tx-token (joined) and WITHOUT it
+		// (standalone control). The joined search must match the uncommitted row;
+		// the standalone one must not. Proves the gRPC read RPCs join T identically
+		// on every backend. Records both counts into the primary's data.
+		"cb-grpc-search-read-your-writes": func(ctx context.Context, entity *Entity, cfg cbConfig, token string, cb *callbackClient) (*Entity, error) {
+			if err := requireCB(cb); err != nil {
+				return nil, err
+			}
+			if gcb == nil {
+				return nil, fmt.Errorf("gRPC callback client unavailable: CYODA_COMPUTE_GRPC_ENDPOINT not set")
+			}
+			res, secID, _, err := cb.createSecondary(ctx, cfg, token, cfg.Marker)
+			if err != nil {
+				return nil, fmt.Errorf("callback create: %w", err)
+			}
+			if res.Status != http.StatusOK {
+				return nil, fmt.Errorf("callback create status=%d body=%s", res.Status, res.Body)
+			}
+			joined, err := gcb.searchSecondary(ctx, cfg, token, cfg.Marker)
+			if err != nil {
+				return nil, fmt.Errorf("joined gRPC search: %w", err)
+			}
+			standalone, err := gcb.searchSecondary(ctx, cfg, "", cfg.Marker)
+			if err != nil {
+				return nil, fmt.Errorf("standalone gRPC search: %w", err)
+			}
+			data, err := decodeData(entity)
+			if err != nil {
+				return nil, err
+			}
+			data["grpcSearchJoinedCount"] = float64(joined)
+			data["grpcSearchStandaloneCount"] = float64(standalone)
+			data["secondaryId"] = secID
+			return withData(entity, data)
 		},
 
 		// cb-create-then-fail — creates a secondary via a joined callback, then

--- a/cmd/compute-test-client/grpc_callback.go
+++ b/cmd/compute-test-client/grpc_callback.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/google/uuid"
@@ -28,6 +30,7 @@ import (
 // imports.
 const (
 	ceTypeEntityCreateRequest = "EntityCreateRequest"
+	ceTypeEntitySearchRequest = "EntitySearchRequest"
 	grpcTxTokenKey            = "tx-token"
 )
 
@@ -137,4 +140,75 @@ func (g *grpcCallbackClient) createSecondary(ctx context.Context, cfg cbConfig, 
 		res.ErrorMsg = env.Error.Message
 	}
 	return res, nil
+}
+
+// searchSecondary issues a streaming EntitySearchCollection(EntitySearchRequest)
+// callback matching data.status == status over (cfg.SecondaryModel, version),
+// presenting the tx-token as gRPC "tx-token" metadata. When txToken is set the
+// search joins T (via the txRouteInterceptor's search routing) and observes T's
+// uncommitted writes; without it the search runs standalone against committed
+// state. Returns the number of matched entities.
+func (g *grpcCallbackClient) searchSecondary(ctx context.Context, cfg cbConfig, txToken, status string) (count int, err error) {
+	version := cfg.SecondaryVersion
+	if version == 0 {
+		version = 1
+	}
+	reqPayload := map[string]any{
+		"id":    uuid.NewString(),
+		"model": map[string]any{"name": cfg.SecondaryModel, "version": version},
+		"condition": map[string]any{
+			"type":         "simple",
+			"jsonPath":     "$.status",
+			"operatorType": "EQUALS",
+			"value":        status,
+		},
+	}
+	ce, err := newCloudEvent(ceTypeEntitySearchRequest, reqPayload)
+	if err != nil {
+		return 0, fmt.Errorf("build EntitySearchRequest: %w", err)
+	}
+
+	pairs := []string{"authorization", "Bearer " + g.bearer}
+	if txToken != "" {
+		pairs = append(pairs, grpcTxTokenKey, txToken)
+	}
+	callCtx, cancel := context.WithTimeout(metadata.NewOutgoingContext(ctx, metadata.Pairs(pairs...)), 15*time.Second)
+	defer cancel()
+
+	stream, err := g.client.EntitySearchCollection(callCtx, ce)
+	if err != nil {
+		return 0, fmt.Errorf("EntitySearchCollection callback: %w", err)
+	}
+	for {
+		frame, rerr := stream.Recv()
+		if errors.Is(rerr, io.EOF) {
+			break
+		}
+		if rerr != nil {
+			return count, fmt.Errorf("search stream recv: %w", rerr)
+		}
+		payload, xerr := extractTextData(frame)
+		if xerr != nil {
+			return count, fmt.Errorf("extract search frame: %w", xerr)
+		}
+		var env struct {
+			Success bool `json:"success"`
+			Error   *struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		if uerr := json.Unmarshal(payload, &env); uerr != nil {
+			return count, fmt.Errorf("decode search frame: %w", uerr)
+		}
+		if !env.Success {
+			msg := ""
+			if env.Error != nil {
+				msg = env.Error.Code + ": " + env.Error.Message
+			}
+			return count, fmt.Errorf("search returned error frame: %s", msg)
+		}
+		count++
+	}
+	return count, nil
 }

--- a/docs/PROCESSOR_EXECUTION_MODES.md
+++ b/docs/PROCESSOR_EXECUTION_MODES.md
@@ -89,15 +89,18 @@ Before dispatching to a compute node the engine mints a signed HMAC tx-token
 `cyodatxtoken` extension attribute.
 
 **Compute node contract:** the compute node MUST echo the received token on
-every callback into cyoda-go:
-- HTTP CRUD callbacks: `X-Tx-Token: <token>` request header
-- gRPC EntityManage callbacks: `tx-token` metadata key
+every callback into cyoda-go — reads as well as writes:
+- HTTP callbacks: `X-Tx-Token: <token>` request header
+- gRPC callbacks: `tx-token` metadata key (both the write RPCs
+  `EntityManage`/`EntityManageCollection` and the read RPCs
+  `EntitySearch`/`EntitySearchCollection`)
 
 When a callback arrives carrying the token, the receiving node verifies the
 HMAC and joins the transaction: if `NodeID` equals self, it calls
 `Join(TxRef)` locally; otherwise it forwards the full request to the owning
-node (HTTP: reverse proxy; gRPC EntityManage: B→A forward). Inside `T` the
-callback sees the cascade's uncommitted writes; other readers do not.
+node (HTTP: reverse proxy; gRPC: B→A forward). Inside `T` the callback
+sees the cascade's uncommitted writes — including via search (read-your-own-writes);
+other readers do not.
 
 A callback ack is **provisional** — it is not durable until the owning
 transaction commits. If the processor fails or the engine rolls back `T`,

--- a/e2e/parity/callback_txjoin.go
+++ b/e2e/parity/callback_txjoin.go
@@ -234,6 +234,45 @@ func RunCallbackSyncReadYourWrites(t *testing.T, fixture BackendFixture) {
 	}
 }
 
+// RunCallbackGRPCSearchReadYourWrites proves that a callback which SEARCHES over
+// the gRPC entity API joins T identically on every backend: a SYNC processor
+// creates a secondary inside T (uncommitted), then issues an EntitySearchCollection
+// gRPC callback for it both WITH the tx-token (joined) and WITHOUT (standalone).
+// The joined search must match the uncommitted row (count >= 1); the standalone
+// control must match nothing (count 0). This guards the search-within-T
+// visibility the gRPC read-RPC routing depends on — before the search RPCs were
+// wired into the txRouteInterceptor, the joined count collapsed to the standalone
+// count on every backend.
+func RunCallbackGRPCSearchReadYourWrites(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.ComputeTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const secondary = "cbtj-gsearch-secondary"
+	const primary = "cbtj-gsearch-primary"
+	const marker = "cbtj-gsearch-marker"
+
+	cbSetupModel(t, c, secondary, `{"name":"child","amount":1,"status":"new"}`, cbSecondaryWorkflow)
+	cbSetupModel(t, c, primary, `{"name":"Test","amount":10,"status":"new"}`,
+		cbPrimaryProcWorkflow("cbtj-gsearch-wf", "cb-grpc-search-read-your-writes", "SYNC", cbContext(secondary, marker)))
+
+	primaryID, err := c.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
+	if err != nil {
+		t.Fatalf("primary create: %v", err)
+	}
+	prim, err := c.GetEntity(t, primaryID)
+	if err != nil {
+		t.Fatalf("GetEntity primary: %v", err)
+	}
+	joined, _ := prim.Data["grpcSearchJoinedCount"].(float64)
+	standalone, _ := prim.Data["grpcSearchStandaloneCount"].(float64)
+	if joined < 1 {
+		t.Fatalf("joined gRPC search matched %v entities; want >= 1 — the tx-token was ignored on the search RPC (read-your-writes broken for gRPC search): data=%+v", prim.Data["grpcSearchJoinedCount"], prim.Data)
+	}
+	if standalone != 0 {
+		t.Errorf("standalone gRPC search (no token) matched %v entities; want 0 — the control must not see the uncommitted secondary", prim.Data["grpcSearchStandaloneCount"])
+	}
+}
+
 // RunCallbackCriteriaReadYourWrites proves invariant 3: a criteria callback that
 // reads an entity written earlier in T joins the transaction and sees the
 // uncommitted state.

--- a/e2e/parity/multinode/callback_route.go
+++ b/e2e/parity/multinode/callback_route.go
@@ -42,6 +42,7 @@ func init() {
 	Register(
 		NamedTest{Name: "Callback_ForwardedDispatch_HTTP", Fn: RunCallback_ForwardedDispatch_HTTP},
 		NamedTest{Name: "Callback_ForwardedDispatch_GRPC", Fn: RunCallback_ForwardedDispatch_GRPC},
+		NamedTest{Name: "Callback_ForwardedGRPCSearch", Fn: RunCallback_ForwardedGRPCSearch},
 	)
 }
 
@@ -329,6 +330,62 @@ func RunCallback_ForwardedDispatch_GRPC(t *testing.T, fixture MultiNodeFixture) 
 		if len(hits) != 0 {
 			t.Fatalf("doomed secondary search via node %d = %d; want 0 — cross-node gRPC callback write was NOT rolled back with T", nodeIdx, len(hits))
 		}
+	}
+}
+
+// RunCallback_ForwardedGRPCSearch proves the cross-node gRPC SEARCH-forward path:
+// a callback that searches within T over gRPC from a non-owner node forwards the
+// EntitySearchCollection call to the owner (B→A) and joins T there, observing the
+// transaction's uncommitted write — the read-side counterpart of the gRPC
+// EntityManage forward (RunCallback_ForwardedDispatch_GRPC).
+//
+//   - Node 1 (OWNER, no member) forwards the tagged processor dispatch to node 0
+//     (A→B). Node 0's member fires two joined gRPC callbacks presenting the
+//     tx-token (owner=node 1): first EntityManage(EntityCreateRequest) to write a
+//     secondary into T on node 1 (B→A), then EntitySearchCollection to search for
+//     it. Node 0 is a non-owner for T, so the search forwards B→A to node 1,
+//     joins T, and matches the uncommitted secondary.
+//   - Without the search RPC wired into the txRouteInterceptor the search would
+//     run locally on node 0 (no T) and match nothing, so the joined count would
+//     collapse to 0 and this scenario would fail.
+func RunCallback_ForwardedGRPCSearch(t *testing.T, fixture MultiNodeFixture) {
+	t.Helper()
+	urls := fixture.BaseURLs()
+	if len(urls) < 2 {
+		t.Fatalf("forwarded gRPC search callback routing needs ≥2 nodes, got %d", len(urls))
+	}
+	tenant := fixture.ComputeTenant(t)
+
+	cSetup := client.NewClient(urls[0], tenant.Token)
+
+	const secondary = "cbroute-gsearch-secondary"
+	const primary = "cbroute-gsearch-primary"
+	const marker = "cbroute-gsearch-marker"
+
+	cbRouteSetupModel(t, cSetup, secondary, `{"name":"child","amount":1,"status":"new"}`, cbRouteSecondaryWorkflow)
+	cbRouteSetupModel(t, cSetup, primary, `{"name":"Test","amount":10,"status":"new"}`,
+		cbRoutePrimaryWorkflow("cbroute-gsearch-wf", "cb-grpc-search-forward", cbRouteContext(secondary, marker)))
+
+	// OWNER = node 1 (no local compute member → dispatch forwards to node 0).
+	const ownerIdx = 1
+	cOwner := client.NewClient(urls[ownerIdx], tenant.Token)
+
+	primaryID, err := cOwner.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
+	if err != nil {
+		t.Fatalf("primary create via owner node %d (forwarded dispatch + cross-node gRPC search): %v", ownerIdx, err)
+	}
+	prim, err := cOwner.GetEntity(t, primaryID)
+	if err != nil {
+		t.Fatalf("GetEntity primary via owner: %v", err)
+	}
+	if prim.Meta.State != "ACTIVE" {
+		t.Fatalf("primary state = %q; want ACTIVE (cross-node gRPC search cascade did not complete): data=%+v", prim.Meta.State, prim.Data)
+	}
+	if empty, _ := prim.Data["tokenWasEmpty"].(bool); empty {
+		t.Errorf("forwarded SYNC dispatch: tokenWasEmpty=true; want false (owner token must survive A→B forward)")
+	}
+	if cnt, _ := prim.Data["grpcForwardSearchCount"].(float64); cnt < 1 {
+		t.Fatalf("forwarded gRPC search matched %v entities; want >= 1 — the B→A search forward did not join T on the owner (search RPC not routed): data=%+v", prim.Data["grpcForwardSearchCount"], prim.Data)
 	}
 }
 

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 196 (guarded by TestParityScenarioCount — bump
+// Total parity scenarios: 197 (guarded by TestParityScenarioCount — bump
 // wantParityScenarioCount in registry_count_test.go when adding/removing an
 // entry, or the test fails).
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
@@ -120,6 +120,7 @@ var allTests = []NamedTest{
 	// Concurrency/torn-write cases are intentionally NOT here (isolated e2e).
 	{"CallbackTxJoin_SyncWriteAtomic", RunCallbackSyncWriteAtomic},
 	{"CallbackTxJoin_SyncReadYourWrites", RunCallbackSyncReadYourWrites},
+	{"CallbackTxJoin_GRPCSearchReadYourWrites", RunCallbackGRPCSearchReadYourWrites},
 	{"CallbackTxJoin_CriteriaReadYourWrites", RunCallbackCriteriaReadYourWrites},
 	{"CallbackTxJoin_IfMatchUpdate", RunCallbackIfMatchUpdate},
 	{"CallbackTxJoin_EmptyTokenStandalone", RunCallbackEmptyTokenStandalone},

--- a/e2e/parity/registry_count_test.go
+++ b/e2e/parity/registry_count_test.go
@@ -6,7 +6,7 @@ import "testing"
 // the registry.go header comment drifted silently for many PRs because nothing
 // asserted it; this test converts that drift into a failure. Bump this constant
 // (and the header comment) in the same change that adds or removes a scenario.
-const wantParityScenarioCount = 196
+const wantParityScenarioCount = 197
 
 // TestParityScenarioCount guards the documented scenario count against silent
 // drift.

--- a/internal/cluster/proxy/grpc_forward.go
+++ b/internal/cluster/proxy/grpc_forward.go
@@ -115,6 +115,31 @@ func ForwardEntityManageCollection(ctx context.Context, pool *ClientPool, addr s
 	return client.EntityManageCollection(withForwardedMetadata(ctx), ce)
 }
 
+// ForwardEntitySearch dials the owning node and replays a unary EntitySearch
+// call, propagating the inbound metadata (auth + tx-token) so the owner joins
+// the referenced transaction and the read observes its uncommitted writes.
+// Connections are cached per addr. The token is never logged.
+func ForwardEntitySearch(ctx context.Context, pool *ClientPool, addr string, ce *cepb.CloudEvent) (*cepb.CloudEvent, error) {
+	conn, err := pool.Get(addr)
+	if err != nil {
+		return nil, err
+	}
+	client := cyodapb.NewCloudEventsServiceClient(conn)
+	return client.EntitySearch(withForwardedMetadata(ctx), ce)
+}
+
+// ForwardEntitySearchCollection dials the owning node and re-issues the
+// server-streaming EntitySearchCollection call, returning the client stream so
+// the caller can copy frames back to the inbound stream.
+func ForwardEntitySearchCollection(ctx context.Context, pool *ClientPool, addr string, ce *cepb.CloudEvent) (grpc.ServerStreamingClient[cepb.CloudEvent], error) {
+	conn, err := pool.Get(addr)
+	if err != nil {
+		return nil, err
+	}
+	client := cyodapb.NewCloudEventsServiceClient(conn)
+	return client.EntitySearchCollection(withForwardedMetadata(ctx), ce)
+}
+
 // withForwardedMetadata copies inbound metadata (auth + tx-token) onto the
 // outgoing context so the owner node re-authenticates and re-routes correctly.
 func withForwardedMetadata(ctx context.Context) context.Context {

--- a/internal/e2e/callback_txjoin_grpc_search_test.go
+++ b/internal/e2e/callback_txjoin_grpc_search_test.go
@@ -1,0 +1,282 @@
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+
+	cepb "github.com/cyoda-platform/cyoda-go/api/grpc/cloudevents"
+	cyodapb "github.com/cyoda-platform/cyoda-go/api/grpc/cyoda"
+	internalgrpc "github.com/cyoda-platform/cyoda-go/internal/grpc"
+)
+
+// callback_txjoin_grpc_search_test.go proves that a compute-node callback which
+// SEARCHES over the gRPC entity API joins the originating transaction T, just as
+// the write RPCs do. The joining txRouteInterceptor originally covered only the
+// write RPCs (EntityManage / EntityManageCollection); the read RPCs
+// (EntitySearch / EntitySearchCollection) were not intercepted, so a callback's
+// tx-token was silently ignored on searches and they ran unjoined against
+// last-committed state.
+//
+// Unlike callback_txjoin_test.go (which exercises the HTTP callback path, whose
+// route-agnostic TxJoin middleware always joined), these callbacks go back over
+// the REAL gRPC entity API carrying the tx-token as gRPC metadata — the exact
+// path the interceptor gates. Each search is issued twice: once WITH the token
+// (must observe the uncommitted same-transaction write) and once WITHOUT (the
+// control: must NOT observe it), so the assertion isolates the join as the cause.
+
+// grpcSearchResult is the outcome of a gRPC search callback, recorded into the
+// primary entity's data so it can be asserted after commit.
+type grpcSearchResult struct {
+	// GetFoundJoined is true when the unary EntitySearch (EntityGetRequest) issued
+	// WITH the tx-token observed the uncommitted secondary.
+	GetFoundJoined bool
+	// GetFoundStandalone is true when the same unary get WITHOUT the token
+	// observed it — must be false (the row is uncommitted).
+	GetFoundStandalone bool
+	// SearchCountJoined is the number of EntitySearchCollection (EntitySearchRequest)
+	// matches WITH the token — must be >= 1.
+	SearchCountJoined int
+	// SearchCountStandalone is the match count WITHOUT the token — must be 0.
+	SearchCountStandalone int
+	// JoinedMarker is the secondary's data.status observed by the joined get.
+	JoinedMarker string
+}
+
+// grpcCtx builds an outgoing gRPC context carrying the member's bearer and,
+// when joinTok is non-empty, the tx-token metadata that joins T.
+func (h *callbackHarness) grpcCtx(joinTok string) context.Context {
+	ctx := context.Background()
+	tok, _ := h.bearerVal.Load().(string)
+	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+tok)
+	if joinTok != "" {
+		ctx = metadata.AppendToOutgoingContext(ctx, internalgrpcTxTokenKey, joinTok)
+	}
+	return ctx
+}
+
+// internalgrpcTxTokenKey mirrors proxy.GRPCTxTokenKey ("tx-token"); duplicated
+// here to avoid importing the internal proxy package into the e2e test.
+const internalgrpcTxTokenKey = "tx-token"
+
+// getEntityGRPC issues a unary EntitySearch (EntityGetRequest) for entityID.
+// When joinTok is set the read joins T. Returns whether the entity was observed
+// and its data.status marker.
+func (h *callbackHarness) getEntityGRPC(entityID, joinTok string) (found bool, marker string, err error) {
+	client := cyodapb.NewCloudEventsServiceClient(h.member.conn)
+	reqCE, err := internalgrpc.NewCloudEvent(internalgrpc.EntityGetRequest, map[string]any{
+		"id":       "cb-grpc-get",
+		"entityId": entityID,
+	})
+	if err != nil {
+		return false, "", fmt.Errorf("build get request: %w", err)
+	}
+	respCE, err := client.EntitySearch(h.grpcCtx(joinTok), reqCE)
+	if err != nil {
+		return false, "", fmt.Errorf("EntitySearch: %w", err)
+	}
+	ok, data, perr := parseEntityResponse(respCE)
+	if perr != nil {
+		return false, "", perr
+	}
+	if !ok {
+		return false, "", nil
+	}
+	m, _ := data["status"].(string)
+	return true, m, nil
+}
+
+// searchGRPC issues a streaming EntitySearchCollection (EntitySearchRequest)
+// matching data.status == statusEq over (entityName, version). When joinTok is
+// set the search joins T. Returns the number of matched entities.
+func (h *callbackHarness) searchGRPC(entityName string, version int, statusEq, joinTok string) (count int, err error) {
+	client := cyodapb.NewCloudEventsServiceClient(h.member.conn)
+	reqCE, err := internalgrpc.NewCloudEvent(internalgrpc.EntitySearchRequest, map[string]any{
+		"id":    "cb-grpc-search",
+		"model": map[string]any{"name": entityName, "version": version},
+		"condition": map[string]any{
+			"type":         "simple",
+			"jsonPath":     "$.status",
+			"operatorType": "EQUALS",
+			"value":        statusEq,
+		},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("build search request: %w", err)
+	}
+	stream, err := client.EntitySearchCollection(h.grpcCtx(joinTok), reqCE)
+	if err != nil {
+		return 0, fmt.Errorf("EntitySearchCollection: %w", err)
+	}
+	for {
+		frame, rerr := stream.Recv()
+		if errors.Is(rerr, io.EOF) {
+			break // stream completed normally
+		}
+		if rerr != nil {
+			return count, fmt.Errorf("search stream recv: %w", rerr)
+		}
+		ok, _, perr := parseEntityResponse(frame)
+		if perr != nil {
+			return count, perr
+		}
+		if !ok {
+			// A Success=false frame is an error envelope, not a match.
+			return count, fmt.Errorf("search returned error frame")
+		}
+		count++
+	}
+	return count, nil
+}
+
+// parseEntityResponse decodes an EntityResponse CloudEvent, returning whether it
+// is a successful result carrying entity data (ok=false for a 404/error envelope).
+func parseEntityResponse(ce *cepb.CloudEvent) (ok bool, data map[string]any, err error) {
+	_, payload, perr := internalgrpc.ParseCloudEvent(ce)
+	if perr != nil {
+		return false, nil, fmt.Errorf("parse response: %w", perr)
+	}
+	var resp struct {
+		Success bool `json:"success"`
+		Payload *struct {
+			Data map[string]any `json:"data"`
+		} `json:"payload"`
+	}
+	if uerr := json.Unmarshal(payload, &resp); uerr != nil {
+		return false, nil, fmt.Errorf("unmarshal response: %w", uerr)
+	}
+	if !resp.Success {
+		return false, nil, nil
+	}
+	if resp.Payload == nil {
+		return true, map[string]any{}, nil
+	}
+	return true, resp.Payload.Data, nil
+}
+
+// TestCallback_GRPCSearch_SeesUncommittedWrite proves read-your-own-writes for
+// gRPC SEARCH callbacks: a SYNC processor creates a secondary entity inside T
+// (uncommitted), then reads it back via the gRPC EntitySearch (unary) and
+// EntitySearchCollection (streaming) RPCs. WITH the tx-token both observe the
+// uncommitted row; WITHOUT it neither does. Before the interceptor was wired for
+// the search RPCs the joined variants behaved like the standalone ones (the
+// token was ignored), so the joined-vs-standalone assertions would collapse.
+func TestCallback_GRPCSearch_SeesUncommittedWrite(t *testing.T) {
+	h := newCallbackHarness(t)
+
+	const primary = "cb-grpc-search-primary"
+	const secondary = "cb-grpc-search-secondary"
+	h.SetupModelWithWorkflow(t, secondary, secondaryWorkflow)
+
+	const marker = "grpc-search-marker-77"
+
+	h.RegisterProc("cb-grpc-search", func(rc *reqCtx) (map[string]any, error) {
+		// 1. Create a secondary entity inside T (uncommitted) via the proven HTTP
+		//    join path.
+		created, err := rc.CreateEntity(secondary, 1, fmt.Sprintf(`{"name":"child","amount":7,"status":%q}`, marker))
+		if err != nil {
+			return nil, fmt.Errorf("callback create failed: %w", err)
+		}
+		if created.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("callback create status=%d body=%s", created.StatusCode, created.Body)
+		}
+
+		var res grpcSearchResult
+
+		// 2. Unary gRPC get WITH the tx-token — must observe the uncommitted row.
+		foundJoined, joinedMarker, err := rc.h.getEntityGRPC(created.EntityID, rc.token)
+		if err != nil {
+			return nil, fmt.Errorf("joined gRPC get: %w", err)
+		}
+		res.GetFoundJoined = foundJoined
+		res.JoinedMarker = joinedMarker
+
+		// 3. Unary gRPC get WITHOUT the token (control) — must NOT observe it.
+		foundStandalone, _, err := rc.h.getEntityGRPC(created.EntityID, "")
+		if err != nil {
+			return nil, fmt.Errorf("standalone gRPC get: %w", err)
+		}
+		res.GetFoundStandalone = foundStandalone
+
+		// 4. Streaming gRPC search WITH the token — must match the uncommitted row.
+		cJoined, err := rc.h.searchGRPC(secondary, 1, marker, rc.token)
+		if err != nil {
+			return nil, fmt.Errorf("joined gRPC search: %w", err)
+		}
+		res.SearchCountJoined = cJoined
+
+		// 5. Streaming gRPC search WITHOUT the token (control) — must match nothing.
+		cStandalone, err := rc.h.searchGRPC(secondary, 1, marker, "")
+		if err != nil {
+			return nil, fmt.Errorf("standalone gRPC search: %w", err)
+		}
+		res.SearchCountStandalone = cStandalone
+
+		out := cloneData(rc.entityData)
+		out["getFoundJoined"] = res.GetFoundJoined
+		out["getFoundStandalone"] = res.GetFoundStandalone
+		out["searchCountJoined"] = float64(res.SearchCountJoined)
+		out["searchCountStandalone"] = float64(res.SearchCountStandalone)
+		out["joinedMarker"] = res.JoinedMarker
+		out["secondaryId"] = created.EntityID
+		return out, nil
+	})
+
+	primaryWF := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "primary-grpc-search-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE":   {"transitions": [{"name": "init", "next": "ACTIVE", "manual": false,
+					"processors": [{"type": "calculator", "name": "cb-grpc-search", "executionMode": "SYNC",
+						"config": {"attachEntity": true, "calculationNodesTags": ""}}]
+				}]},
+				"ACTIVE": {}
+			}
+		}]
+	}`
+	h.SetupModelWithWorkflow(t, primary, primaryWF)
+
+	primaryID, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
+	if status != http.StatusOK {
+		t.Fatalf("primary create: status=%d body=%s", status, body)
+	}
+
+	data := h.GetEntityData(t, primaryID)
+
+	// The joined unary get saw the uncommitted secondary; the standalone one did not.
+	if found, _ := data["getFoundJoined"].(bool); !found {
+		t.Errorf("joined gRPC EntitySearch did NOT observe the uncommitted secondary — the tx-token was ignored on the read RPC (read-your-own-writes broken for gRPC search)")
+	}
+	if found, _ := data["getFoundStandalone"].(bool); found {
+		t.Errorf("standalone gRPC EntitySearch (no token) observed the uncommitted secondary — the control must not see it; the test would not isolate the join")
+	}
+	if got := data["joinedMarker"]; got != marker {
+		t.Errorf("joined gRPC get observed status=%v; want the uncommitted marker %q", got, marker)
+	}
+
+	// The joined streaming search matched the uncommitted secondary; standalone matched nothing.
+	if c, _ := data["searchCountJoined"].(float64); c < 1 {
+		t.Errorf("joined gRPC EntitySearchCollection matched %v entities; want >= 1 (uncommitted secondary must be visible within T)", data["searchCountJoined"])
+	}
+	if c, _ := data["searchCountStandalone"].(float64); c != 0 {
+		t.Errorf("standalone gRPC EntitySearchCollection matched %v entities; want 0 (uncommitted secondary must be invisible outside T)", data["searchCountStandalone"])
+	}
+
+	// After commit the secondary is durable (belt-and-braces).
+	secondaryID, _ := data["secondaryId"].(string)
+	if secondaryID == "" {
+		t.Fatal("primary data missing secondaryId")
+	}
+	if st, code := h.GetEntityState(t, secondaryID); code != http.StatusOK {
+		t.Fatalf("secondary GET after commit: http %d; want 200", code)
+	} else if st != "STORED" {
+		t.Errorf("secondary state = %q; want STORED", st)
+	}
+}

--- a/internal/grpc/txroute_interceptor.go
+++ b/internal/grpc/txroute_interceptor.go
@@ -20,12 +20,28 @@ import (
 	"github.com/cyoda-platform/cyoda-go/internal/domain/txjoin"
 )
 
-// txRouteInterceptor routes inbound EntityManage / EntityManageCollection
-// callbacks by their tx-token: a token for the local node joins the referenced
-// transaction onto the request context; a token for a live peer forwards the
-// whole call to that peer (B→A). Routing/join failures are returned as the
-// EntityManage error envelope (Success=false), never as a raw gRPC status, so
-// clients read them the same way as any other EntityManage failure.
+// forwardUnaryFn re-issues a unary CloudEvent RPC to a peer node.
+type forwardUnaryFn func(context.Context, *proxy.ClientPool, string, *cepb.CloudEvent) (*cepb.CloudEvent, error)
+
+// forwardStreamFn re-issues a server-streaming CloudEvent RPC to a peer node.
+type forwardStreamFn func(context.Context, *proxy.ClientPool, string, *cepb.CloudEvent) (googlegrpc.ServerStreamingClient[cepb.CloudEvent], error)
+
+// envelopeFn renders a routing/join failure as a schema-valid error CloudEvent
+// for a given RPC family, so the client parses it like any other failure of
+// that RPC rather than a raw gRPC status.
+type envelopeFn func(ctx context.Context, ceID string, err error) (*cepb.CloudEvent, error)
+
+// txRouteInterceptor routes inbound entity callbacks by their tx-token: a token
+// for the local node joins the referenced transaction onto the request context;
+// a token for a live peer forwards the whole call to that peer (B→A). It covers
+// both the write RPCs (EntityManage / EntityManageCollection) and the read RPCs
+// (EntitySearch / EntitySearchCollection) — a callback that presents a valid
+// token joins T for reads too, so reads-your-own-writes is symmetric with writes.
+//
+// Routing/join failures are returned as that RPC's error envelope
+// (Success=false) — the transaction envelope for the write RPCs, the entity
+// response envelope for the search RPCs — never as a raw gRPC status, so clients
+// read them the same way as any other failure of that RPC.
 type txRouteInterceptor struct {
 	signer        *token.Signer
 	registry      contract.NodeRegistry
@@ -35,29 +51,49 @@ type txRouteInterceptor struct {
 	localGRPCPort int
 
 	// forward seams — overridable in tests.
-	forwardUnary  func(context.Context, *proxy.ClientPool, string, *cepb.CloudEvent) (*cepb.CloudEvent, error)
-	forwardStream func(context.Context, *proxy.ClientPool, string, *cepb.CloudEvent) (googlegrpc.ServerStreamingClient[cepb.CloudEvent], error)
+	forwardUnary        forwardUnaryFn
+	forwardStream       forwardStreamFn
+	forwardSearchUnary  forwardUnaryFn
+	forwardSearchStream forwardStreamFn
 }
 
 func newTxRouteInterceptor(signer *token.Signer, reg contract.NodeRegistry, selfNodeID string, txMgr spi.TransactionManager, localGRPCPort int, allowLoopback bool) *txRouteInterceptor {
 	return &txRouteInterceptor{
-		signer:        signer,
-		registry:      reg,
-		selfNodeID:    selfNodeID,
-		txMgr:         txMgr,
-		pool:          proxy.NewClientPool(allowLoopback),
-		localGRPCPort: localGRPCPort,
-		forwardUnary:  proxy.ForwardEntityManage,
-		forwardStream: proxy.ForwardEntityManageCollection,
+		signer:              signer,
+		registry:            reg,
+		selfNodeID:          selfNodeID,
+		txMgr:               txMgr,
+		pool:                proxy.NewClientPool(allowLoopback),
+		localGRPCPort:       localGRPCPort,
+		forwardUnary:        proxy.ForwardEntityManage,
+		forwardStream:       proxy.ForwardEntityManageCollection,
+		forwardSearchUnary:  proxy.ForwardEntitySearch,
+		forwardSearchStream: proxy.ForwardEntitySearchCollection,
 	}
 }
 
-func isEntityManage(fullMethod string) bool {
-	return fullMethod == cyodapb.CloudEventsService_EntityManage_FullMethodName
+// unaryRoute reports whether a unary method is tx-token-routed and, if so,
+// returns the peer-forward function and the error-envelope builder for its RPC
+// family. A non-routed method (routed=false) passes through untouched.
+func (i *txRouteInterceptor) unaryRoute(fullMethod string) (forward forwardUnaryFn, envelope envelopeFn, routed bool) {
+	switch fullMethod {
+	case cyodapb.CloudEventsService_EntityManage_FullMethodName:
+		return i.forwardUnary, entityTransactionError, true
+	case cyodapb.CloudEventsService_EntitySearch_FullMethodName:
+		return i.forwardSearchUnary, entityResponseError, true
+	}
+	return nil, nil, false
 }
 
-func isEntityManageCollection(fullMethod string) bool {
-	return fullMethod == cyodapb.CloudEventsService_EntityManageCollection_FullMethodName
+// streamRoute is the server-streaming counterpart of unaryRoute.
+func (i *txRouteInterceptor) streamRoute(fullMethod string) (forward forwardStreamFn, envelope envelopeFn, routed bool) {
+	switch fullMethod {
+	case cyodapb.CloudEventsService_EntityManageCollection_FullMethodName:
+		return i.forwardStream, entityTransactionError, true
+	case cyodapb.CloudEventsService_EntitySearchCollection_FullMethodName:
+		return i.forwardSearchStream, entityResponseError, true
+	}
+	return nil, nil, false
 }
 
 // classifyRouteErr maps a proxy.ResolveTarget error onto the canonical
@@ -82,7 +118,8 @@ func classifyRouteErr(err error) error {
 // check.
 func (i *txRouteInterceptor) unary() googlegrpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *googlegrpc.UnaryServerInfo, handler googlegrpc.UnaryHandler) (any, error) {
-		if !isEntityManage(info.FullMethod) {
+		forward, envelope, routed := i.unaryRoute(info.FullMethod)
+		if !routed {
 			return handler(ctx, req)
 		}
 		ce, _ := req.(*cepb.CloudEvent)
@@ -90,45 +127,47 @@ func (i *txRouteInterceptor) unary() googlegrpc.UnaryServerInterceptor {
 		tok := proxy.ExtractGRPCToken(ctx)
 		ni, shouldProxy, err := proxy.ResolveNodeInfo(ctx, i.signer, i.registry, i.selfNodeID, tok)
 		if err != nil {
-			return i.unaryErr(ctx, ce, classifyRouteErr(err))
+			return i.unaryErr(ctx, ce, envelope, classifyRouteErr(err))
 		}
 		if shouldProxy {
 			if ce == nil {
-				return i.unaryErr(ctx, nil, fmt.Errorf("proxy path: request is not a CloudEvent"))
+				return i.unaryErr(ctx, nil, envelope, fmt.Errorf("proxy path: request is not a CloudEvent"))
 			}
 			grpcAddr, addrErr := resolveGRPCAddr(ni, i.localGRPCPort)
 			if addrErr != nil {
-				return i.unaryErr(ctx, ce, fmt.Errorf("resolve peer gRPC addr: %w", addrErr))
+				return i.unaryErr(ctx, ce, envelope, fmt.Errorf("resolve peer gRPC addr: %w", addrErr))
 			}
-			resp, fwdErr := i.forwardUnary(ctx, i.pool, grpcAddr, ce)
+			resp, fwdErr := forward(ctx, i.pool, grpcAddr, ce)
 			if fwdErr != nil {
-				return i.unaryErr(ctx, ce, fwdErr)
+				return i.unaryErr(ctx, ce, envelope, fwdErr)
 			}
 			return resp, nil
 		}
 
 		joinedCtx, jerr := txjoin.JoinFromToken(ctx, i.signer, i.txMgr, tok)
 		if jerr != nil {
-			return i.unaryErr(ctx, ce, jerr)
+			return i.unaryErr(ctx, ce, envelope, jerr)
 		}
 		return handler(joinedCtx, req)
 	}
 }
 
-// unaryErr renders err as an EntityManage error envelope. If the request could
+// unaryErr renders err as the routed RPC's error envelope. If the request could
 // not be parsed as a CloudEvent the id is empty.
-func (i *txRouteInterceptor) unaryErr(ctx context.Context, ce *cepb.CloudEvent, err error) (any, error) {
+func (i *txRouteInterceptor) unaryErr(ctx context.Context, ce *cepb.CloudEvent, envelope envelopeFn, err error) (any, error) {
 	id := ""
 	if ce != nil {
 		id = ce.Id
 	}
-	return entityTransactionError(common.WithDiagnostics(ctx), id, err)
+	return envelope(common.WithDiagnostics(ctx), id, err)
 }
 
-// stream returns the stream interceptor for EntityManageCollection.
+// stream returns the stream interceptor for the routed server-streaming RPCs
+// (EntityManageCollection and EntitySearchCollection).
 func (i *txRouteInterceptor) stream() googlegrpc.StreamServerInterceptor {
 	return func(srv any, ss googlegrpc.ServerStream, info *googlegrpc.StreamServerInfo, handler googlegrpc.StreamHandler) error {
-		if !isEntityManageCollection(info.FullMethod) {
+		forward, envelope, routed := i.streamRoute(info.FullMethod)
+		if !routed {
 			return handler(srv, ss)
 		}
 		ctx := ss.Context()
@@ -136,19 +175,19 @@ func (i *txRouteInterceptor) stream() googlegrpc.StreamServerInterceptor {
 		tok := proxy.ExtractGRPCToken(ctx)
 		ni, shouldProxy, err := proxy.ResolveNodeInfo(ctx, i.signer, i.registry, i.selfNodeID, tok)
 		if err != nil {
-			return i.streamErr(ss, "", classifyRouteErr(err))
+			return i.streamErr(ss, "", envelope, classifyRouteErr(err))
 		}
 		if shouldProxy {
 			grpcAddr, addrErr := resolveGRPCAddr(ni, i.localGRPCPort)
 			if addrErr != nil {
-				return i.streamErr(ss, "", fmt.Errorf("resolve peer gRPC addr: %w", addrErr))
+				return i.streamErr(ss, "", envelope, fmt.Errorf("resolve peer gRPC addr: %w", addrErr))
 			}
-			return i.proxyStream(ctx, ss, grpcAddr)
+			return i.proxyStream(ctx, ss, forward, envelope, grpcAddr)
 		}
 
 		joinedCtx, jerr := txjoin.JoinFromToken(ctx, i.signer, i.txMgr, tok)
 		if jerr != nil {
-			return i.streamErr(ss, "", jerr)
+			return i.streamErr(ss, "", envelope, jerr)
 		}
 		return handler(srv, &wrappedStream{ServerStream: ss, ctx: joinedCtx})
 	}
@@ -157,14 +196,14 @@ func (i *txRouteInterceptor) stream() googlegrpc.StreamServerInterceptor {
 // proxyStream consumes the inbound request message, re-issues the
 // server-streaming call to the owner node, and copies every response frame back
 // onto the inbound stream verbatim.
-func (i *txRouteInterceptor) proxyStream(ctx context.Context, ss googlegrpc.ServerStream, addr string) error {
+func (i *txRouteInterceptor) proxyStream(ctx context.Context, ss googlegrpc.ServerStream, forward forwardStreamFn, envelope envelopeFn, addr string) error {
 	var ce cepb.CloudEvent
 	if err := ss.RecvMsg(&ce); err != nil {
 		return err
 	}
-	cs, err := i.forwardStream(ctx, i.pool, addr, &ce)
+	cs, err := forward(ctx, i.pool, addr, &ce)
 	if err != nil {
-		return i.streamErr(ss, ce.Id, err)
+		return i.streamErr(ss, ce.Id, envelope, err)
 	}
 	for {
 		frame, err := cs.Recv()
@@ -180,13 +219,13 @@ func (i *txRouteInterceptor) proxyStream(ctx context.Context, ss googlegrpc.Serv
 	}
 }
 
-// streamErr sends err as an EntityManage error envelope on the stream. reqID
+// streamErr sends err as the routed RPC's error envelope on the stream. reqID
 // is the already-consumed request id (empty string when no request has been
 // read yet — pre-body token rejections legitimately have no request id).
-func (i *txRouteInterceptor) streamErr(ss googlegrpc.ServerStream, reqID string, err error) error {
-	respCE, buildErr := entityTransactionError(common.WithDiagnostics(ss.Context()), reqID, err)
+func (i *txRouteInterceptor) streamErr(ss googlegrpc.ServerStream, reqID string, envelope envelopeFn, err error) error {
+	respCE, buildErr := envelope(common.WithDiagnostics(ss.Context()), reqID, err)
 	if buildErr != nil {
-		slog.Error("failed to build EntityManage error envelope", "err", buildErr)
+		slog.Error("failed to build tx-route error envelope", "err", buildErr)
 		return buildErr
 	}
 	return ss.SendMsg(respCE)

--- a/internal/grpc/txroute_interceptor_test.go
+++ b/internal/grpc/txroute_interceptor_test.go
@@ -114,6 +114,14 @@ func entityManageCollectionInfo() *googlegrpc.StreamServerInfo {
 	return &googlegrpc.StreamServerInfo{FullMethod: cyodapb.CloudEventsService_EntityManageCollection_FullMethodName}
 }
 
+func entitySearchInfo() *googlegrpc.UnaryServerInfo {
+	return &googlegrpc.UnaryServerInfo{FullMethod: cyodapb.CloudEventsService_EntitySearch_FullMethodName}
+}
+
+func entitySearchCollectionInfo() *googlegrpc.StreamServerInfo {
+	return &googlegrpc.StreamServerInfo{FullMethod: cyodapb.CloudEventsService_EntitySearchCollection_FullMethodName}
+}
+
 func decodeTxResp(t *testing.T, ce *cepb.CloudEvent) events.EntityTransactionResponseJson {
 	t.Helper()
 	_, payload, err := ParseCloudEvent(ce)
@@ -121,6 +129,30 @@ func decodeTxResp(t *testing.T, ce *cepb.CloudEvent) events.EntityTransactionRes
 		t.Fatalf("ParseCloudEvent: %v", err)
 	}
 	var r events.EntityTransactionResponseJson
+	if err := json.Unmarshal(payload, &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return r
+}
+
+// decodeEntityResp decodes a unary interceptor result as an EntityResponse — the
+// error-envelope shape used by the search RPCs (EntitySearch / EntitySearchCollection).
+func decodeEntityResp(t *testing.T, resp any) events.EntityResponseJson {
+	t.Helper()
+	ce, ok := resp.(*cepb.CloudEvent)
+	if !ok {
+		t.Fatalf("expected *cepb.CloudEvent, got %T", resp)
+	}
+	return decodeEntityRespCE(t, ce)
+}
+
+func decodeEntityRespCE(t *testing.T, ce *cepb.CloudEvent) events.EntityResponseJson {
+	t.Helper()
+	_, payload, err := ParseCloudEvent(ce)
+	if err != nil {
+		t.Fatalf("ParseCloudEvent: %v", err)
+	}
+	var r events.EntityResponseJson
 	if err := json.Unmarshal(payload, &r); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -146,6 +178,184 @@ func TestTxRouteInterceptor_LocalJoin(t *testing.T) {
 	resp, err := ic.unary()(ctx, &cepb.CloudEvent{Id: "req-1"}, entityManageInfo(), handler)
 	if err != nil || sawTx != "tx-1" || resp != "ok" {
 		t.Fatalf("expected local join tx-1, sawTx=%q resp=%v err=%v", sawTx, resp, err)
+	}
+}
+
+// A valid self-node token on EntitySearch (unary) joins the tx onto the handler
+// context, symmetric with EntityManage: a compute-node callback that searches
+// within its still-open transaction must observe its own uncommitted writes.
+func TestTxRouteInterceptor_SearchLocalJoin(t *testing.T) {
+	s, _ := token.NewSigner(make32(t))
+	tok, _ := s.Issue("local", "tx-search-1", time.Now().Add(time.Minute))
+	ic := newTxRouteInterceptor(s, fakeRouteRegistry{}, "local", fakeJoinTM{}, 9090, true)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("tx-token", tok))
+
+	var sawTx string
+	handler := func(ctx context.Context, req any) (any, error) {
+		if tx := spi.GetTransaction(ctx); tx != nil {
+			sawTx = tx.ID
+		}
+		return "ok", nil
+	}
+	resp, err := ic.unary()(ctx, &cepb.CloudEvent{Id: "req-s1"}, entitySearchInfo(), handler)
+	if err != nil || sawTx != "tx-search-1" || resp != "ok" {
+		t.Fatalf("expected search local join tx-search-1, sawTx=%q resp=%v err=%v", sawTx, resp, err)
+	}
+}
+
+// A valid self-node token on EntitySearchCollection (stream) joins the tx onto
+// the stream context, symmetric with EntityManageCollection.
+func TestTxRouteInterceptor_SearchStreamLocalJoin(t *testing.T) {
+	s, _ := token.NewSigner(make32(t))
+	tok, _ := s.Issue("local", "tx-search-7", time.Now().Add(time.Minute))
+	ic := newTxRouteInterceptor(s, fakeRouteRegistry{}, "local", fakeJoinTM{}, 9090, true)
+	baseCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("tx-token", tok))
+	ss := &fakeServerStream{ctx: baseCtx}
+
+	var sawTx string
+	handler := func(_ any, stream googlegrpc.ServerStream) error {
+		if tx := spi.GetTransaction(stream.Context()); tx != nil {
+			sawTx = tx.ID
+		}
+		return nil
+	}
+	if err := ic.stream()(nil, ss, entitySearchCollectionInfo(), handler); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if sawTx != "tx-search-7" {
+		t.Fatalf("expected joined tx-search-7 on search stream ctx, got %q", sawTx)
+	}
+}
+
+// A search token for a foreign, alive node forwards the EntitySearch (unary) to
+// the owner via the search forward seam — mirroring the write path, so a
+// peer-owned transaction's reads execute on the owner (where T is live).
+func TestTxRouteInterceptor_SearchForeignProxies(t *testing.T) {
+	s, _ := token.NewSigner(make32(t))
+	tok, _ := s.Issue("node-B", "tx-search-9", time.Now().Add(time.Minute))
+	reg := fakeRouteRegistry{nodes: map[string]contract.NodeInfo{
+		"node-B": {NodeID: "node-B", Addr: "http://node-b:8080", Alive: true},
+	}}
+	ic := newTxRouteInterceptor(s, reg, "node-A", fakeJoinTM{}, 9090, true)
+
+	var gotAddr string
+	writeForwardCalled := false
+	ic.forwardUnary = func(context.Context, *proxy.ClientPool, string, *cepb.CloudEvent) (*cepb.CloudEvent, error) {
+		writeForwardCalled = true // the search path must NOT use the write forward
+		return nil, nil
+	}
+	ic.forwardSearchUnary = func(_ context.Context, _ *proxy.ClientPool, addr string, _ *cepb.CloudEvent) (*cepb.CloudEvent, error) {
+		gotAddr = addr
+		return &cepb.CloudEvent{Id: "search-forwarded"}, nil
+	}
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("tx-token", tok))
+
+	resp, err := ic.unary()(ctx, &cepb.CloudEvent{Id: "req-s9"}, entitySearchInfo(), func(context.Context, any) (any, error) {
+		t.Fatal("handler must not run for a proxied search")
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if writeForwardCalled {
+		t.Fatal("search proxy must use the search forward, not the write forward")
+	}
+	if gotAddr != "node-b:9090" {
+		t.Fatalf("expected search forward to derived gRPC addr %q, got %q", "node-b:9090", gotAddr)
+	}
+	if ce, ok := resp.(*cepb.CloudEvent); !ok || ce.Id != "search-forwarded" {
+		t.Fatalf("expected forwarded search response verbatim, got %v", resp)
+	}
+}
+
+// A search token for a foreign node re-issues EntitySearchCollection (stream) to
+// the owner via the search stream forward seam and copies frames back.
+func TestTxRouteInterceptor_SearchStreamForeignProxies(t *testing.T) {
+	s, _ := token.NewSigner(make32(t))
+	tok, _ := s.Issue("node-B", "tx-search-11", time.Now().Add(time.Minute))
+	reg := fakeRouteRegistry{nodes: map[string]contract.NodeInfo{
+		"node-B": {NodeID: "node-B", Addr: "http://node-b:8080", Alive: true},
+	}}
+	ic := newTxRouteInterceptor(s, reg, "node-A", fakeJoinTM{}, 9090, true)
+
+	var gotAddr string
+	ic.forwardStream = func(context.Context, *proxy.ClientPool, string, *cepb.CloudEvent) (googlegrpc.ServerStreamingClient[cepb.CloudEvent], error) {
+		t.Fatal("search stream proxy must use the search forward, not the write forward")
+		return nil, nil
+	}
+	ic.forwardSearchStream = func(_ context.Context, _ *proxy.ClientPool, addr string, _ *cepb.CloudEvent) (googlegrpc.ServerStreamingClient[cepb.CloudEvent], error) {
+		gotAddr = addr
+		return &fakeClientStream{frames: []*cepb.CloudEvent{{Id: "sf1"}, {Id: "sf2"}}}, nil
+	}
+	baseCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("tx-token", tok))
+	ss := &fakeServerStream{ctx: baseCtx, recv: []*cepb.CloudEvent{{Id: "req-search-2"}}}
+
+	handler := func(any, googlegrpc.ServerStream) error {
+		t.Fatal("handler must not run for a proxied search stream")
+		return nil
+	}
+	if err := ic.stream()(nil, ss, entitySearchCollectionInfo(), handler); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if gotAddr != "node-b:9090" {
+		t.Fatalf("expected search stream forward to derived gRPC addr %q, got %q", "node-b:9090", gotAddr)
+	}
+	if len(ss.sent) != 2 || ss.sent[0].Id != "sf1" || ss.sent[1].Id != "sf2" {
+		t.Fatalf("expected 2 forwarded frames sf1,sf2; got %+v", ss.sent)
+	}
+}
+
+// A bad token on EntitySearch (unary) yields the SEARCH error envelope
+// (EntityResponse, not the transaction envelope), never a raw gRPC status, and
+// never reaches the handler — the loud-fail contract, symmetric with writes.
+func TestTxRouteInterceptor_SearchBadTokenEnvelope(t *testing.T) {
+	s, _ := token.NewSigner(make32(t))
+	ic := newTxRouteInterceptor(s, fakeRouteRegistry{}, "local", fakeJoinTM{}, 9090, true)
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("tx-token", "garbage.token"))
+
+	resp, err := ic.unary()(ctx, &cepb.CloudEvent{Id: "req-sx"}, entitySearchInfo(), func(context.Context, any) (any, error) {
+		t.Fatal("handler must not run for a bad search token")
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("expected envelope response, got gRPC err: %v", err)
+	}
+	r := decodeEntityResp(t, resp)
+	if r.Success {
+		t.Fatal("expected Success=false")
+	}
+	if r.RequestID != "req-sx" {
+		t.Fatalf("expected RequestID req-sx, got %q", r.RequestID)
+	}
+	if r.Error == nil || r.Error.Message == "" {
+		t.Fatalf("expected error detail, got %+v", r.Error)
+	}
+}
+
+// A bad token on EntitySearchCollection (stream) yields the SEARCH error
+// envelope frame (EntityResponse), never a raw gRPC status.
+func TestTxRouteInterceptor_SearchStreamBadTokenEnvelope(t *testing.T) {
+	s, _ := token.NewSigner(make32(t))
+	ic := newTxRouteInterceptor(s, fakeRouteRegistry{}, "local", fakeJoinTM{}, 9090, true)
+	baseCtx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("tx-token", "garbage.token"))
+	ss := &fakeServerStream{ctx: baseCtx}
+
+	handler := func(any, googlegrpc.ServerStream) error {
+		t.Fatal("handler must not run for a bad search token")
+		return nil
+	}
+	if err := ic.stream()(nil, ss, entitySearchCollectionInfo(), handler); err != nil {
+		t.Fatalf("expected envelope on stream, got raw err: %v", err)
+	}
+	if len(ss.sent) != 1 {
+		t.Fatalf("expected 1 envelope frame, got %d", len(ss.sent))
+	}
+	r := decodeEntityRespCE(t, ss.sent[0])
+	if r.Success {
+		t.Fatal("expected Success=false")
+	}
+	if r.Error == nil || r.Error.Message == "" {
+		t.Fatalf("expected error detail, got %+v", r.Error)
 	}
 }
 
@@ -367,7 +577,8 @@ func TestTxRouteInterceptor_TenantMismatchEnvelope(t *testing.T) {
 	assertEnvelopeCode(t, resp, "req-tenant", "FORBIDDEN")
 }
 
-// Non-EntityManage methods pass through untouched (no token processing).
+// A non-routed unary method (EntityModelManage) passes through untouched (no
+// token processing), even with a bad token present.
 func TestTxRouteInterceptor_NonEntityManagePassThrough(t *testing.T) {
 	s, _ := token.NewSigner(make32(t))
 	ic := newTxRouteInterceptor(s, fakeRouteRegistry{}, "local", fakeJoinTM{}, 9090, true)
@@ -382,7 +593,7 @@ func TestTxRouteInterceptor_NonEntityManagePassThrough(t *testing.T) {
 		}
 		return "ok", nil
 	}
-	info := &googlegrpc.UnaryServerInfo{FullMethod: cyodapb.CloudEventsService_EntitySearch_FullMethodName}
+	info := &googlegrpc.UnaryServerInfo{FullMethod: cyodapb.CloudEventsService_EntityModelManage_FullMethodName}
 	resp, err := ic.unary()(ctx, nil, info, handler)
 	if err != nil || !called || resp != "ok" {
 		t.Fatalf("expected passthrough, called=%v resp=%v err=%v", called, resp, err)
@@ -414,7 +625,7 @@ func TestTxRouteInterceptor_StreamLocalJoin(t *testing.T) {
 	}
 }
 
-// A non-EntityManageCollection stream method with a bad token must pass through
+// A non-routed stream method (StartStreaming) with a bad token must pass through
 // untouched — no routing, no envelope, handler invoked directly.
 func TestTxRouteInterceptor_StreamNonEntityManagePassThrough(t *testing.T) {
 	s, _ := token.NewSigner(make32(t))
@@ -430,7 +641,7 @@ func TestTxRouteInterceptor_StreamNonEntityManagePassThrough(t *testing.T) {
 		}
 		return nil
 	}
-	info := &googlegrpc.StreamServerInfo{FullMethod: cyodapb.CloudEventsService_EntitySearch_FullMethodName}
+	info := &googlegrpc.StreamServerInfo{FullMethod: cyodapb.CloudEventsService_StartStreaming_FullMethodName}
 	if err := ic.stream()(nil, ss, info, handler); err != nil {
 		t.Fatalf("expected passthrough, got err: %v", err)
 	}


### PR DESCRIPTION
## Summary

The compute-node callback transaction-join (#287) lets a processor/criteria callback join the originating workflow transaction `T` via the signed `tx-token`. The joining `txRouteInterceptor` was wired only for the **write** RPCs (`EntityManage` / `EntityManageCollection`). The **read/search** RPCs (`EntitySearch` / `EntitySearchCollection`) were not intercepted, so a callback's `tx-token` was silently ignored on searches — they ran unjoined against last-committed state. Read-your-own-writes was therefore asymmetric: a processor could not search for entities it created or transitioned earlier in the same still-open transaction (silent stale results, no error).

The design spec already specified search-join (`reads (Get/Search)` over gRPC), so this is a **conformance fix**, not a contract change.

## What changed

- `internal/grpc/txroute_interceptor.go` — route `EntitySearch` / `EntitySearchCollection` through the same join / peer-forward path as the write RPCs, parameterized per-RPC by a forward function and an error-envelope builder. Search routing/join failures return the **search-shaped** envelope (`EntityResponse`, `Success=false`) rather than the transaction envelope; a **token-less** search is unchanged (no join, no proxy).
- `internal/cluster/proxy/grpc_forward.go` — new `ForwardEntitySearch` / `ForwardEntitySearchCollection` for the B→A peer-forward of a search to the owner node.
- Docs: `PROCESSOR_EXECUTION_MODES.md` (reads join too), `CHANGELOG.md` (Fixed).

The HTTP entity API already joined reads via the route-agnostic `X-Tx-Token` middleware and was unaffected.

## Coverage

| Layer | Test |
|---|---|
| gRPC interceptor unit | local-join, peer-forward, and error-envelope — for **both** unary (`EntitySearch`) and stream (`EntitySearchCollection`) |
| Running backend (e2e) | `TestCallback_GRPCSearch_SeesUncommittedWrite` — RYOW over the real gRPC stack (postgres), unary + stream, each WITH the token (sees uncommitted) and WITHOUT (control does not) |
| Cross-backend parity | `CallbackTxJoin_GRPCSearchReadYourWrites` (memory / sqlite / postgres) |
| Multi-node | `Callback_ForwardedGRPCSearch` — B→A cross-node search forward joins T on the owner |

TDD RED confirmed at both the interceptor unit level and the e2e level (un-wiring the search routing makes the joined search see nothing). `go vet ./...`, full `./internal/...`, and `make race` all green. No token is logged; tenant isolation is preserved via the shared `JoinFromToken` (`ErrTxTenantMismatch` → 403).

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)