### PR TITLE
fix(txgate): release per-tx gate across external dispatch (depth-2 nested join)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,23 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Fixed
 
+- **Depth-2 nested joined cascade no longer deadlocks the transaction** — when a
+  joined compute-node callback ran a transition whose own SYNC processor drove a
+  *further* joined write on the same transaction `T` (a 2-deep same-transaction
+  cascade), the third-level write blocked on the per-transaction gate the
+  second-level callback still held while parked in its processor dispatch. The
+  transaction hung for the full 30 s dispatch timeout and then failed
+  `WORKFLOW_FAILED`, forcing callers to break the join (run the inner transition
+  in its own transaction) and sacrifice cross-entity atomicity. The per-tx gate
+  is now **released across every external dispatch** (SYNC processor and FUNCTION
+  criterion call-out) and re-acquired before the buffer is touched again —
+  generalising the owner-side H3 invariant ("never hold the gate across the
+  engine's dispatch") to every joined callback. The dispatch window touches no
+  local buffer and is the one place a descendant callback can re-enter, so the
+  release is safe for concurrent same-tx siblings. Covers both HTTP and gRPC entry
+  points (both funnel through the same entity handler).
+  ([#410](https://github.com/Cyoda-platform/cyoda-go/issues/410))
+
 - **Compute-node callback transaction-join now covers the gRPC search RPCs** — a
   processor/criteria callback that presented a valid `tx-token` on `EntitySearch` /
   `EntitySearchCollection` had the token silently ignored: the joining

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,8 +185,9 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
   transaction hung for the full 30 s dispatch timeout and then failed
   `WORKFLOW_FAILED`, forcing callers to break the join (run the inner transition
   in its own transaction) and sacrifice cross-entity atomicity. The per-tx gate
-  is now **released across every external dispatch** (SYNC processor and FUNCTION
-  criterion call-out) and re-acquired before the buffer is touched again —
+  is now **released across every external dispatch** (every processor mode —
+  SYNC / ASYNC_SAME_TX / ASYNC_NEW_TX — and FUNCTION criterion call-out) and
+  re-acquired before the buffer is touched again —
   generalising the owner-side H3 invariant ("never hold the gate across the
   engine's dispatch") to every joined callback. The dispatch window touches no
   local buffer and is the one place a descendant callback can re-enter, so the

--- a/docs/cloud-parity/README.md
+++ b/docs/cloud-parity/README.md
@@ -23,3 +23,4 @@ Cloud needs to adopt.
 | `openapi-conformance.md` | OpenAPI operation status, live common ground, tolerant-reader obligation, deferred open questions (E6, D2) |
 | `search-sort.md` | Search result sorting — HTTP `sort` grammar, gRPC `orderBy`, canonical ordering semantics |
 | `processor-criteria-annotations.md` | Processor `annotations` + workflow/transition `criterionAnnotations`, well-known renderer keys, schema 1.1 → 1.2 |
+| `nested-join-tx-serialisation.md` | Per-tx gate must release across external dispatch so depth-2+ nested joined cascades commit atomically instead of deadlocking |

--- a/docs/cloud-parity/nested-join-tx-serialisation.md
+++ b/docs/cloud-parity/nested-join-tx-serialisation.md
@@ -1,0 +1,37 @@
+# Nested joined-transaction serialisation — Cloud twin-alignment spec
+
+This document is the contract Cyoda Cloud implements to stay aligned with
+cyoda-go's transaction-join model. cyoda-go is the authoritative implementation.
+
+## Behaviour
+
+A compute-node callback that runs inside a transaction `T` (a routed
+processor/criterion dispatch that joined `T` via its tx-token) may itself drive
+a further transition on `T` whose own SYNC processor drives yet another joined
+write on `T`. This **depth-2+ cascade in a single transaction** must complete and
+commit atomically — the whole nested chain succeeds or rolls back together.
+
+## Invariant Cloud must uphold
+
+Access to a transaction's shared buffer / connection is serialised by a
+**per-transaction exclusive gate** (a non-reentrant mutex keyed by tx id). Every
+holder of that gate — the transaction owner **and** every joined callback — MUST
+**release the gate for the duration of any blocking external dispatch** (SYNC
+processor or FUNCTION criterion call-out) and re-acquire it before touching the
+buffer again. The dispatch window touches no local buffer but can re-enter with a
+descendant joined callback on the same tx; holding the gate across it is a
+hold-and-wait that deadlocks the transaction until the dispatch timeout.
+
+This generalises the owner-side rule ("never hold the gate across the engine's
+processor dispatch") to **every** gate holder. Releasing during a remote dispatch
+is safe: no local buffer write is pending at the dispatch point (state and audit
+writes happen only after the processor pipeline returns), so concurrent siblings
+on the same tx stay consistent.
+
+## Failure mode this prevents
+
+Without the release-across-dispatch rule, a 2-deep same-transaction cascade
+(a manual/automated transition whose SYNC processor drives a cross-entity
+transition that *itself* has a SYNC processor) hangs for the dispatch timeout and
+then fails `WORKFLOW_FAILED`. Callers were forced to break the join (run the
+inner transition in its own transaction), sacrificing cross-entity atomicity.

--- a/docs/cloud-parity/nested-join-tx-serialisation.md
+++ b/docs/cloud-parity/nested-join-tx-serialisation.md
@@ -16,9 +16,12 @@ commit atomically — the whole nested chain succeeds or rolls back together.
 Access to a transaction's shared buffer / connection is serialised by a
 **per-transaction exclusive gate** (a non-reentrant mutex keyed by tx id). Every
 holder of that gate — the transaction owner **and** every joined callback — MUST
-**release the gate for the duration of any blocking external dispatch** (SYNC
-processor or FUNCTION criterion call-out) and re-acquire it before touching the
-buffer again. The dispatch window touches no local buffer but can re-enter with a
+**release the gate for the duration of any blocking external dispatch** (every
+processor dispatch — SYNC / ASYNC_SAME_TX / ASYNC_NEW_TX — and FUNCTION criterion
+call-out) and re-acquire it before touching the buffer again. Where the dispatch
+is bracketed by buffer work (e.g. an ASYNC_NEW_TX savepoint create/rollback), the
+release spans only the call-out, not the surrounding buffer ops. The dispatch
+window touches no local buffer but can re-enter with a
 descendant joined callback on the same tx; holding the gate across it is a
 hold-and-wait that deadlocks the transaction until the dispatch timeout.
 

--- a/internal/domain/entity/handler.go
+++ b/internal/domain/entity/handler.go
@@ -115,6 +115,25 @@ func (h *Handler) beginOrJoin(ctx context.Context) (string, context.Context, boo
 	return txID, txCtx, true, err
 }
 
+// acquireJoinedGate acquires the per-tx gate for a joined (owned==false) call
+// and installs a suspendable handle on txCtx so the engine can release the gate
+// across a blocking external dispatch (SYNC processor / FUNCTION criterion) and
+// re-acquire it afterward. This generalises the owner's H3 invariant — "never
+// hold the gate across engine.Execute" — to the joined-callback path: without
+// it, a depth-2 cascade (a joined callback whose own SYNC processor drives a
+// further joined write on the same tx) hold-and-waits on the non-reentrant gate
+// and deadlocks until the 30s dispatch timeout.
+//
+// It returns the ctx to pass to engine.Execute and a release func the caller
+// MUST defer. Both the returned release closure and the installed handle alias
+// the same release variable, so a mid-dispatch Suspend/resume that re-acquires
+// the gate is observed by the caller's deferred release.
+func (h *Handler) acquireJoinedGate(txCtx context.Context, txID string) (context.Context, func()) {
+	release := h.gate.Acquire(txID)
+	txCtx, _ = txgate.WithHeld(txCtx, h.gate, txID, &release)
+	return txCtx, func() { release() }
+}
+
 // commitOwned commits the transaction only when this request owns it. For a
 // joined callback (owned==false) the owner is responsible for the commit, so
 // this is a no-op. Callers gate the whole final Save+Commit critical section

--- a/internal/domain/entity/service.go
+++ b/internal/domain/entity/service.go
@@ -266,7 +266,9 @@ func (h *Handler) CreateEntity(ctx context.Context, input CreateEntityInput) (*E
 		return nil, common.Internal("failed to begin transaction", err)
 	}
 	if !owned {
-		defer h.gate.Acquire(txID)()
+		var releaseGate func()
+		txCtx, releaseGate = h.acquireJoinedGate(txCtx, txID)
+		defer releaseGate()
 	}
 
 	entityID := uuid.UUID(h.uuids.NewTimeUUID())
@@ -639,7 +641,9 @@ func (h *Handler) DeleteEntity(ctx context.Context, entityID string) (*deleteEnt
 		return nil, common.Internal("failed to begin transaction", err)
 	}
 	if !owned {
-		defer h.gate.Acquire(txID)()
+		var releaseGate func()
+		txCtx, releaseGate = h.acquireJoinedGate(txCtx, txID)
+		defer releaseGate()
 	}
 
 	entityStore, err := h.factory.EntityStore(txCtx)
@@ -775,7 +779,9 @@ func (h *Handler) DeleteAllEntities(ctx context.Context, entityName string, mode
 		return nil, common.Internal("failed to begin transaction", err)
 	}
 	if !owned {
-		defer h.gate.Acquire(txID)()
+		var releaseGate func()
+		txCtx, releaseGate = h.acquireJoinedGate(txCtx, txID)
+		defer releaseGate()
 	}
 
 	entityStore, err := h.factory.EntityStore(txCtx)
@@ -894,7 +900,9 @@ func (h *Handler) DeleteEntitiesConditional(ctx context.Context, entityName, mod
 		return nil, common.Internal("failed to begin transaction", err)
 	}
 	if !owned {
-		defer h.gate.Acquire(txID)()
+		var releaseGate func()
+		txCtx, releaseGate = h.acquireJoinedGate(txCtx, txID)
+		defer releaseGate()
 	}
 
 	modelStore, err := h.factory.ModelStore(txCtx)
@@ -1145,7 +1153,9 @@ func (h *Handler) CreateEntityCollection(ctx context.Context, items []Collection
 		return nil, common.Internal("failed to begin transaction", err)
 	}
 	if !owned {
-		defer h.gate.Acquire(txID)()
+		var releaseGate func()
+		txCtx, releaseGate = h.acquireJoinedGate(txCtx, txID)
+		defer releaseGate()
 	}
 
 	now := time.Now()
@@ -1321,7 +1331,9 @@ func (h *Handler) updateEntityCore(ctx context.Context, input UpdateEntityInput,
 		return nil, common.Internal("failed to begin transaction", err)
 	}
 	if !owned {
-		defer h.gate.Acquire(txID)()
+		var releaseGate func()
+		txCtx, releaseGate = h.acquireJoinedGate(txCtx, txID)
+		defer releaseGate()
 	}
 
 	// Load existing entity within transaction (adds to read set).
@@ -1665,7 +1677,9 @@ func (h *Handler) UpdateEntityCollection(ctx context.Context, items []UpdateColl
 		return nil, common.Internal("failed to begin transaction", err)
 	}
 	if !owned {
-		defer h.gate.Acquire(txID)()
+		var releaseGate func()
+		txCtx, releaseGate = h.acquireJoinedGate(txCtx, txID)
+		defer releaseGate()
 	}
 
 	now := time.Now()

--- a/internal/domain/workflow/engine.go
+++ b/internal/domain/workflow/engine.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cyoda-platform/cyoda-go/internal/contract"
 	"github.com/cyoda-platform/cyoda-go/internal/match"
 	"github.com/cyoda-platform/cyoda-go/internal/observability"
+	"github.com/cyoda-platform/cyoda-go/internal/txgate"
 )
 
 var tracer = otel.Tracer("github.com/cyoda-platform/cyoda-go/workflow")
@@ -629,6 +630,12 @@ func (e *Engine) evaluateCriterion(criterion []byte, entity *spi.Entity, cc *cri
 		if e.extProc == nil {
 			return false, fmt.Errorf("no external processing service configured for FUNCTION criteria")
 		}
+		// Release any per-tx gate this call chain holds across the blocking
+		// FUNCTION-criterion dispatch — same H3 rationale as executeSyncProcessor:
+		// the callout can re-enter with a descendant joined callback on the same
+		// txID. No-op for the owner / non-joined calls.
+		resume := txgate.Suspend(cc.ctx)
+		defer resume()
 		return e.extProc.DispatchCriteria(cc.ctx, entity, criterion, cc.target, cc.workflowName, cc.transitionName, "", cc.txID)
 	}
 

--- a/internal/domain/workflow/engine_processors.go
+++ b/internal/domain/workflow/engine_processors.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/cyoda-platform/cyoda-go/internal/txgate"
 	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go/internal/txgate"
 )
 
 // ErrCommitBeforeDispatchInfra wraps every infrastructure-layer failure

--- a/internal/domain/workflow/engine_processors.go
+++ b/internal/domain/workflow/engine_processors.go
@@ -195,7 +195,14 @@ func (e *Engine) executeAsyncNewTx(ctx context.Context, entity *spi.Entity, proc
 
 	// Without a transaction manager, fall back to plain dispatch (no savepoint).
 	if e.txMgr == nil {
+		// Release any per-tx gate this chain holds across the blocking dispatch
+		// (H3 invariant) — this dispatch reuses the gated txID and can re-enter
+		// with a descendant joined callback on the same tx, so holding the gate
+		// here deadlocks exactly like the SYNC path.
+		resume := txgate.Suspend(ctx)
+		defer resume()
 		_, err := e.extProc.DispatchProcessor(ctx, entity, proc, workflow, transition, txID)
+		resume()
 		return err
 	}
 
@@ -204,7 +211,14 @@ func (e *Engine) executeAsyncNewTx(ctx context.Context, entity *spi.Entity, proc
 		return fmt.Errorf("savepoint creation failed: %w", err)
 	}
 
+	// Release the per-tx gate across the blocking dispatch (H3 invariant). The
+	// savepoint create above and the rollback/release below are buffer ops that
+	// must stay gated, so suspend only spans the callout: re-acquire before
+	// touching the savepoint again. No-op for the owner / non-joined calls.
+	resume := txgate.Suspend(ctx)
+	defer resume()
 	_, dispatchErr := e.extProc.DispatchProcessor(ctx, entity, proc, workflow, transition, txID)
+	resume()
 	if dispatchErr != nil {
 		if rbErr := e.txMgr.RollbackToSavepoint(ctx, txID, spID); rbErr != nil {
 			slog.Warn("failed to rollback savepoint after processor error",

--- a/internal/domain/workflow/engine_processors.go
+++ b/internal/domain/workflow/engine_processors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/cyoda-platform/cyoda-go/internal/txgate"
 	spi "github.com/cyoda-platform/cyoda-go-spi"
 )
 
@@ -161,7 +162,18 @@ func (e *Engine) executeSyncProcessor(ctx context.Context, entity *spi.Entity, p
 	if e.extProc == nil {
 		return nil
 	}
+	// Release any per-tx gate this call chain holds across the blocking dispatch
+	// (H3 invariant, generalised to the joined-callback path): the dispatch
+	// touches no local buffer but can re-enter with a descendant joined callback
+	// on the same txID, which would otherwise deadlock waiting for the gate this
+	// chain holds. resume() re-acquires before we apply the processor's result.
+	// No-op for the owner and for plain non-joined calls. Deferred resume keeps
+	// the re-acquire panic-safe; the explicit call re-acquires before touching
+	// entity so the buffer write below is gated.
+	resume := txgate.Suspend(ctx)
+	defer resume()
 	modifiedEntity, err := e.extProc.DispatchProcessor(ctx, entity, proc, workflow, transition, txID)
+	resume()
 	if err != nil {
 		return err
 	}

--- a/internal/e2e/callback_depth2_test.go
+++ b/internal/e2e/callback_depth2_test.go
@@ -18,21 +18,42 @@ import (
 // primary create (OWNER T)
 //   └─ SYNC proc cb-d2-primary  ── owner does NOT hold gate ──▶
 //        joined create secondary (owned==false: ACQUIRES gate(T), holds whole body)
-//          └─ SYNC proc cb-d2-secondary ── gate(T) STILL HELD (pre-fix) ──▶
+//          └─ inner proc cb-d2-secondary ── gate(T) STILL HELD (pre-fix) ──▶
 //               joined create tertiary  ──▶ Acquire(gate(T)) BLOCKS until the
 //               outer dispatch times out at 30s (pre-fix) / progresses (post-fix)
-func TestCallback_Depth2NestedJoin_Deadlocks(t *testing.T) {
+//
+// The inner processor's executionMode is parameterised so the same cascade is
+// proven for every dispatch site that keeps the gated txID: SYNC
+// (executeSyncProcessor) and ASYNC_NEW_TX (executeAsyncNewTx, which dispatches
+// inside a savepoint on the SAME tx). Both must suspend the gate across their
+// callout or the third-level joined write deadlocks.
+
+// depth2Chain sets up the primary→secondary→tertiary model chain where the
+// secondary's `store` transition runs one processor (execMode) that creates a
+// tertiary joined write, and returns the tertiary id the innermost callback
+// minted (via tertiaryID) once the cascade commits. It fails the test with a
+// labelled DEADLOCK if the cascade does not complete within 20s.
+func depth2Chain(t *testing.T, tag, execMode string) {
+	t.Helper()
 	h := newCallbackHarness(t)
 
-	const primary = "cb-d2-primary-ent"
-	const secondary = "cb-d2-secondary-ent"
-	const tertiary = "cb-d2-tertiary-ent"
+	primary := "cb-d2-" + tag + "-primary-ent"
+	secondary := "cb-d2-" + tag + "-secondary-ent"
+	tertiary := "cb-d2-" + tag + "-tertiary-ent"
 
 	// tertiary: processor-less innermost joined write (only needs to Acquire the gate).
 	h.SetupModelWithWorkflow(t, tertiary, secondaryWorkflow)
 
-	// secondary: `store` runs a SYNC processor that creates a tertiary in T.
-	h.RegisterProc("cb-d2-secondary", func(rc *reqCtx) (map[string]any, error) {
+	// tertiaryIDs captures the id the innermost callback minted, so the test can
+	// assert durability after T commits regardless of whether the inner
+	// processor's returned data is applied (ASYNC_NEW_TX discards it).
+	tertiaryIDs := make(chan string, 1)
+
+	// secondary: `store` runs a processor (SYNC or ASYNC_NEW_TX) that creates a
+	// tertiary in T. Its callout must release the gate or the tertiary write
+	// cannot acquire it.
+	secProc := "cb-d2-" + tag + "-secondary"
+	h.RegisterProc(secProc, func(rc *reqCtx) (map[string]any, error) {
 		res, err := rc.CreateEntity(tertiary, 1, `{"name":"t","amount":1,"status":"new"}`)
 		if err != nil {
 			return nil, fmt.Errorf("tertiary create failed: %w", err)
@@ -40,18 +61,156 @@ func TestCallback_Depth2NestedJoin_Deadlocks(t *testing.T) {
 		if res.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("tertiary create status=%d body=%s", res.StatusCode, res.Body)
 		}
+		select {
+		case tertiaryIDs <- res.EntityID:
+		default:
+		}
 		out := cloneData(rc.entityData)
 		out["tertiaryId"] = res.EntityID
 		return out, nil
 	})
-	secondaryWF := `{
+	secondaryWF := fmt.Sprintf(`{
 		"importMode": "REPLACE",
 		"workflows": [{
 			"version": "1.1", "name": "secondary-d2-wf", "initialState": "NONE", "active": true,
 			"states": {
 				"NONE":   {"transitions": [{"name": "store", "next": "STORED", "manual": false,
-					"processors": [{"type": "calculator", "name": "cb-d2-secondary", "executionMode": "SYNC",
+					"processors": [{"type": "calculator", "name": %q, "executionMode": %q,
 						"config": {"attachEntity": true, "calculationNodesTags": ""}}]
+				}]},
+				"STORED": {}
+			}
+		}]
+	}`, secProc, execMode)
+	h.SetupModelWithWorkflow(t, secondary, secondaryWF)
+
+	// primary: `init` runs a SYNC processor that creates a secondary in T.
+	primProc := "cb-d2-" + tag + "-primary"
+	h.RegisterProc(primProc, func(rc *reqCtx) (map[string]any, error) {
+		res, err := rc.CreateEntity(secondary, 1, `{"name":"s","amount":1,"status":"new"}`)
+		if err != nil {
+			return nil, fmt.Errorf("secondary create failed: %w", err)
+		}
+		if res.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("secondary create status=%d body=%s", res.StatusCode, res.Body)
+		}
+		out := cloneData(rc.entityData)
+		out["secondaryId"] = res.EntityID
+		return out, nil
+	})
+	primaryWF := fmt.Sprintf(`{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "primary-d2-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE":   {"transitions": [{"name": "init", "next": "ACTIVE", "manual": false,
+					"processors": [{"type": "calculator", "name": %q, "executionMode": "SYNC",
+						"config": {"attachEntity": true, "calculationNodesTags": ""}}]
+				}]},
+				"ACTIVE": {}
+			}
+		}]
+	}`, primProc)
+	h.SetupModelWithWorkflow(t, primary, primaryWF)
+
+	type result struct {
+		id     string
+		status int
+		body   string
+	}
+	done := make(chan result, 1)
+	go func() {
+		id, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
+		done <- result{id, status, body}
+	}()
+
+	var r result
+	select {
+	case r = <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatalf("DEADLOCK (%s inner processor): depth-2 nested joined transition did not complete "+
+			"within 20s — a joined callback is holding the txgate across engine.Execute (H3 invariant "+
+			"not upheld for the joined path); the third-level joined write cannot acquire the gate", execMode)
+	}
+
+	if r.status != http.StatusOK {
+		t.Fatalf("primary create: status=%d body=%s", r.status, r.body)
+	}
+	if got := h.GetEntityData(t, r.id)["secondaryId"]; got == nil || got == "" {
+		t.Fatal("primary missing secondaryId — depth-2 cascade did not complete")
+	}
+
+	// The innermost joined write actually happened and committed atomically with T.
+	select {
+	case tid := <-tertiaryIDs:
+		if st, code := h.GetEntityState(t, tid); code != http.StatusOK {
+			t.Errorf("tertiary %s GET after commit: http %d; want 200 (joined write must be durable)", tid, code)
+		} else if st != "STORED" {
+			t.Errorf("tertiary %s state = %q; want STORED", tid, st)
+		}
+	default:
+		t.Fatal("inner processor never created a tertiary — depth-2 cascade did not reach the third level")
+	}
+}
+
+// TestCallback_Depth2NestedJoin_Deadlocks proves a depth-2 nested joined cascade
+// whose inner (secondary) processor is SYNC completes instead of deadlocking on
+// the per-tx gate. This is the issue #410 reproduction: it deadlocks at ~20s
+// before the fix (the joined callback held the gate across engine.Execute) and
+// passes after.
+func TestCallback_Depth2NestedJoin_Deadlocks(t *testing.T) {
+	depth2Chain(t, "sync", "SYNC")
+}
+
+// TestCallback_Depth2NestedJoin_AsyncNewTx proves the same H3 invariant for an
+// ASYNC_NEW_TX inner processor: executeAsyncNewTx dispatches inside a savepoint
+// on the SAME (gated) txID, so it too must suspend the gate across its callout —
+// otherwise the third-level joined write deadlocks identically.
+func TestCallback_Depth2NestedJoin_AsyncNewTx(t *testing.T) {
+	depth2Chain(t, "asyncnewtx", "ASYNC_NEW_TX")
+}
+
+// TestCallback_Depth2NestedJoin_FunctionCriterion proves the H3 invariant for
+// the OTHER external-dispatch site: a FUNCTION criterion. The secondary's `store`
+// transition is gated by a FUNCTION criterion whose evaluation (evaluateCriterion
+// → DispatchCriteria) issues a joined callback that creates a tertiary in T. The
+// criterion dispatch must suspend the gate across its callout or the third-level
+// joined write deadlocks exactly like the processor paths.
+func TestCallback_Depth2NestedJoin_FunctionCriterion(t *testing.T) {
+	h := newCallbackHarness(t)
+
+	const primary = "cb-d2-crit-primary-ent"
+	const secondary = "cb-d2-crit-secondary-ent"
+	const tertiary = "cb-d2-crit-tertiary-ent"
+
+	h.SetupModelWithWorkflow(t, tertiary, secondaryWorkflow)
+
+	tertiaryIDs := make(chan string, 1)
+
+	// secondary's `store` transition is guarded by a FUNCTION criterion that
+	// creates a tertiary in T during evaluation, then matches (true).
+	h.RegisterCriteria("cb-d2-crit-secondary", func(rc *reqCtx) (bool, error) {
+		res, err := rc.CreateEntity(tertiary, 1, `{"name":"t","amount":1,"status":"new"}`)
+		if err != nil {
+			return false, fmt.Errorf("tertiary create failed: %w", err)
+		}
+		if res.StatusCode != http.StatusOK {
+			return false, fmt.Errorf("tertiary create status=%d body=%s", res.StatusCode, res.Body)
+		}
+		select {
+		case tertiaryIDs <- res.EntityID:
+		default:
+		}
+		return true, nil
+	})
+	secondaryWF := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "secondary-crit-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE":   {"transitions": [{"name": "store", "next": "STORED", "manual": false,
+					"criterion": {"type": "function", "function": {"name": "cb-d2-crit-secondary",
+						"config": {"attachEntity": true, "calculationNodesTags": ""}}}
 				}]},
 				"STORED": {}
 			}
@@ -59,8 +218,7 @@ func TestCallback_Depth2NestedJoin_Deadlocks(t *testing.T) {
 	}`
 	h.SetupModelWithWorkflow(t, secondary, secondaryWF)
 
-	// primary: `init` runs a SYNC processor that creates a secondary in T.
-	h.RegisterProc("cb-d2-primary", func(rc *reqCtx) (map[string]any, error) {
+	h.RegisterProc("cb-d2-crit-primary", func(rc *reqCtx) (map[string]any, error) {
 		res, err := rc.CreateEntity(secondary, 1, `{"name":"s","amount":1,"status":"new"}`)
 		if err != nil {
 			return nil, fmt.Errorf("secondary create failed: %w", err)
@@ -75,10 +233,10 @@ func TestCallback_Depth2NestedJoin_Deadlocks(t *testing.T) {
 	primaryWF := `{
 		"importMode": "REPLACE",
 		"workflows": [{
-			"version": "1.1", "name": "primary-d2-wf", "initialState": "NONE", "active": true,
+			"version": "1.1", "name": "primary-crit-wf", "initialState": "NONE", "active": true,
 			"states": {
 				"NONE":   {"transitions": [{"name": "init", "next": "ACTIVE", "manual": false,
-					"processors": [{"type": "calculator", "name": "cb-d2-primary", "executionMode": "SYNC",
+					"processors": [{"type": "calculator", "name": "cb-d2-crit-primary", "executionMode": "SYNC",
 						"config": {"attachEntity": true, "calculationNodesTags": ""}}]
 				}]},
 				"ACTIVE": {}
@@ -98,18 +256,28 @@ func TestCallback_Depth2NestedJoin_Deadlocks(t *testing.T) {
 		done <- result{id, status, body}
 	}()
 
+	var r result
 	select {
-	case r := <-done:
-		if r.status != http.StatusOK {
-			t.Fatalf("primary create: status=%d body=%s", r.status, r.body)
-		}
-		data := h.GetEntityData(t, r.id)
-		if data["secondaryId"] == nil || data["secondaryId"] == "" {
-			t.Fatal("primary missing secondaryId — depth-2 cascade did not complete")
-		}
+	case r = <-done:
 	case <-time.After(20 * time.Second):
-		t.Fatal("DEADLOCK: depth-2 nested joined transition did not complete within 20s — " +
-			"a joined callback is holding the txgate across engine.Execute (H3 invariant " +
-			"not upheld for the joined path); the third-level joined write cannot acquire the gate")
+		t.Fatal("DEADLOCK (FUNCTION criterion): depth-2 nested joined transition did not complete " +
+			"within 20s — a joined callback is holding the txgate across the criterion dispatch")
+	}
+
+	if r.status != http.StatusOK {
+		t.Fatalf("primary create: status=%d body=%s", r.status, r.body)
+	}
+	if got := h.GetEntityData(t, r.id)["secondaryId"]; got == nil || got == "" {
+		t.Fatal("primary missing secondaryId — depth-2 cascade did not complete")
+	}
+	select {
+	case tid := <-tertiaryIDs:
+		if st, code := h.GetEntityState(t, tid); code != http.StatusOK {
+			t.Errorf("tertiary %s GET after commit: http %d; want 200 (joined write must be durable)", tid, code)
+		} else if st != "STORED" {
+			t.Errorf("tertiary %s state = %q; want STORED", tid, st)
+		}
+	default:
+		t.Fatal("criterion never created a tertiary — depth-2 cascade did not reach the third level")
 	}
 }

--- a/internal/e2e/callback_depth2_test.go
+++ b/internal/e2e/callback_depth2_test.go
@@ -1,0 +1,115 @@
+package e2e_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// callback_depth2_test.go — ISOLATED single-backend coverage for the depth-2
+// nested-join deadlock (a joined callback must NOT hold the per-tx txgate across
+// engine.Execute — the H3 invariant, generalised from the owner path to the
+// joined path). Like the other txgate-invariant tests (callback_concurrency_test.go)
+// this lives in internal/e2e, NOT the shared parity suite: the deadlock is a
+// domain-layer lock property identical across every backend, and a gate-hang
+// would destabilise unrelated parity scenarios.
+//
+// primary create (OWNER T)
+//   └─ SYNC proc cb-d2-primary  ── owner does NOT hold gate ──▶
+//        joined create secondary (owned==false: ACQUIRES gate(T), holds whole body)
+//          └─ SYNC proc cb-d2-secondary ── gate(T) STILL HELD (pre-fix) ──▶
+//               joined create tertiary  ──▶ Acquire(gate(T)) BLOCKS until the
+//               outer dispatch times out at 30s (pre-fix) / progresses (post-fix)
+func TestCallback_Depth2NestedJoin_Deadlocks(t *testing.T) {
+	h := newCallbackHarness(t)
+
+	const primary = "cb-d2-primary-ent"
+	const secondary = "cb-d2-secondary-ent"
+	const tertiary = "cb-d2-tertiary-ent"
+
+	// tertiary: processor-less innermost joined write (only needs to Acquire the gate).
+	h.SetupModelWithWorkflow(t, tertiary, secondaryWorkflow)
+
+	// secondary: `store` runs a SYNC processor that creates a tertiary in T.
+	h.RegisterProc("cb-d2-secondary", func(rc *reqCtx) (map[string]any, error) {
+		res, err := rc.CreateEntity(tertiary, 1, `{"name":"t","amount":1,"status":"new"}`)
+		if err != nil {
+			return nil, fmt.Errorf("tertiary create failed: %w", err)
+		}
+		if res.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("tertiary create status=%d body=%s", res.StatusCode, res.Body)
+		}
+		out := cloneData(rc.entityData)
+		out["tertiaryId"] = res.EntityID
+		return out, nil
+	})
+	secondaryWF := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "secondary-d2-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE":   {"transitions": [{"name": "store", "next": "STORED", "manual": false,
+					"processors": [{"type": "calculator", "name": "cb-d2-secondary", "executionMode": "SYNC",
+						"config": {"attachEntity": true, "calculationNodesTags": ""}}]
+				}]},
+				"STORED": {}
+			}
+		}]
+	}`
+	h.SetupModelWithWorkflow(t, secondary, secondaryWF)
+
+	// primary: `init` runs a SYNC processor that creates a secondary in T.
+	h.RegisterProc("cb-d2-primary", func(rc *reqCtx) (map[string]any, error) {
+		res, err := rc.CreateEntity(secondary, 1, `{"name":"s","amount":1,"status":"new"}`)
+		if err != nil {
+			return nil, fmt.Errorf("secondary create failed: %w", err)
+		}
+		if res.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("secondary create status=%d body=%s", res.StatusCode, res.Body)
+		}
+		out := cloneData(rc.entityData)
+		out["secondaryId"] = res.EntityID
+		return out, nil
+	})
+	primaryWF := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "primary-d2-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE":   {"transitions": [{"name": "init", "next": "ACTIVE", "manual": false,
+					"processors": [{"type": "calculator", "name": "cb-d2-primary", "executionMode": "SYNC",
+						"config": {"attachEntity": true, "calculationNodesTags": ""}}]
+				}]},
+				"ACTIVE": {}
+			}
+		}]
+	}`
+	h.SetupModelWithWorkflow(t, primary, primaryWF)
+
+	type result struct {
+		id     string
+		status int
+		body   string
+	}
+	done := make(chan result, 1)
+	go func() {
+		id, status, body := h.CreateEntity(t, primary, 1, `{"name":"parent","amount":100,"status":"new"}`)
+		done <- result{id, status, body}
+	}()
+
+	select {
+	case r := <-done:
+		if r.status != http.StatusOK {
+			t.Fatalf("primary create: status=%d body=%s", r.status, r.body)
+		}
+		data := h.GetEntityData(t, r.id)
+		if data["secondaryId"] == nil || data["secondaryId"] == "" {
+			t.Fatal("primary missing secondaryId — depth-2 cascade did not complete")
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("DEADLOCK: depth-2 nested joined transition did not complete within 20s — " +
+			"a joined callback is holding the txgate across engine.Execute (H3 invariant " +
+			"not upheld for the joined path); the third-level joined write cannot acquire the gate")
+	}
+}

--- a/internal/e2e/callback_harness_test.go
+++ b/internal/e2e/callback_harness_test.go
@@ -115,6 +115,12 @@ func (rc *reqCtx) GetEntity(entityID string) (callbackResult, error) {
 // applied as the primary entity's new data.
 type callbackProc func(rc *reqCtx) (applyData map[string]any, err error)
 
+// callbackCrit is a FUNCTION criterion implemented on the compute member. Like
+// callbackProc it runs on a per-request handler goroutine and may issue joined
+// callbacks (e.g. create an entity in T as a side effect) before returning its
+// boolean match. Used to exercise the criterion-dispatch txgate seam.
+type callbackCrit func(rc *reqCtx) (matches bool, err error)
+
 // callbackHarness is a full HTTP+gRPC cyoda-go stack (real Postgres) with a
 // connected gRPC compute member. Reused across the #287 callback E2E tests.
 type callbackHarness struct {
@@ -124,6 +130,7 @@ type callbackHarness struct {
 
 	mu    sync.Mutex
 	procs map[string]callbackProc
+	crits map[string]callbackCrit
 
 	// bearerVal caches the client-credentials JWT for this stack (ROLE_ADMIN,ROLE_M2M).
 	// atomic.Value synchronises the writer (test goroutine, bearerOnce.Do) and the
@@ -171,7 +178,7 @@ func newCallbackHarness(t *testing.T) *callbackHarness {
 	// is built from cfg.HTTPPort and must match the live server).
 	srv := httptest.NewUnstartedServer(nil)
 	srv.Start()
-	h := &callbackHarness{baseURL: srv.URL, procs: map[string]callbackProc{}}
+	h := &callbackHarness{baseURL: srv.URL, procs: map[string]callbackProc{}, crits: map[string]callbackCrit{}}
 	t.Cleanup(srv.Close)
 
 	srvPort := srv.Listener.Addr().(*net.TCPAddr).Port
@@ -209,6 +216,20 @@ func (h *callbackHarness) lookupProc(name string) (callbackProc, bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	fn, ok := h.procs[name]
+	return fn, ok
+}
+
+// RegisterCriteria registers a FUNCTION criterion implementation on the member.
+func (h *callbackHarness) RegisterCriteria(name string, fn callbackCrit) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.crits[name] = fn
+}
+
+func (h *callbackHarness) lookupCrit(name string) (callbackCrit, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	fn, ok := h.crits[name]
 	return fn, ok
 }
 
@@ -486,6 +507,14 @@ func newComputeMember(t *testing.T, h *callbackHarness, grpcAddr string) *comput
 					defer m.handlers.Done()
 					h.handleCalcRequest(send, ce, payload)
 				}(ce, payload)
+			case internalgrpc.EntityCriteriaCalculationRequest:
+				// Same concurrency rationale as processors: a FUNCTION criterion
+				// may block on a joined callback that drives a further dispatch.
+				m.handlers.Add(1)
+				go func(ce *cepb.CloudEvent, payload []byte) {
+					defer m.handlers.Done()
+					h.handleCriteriaRequest(send, ce, payload)
+				}(ce, payload)
 			default:
 				// ignore other server events
 			}
@@ -507,15 +536,18 @@ func (m *computeMember) stop() {
 	m.conn.Close()
 	select {
 	case <-m.done:
+		// The receive loop has exited, so no further handlers.Add can race the
+		// Wait below. Drain any in-flight concurrent calc handlers (their Sends
+		// now no-op on the closed stream) so none outlives the test.
+		drained := make(chan struct{})
+		go func() { m.handlers.Wait(); close(drained) }()
+		select {
+		case <-drained:
+		case <-time.After(5 * time.Second):
+		}
 	case <-time.After(5 * time.Second):
-	}
-	// Drain any in-flight concurrent calc handlers (their Sends now no-op on the
-	// closed stream) so no handler goroutine outlives the test.
-	drained := make(chan struct{})
-	go func() { m.handlers.Wait(); close(drained) }()
-	select {
-	case <-drained:
-	case <-time.After(5 * time.Second):
+		// Receive loop hung (already a failing test); skip the drain rather than
+		// race handlers.Add against Wait.
 	}
 }
 
@@ -588,6 +620,78 @@ func (h *callbackHarness) handleCalcRequest(send func(*cepb.CloudEvent) error, c
 		respPayload["payload"] = map[string]any{"data": applyData}
 	}
 	resp, err := internalgrpc.NewCloudEvent(internalgrpc.EntityProcessorCalculationResponse, respPayload)
+	if err != nil {
+		sendErr(fmt.Sprintf("failed to build response: %v", err))
+		return
+	}
+	_ = send(resp)
+}
+
+// handleCriteriaRequest runs the registered FUNCTION criterion for an inbound
+// criteria calc request and replies with an EntityCriteriaCalculationResponse
+// (success + matches). Dispatched on a per-request goroutine; send serialises
+// the reply.
+func (h *callbackHarness) handleCriteriaRequest(send func(*cepb.CloudEvent) error, ce *cepb.CloudEvent, payload []byte) {
+	var req struct {
+		RequestID    string `json:"requestId"`
+		ID           string `json:"id"`
+		EntityID     string `json:"entityId"`
+		CriteriaName string `json:"criteriaName"`
+		CriteriaID   string `json:"criteriaId"`
+		Payload      *struct {
+			Data json.RawMessage `json:"data"`
+			Meta map[string]any  `json:"meta"`
+		} `json:"payload"`
+	}
+	_ = json.Unmarshal(payload, &req)
+	reqID := req.RequestID
+	if reqID == "" {
+		reqID = req.ID
+	}
+	critName := req.CriteriaName
+	if critName == "" {
+		critName = req.CriteriaID
+	}
+
+	sendErr := func(msg string) {
+		resp, _ := internalgrpc.NewCloudEvent(internalgrpc.EntityCriteriaCalculationResponse, map[string]any{
+			"requestId": reqID,
+			"success":   false,
+			"error":     map[string]any{"message": msg},
+		})
+		_ = send(resp)
+	}
+
+	fn, ok := h.lookupCrit(critName)
+	if !ok {
+		sendErr(fmt.Sprintf("no callback criterion registered for %q", critName))
+		return
+	}
+
+	rc := &reqCtx{
+		token:     internalgrpc.TxTokenFromCloudEvent(ce),
+		requestID: reqID,
+		entityID:  req.EntityID,
+		h:         h,
+	}
+	if req.Payload != nil {
+		rc.entityMeta = req.Payload.Meta
+		var d map[string]any
+		if json.Unmarshal(req.Payload.Data, &d) == nil {
+			rc.entityData = d
+		}
+	}
+
+	matches, critErr := fn(rc)
+	if critErr != nil {
+		sendErr(critErr.Error())
+		return
+	}
+	resp, err := internalgrpc.NewCloudEvent(internalgrpc.EntityCriteriaCalculationResponse, map[string]any{
+		"requestId": reqID,
+		"success":   true,
+		"matches":   matches,
+	})
 	if err != nil {
 		sendErr(fmt.Sprintf("failed to build response: %v", err))
 		return

--- a/internal/e2e/callback_harness_test.go
+++ b/internal/e2e/callback_harness_test.go
@@ -107,8 +107,8 @@ func (rc *reqCtx) GetEntity(entityID string) (callbackResult, error) {
 	return rc.h.callback(http.MethodGet, path, "", rc.token)
 }
 
-// callbackProc is a processor implemented on the compute member. It runs on the
-// member's receive-loop goroutine while the engine blocks on the dispatch
+// callbackProc is a processor implemented on the compute member. It runs on a
+// per-request handler goroutine while the engine blocks on the dispatch
 // response, so it MUST NOT call t.Fatal (record into test-owned state and assert
 // on the main goroutine instead). Returning a non-nil error fails the transition
 // (and, for a SYNC processor, rolls back T). The returned map, when non-nil, is
@@ -389,6 +389,16 @@ type computeMember struct {
 	conn   *grpc.ClientConn
 	cancel context.CancelFunc
 	done   chan struct{}
+
+	// sendMu serialises stream.Send — gRPC bidi streams are not safe for
+	// concurrent Send, and calc requests are now dispatched to concurrent
+	// handler goroutines (mirroring a real compute node's thread pool, which a
+	// depth-2 nested cascade requires: the member must run the inner processor
+	// while the outer processor's callback is still in flight).
+	sendMu sync.Mutex
+	// handlers tracks in-flight concurrent calc handlers so teardown can drain
+	// them before closing the connection.
+	handlers sync.WaitGroup
 }
 
 // newComputeMember dials the stack's gRPC server, opens StartStreaming with an
@@ -434,6 +444,14 @@ func newComputeMember(t *testing.T, h *callbackHarness, grpcAddr string) *comput
 	greeted := make(chan struct{})
 	m := &computeMember{conn: conn, cancel: cancel, done: make(chan struct{})}
 
+	// send serialises all outbound frames (keep-alive replies + concurrent calc
+	// responses) so no two goroutines call stream.Send at once.
+	send := func(ce *cepb.CloudEvent) error {
+		m.sendMu.Lock()
+		defer m.sendMu.Unlock()
+		return stream.Send(ce)
+	}
+
 	go func() {
 		defer close(m.done)
 		var greetOnce sync.Once
@@ -456,10 +474,18 @@ func newComputeMember(t *testing.T, h *callbackHarness, grpcAddr string) *comput
 					"success": true,
 				})
 				if kerr == nil {
-					_ = stream.Send(ka)
+					_ = send(ka)
 				}
 			case internalgrpc.EntityProcessorCalculationRequest:
-				h.handleCalcRequest(stream, ce, payload)
+				// Dispatch concurrently: a processor callback may block on an HTTP
+				// call that drives a further dispatch to this same member (depth-2
+				// cascade). Handling inline on the receive loop would deadlock the
+				// member before the txgate is ever exercised.
+				m.handlers.Add(1)
+				go func(ce *cepb.CloudEvent, payload []byte) {
+					defer m.handlers.Done()
+					h.handleCalcRequest(send, ce, payload)
+				}(ce, payload)
 			default:
 				// ignore other server events
 			}
@@ -483,12 +509,21 @@ func (m *computeMember) stop() {
 	case <-m.done:
 	case <-time.After(5 * time.Second):
 	}
+	// Drain any in-flight concurrent calc handlers (their Sends now no-op on the
+	// closed stream) so no handler goroutine outlives the test.
+	drained := make(chan struct{})
+	go func() { m.handlers.Wait(); close(drained) }()
+	select {
+	case <-drained:
+	case <-time.After(5 * time.Second):
+	}
 }
 
 // handleCalcRequest runs the registered processor for an inbound calc request
-// and replies with an EntityProcessorCalculationResponse. It runs on the member
-// receive-loop goroutine.
-func (h *callbackHarness) handleCalcRequest(stream grpc.BidiStreamingClient[cepb.CloudEvent, cepb.CloudEvent], ce *cepb.CloudEvent, payload []byte) {
+// and replies with an EntityProcessorCalculationResponse. It is dispatched on a
+// per-request goroutine; send serialises the reply against other concurrent
+// handlers and the receive loop's keep-alive replies.
+func (h *callbackHarness) handleCalcRequest(send func(*cepb.CloudEvent) error, ce *cepb.CloudEvent, payload []byte) {
 	var req struct {
 		RequestID     string `json:"requestId"`
 		ID            string `json:"id"`
@@ -516,7 +551,7 @@ func (h *callbackHarness) handleCalcRequest(stream grpc.BidiStreamingClient[cepb
 			"success":   false,
 			"error":     map[string]any{"message": msg},
 		})
-		_ = stream.Send(resp)
+		_ = send(resp)
 	}
 
 	fn, ok := h.lookupProc(procName)
@@ -557,7 +592,7 @@ func (h *callbackHarness) handleCalcRequest(stream grpc.BidiStreamingClient[cepb
 		sendErr(fmt.Sprintf("failed to build response: %v", err))
 		return
 	}
-	_ = stream.Send(resp)
+	_ = send(resp)
 }
 
 // cloneData returns a shallow copy of an entity data map (nil-safe), so a

--- a/internal/txgate/txgate.go
+++ b/internal/txgate/txgate.go
@@ -6,7 +6,10 @@
 // concurrent in-flight ops on the same tx").
 package txgate
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 type gate struct {
 	mu   sync.Mutex
@@ -54,4 +57,77 @@ func (r *Registry) len() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.gates)
+}
+
+// heldKeyT is the (unexported, collision-free) context key under which a joined
+// caller records the gate it currently holds so the engine can Suspend it across
+// a blocking external dispatch.
+type heldKeyT struct{}
+
+var heldKey = heldKeyT{}
+
+// held is the ctx-scoped handle to a gate the current call chain holds. The
+// engine releases it across a blocking callout (SYNC processor / FUNCTION
+// criterion dispatch) via Suspend and re-acquires it afterward — the one window
+// that touches no local buffer yet can re-enter with a descendant callback on
+// the same txID. This generalises the owner's H3 invariant ("never hold the
+// gate across engine.Execute") to the joined-callback path.
+//
+// Suspend/resume run on the same goroutine that installed the handle (the
+// synchronous handler→engine→dispatch call chain); the mutex guards only the
+// active flag against the once-guarded resume, and keeps the handle safe if a
+// future caller ever shares it.
+type held struct {
+	reg     *Registry
+	txID    string
+	release *func() // points at the caller's live release variable
+	mu      sync.Mutex
+	active  bool // true while the gate is currently held via *release
+}
+
+// WithHeld records, on the returned ctx, that the caller holds reg's gate for
+// txID via the release func pointed to by release. release MUST point at the
+// caller's own release variable: a re-acquire (Suspend's resume) mints a fresh
+// release func and stores it through the pointer, so the caller's deferred
+// release frees the re-acquired gate rather than double-freeing the old one.
+func WithHeld(ctx context.Context, reg *Registry, txID string, release *func()) (context.Context, *held) {
+	h := &held{reg: reg, txID: txID, release: release, active: true}
+	return context.WithValue(ctx, heldKey, h), h
+}
+
+// Suspend releases the gate the ctx's call chain currently holds (installed via
+// WithHeld) and returns a resume func that re-acquires it. If ctx carries no
+// held gate — the transaction owner (which never installs one), or a plain
+// non-joined call — Suspend and its resume are both no-ops. Callers MUST invoke
+// resume before touching the shared tx buffer again; a deferred resume also
+// makes the re-acquire panic-safe.
+func Suspend(ctx context.Context) (resume func()) {
+	h, _ := ctx.Value(heldKey).(*held)
+	if h == nil {
+		return func() {}
+	}
+	return h.suspend()
+}
+
+func (h *held) suspend() func() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !h.active {
+		// Already suspended (no nested Suspend is expected on the engine's
+		// sequential dispatch path; this guard keeps a double call harmless
+		// rather than double-releasing the gate).
+		return func() {}
+	}
+	(*h.release)()
+	h.active = false
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			h.mu.Lock()
+			defer h.mu.Unlock()
+			*h.release = h.reg.Acquire(h.txID) // blocks until a descendant frees the gate
+			h.active = true
+		})
+	}
 }

--- a/internal/txgate/txgate.go
+++ b/internal/txgate/txgate.go
@@ -73,10 +73,12 @@ var heldKey = heldKeyT{}
 // the same txID. This generalises the owner's H3 invariant ("never hold the
 // gate across engine.Execute") to the joined-callback path.
 //
-// Suspend/resume run on the same goroutine that installed the handle (the
-// synchronous handler→engine→dispatch call chain); the mutex guards only the
-// active flag against the once-guarded resume, and keeps the handle safe if a
-// future caller ever shares it.
+// The handle is single-goroutine by construction: Suspend/resume and the
+// caller's deferred release all run on the synchronous handler→engine→dispatch
+// call chain, and the deferred release reads *release with no lock, so the
+// handle is not shareable across goroutines regardless of the mutex. The mutex
+// only orders the explicit + deferred resume against a redundant Suspend so a
+// double call cannot double-release the gate.
 type held struct {
 	reg     *Registry
 	txID    string

--- a/internal/txgate/txgate_test.go
+++ b/internal/txgate/txgate_test.go
@@ -1,6 +1,7 @@
 package txgate
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -50,6 +51,83 @@ func TestRegistry_ReleasesMapEntry(t *testing.T) {
 	r.Acquire("tx-1")() // acquire+release
 	if n := r.len(); n != 0 {
 		t.Fatalf("expected empty gate map after release, got %d", n)
+	}
+}
+
+// TestSuspend_NoHeldGate_NoOp: a ctx with no held gate installed (the owner
+// path, or a plain non-joined call) yields a no-op Suspend whose resume is also
+// a harmless no-op — it must never touch any gate.
+func TestSuspend_NoHeldGate_NoOp(t *testing.T) {
+	resume := Suspend(context.Background())
+	if resume == nil {
+		t.Fatal("Suspend returned a nil resume for a ctx with no held gate")
+	}
+	resume() // must not panic
+}
+
+// TestSuspend_ReleasesHeldGate_ResumeReacquires encodes the fix's core seam.
+// A joined caller holds gate(T) and installs a held handle on ctx via WithHeld.
+// While it is "parked in dispatch" it calls Suspend(ctx): the gate MUST be
+// released so a descendant on the same txID can Acquire and progress. After the
+// descendant releases, resume() MUST re-acquire the gate before the caller
+// resumes its buffer access — and the caller's own release variable must observe
+// the fresh release func so the deferred release matches the re-acquire.
+func TestSuspend_ReleasesHeldGate_ResumeReacquires(t *testing.T) {
+	r := New()
+	const txID = "tx-suspend"
+
+	// Joined caller acquires the gate and records it on ctx.
+	release := r.Acquire(txID)
+	ctx, _ := WithHeld(context.Background(), r, txID, &release)
+
+	// Descendant tries to acquire the SAME gate. It must block until Suspend
+	// releases, then complete, then release before resume can re-acquire.
+	descendantAcquired := make(chan struct{})
+	descendantReleased := make(chan struct{})
+	go func() {
+		rel := r.Acquire(txID) // blocks until the caller Suspends
+		close(descendantAcquired)
+		time.Sleep(20 * time.Millisecond) // hold briefly so resume must wait
+		rel()
+		close(descendantReleased)
+	}()
+
+	// Before Suspend the descendant must NOT be able to acquire.
+	select {
+	case <-descendantAcquired:
+		t.Fatal("descendant acquired gate(T) while the caller still held it — Suspend not yet called")
+	case <-time.After(30 * time.Millisecond):
+	}
+
+	resume := Suspend(ctx)
+
+	// Now the descendant progresses (the gate was released).
+	select {
+	case <-descendantAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("descendant could not acquire gate(T) after Suspend — the held gate was not released")
+	}
+
+	// resume() must block until the descendant releases, then re-acquire.
+	resume()
+	select {
+	case <-descendantReleased:
+	case <-time.After(time.Second):
+		t.Fatal("resume() returned before the descendant released — it did not re-acquire the gate")
+	}
+
+	// The caller's release variable now points at the re-acquired gate; calling
+	// it must free the gate (a fresh Acquire must not block afterward).
+	release()
+	done := make(chan struct{})
+	go func() { r.Acquire(txID)(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("gate still held after the caller's release() — resume did not rebind the release func")
+	}
+	if n := r.len(); n != 0 {
+		t.Fatalf("expected empty gate map after all releases, got %d", n)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #410 — a **depth-2 nested joined cascade** deadlocked the transaction for 30 s and then failed `WORKFLOW_FAILED`. When a joined compute-node callback ran a transition whose own SYNC processor drove a *further* joined write on the same transaction `T`, the third-level `txgate.Acquire(T)` blocked on the gate the second-level joined callback still held while parked in `DispatchProcessor`. The owner path already avoided this via the **H3 invariant** ("never hold the gate across `engine.Execute`"); the joined-callback path did not uphold it.

## Fix — generalise H3 to every gate holder

The per-transaction gate (`internal/txgate`, a non-reentrant per-txID mutex) is now **released across every blocking external dispatch** and re-acquired before the shared buffer is touched again. The dispatch window touches no local buffer and is the one place a descendant callback can re-enter on the same tx, so the release is safe for concurrent same-tx siblings (identical to the owner path's long-standing behaviour).

- `internal/txgate`: ctx-scoped suspendable held-gate handle — `WithHeld(ctx, reg, txID, *release)` installs it; `Suspend(ctx)` releases the held gate and returns a `resume` that re-acquires (rebinding the caller's deferred release via a `*func()` alias).
- Engine dispatch sites bracketed with `Suspend`/`resume`: `executeSyncProcessor` (SYNC / ASYNC_SAME_TX), `executeAsyncNewTx` (both the no-txmgr fallback and the savepoint path — the release spans only the call-out, not the savepoint create/rollback/release), and `evaluateCriterion` (FUNCTION criterion). The two `COMMIT_BEFORE_DISPATCH` sites are unaffected (fresh `TX_post` gate / no tx).
- Entity handler: the 7 joined-path (`!owned`) gate acquisitions install the handle on `txCtx` via `acquireJoinedGate`. **Covers HTTP and gRPC** — both funnel through the same handler.

## Reproduction / test harness

The reproduction requires the compute member to handle **concurrent** dispatches (a real compute node's thread pool): the inner processor must run while the outer processor's callback is still in flight. The previous serial test harness masked the txgate bug behind a member-level deadlock, so the callback harness now dispatches calc/criteria requests on per-request goroutines with **serialised** `stream.Send` (gRPC bidi Send is not concurrent-safe).

New isolated single-backend e2e tests (real Postgres), each red/green-verified (deadlocks without the fix, passes with it):
- `TestCallback_Depth2NestedJoin_Deadlocks` — SYNC inner processor (the issue's reproduction)
- `TestCallback_Depth2NestedJoin_AsyncNewTx` — ASYNC_NEW_TX inner processor
- `TestCallback_Depth2NestedJoin_FunctionCriterion` — FUNCTION criterion dispatch
- txgate unit tests for `Suspend`/`WithHeld`

## Verification

- `go build ./...`, `go vet ./...` — clean
- Full `go test ./internal/e2e/...` — pass (109 s)
- `internal/txgate` / `internal/domain/workflow` / `internal/domain/entity` unit — pass
- `make race` — clean; callback suite under `-race` — clean
- Existing gate-invariant tests (`TestDispatch_NeverHoldsGateAcrossDispatch`, `TestCallback_ConcurrentCallbacks_Serialise`) still pass

## Reviews

Independent fresh-context concurrency and security reviews were run. Security: clean. Concurrency: confirmed the core mechanism sound; its one Important finding (ASYNC_NEW_TX dispatch still held the gate) and minor items are all resolved in this PR.

## Docs (gates)

- `docs/cloud-parity/nested-join-tx-serialisation.md` — Cloud twin-alignment contract (Gate 7)
- `CHANGELOG.md` — Fixed entry

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)