### PR TITLE
docs(grpc): entity PATCH in cyoda help + event-type parity guard

### DIFF
--- a/cmd/cyoda/help/content/grpc.md
+++ b/cmd/cyoda/help/content/grpc.md
@@ -162,6 +162,7 @@ The full CloudEvent envelope for an ack:
 - `EntityDeleteRequest` / `EntityDeleteResponse`
 - `EntityDeleteAllRequest` / `EntityDeleteAllResponse`
 - `EntityTransitionRequest` / `EntityTransitionResponse`
+- `EntityPatchRequest` / `EntityTransactionResponse` — partial update; `PatchFormat` selects the dialect (`MERGE_PATCH`, RFC 7386 `application/merge-patch+json`, or `JSON_PATCH` `application/json-patch+json`). Requires `ifMatch` (the `transactionId` from the last read, or `"*"` for last-writer-wins); an optional `transition` names the transition to fire.
 
 **Model management event types**:
 
@@ -170,6 +171,7 @@ The full CloudEvent envelope for an ack:
 - `EntityModelTransitionRequest` / `EntityModelTransitionResponse`
 - `EntityModelDeleteRequest` / `EntityModelDeleteResponse`
 - `EntityModelGetAllRequest` / `EntityModelGetAllResponse`
+- `EntityModelSetUniqueKeysRequest` / `EntityModelSetUniqueKeysResponse`
 
 **Search / query event types**:
 

--- a/cmd/cyoda/help/help_test.go
+++ b/cmd/cyoda/help/help_test.go
@@ -664,6 +664,44 @@ func TestSeeAlsoResolution(t *testing.T) {
 	}
 }
 
+// TestGRPCEventTypeCatalogueParity asserts every registered Entity…Request
+// CloudEvent constant in internal/grpc/cloudevent_types.go appears literally
+// in the grpc help topic. grpc.md is the machine-consumable spec surface
+// downstream docs consume, so a missing entry silently drifts the catalogue
+// away from the registered types. Regex over the source (not a hand-kept
+// slice) means any future Entity…Request addition is covered automatically.
+func TestGRPCEventTypeCatalogueParity(t *testing.T) {
+	root := repoRoot(t)
+
+	src, err := os.ReadFile(filepath.Join(root, "internal/grpc/cloudevent_types.go"))
+	if err != nil {
+		t.Fatalf("read cloudevent_types.go: %v", err)
+	}
+	grpcDoc, err := os.ReadFile(filepath.Join(root, "cmd/cyoda/help/content/grpc.md"))
+	if err != nil {
+		t.Fatalf("read grpc.md: %v", err)
+	}
+	doc := string(grpcDoc)
+
+	re := regexp.MustCompile(`\bEntity[A-Za-z]*Request\b`)
+	seen := map[string]bool{}
+	var missing []string
+	for _, name := range re.FindAllString(string(src), -1) {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		if !strings.Contains(doc, name) {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("Entity…Request CloudEvent constants missing from grpc.md:\n  %s",
+			strings.Join(missing, "\n  "))
+	}
+}
+
 // scanEnvVarsInConfigDocs walks the help content directory and extracts
 // every CYODA_* mention from config.md and config/**/*.md.
 func scanEnvVarsInConfigDocs(t *testing.T, contentRoot string) map[string]bool {


### PR DESCRIPTION
## Summary

The `grpc` help topic's event-type catalogue silently drifted from the
registered CloudEvent types, omitting two `Entity…Request` constants:

- `EntityPatchRequest` (entity management) — gRPC entity PATCH was documented
  only in the emitted OpenAPI spec, invisible to every consumer of the help
  artefacts (cyoda-docs consumes `cyoda help grpc`).
- `EntityModelSetUniqueKeysRequest` (model management) — the corroborating
  omission that showed the list drifts unguarded.

Documentation + one regression-guard test. **No production/runtime code changed.**

## Changes

1. **grpc.md — entity management:** add `EntityPatchRequest` / `EntityTransactionResponse`
   with a compact note on the `MERGE_PATCH` / `JSON_PATCH` dialects (via `PatchFormat`),
   required `ifMatch` (`transactionId` from last read, or `"*"` for last-writer-wins),
   and optional `transition`.
2. **grpc.md — model management:** add `EntityModelSetUniqueKeysRequest` / `EntityModelSetUniqueKeysResponse`.
3. **Parity guard (durable fix):** `TestGRPCEventTypeCatalogueParity` regex-extracts every
   `Entity…Request` constant from `internal/grpc/cloudevent_types.go` and asserts each appears
   in `grpc.md`. Because it reads the source (not a hand-kept slice), any future addition is
   covered automatically. Follows the `TestConfig_EnvVarCoverage` precedent.

HTTP PATCH prose already exists in `crud.md` (verbs table + full section), so no HTTP help change was needed.

## TDD

- **RED:** the new parity test failed naming exactly `EntityPatchRequest` and `EntityModelSetUniqueKeysRequest`.
- **GREEN:** adding both catalogue entries makes it pass.

## Verification

- `go test ./cmd/cyoda/help/...` — green
- `go test ./internal/grpc/...` — green
- `go test -short ./...` — green
- `go vet ./...` — clean
- `go run ./cmd/cyoda help grpc | grep -iE 'EntityPatchRequest|EntityModelSetUniqueKeys'` — both render

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)