### PR TITLE
feat(workflow): criterion stoppage reason — direct 400 response + durable audit for committed paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Added
 
+- **Criterion stoppage reason** — a criteria compute node's `EntityCriteriaCalculationResponse`
+  may now carry an optional `reason` string on `matches: false`, explaining why a passage was
+  blocked. A manual explicit transition rejected by its criterion appends the reason to the
+  `400 WORKFLOW_FAILED` detail (`transition "<name>" criterion not matched: <reason>`) — the
+  guaranteed, backend-independent surface. For the automated-cascade and workflow-selection
+  paths, the reason is additionally recorded durably on the state-machine audit trail:
+  `TRANSITION_NOT_MATCH_CRITERION`'s `data` carries `{workflowName, transition, criterion, reason}`
+  and `WORKFLOW_SKIP`'s carries `{workflowName, reason}`. A manual rejection's own audit event is
+  not forced durable (it rolls back with the no-op transaction, same as before). Reason is capped
+  at 2 KiB; an omitted reason defaults to `"criterion did not match"`. No new error codes.
+
 - **Entity partial-update (PATCH / RFC 7386 merge patch)** — `PATCH /api/entity/{format}/{entityId}`
   and `PATCH /api/entity/{format}/{entityId}/{transition}` apply a sparse JSON patch to the stored
   payload with RFC 7386 merge semantics (non-null key overwrites, explicit `null` deletes, omitted

--- a/api/generated.go
+++ b/api/generated.go
@@ -2640,7 +2640,7 @@ type StateMachineAuditEventDto struct {
 	// ConsistencyTime Cyoda consistency time
 	ConsistencyTime *time.Time `json:"consistencyTime,omitempty"`
 
-	// Data Optional event-specific payload. Present for some event types (e.g. STATE_MACHINE_FINISH includes {"success": true}, STATE_PROCESS_RESULT includes {"success": false}). Null for most event types.
+	// Data Optional event-specific payload. Present for some event types (e.g. STATE_MACHINE_FINISH includes {"success": true}, STATE_PROCESS_RESULT includes {"success": false}). TRANSITION_NOT_MATCH_CRITERION carries {workflowName, transition, criterion, reason} and WORKFLOW_SKIP carries {workflowName, reason}, where reason explains why the criterion blocked the passage. Null for most event types.
 	Data *map[string]interface{} `json:"data,omitempty"`
 
 	// Details Details of the event

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2894,7 +2894,7 @@ paths:
                 entityIds:
                   - cdcff600-bab1-11ee-a357-ae468cd3ed16
         "400":
-          description: "Bad request — BAD_REQUEST: invalid payload or parameter; TRANSITION_NOT_FOUND: named transition absent from the model; WORKFLOW_FAILED: workflow processor rejected the update."
+          description: "Bad request — BAD_REQUEST: invalid payload or parameter; TRANSITION_NOT_FOUND: named transition absent from the model; WORKFLOW_FAILED: workflow processor rejected the update. When the transition's criterion evaluates false, `detail` is `transition \"<name>\" criterion not matched: <reason>` — <reason> is the criteria compute node's explanation, or omitted (bare `criterion not matched`) when no reason was supplied."
           content:
             application/problem+json:
               schema:
@@ -10897,7 +10897,10 @@ components:
                 Optional event-specific payload. Present for some event types
                 (e.g. STATE_MACHINE_FINISH includes {"success": true},
                 STATE_PROCESS_RESULT includes {"success": false}).
-                Null for most event types.
+                TRANSITION_NOT_MATCH_CRITERION carries
+                {workflowName, transition, criterion, reason} and WORKFLOW_SKIP
+                carries {workflowName, reason}, where reason explains why the
+                criterion blocked the passage. Null for most event types.
               additionalProperties: true
       required:
         - eventType

--- a/cmd/cyoda/help/content/grpc.md
+++ b/cmd/cyoda/help/content/grpc.md
@@ -297,6 +297,17 @@ Client responds with `EntityCriteriaCalculationResponse`:
 }
 ```
 
+On `matches: false`, the response may also carry a `reason` string explaining
+why the criterion blocked the passage (capped at 2 KiB). It surfaces in two
+places: the manual-transition `400 WORKFLOW_FAILED` body
+(`detail: transition "<name>" criterion not matched: <reason>` — the
+guaranteed, backend-independent delivery for a manual rejection), and the
+`TRANSITION_NOT_MATCH_CRITERION` / `WORKFLOW_SKIP` state-machine audit events'
+`data.reason` — durable there only for the automated-cascade and
+workflow-selection paths, since a manual rejection rolls its transaction back.
+An omitted `reason` defaults to `"criterion did not match"` in the audit and
+is left out of the 400 detail (bare `criterion not matched`).
+
 **Auth context on dispatched events:**
 
 The server attaches CloudEvent Auth Context extension attributes to every dispatched request:

--- a/docs/cloud-parity/criterion-stoppage-reason.md
+++ b/docs/cloud-parity/criterion-stoppage-reason.md
@@ -1,0 +1,71 @@
+# Criterion stoppage reason — Cloud twin-alignment spec
+
+This document is the contract Cyoda Cloud implements to stay aligned with
+cyoda-go's criterion stoppage reason feature. cyoda-go is the authoritative
+implementation; the behaviour described here is derived directly from its
+design spec and implemented code.
+
+## 1. Wire shape
+
+`EntityCriteriaCalculationResponse` (the compute-node → server criteria
+response, unchanged wire shape) may carry an optional `reason` string
+alongside `matches: false`:
+
+```jsonc
+{
+  "requestId": "<requestId>",
+  "success": true,
+  "matches": false,
+  "reason": "credit score 540 below threshold 600"
+}
+```
+
+`reason` is capped at **2 KiB**; longer values are truncated once, server-side.
+When a criterion evaluates false without a compute-node-supplied reason
+(inline predicate criteria, or a `FUNCTION` criterion that returns none), the
+engine substitutes the inline default `"criterion did not match"`.
+
+## 2. Delivery surfaces
+
+Two independent surfaces carry the reason — they are not interchangeable:
+
+1. **Manual-transition 400 response (primary, guaranteed).** When an explicit
+   `PUT .../entity/{format}/{entityId}/{transition}` is rejected by its
+   criterion, the `400 WORKFLOW_FAILED` `ProblemDetail.detail` is
+   `transition "<name>" criterion not matched: <reason>`. The inline default
+   is *not* appended — a criterion rejected with no external reason yields the
+   bare `transition "<name>" criterion not matched`. This is the only
+   delivery guaranteed for a manual rejection (see §3).
+
+2. **State-machine audit `data.reason` (durable, automated/skip paths only).**
+   The `TRANSITION_NOT_MATCH_CRITERION` event's `data` carries
+   `{workflowName, transition, criterion, reason}`; the `WORKFLOW_SKIP`
+   event's `data` carries `{workflowName, reason}`. `reason` is always present
+   on both (external reason, else the inline default). `criterion` is the
+   `FUNCTION` name, or the inline condition's type (e.g. `"simple"`) for a
+   predicate criterion.
+
+## 3. Transactional-audit invariant (no tx-semantics change)
+
+A manual transition rejected by its criterion performs zero mutation and its
+transaction is rolled back like any other no-op manual attempt — this feature
+does **not** force that rollback to a commit. On a TX-bound audit store
+(Postgres), the `TRANSITION_NOT_MATCH_CRITERION` audit event recorded for a
+*manual* rejection is therefore rolled back with the rest of the transaction
+and is not retrievable via `GET /audit/entity/{id}` afterward. This is by
+design: the manual reason's guaranteed delivery is the 400 response (§2.1),
+not the audit trail.
+
+The audit `data.reason` **is** durable for the automated cascade and
+workflow-selection (`WORKFLOW_SKIP`) paths, because those evaluations happen
+inside a transaction that commits regardless of the no-match outcome — the
+no-match simply stops the cascade rather than aborting the request.
+
+## 4. Backend support
+
+Delivery surface 1 (400 response) is backend-agnostic — it is produced by the
+engine before any storage write. Delivery surface 2 (durable audit
+`data.reason`) is exercised across memory, sqlite, and postgres by the
+cross-backend parity suite (inline-default scenario, backend-agnostic by
+construction since it requires no compute node); the commercial backend must
+match the same `data` shape and the same transactional-audit invariant (§3).

--- a/docs/cyoda/openapi.yml
+++ b/docs/cyoda/openapi.yml
@@ -9244,10 +9244,10 @@ components:
               description: >
                 Why the criterion blocked the passage: the criteria compute
                 node's explanation, or "criterion did not match" when none was
-                supplied. Always present on this event.
+                supplied. Present on events recorded since this field was
+                introduced; older audit events omit it.
       required:
         - criterion
-        - reason
         - transition
         - workflowName
     StateMachineTransitionMadeDto:
@@ -9307,9 +9307,10 @@ components:
               description: >
                 Why the workflow-selection criterion blocked the workflow: the
                 criteria compute node's explanation, or "criterion did not
-                match" when none was supplied. Always present on this event.
+                match" when none was supplied. Present on events recorded since
+                this field was introduced; older audit events omit it.
       required:
-        - reason
+        - workflowName
         - workflowName
     StateProcessIdDto:
       type: object

--- a/docs/cyoda/openapi.yml
+++ b/docs/cyoda/openapi.yml
@@ -2257,6 +2257,17 @@ paths:
                 transactionId: 733e7180-c055-11ef-a357-ae468cd3ed16
                 entityIds:
                   - cdcff600-bab1-11ee-a357-ae468cd3ed16
+        "400":
+          description: >
+            Bad request — TRANSITION_NOT_FOUND: named transition absent from
+            the model; WORKFLOW_FAILED: workflow processor rejected the
+            update. When the transition's criterion evaluates false, `detail`
+            is `transition "<name>" criterion not matched: <reason>`
+            (`<reason>` omitted when the criteria compute node supplied none).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
   /entity/{format}/{entityName}/{modelVersion}:
     post:
       tags:
@@ -9230,9 +9241,13 @@ components:
               description: Name of the criterion that was not matched
             reason:
               type: string
-              description: Reason why the criterion was not matched
+              description: >
+                Why the criterion blocked the passage: the criteria compute
+                node's explanation, or "criterion did not match" when none was
+                supplied. Always present on this event.
       required:
         - criterion
+        - reason
         - transition
         - workflowName
     StateMachineTransitionMadeDto:
@@ -9289,7 +9304,10 @@ components:
               description: Name of the workflow that was skipped
             reason:
               type: string
-              description: Reason for skipping the workflow
+              description: >
+                Why the workflow-selection criterion blocked the workflow: the
+                criteria compute node's explanation, or "criterion did not
+                match" when none was supplied. Always present on this event.
       required:
         - reason
         - workflowName

--- a/docs/superpowers/plans/2026-07-14-criterion-response-reason-audit.md
+++ b/docs/superpowers/plans/2026-07-14-criterion-response-reason-audit.md
@@ -1,0 +1,1058 @@
+# Criterion Stoppage Reason in State-Machine Audit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the criterion "stoppage reason" (from `EntityCriteriaCalculationResponse.reason`) on the entity state-machine audit trail and the manual-transition 400 body, so clients can analyse *why* a passage was blocked.
+
+**Architecture:** Thread the reason from the gRPC criteria response through `ProcessingResponse` → the widened `DispatchCriteria` interface → the widened engine `evaluateCriterion`, then populate the `data` payload of the existing `TRANSITION_NOT_MATCH_CRITERION` and `WORKFLOW_SKIP` state-machine audit events (which already fire with `nil` data) and enrich the manual-transition 400 error. All-internal; no `cyoda-go-spi` change.
+
+**Tech Stack:** Go 1.26+, `log/slog`, testcontainers-go (e2e Postgres), the in-tree `internal/testing/localproc` in-process criteria harness.
+
+**Spec:** `docs/superpowers/specs/2026-07-14-criterion-response-reason-audit-design.md`. Issue #413 (v0.8.3). Follow-on #414 (processor criteria — out of scope).
+
+## Global Constraints
+
+- Go 1.26+. Use `log/slog` exclusively — never `log.Printf`/`fmt.Printf` for operational logging.
+- Wrap errors: `fmt.Errorf("...: %w", err)`. Use `uuid.UUID`, not `string`, for UUIDs.
+- **No `cyoda-go-spi` change, no coordinated SPI release, no schema-version bump** — every type touched is in `internal/…`.
+- **No issue IDs (`#NNN`) in shipped artefacts** — code, error messages, response bodies, comments, OpenAPI/help content. Issue IDs only in commits, PR bodies, and `docs/`.
+- 4xx errors carry full domain detail; the reason appended to the 400 is same-tenant compute-node-supplied and reflected into a JSON body (no HTML surface).
+- **Reason length cap:** `maxCriterionReasonLen = 2048` bytes; truncate once in `evaluateCriterion`'s return.
+- **Inline D3 default reason:** `"criterion did not match"`.
+- Never log the reason beyond existing `common.AddWarning`/diagnostics.
+- Run `go build ./... && go vet ./...` after any signature change; it surfaces every broken call site.
+- `data` field names align to the typed DTOs: transition events use `transition` (not `transitionName`).
+
+---
+
+### Task 1: Ingest `reason` into `ProcessingResponse`
+
+Additive only — no signature change. The gRPC criteria response's `reason` field is currently dropped by `handleCriteriaResponse`.
+
+**Files:**
+- Modify: `internal/grpc/members.go` (ProcessingResponse struct, ~line 24)
+- Modify: `internal/grpc/streaming.go` (`handleCriteriaResponse`, ~line 281)
+- Test: `internal/grpc/streaming_test.go` (new test after `TestStreaming_CriteriaResponse`, ~line 488)
+
+**Interfaces:**
+- Produces: `ProcessingResponse.Reason string` — populated from the wire `reason` field on criteria responses; empty for processor responses.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/grpc/streaming_test.go`:
+
+```go
+func TestStreaming_CriteriaResponse_PropagatesReason(t *testing.T) {
+	svc := newServiceForTest()
+	ctx, cancel := context.WithCancel(m2mContext("tenant-1"))
+	defer cancel()
+
+	stream := newMockBidiStream(ctx)
+	stream.enqueue(makeJoinEvent(t, "tenant-1", []string{"python"}))
+
+	done := make(chan error, 1)
+	go func() { done <- svc.StartStreaming(stream) }()
+
+	greetCE := stream.waitForSent(t, 2*time.Second)
+	_, greetPayload, _ := ParseCloudEvent(greetCE)
+	memberID := ExtractStringField(greetPayload, "memberId")
+
+	member := svc.registry.Get(memberID)
+	if member == nil {
+		t.Fatal("member not found")
+	}
+	respCh := member.TrackRequest("req-reason-1")
+
+	respPayload := map[string]any{
+		"requestId": "req-reason-1",
+		"success":   true,
+		"matches":   false,
+		"reason":    "credit score 540 below threshold 600",
+	}
+	respCE, err := NewCloudEvent(EntityCriteriaCalculationResponse, respPayload)
+	if err != nil {
+		t.Fatalf("failed to create criteria response event: %v", err)
+	}
+	stream.enqueue(respCE)
+
+	select {
+	case resp := <-respCh:
+		if resp == nil {
+			t.Fatal("expected non-nil response")
+		}
+		if resp.Reason != "credit score 540 below threshold 600" {
+			t.Errorf("expected reason propagated, got %q", resp.Reason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for criteria response")
+	}
+
+	stream.closeRecv()
+	<-done
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/grpc/ -run TestStreaming_CriteriaResponse_PropagatesReason -v`
+Expected: FAIL — `resp.Reason` undefined (compile error) or empty.
+
+- [ ] **Step 3: Add the field to `ProcessingResponse`**
+
+In `internal/grpc/members.go`, inside `type ProcessingResponse struct`, after the `Matches` field:
+
+```go
+	// Reason is the criteria-response explanation for a matches=false result
+	// (EntityCriteriaCalculationResponse.reason). Empty for processor
+	// responses and for criteria that supply no reason.
+	Reason string
+```
+
+- [ ] **Step 4: Deserialize and propagate it**
+
+In `internal/grpc/streaming.go` `handleCriteriaResponse`, add `Reason` to the anonymous struct:
+
+```go
+	var resp struct {
+		RequestID string `json:"requestId"`
+		Success   bool   `json:"success"`
+		Matches   bool   `json:"matches"`
+		Reason    string `json:"reason"`
+		Error     *struct {
+			Message   string `json:"message"`
+			Retryable *bool  `json:"retryable"`
+		} `json:"error"`
+		Warnings []string `json:"warnings"`
+	}
+```
+
+and set it in the `CompleteRequest` call:
+
+```go
+	member.CompleteRequest(resp.RequestID, &ProcessingResponse{
+		Success:   resp.Success,
+		Error:     errMsg,
+		Matches:   &matches,
+		Reason:    resp.Reason,
+		Warnings:  resp.Warnings,
+		Retryable: retryable,
+	})
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/grpc/ -run TestStreaming_CriteriaResponse -v`
+Expected: PASS (both the original and the new test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/grpc/members.go internal/grpc/streaming.go internal/grpc/streaming_test.go
+git commit -m "feat(grpc): ingest criteria-response reason into ProcessingResponse"
+```
+
+---
+
+### Task 2: Add `Reason` to cross-node `DispatchCriteriaResponse`
+
+Additive only. Prepares the cross-node carrier before the interface widens (Task 3) so the peer branch can compile.
+
+**Files:**
+- Modify: `internal/cluster/dispatch/types.go` (`DispatchCriteriaResponse`, ~line 49)
+- Test: `internal/cluster/dispatch/types_test.go` (`TestDispatchCriteriaResponse_JSONRoundTrip`, ~line 210)
+
+**Interfaces:**
+- Produces: `DispatchCriteriaResponse.Reason string` (json `reason,omitempty`) — the criteria reason as evaluated on the peer node.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/cluster/dispatch/types_test.go`:
+
+```go
+func TestDispatchCriteriaResponse_ReasonRoundTrip(t *testing.T) {
+	in := DispatchCriteriaResponse{Matches: false, Success: true, Reason: "amount 5 below minimum 10"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out DispatchCriteriaResponse
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Reason != in.Reason {
+		t.Errorf("reason not round-tripped: got %q want %q", out.Reason, in.Reason)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/cluster/dispatch/ -run TestDispatchCriteriaResponse_ReasonRoundTrip -v`
+Expected: FAIL — `Reason` undefined (compile error).
+
+- [ ] **Step 3: Add the field**
+
+In `internal/cluster/dispatch/types.go`, inside `type DispatchCriteriaResponse struct`, after `Error`:
+
+```go
+	Reason   string   `json:"reason,omitempty"`
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/cluster/dispatch/ -run TestDispatchCriteriaResponse_ReasonRoundTrip -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/cluster/dispatch/types.go internal/cluster/dispatch/types_test.go
+git commit -m "feat(cluster): add Reason to cross-node DispatchCriteriaResponse"
+```
+
+---
+
+### Task 3: Widen `DispatchCriteria` to `(bool, string, error)` across all implementors
+
+Compilation-atomic: the interface change breaks every implementor, test double, and call site at once. `ExternalProcessingService` is `internal/contract/processing.go:12` (internal — no SPI change). Verified implementor set: `ProcessorDispatcher` (grpc), `ClusterDispatcher`, `skeleton`, `localproc`, `TracingExternalProcessingService`. Verified 6 doubles: `stubDispatcher`, `fakeLocalDispatcher`, `capturingLocalDispatcher`, `fakeDispatcher`, `mockExtProc`, `mockExternalProcessing`.
+
+**Files:**
+- Modify: `internal/contract/processing.go` (interface, ~line 12)
+- Modify: `internal/grpc/dispatch.go` (`DispatchCriteria`, ~line 195)
+- Modify: `internal/cluster/dispatch/cluster_dispatcher.go` (`DispatchCriteria`, lines 121, 135-137, 171)
+- Modify: `internal/cluster/dispatch/handler.go` (`handleCriteria`, ~line 96-109)
+- Modify: `internal/skeleton/processing.go` (~line 20)
+- Modify: `internal/observability/dispatch_tracing.go` (~line 77)
+- Modify: `internal/testing/localproc/localproc.go` (interface method + `CriteriaFunc` plumbing)
+- Modify (test doubles): `internal/cluster/dispatch/cluster_dispatcher_test.go:39`, `internal/cluster/dispatch/handler_test.go:40`, `internal/cluster/dispatch/integration_txtoken_test.go:41`, `internal/observability/dispatch_tracing_test.go:32`, `internal/domain/workflow/engine_test.go:871` and `:1600`
+- Test: `internal/grpc/dispatch_test.go` (`TestDispatchCriteria_MatchesFalse`, ~line 313), `internal/cluster/dispatch/handler_test.go`
+
+**Interfaces:**
+- Consumes: `ProcessingResponse.Reason` (Task 1), `DispatchCriteriaResponse.Reason` (Task 2).
+- Produces:
+  - `contract.ExternalProcessingService.DispatchCriteria(ctx, entity, criterion, target, workflowName, transitionName, processorName, txID) (matches bool, reason string, err error)`.
+  - `localproc.RegisterCriteriaReason(name string, fn func(ctx, *spi.Entity, json.RawMessage) (bool, string, error))` — registers a reason-returning criterion. Existing `RegisterCriteria` (the `(bool, error)` form) is preserved as a shim returning `""`, so its existing call sites are untouched.
+
+- [ ] **Step 1: Write the failing tests**
+
+Modify `internal/grpc/dispatch_test.go` `TestDispatchCriteria_MatchesFalse` — set a reason on the response and assert it is returned:
+
+```go
+		member.CompleteRequest(reqID, &ProcessingResponse{
+			Success: true,
+			Matches: &matchesFalse,
+			Reason:  "amount 5 below minimum 10",
+		})
+	}()
+
+	result, reason, err := dispatcher.DispatchCriteria(ctx, entity, criterion, "transition", "wf1", "t1", "", "tx-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result {
+		t.Error("expected matches=false")
+	}
+	if reason != "amount 5 below minimum 10" {
+		t.Errorf("expected reason returned, got %q", reason)
+	}
+```
+
+Add to `internal/cluster/dispatch/handler_test.go` a peer-producer assertion (adapt to the file's existing `fakeLocalDispatcher` — give it a `reason` return, then assert the built `DispatchCriteriaResponse.Reason`):
+
+```go
+func TestHandleCriteria_PropagatesReason(t *testing.T) {
+	// fakeLocalDispatcher.DispatchCriteria returns (false, "peer reason here", nil).
+	// Drive handleCriteria and assert the response body carries Reason.
+	h := newTestHandlerWithLocal(t, &fakeLocalDispatcher{matches: false, reason: "peer reason here"})
+	rec := httptest.NewRecorder()
+	h.handleCriteria(rec, newCriteriaRequest(t))
+	var resp DispatchCriteriaResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Reason != "peer reason here" {
+		t.Errorf("expected peer reason propagated, got %q", resp.Reason)
+	}
+}
+```
+
+(If `newTestHandlerWithLocal`/`newCriteriaRequest` helpers do not exist, reuse the construction already present in `handler_test.go`'s other criteria tests; the assertion on `resp.Reason` is the point.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go build ./... 2>&1 | head`
+Expected: compile errors — call sites now expect 3 return values / doubles have wrong signature. This is the RED for a signature change.
+
+- [ ] **Step 3: Widen the interface**
+
+In `internal/contract/processing.go`, change the `DispatchCriteria` method signature to:
+
+```go
+	DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (matches bool, reason string, err error)
+```
+
+- [ ] **Step 4: Update the grpc dispatcher**
+
+In `internal/grpc/dispatch.go` `DispatchCriteria`, update the signature to `(bool, string, error)` and every `return`. On the response path return `resp.Reason`; on all error/empty paths return `""`:
+
+```go
+		if resp == nil || !resp.Success {
+			errMsg := "criteria returned failure"
+			if resp != nil && resp.Error != "" {
+				errMsg = resp.Error
+				common.AddError(ctx, fmt.Sprintf("criteria %s: %s", parsed.Function.Name, errMsg))
+			}
+			return false, "", fmt.Errorf("criteria dispatch failed: %s", errMsg)
+		}
+		slog.Info("criteria completed", "pkg", "grpc", "memberId", member.ID, "criteria", parsed.Function.Name, "requestId", requestID, "success", true)
+		if resp.Matches != nil {
+			return *resp.Matches, resp.Reason, nil
+		}
+		return false, resp.Reason, nil
+```
+
+Update the earlier error returns (`invalid criterion JSON`, `ErrNoMatchingMember`, send failure, cloud-event build failure, timeout, `ctx.Done`) to `return false, "", <err>`.
+
+- [ ] **Step 5: Update the cluster dispatcher (local + peer branches)**
+
+In `internal/cluster/dispatch/cluster_dispatcher.go` `DispatchCriteria`, signature → `(bool, string, error)`. Local branch (lines 135-137):
+
+```go
+	// Try local first.
+	matches, reason, err := d.local.DispatchCriteria(ctx, entity, criterion, target, workflowName, transitionName, processorName, txID)
+	if err == nil {
+		return matches, reason, nil
+	}
+	if !isNoMatchingMember(err) {
+		return false, "", err
+	}
+```
+
+All intermediate error returns → `return false, "", <err>`. Peer branch final return (line 171):
+
+```go
+	return resp.Matches, resp.Reason, nil
+```
+
+- [ ] **Step 6: Update the cluster peer producer**
+
+In `internal/cluster/dispatch/handler.go` `handleCriteria` (~line 96-109):
+
+```go
+	matches, reason, err := h.local.DispatchCriteria(ctx, entity, req.Criterion, req.Target, req.WorkflowName, req.TransitionName, req.ProcessorName, req.TxID)
+	if err != nil {
+		slog.Error("dispatch criteria failed", "pkg", "dispatch", "err", err)
+		writeJSON(w, http.StatusOK, DispatchCriteriaResponse{
+			Success: false,
+			Error:   "dispatch criteria failed",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, DispatchCriteriaResponse{
+		Success: true,
+		Matches: matches,
+		Reason:  reason,
+	})
+```
+
+- [ ] **Step 7: Update the leaf implementors**
+
+`internal/skeleton/processing.go` — return `(false, "", <err>)` (it is a not-configured stub).
+
+`internal/observability/dispatch_tracing.go` `DispatchCriteria` — pass through the extra value:
+
+```go
+func (t *TracingExternalProcessingService) DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target, workflowName, transitionName, processorName, txID string) (bool, string, error) {
+	// ... existing span setup ...
+	matches, reason, err := t.inner.DispatchCriteria(ctx, entity, criterion, target, workflowName, transitionName, processorName, txID)
+	// ... existing span end / error recording ...
+	return matches, reason, err
+}
+```
+
+`internal/testing/localproc/localproc.go` — store a reason-returning form internally, keep `RegisterCriteria` as a shim, add `RegisterCriteriaReason`, and return the reason from `DispatchCriteria`:
+
+```go
+// criteriaFuncR is the internal reason-returning criterion form.
+type criteriaFuncR func(ctx context.Context, entity *spi.Entity, criterion json.RawMessage) (bool, string, error)
+
+// (change the field type)
+//   criteria map[string]criteriaFuncR
+
+// RegisterCriteria registers a criteria callback by function name (no reason).
+func (s *LocalProcessingService) RegisterCriteria(name string, fn CriteriaFunc) {
+	s.RegisterCriteriaReason(name, func(ctx context.Context, e *spi.Entity, c json.RawMessage) (bool, string, error) {
+		m, err := fn(ctx, e, c)
+		return m, "", err
+	})
+}
+
+// RegisterCriteriaReason registers a criteria callback that also returns a reason.
+func (s *LocalProcessingService) RegisterCriteriaReason(name string, fn criteriaFuncR) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.criteria[name] = fn
+	if _, ok := s.criteriaCalls[name]; !ok {
+		s.criteriaCalls[name] = &atomic.Int64{}
+	}
+}
+
+func (s *LocalProcessingService) DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (bool, string, error) {
+	// ... existing name-parse ...
+	if err := json.Unmarshal(criterion, &parsed); err != nil {
+		return false, "", fmt.Errorf("invalid criterion JSON: %w", err)
+	}
+	// ... lookup ...
+	if !ok {
+		return false, "", fmt.Errorf("no local criteria registered for %q", name)
+	}
+	counter.Add(1)
+	return fn(ctx, entity, criterion)
+}
+```
+
+Leave `type CriteriaFunc` as `func(...) (bool, error)` (the shim source) so existing `RegisterCriteria` call sites across e2e/engine tests compile unchanged.
+
+- [ ] **Step 8: Update the 6 test doubles**
+
+For each, change the `DispatchCriteria` method to `(bool, string, error)` and return `""` for reason (or a fixed reason where the test asserts one):
+- `internal/cluster/dispatch/cluster_dispatcher_test.go:39` `stubDispatcher`
+- `internal/cluster/dispatch/handler_test.go:40` `fakeLocalDispatcher` — add a `reason string` field and return it (used by the Step-1 test)
+- `internal/cluster/dispatch/integration_txtoken_test.go:41` `capturingLocalDispatcher`
+- `internal/observability/dispatch_tracing_test.go:32` `fakeDispatcher`
+- `internal/domain/workflow/engine_test.go:871` `mockExtProc`
+- `internal/domain/workflow/engine_test.go:1600` `mockExternalProcessing`
+
+- [ ] **Step 9: Sweep remaining call sites**
+
+Run: `go build ./... && go vet ./... 2>&1 | head -40`
+Fix each reported call site (`matches, err :=` → `matches, _, err :=` where the reason is unused). These are compilation-enforced; the build output is the checklist.
+
+- [ ] **Step 10: Run tests to verify they pass**
+
+Run: `go test ./internal/grpc/ ./internal/cluster/... ./internal/observability/ ./internal/skeleton/ ./internal/testing/localproc/ -v 2>&1 | tail -30`
+Expected: PASS, including the new reason tests.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add internal/contract internal/grpc internal/cluster internal/skeleton internal/observability internal/testing/localproc
+git commit -m "feat: widen DispatchCriteria to return the criterion reason"
+```
+
+---
+
+### Task 4: Engine — thread reason into audit `data` and the manual-transition 400
+
+Compilation-atomic within `internal/domain/workflow`: widening `evaluateCriterion` breaks its three callers (`selectWorkflow:386`, manual `attemptTransition:476`, `cascadeAutomated:553`), which are exactly the three no-match sites.
+
+**Files:**
+- Modify: `internal/domain/workflow/engine.go` (`evaluateCriterion` ~623; sites ~399, ~483/486, ~560; add helpers + consts)
+- Test: `internal/domain/workflow/engine_test.go`
+
+**Interfaces:**
+- Consumes: `contract.ExternalProcessingService.DispatchCriteria(...) (bool, string, error)` (Task 3).
+- Produces:
+  - `evaluateCriterion(criterion []byte, entity *spi.Entity, cc *criterionContext) (matched bool, reason string, err error)` — `reason` is the capped external reason for a clean `matches=false` (empty for inline predicates and for `matched=true`).
+  - `data` payloads: `TRANSITION_NOT_MATCH_CRITERION` → `{"workflowName","transition","criterion","reason"}`; `WORKFLOW_SKIP` → `{"workflowName","reason"}`. `reason` is always present (external reason, else the inline default `"criterion did not match"`).
+  - Manual-transition rejection error: `transition %q criterion not matched: %s` (reason appended) — but **only when the reason is a real external reason**; the bare `transition %q criterion not matched` is kept when the reason is the inline default.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/domain/workflow/engine_test.go`. Use the existing pattern: build an engine with a `mockExtProc` whose `DispatchCriteria` returns `(false, "amount 5 below minimum 10", nil)` for a FUNCTION criterion, run an automated cascade whose transition has a FUNCTION criterion, then read the audit store and assert the `TRANSITION_NOT_MATCH_CRITERION` event's `Data`:
+
+```go
+func TestEngine_AutomatedCriterionNoMatch_RecordsReason(t *testing.T) {
+	// ... build engine with extProc returning (false, "amount 5 below minimum 10", nil) ...
+	// ... workflow: CREATED --[auto, criterion function "min-amount"]--> PREMIUM ...
+	// ... run Execute so the cascade evaluates the criterion and stops ...
+
+	events, err := auditStore.GetEventsByTransaction(ctx, "txid", txID)
+	if err != nil {
+		t.Fatalf("GetEventsByTransaction: %v", err)
+	}
+	var found bool
+	for _, ev := range events {
+		if ev.EventType == spi.SMEventTransitionCriterionNoMatch {
+			found = true
+			if ev.Data["reason"] != "amount 5 below minimum 10" {
+				t.Errorf("reason: got %v", ev.Data["reason"])
+			}
+			if ev.Data["transition"] == "" || ev.Data["workflowName"] == "" || ev.Data["criterion"] == "" {
+				t.Errorf("missing data keys: %v", ev.Data)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no TRANSITION_NOT_MATCH_CRITERION event recorded")
+	}
+}
+
+func TestEngine_InlineCriterionNoMatch_DefaultsReason(t *testing.T) {
+	// ... workflow transition with an INLINE criterion that evaluates false
+	//     (e.g. {"type":"simple","jsonPath":"$.amount","operatorType":"GREATER_THAN","value":100} with amount=5) ...
+	// assert ev.Data["reason"] == "criterion did not match" and ev.Data["criterion"] == "simple"
+}
+
+func TestEngine_ManualCriterionNoMatch_EnrichesError(t *testing.T) {
+	// ... manual transition whose FUNCTION criterion returns (false, "reason X", nil) ...
+	_, err := eng.ManualTransition(ctx, entity, "approve", auditStore, txID)
+	if err == nil || !strings.Contains(err.Error(), "criterion not matched: reason X") {
+		t.Fatalf("expected enriched error, got %v", err)
+	}
+}
+
+func TestEngine_ManualInlineCriterionNoMatch_NoRedundantSuffix(t *testing.T) {
+	// inline criterion → error stays "transition \"approve\" criterion not matched" (no ": criterion did not match")
+	_, err := eng.ManualTransition(ctx, entity, "approve", auditStore, txID)
+	if err == nil || strings.Contains(err.Error(), "criterion not matched: criterion did not match") {
+		t.Fatalf("unexpected redundant suffix: %v", err)
+	}
+}
+
+func TestEngine_WorkflowSkipped_RecordsReason(t *testing.T) {
+	// workflow-selection FUNCTION criterion returns (false, "tenant not eligible", nil) → WORKFLOW_SKIP data.reason
+	// assert an SMEventWorkflowSkipped event with Data["reason"]=="tenant not eligible" and Data["workflowName"] set
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/domain/workflow/ -run 'TestEngine_(AutomatedCriterionNoMatch|InlineCriterionNoMatch|ManualCriterionNoMatch|ManualInlineCriterionNoMatch|WorkflowSkipped)' -v`
+Expected: FAIL (compile error on `evaluateCriterion` return / missing data keys).
+
+- [ ] **Step 3: Add helpers and constants**
+
+In `internal/domain/workflow/engine.go` (near the other package consts):
+
+```go
+// maxCriterionReasonLen bounds the criterion reason stored in the audit and
+// reflected into the 400 body. The reason is compute-node-supplied and the
+// audit is durable storage, so it is capped defensively.
+const maxCriterionReasonLen = 2048
+
+// defaultCriterionReason is recorded when a criterion returns false without an
+// explanatory reason (inline predicates, or a FUNCTION criterion that supplies
+// none). Keeps the audit data.reason shape stable.
+const defaultCriterionReason = "criterion did not match"
+
+func capReason(s string) string {
+	if len(s) > maxCriterionReasonLen {
+		return s[:maxCriterionReasonLen]
+	}
+	return s
+}
+
+// criterionName derives the audit "criterion" field: the FUNCTION name for a
+// function criterion, else the parsed condition type (e.g. "simple", "group").
+func criterionName(criterion []byte) string {
+	var fn struct {
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if json.Unmarshal(criterion, &fn) == nil && fn.Function.Name != "" {
+		return fn.Function.Name
+	}
+	if cond, err := predicate.ParseCondition(criterion); err == nil {
+		return cond.Type()
+	}
+	return ""
+}
+```
+
+- [ ] **Step 4: Widen `evaluateCriterion`**
+
+Change the signature to `(bool, string, error)`. Return the capped reason from the FUNCTION dispatch; `""` for the inline `match.Match` path and for `matched=true`:
+
+```go
+func (e *Engine) evaluateCriterion(criterion []byte, entity *spi.Entity, cc *criterionContext) (bool, string, error) {
+	cond, err := predicate.ParseCondition(criterion)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to parse criterion: %w", err)
+	}
+	if _, ok := cond.(*predicate.FunctionCondition); ok {
+		if e.extProc == nil {
+			return false, "", fmt.Errorf("no external processing service configured for FUNCTION criteria")
+		}
+		matched, reason, dErr := e.extProc.DispatchCriteria(cc.ctx, entity, criterion, cc.target, cc.workflowName, cc.transitionName, "", cc.txID)
+		return matched, capReason(reason), dErr
+	}
+	matched, mErr := match.Match(cond, entity) // preserve the existing inline evaluation call
+	return matched, "", mErr
+}
+```
+
+(Adapt the inline branch to the file's actual local evaluation — the point is: FUNCTION returns the reason, inline returns `""`.)
+
+- [ ] **Step 5: Populate `data` at the automated-cascade site (~line 560)**
+
+```go
+			matched, reason, err := e.evaluateCriterion(tr.Criterion, entity, &criterionContext{
+				ctx: currentCtx, txID: txID, workflowName: wf.Name, transitionName: tr.Name, target: "TRANSITION",
+			})
+			if err != nil {
+				return currentCtx, currentTxID, fmt.Errorf("failed to evaluate transition criterion: %w", err)
+			}
+			if !matched {
+				if reason == "" {
+					reason = defaultCriterionReason
+				}
+				e.recordEvent(auditStore, currentCtx, entity.Meta.ID, txID, entity.Meta.State,
+					spi.SMEventTransitionCriterionNoMatch,
+					fmt.Sprintf("Automated transition %q criterion not matched", tr.Name),
+					map[string]any{
+						"workflowName": wf.Name,
+						"transition":   tr.Name,
+						"criterion":    criterionName(tr.Criterion),
+						"reason":       reason,
+					})
+				continue
+			}
+```
+
+- [ ] **Step 6: Populate `data` + enrich the error at the manual site (~line 476-486)**
+
+```go
+	if len(transition.Criterion) > 0 && string(transition.Criterion) != "null" {
+		matched, reason, err := e.evaluateCriterion(transition.Criterion, entity, &criterionContext{
+			ctx: ctx, txID: txID, workflowName: wf.Name, transitionName: transitionName, target: "TRANSITION",
+		})
+		if err != nil {
+			return ctx, txID, fmt.Errorf("failed to evaluate transition criterion: %w", err)
+		}
+		if !matched {
+			external := reason != ""
+			if reason == "" {
+				reason = defaultCriterionReason
+			}
+			e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
+				spi.SMEventTransitionCriterionNoMatch,
+				fmt.Sprintf("Transition %q criterion not matched", transitionName),
+				map[string]any{
+					"workflowName": wf.Name,
+					"transition":   transitionName,
+					"criterion":    criterionName(transition.Criterion),
+					"reason":       reason,
+				})
+			if external {
+				return ctx, txID, fmt.Errorf("transition %q criterion not matched: %s", transitionName, reason)
+			}
+			return ctx, txID, fmt.Errorf("transition %q criterion not matched", transitionName)
+		}
+	}
+```
+
+- [ ] **Step 7: Populate `data` at the workflow-skip site (~line 399)**
+
+```go
+		matched, reason, err := e.evaluateCriterion(wf.Criterion, entity, &criterionContext{
+			ctx: ctx, txID: txID, workflowName: wf.Name, target: "WORKFLOW",
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate workflow criterion for %q: %w", wf.Name, err)
+		}
+		if matched {
+			e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
+				spi.SMEventWorkflowFound, fmt.Sprintf("Workflow %q matched criterion", wf.Name), nil)
+			return wf, nil
+		}
+		if reason == "" {
+			reason = defaultCriterionReason
+		}
+		e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
+			spi.SMEventWorkflowSkipped, fmt.Sprintf("Workflow %q criterion not matched", wf.Name),
+			map[string]any{"workflowName": wf.Name, "reason": reason})
+```
+
+- [ ] **Step 8: Sweep and run**
+
+Run: `go build ./... && go test ./internal/domain/workflow/ -v 2>&1 | tail -30`
+Expected: PASS (new tests green, no regressions). Fix any remaining `evaluateCriterion` caller the build flags.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/domain/workflow/engine.go internal/domain/workflow/engine_test.go
+git commit -m "feat(workflow): record criterion reason in state-machine audit + 400 body"
+```
+
+---
+
+### Task 5: HTTP e2e coverage (running Postgres backend)
+
+Covers the manual-transition 400 body, the audit `data.reason` for all three events, and the inline default. Uses the `procSvc.RegisterCriteriaReason` harness (Task 3) and the existing `getSMAuditEvents` helper (`internal/e2e/workflow_proc_test.go:34`).
+
+**Files:**
+- Create: `internal/e2e/criterion_reason_test.go`
+
+**Interfaces:**
+- Consumes: `procSvc *localproc.LocalProcessingService` (the e2e-global processing service), `getSMAuditEvents`, `setupModelWithWorkflow`, `createEntityE2E`, `doAuth`, `readBody` (all in `internal/e2e`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/e2e/criterion_reason_test.go`:
+
+```go
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// smEventReason returns the reason recorded on the first StateMachine audit
+// event of the given eventType for the entity, or "" if none.
+func smEventReason(t *testing.T, entityID, eventType string) (string, bool) {
+	t.Helper()
+	for _, ev := range getSMAuditEvents(t, entityID) {
+		if ev["eventType"] == eventType {
+			data, _ := ev["data"].(map[string]any)
+			if data == nil {
+				return "", true
+			}
+			r, _ := data["reason"].(string)
+			return r, true
+		}
+	}
+	return "", false
+}
+
+func TestCriterionReason_ManualReject_Enriches400AndAudit(t *testing.T) {
+	const model = "e2e-critreason-manual"
+	procSvc.RegisterCriteriaReason("credit-check",
+		func(ctx context.Context, e *spi.Entity, c json.RawMessage) (bool, string, error) {
+			return false, "credit score 540 below threshold 600", nil
+		})
+	defer procSvc.Reset()
+
+	wf := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "cr-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {"transitions": [{"name": "approve", "next": "APPROVED", "manual": true,
+					"criterion": {"type": "function", "function": {"name": "credit-check"}}}]},
+				"APPROVED": {}
+			}
+		}]
+	}`
+	setupModelWithWorkflow(t, model, wf)
+	entityID := createEntityE2E(t, model, 1, `{"name":"X","amount":10}`)
+
+	// Manual transition rejected → 400 WORKFLOW_FAILED carrying the reason.
+	path := fmt.Sprintf("/api/entity/JSON/%s/approve", entityID)
+	resp := doAuth(t, http.MethodPut, path, `{"name":"X","amount":10}`)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, "credit score 540 below threshold 600") {
+		t.Errorf("400 body missing reason: %s", body)
+	}
+
+	// Audit carries it too.
+	reason, ok := smEventReason(t, entityID, "TRANSITION_NOT_MATCH_CRITERION")
+	if !ok {
+		t.Fatal("no TRANSITION_NOT_MATCH_CRITERION audit event")
+	}
+	if reason != "credit score 540 below threshold 600" {
+		t.Errorf("audit reason: got %q", reason)
+	}
+}
+
+func TestCriterionReason_AutomatedReject_Audit(t *testing.T) {
+	const model = "e2e-critreason-auto"
+	procSvc.RegisterCriteriaReason("min-amount",
+		func(ctx context.Context, e *spi.Entity, c json.RawMessage) (bool, string, error) {
+			return false, "amount 10 below minimum 100", nil
+		})
+	defer procSvc.Reset()
+
+	wf := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "auto-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {"transitions": [{"name": "auto-promote", "next": "PREMIUM", "manual": false,
+					"criterion": {"type": "function", "function": {"name": "min-amount"}}}]},
+				"PREMIUM": {}
+			}
+		}]
+	}`
+	setupModelWithWorkflow(t, model, wf)
+	entityID := createEntityE2E(t, model, 1, `{"name":"X","amount":10}`)
+
+	reason, ok := smEventReason(t, entityID, "TRANSITION_NOT_MATCH_CRITERION")
+	if !ok {
+		t.Fatal("no TRANSITION_NOT_MATCH_CRITERION audit event")
+	}
+	if reason != "amount 10 below minimum 100" {
+		t.Errorf("audit reason: got %q", reason)
+	}
+}
+
+func TestCriterionReason_InlineReject_DefaultReason(t *testing.T) {
+	const model = "e2e-critreason-inline"
+	wf := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "inline-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {"transitions": [{"name": "auto-promote", "next": "PREMIUM", "manual": false,
+					"criterion": {"type":"simple","jsonPath":"$.amount","operatorType":"GREATER_THAN","value":100}}]},
+				"PREMIUM": {}
+			}
+		}]
+	}`
+	setupModelWithWorkflow(t, model, wf)
+	entityID := createEntityE2E(t, model, 1, `{"name":"X","amount":10}`)
+
+	reason, ok := smEventReason(t, entityID, "TRANSITION_NOT_MATCH_CRITERION")
+	if !ok {
+		t.Fatal("no TRANSITION_NOT_MATCH_CRITERION audit event")
+	}
+	if reason != "criterion did not match" {
+		t.Errorf("expected default reason, got %q", reason)
+	}
+}
+```
+
+(If the inline `simple`/`GREATER_THAN` criterion shape differs from the engine's parser, mirror the exact shape used by an existing passing e2e workflow criterion; the assertion is the default reason.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/e2e/ -run TestCriterionReason -v 2>&1 | tail -30` (Docker required)
+Expected: initially FAIL if run before Tasks 3-4 land; after them, they exercise the full stack — run to confirm they PASS. (If executing strictly in order, they pass here.)
+
+- [ ] **Step 3: Run to verify pass**
+
+Run: `go test ./internal/e2e/ -run TestCriterionReason -v 2>&1 | tail -30`
+Expected: PASS (3 tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/e2e/criterion_reason_test.go
+git commit -m "test(e2e): criterion reason in 400 body and state-machine audit"
+```
+
+---
+
+### Task 6: Cross-backend parity scenario
+
+Backend-agnostic behaviour: an inline criterion that fails records `data.reason == "criterion did not match"` on the audit, identically across memory/sqlite/postgres (+ commercial). Inline is chosen so no compute node is required in the parity harness.
+
+**Files:**
+- Create: `e2e/parity/criterion_reason.go`
+- Modify: `e2e/parity/registry.go` (add entry to `allTests`)
+- Modify: `e2e/parity/registry_count_test.go` (`wantParityScenarioCount` +1)
+
+**Interfaces:**
+- Consumes: `BackendFixture`, its client `c` (`ImportWorkflow`, `CreateEntity`, `GetAuditEvents`), and `AuditEvent.AsStateMachine()` → typed SM event with `.EventType` and `.Data`.
+
+- [ ] **Step 1: Write the scenario (failing until registered/implemented)**
+
+Create `e2e/parity/criterion_reason.go`:
+
+```go
+package parity
+
+import "testing"
+
+// RunCriterionReasonInlineDefault verifies that an inline transition criterion
+// which evaluates false records the default stoppage reason on the
+// TRANSITION_NOT_MATCH_CRITERION state-machine audit event, identically across
+// all backends.
+func RunCriterionReasonInlineDefault(t *testing.T, fixture BackendFixture) {
+	c := fixture.Client()
+	modelName, modelVersion := fixture.UniqueModel("critreason"), 1
+
+	if err := c.ImportModelAndLock(t, modelName, modelVersion); err != nil {
+		t.Fatalf("ImportModelAndLock: %v", err)
+	}
+	wf := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "critreason-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {"transitions": [{"name": "auto-promote", "next": "PREMIUM", "manual": false,
+					"criterion": {"type":"simple","jsonPath":"$.amount","operatorType":"GREATER_THAN","value":100}}]},
+				"PREMIUM": {}
+			}
+		}]
+	}`
+	if err := c.ImportWorkflow(t, modelName, modelVersion, wf); err != nil {
+		t.Fatalf("ImportWorkflow: %v", err)
+	}
+	entityID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"X","amount":10}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	auditResp, err := c.GetAuditEvents(t, entityID)
+	if err != nil {
+		t.Fatalf("GetAuditEvents: %v", err)
+	}
+	var found bool
+	for i := range auditResp.Items {
+		ev := &auditResp.Items[i]
+		if ev.AuditEventType != "StateMachine" {
+			continue
+		}
+		sm, err := ev.AsStateMachine()
+		if err != nil || sm.EventType != "TRANSITION_NOT_MATCH_CRITERION" {
+			continue
+		}
+		found = true
+		reason, _ := sm.Data["reason"].(string)
+		if reason != "criterion did not match" {
+			t.Errorf("backend %s: reason = %q, want default", fixture.Name(), reason)
+		}
+	}
+	if !found {
+		t.Fatalf("backend %s: no TRANSITION_NOT_MATCH_CRITERION event", fixture.Name())
+	}
+}
+```
+
+(Adapt `fixture.Client()`, `UniqueModel`, `ImportModelAndLock`, `fixture.Name()`, and the `sm.Data` accessor to the exact `BackendFixture`/generated-client API in `e2e/parity/fixture.go` and the parity client. If `AsStateMachine().Data` is not exposed by the generated client, extend the parity client's SM-event accessor to surface the `data` map — mirror how `AsEntityChange().ChangeType` is exposed.)
+
+- [ ] **Step 2: Register it and bump the count**
+
+In `e2e/parity/registry.go` add to `allTests` (near the other workflow entries):
+
+```go
+	{"CriterionReasonInlineDefault", RunCriterionReasonInlineDefault},
+```
+
+In `e2e/parity/registry_count_test.go`, increment `wantParityScenarioCount` by 1.
+
+- [ ] **Step 3: Run to verify it passes on every backend**
+
+Run: `go test ./e2e/parity/... -run 'Parity.*CriterionReasonInlineDefault' -v 2>&1 | tail -40` (Docker required for postgres)
+Expected: PASS for memory, sqlite, postgres; `TestParityScenarioCount` green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/parity/criterion_reason.go e2e/parity/registry.go e2e/parity/registry_count_test.go
+git commit -m "test(parity): criterion default reason is backend-agnostic in audit"
+```
+
+---
+
+### Task 7: Documentation (Gate 4 & Gate 7)
+
+**Files:**
+- Modify: `api/openapi.yaml` (`StateMachineAuditEventDto.data` description, ~line 10893)
+- Modify: `docs/cyoda/openapi.yml` (mirror the same description)
+- Modify: `cmd/cyoda/help/content/grpc.md` (criteria-response section)
+- Create: `docs/cloud-parity/criterion-stoppage-reason.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update the OpenAPI `data` description**
+
+In `api/openapi.yaml`, extend the `StateMachineAuditEventDto.data` `description` to document the two new data-bearing events (keep it compact):
+
+```yaml
+              description: >
+                Optional event-specific payload. Present for some event types
+                (e.g. STATE_MACHINE_FINISH includes {"success": true},
+                STATE_PROCESS_RESULT includes {"success": false}).
+                TRANSITION_NOT_MATCH_CRITERION carries
+                {workflowName, transition, criterion, reason} and WORKFLOW_SKIP
+                carries {workflowName, reason}, where reason explains why the
+                criterion blocked the passage. Null for most event types.
+```
+
+Apply the identical change to `docs/cyoda/openapi.yml`. Run the OpenAPI conformance/lint check the repo uses (e.g. `go test ./internal/e2e/openapivalidator/... ./e2e/parity/... -run OpenAPI` or the project's `oasdiff` task) and confirm no unintended diff.
+
+- [ ] **Step 2: Update the gRPC help topic**
+
+In `cmd/cyoda/help/content/grpc.md`, in the criteria-response section, add a compact note that a compute node may return `reason` on a `matches:false` response, and that it surfaces on the state-machine audit (`TRANSITION_NOT_MATCH_CRITERION` / `WORKFLOW_SKIP` `data.reason`) and in the manual-transition 400 body. No issue IDs.
+
+- [ ] **Step 3: Write the cloud-parity note**
+
+Create `docs/cloud-parity/criterion-stoppage-reason.md` describing: cyoda-go leads; the criterion reason flows `EntityCriteriaCalculationResponse.reason` → audit `data.reason` on `TRANSITION_NOT_MATCH_CRITERION`/`WORKFLOW_SKIP` and the manual-transition 400 detail; the `data` field names (`workflowName`, `transition`, `criterion`, `reason`); the inline default; the 2 KiB cap; and that Cloud mirrors this shape. Mirror the structure of an existing file such as `docs/cloud-parity/processor-criteria-annotations.md`.
+
+- [ ] **Step 4: Update the CHANGELOG**
+
+Add an entry under the unreleased/v0.8.3 section:
+
+```markdown
+### Added
+- Workflow criteria can now explain *why* a passage was blocked: a criteria
+  compute node's `reason` is recorded on the `TRANSITION_NOT_MATCH_CRITERION`
+  and `WORKFLOW_SKIP` state-machine audit events (`data.reason`) and appended to
+  the manual-transition `400 WORKFLOW_FAILED` detail.
+```
+
+- [ ] **Step 5: Verify help/openapi self-report and commit**
+
+Run: `go test ./cmd/... ./internal/e2e/openapivalidator/... 2>&1 | tail -20`
+Expected: PASS (help-topic and OpenAPI parity guards green).
+
+```bash
+git add api/openapi.yaml docs/cyoda/openapi.yml cmd/cyoda/help/content/grpc.md docs/cloud-parity/criterion-stoppage-reason.md CHANGELOG.md
+git commit -m "docs: criterion stoppage reason (openapi data, help, cloud-parity, changelog)"
+```
+
+---
+
+### Task 8: Final verification (Gate 5)
+
+- [ ] **Step 1: Full root-module test (incl. e2e)**
+
+Run: `go test ./... 2>&1 | tail -30` (Docker required)
+Expected: all PASS.
+
+- [ ] **Step 2: Plugin submodules**
+
+Run: `make test-short-all 2>&1 | tail -20` (and `make test-all` if Docker is available for the postgres plugin)
+Expected: PASS across `plugins/memory|sqlite|postgres`. (No plugin implements `DispatchCriteria`, so these should be unaffected — this confirms it.)
+
+- [ ] **Step 3: Vet**
+
+Run: `go vet ./...`
+Expected: clean.
+
+- [ ] **Step 4: Race sanity (once, end-of-deliverable)**
+
+Run: `make race 2>&1 | tail -20`
+Expected: PASS (per `.claude/rules/race-testing.md`; e2e excluded by the target).
+
+- [ ] **Step 5: Confirm no issue IDs leaked into shipped artefacts**
+
+Run: `git diff 7bc8bf9..HEAD -- ':!docs' ':!CHANGELOG.md' | grep -nE '#[0-9]{2,}' || echo "clean"`
+Expected: `clean` (issue IDs only in commits/docs).
+
+---
+
+## Self-Review
+
+**Spec coverage** — every spec section maps to a task:
+- Audit surface (transition manual/auto, workflow-skip) → Task 4 (Steps 5-7), Task 5, Task 6.
+- Manual-transition 400 enrichment (suppress inline default) → Task 4 (Step 6), Task 5 (Test 1).
+- Plumbing (ingest, `ProcessingResponse.Reason`, `DispatchCriteria` widen, cross-node producer + local/peer branches, `evaluateCriterion`) → Tasks 1, 2, 3, 4.
+- D1 `(bool, string, error)` → Task 3. D3 default + always-present reason → Task 4 helpers/sites. Criterion-name derivation → Task 4 Step 3.
+- Reason length cap (once, in `evaluateCriterion`) → Task 4 Step 4.
+- Data-shape field names aligned to typed DTOs → Task 4 Steps 5-7; documented → Task 7 Step 1.
+- Coverage matrix: gRPC ingestion → Task 1/3; e2e (external manual+400, automated, inline default) → Task 5; parity (backend-agnostic inline default) → Task 6; multi-node peer + local-branch reason → Task 3 (handler test + dispatcher branches). Concurrency: none required (spec).
+- Gate 4 docs (OpenAPI both files, help, CHANGELOG) + Gate 7 cloud-parity → Task 7. No new error code → no `errors/<CODE>.md` task (correct).
+- Verification (Gate 5) incl. plugins + race → Task 8.
+
+**Placeholder scan** — no TBD/TODO; every code step shows real code. Two adaptation notes (parity client `sm.Data` accessor; inline-criterion JSON shape) are explicit "mirror the existing X" instructions with a named reference, not vague placeholders.
+
+**Type consistency** — `DispatchCriteria(...) (bool, string, error)` and `evaluateCriterion(...) (bool, string, error)` used consistently; `ProcessingResponse.Reason` (Task 1) and `DispatchCriteriaResponse.Reason` (Task 2) consumed in Task 3; `data` keys `workflowName`/`transition`/`criterion`/`reason` consistent across Task 4 sites, Task 5/6 assertions, and Task 7 docs; `defaultCriterionReason` / `maxCriterionReasonLen` defined once (Task 4) and referenced by name.

--- a/docs/superpowers/specs/2026-07-14-criterion-response-reason-audit-design.md
+++ b/docs/superpowers/specs/2026-07-14-criterion-response-reason-audit-design.md
@@ -55,7 +55,11 @@ the `data` argument.
 
 The OpenAPI already defines per-event typed shapes (Java-parity family, presently
 unwired from the actual flat audit response — that reconciliation is #369, out of
-scope here). We adopt their field names so a future reconciliation is trivial:
+scope here). We adopt their field **names** so a future reconciliation is
+field-name-aligned. Note this is only a naming alignment: the typed DTOs put these
+fields at the top level (`allOf StateMachineEventDto`), whereas the shipped audit
+response nests them under `data`; #369 still owns the shape move, which is not
+trivial.
 
 - `StateMachineTransitionCriterionNotMatchedDto` = `{workflowName, transition, criterion, reason}`
   (`api/openapi.yaml:11019`; `reason` optional there).
@@ -123,20 +127,27 @@ such type in the SPI). No coordinated SPI release, no schema-version bump.
 4. **grpc dispatcher** — `internal/grpc/dispatch.go DispatchCriteria`: return
    `resp.Reason` on the `matches=false` path (and generally alongside the bool).
 5. **Cluster cross-node** — `internal/cluster/dispatch/types.go`: add `Reason` to
-   `DispatchCriteriaResponse`. **Producer wiring (M2, multi-node-primary):**
+   `DispatchCriteriaResponse`. Both `ClusterDispatcher.DispatchCriteria` return
+   branches must carry the reason: the **local** branch
+   (`cluster_dispatcher.go:137`, same-node evaluation) and the **peer-forward**
+   branch (`:171`). **Producer wiring (M2, multi-node-primary):**
    `internal/cluster/dispatch/handler.go handleCriteria` (~`:96-109`) must copy
-   the local `DispatchCriteria` reason into the outbound response; the routing
-   node `cluster_dispatcher.go:171` returns it. Without this, peer-evaluated
-   criteria silently lose the reason in cluster mode.
+   the local `DispatchCriteria` reason into the outbound `DispatchCriteriaResponse`;
+   without this, peer-evaluated criteria silently lose the reason in cluster mode.
 6. **Engine** — `evaluateCriterion` (`engine.go:623`): `(bool, error)` →
    `(bool, string, error)`; propagate the reason (external reason for FUNCTION,
-   `""` for inline). Populate `data` at the three no-match sites, applying the D3
-   default and the length cap.
+   `""` for inline). This is the single chokepoint where local, peer, audit, and
+   400-body all converge, so **apply the length cap here, once**, on the returned
+   reason. Populate `data` at the three no-match sites, applying the D3 default.
 7. **Manual-transition 400** — the manual path returns
    `fmt.Errorf("transition %q criterion not matched", name)` (`engine.go:486`),
    reflected verbatim into the 400 body via `classifyWorkflowError`
-   (`service.go:1950`, `ErrCodeWorkflowFailed`). Append the reason:
-   `"transition %q criterion not matched: %s"`. No new error code.
+   (`service.go:1950`, `ErrCodeWorkflowFailed`; verified: no sentinel-wrap hides
+   it). Append the reason only when it is a **real (external) reason** —
+   `"transition %q criterion not matched: %s"`; **suppress the append when the
+   reason is the inline D3 default** (`"criterion did not match"`) to avoid the
+   redundant `"...not matched: criterion did not match"`. The audit event still
+   carries the default for inline (see D3). No new error code.
 
 ### Test doubles to update (compilation-enforced, listed to prevent silent revert)
 
@@ -147,7 +158,11 @@ such type in the SPI). No coordinated SPI release, no schema-version bump.
 `internal/domain/workflow/engine_test.go:871` and `:1600`. Plus the real
 implementors: `internal/skeleton/processing.go`,
 `internal/observability/dispatch_tracing.go`,
-`internal/testing/localproc/localproc.go`.
+`internal/testing/localproc/localproc.go`. Individual *call-site* test files that
+invoke `DispatchCriteria` (e.g. `internal/grpc/dispatch_test.go`,
+`internal/cluster/dispatch/*_test.go`, `internal/testing/localproc/localproc_test.go`)
+also need the extra return value — compilation-enforced, so this list need not be
+exhaustive; `go build ./... && go vet ./...` surfaces the rest.
 
 ## Contract & documentation (Gate 4, Gate 7)
 
@@ -157,6 +172,8 @@ implementors: `internal/skeleton/processing.go`,
   carries `{workflowName, reason}`. Also update the mirror
   `docs/cyoda/openapi.yml`. The manual-transition endpoint's 400 description
   already covers `WORKFLOW_FAILED`; note the reason is now appended to the detail.
+  (The typed `StateMachine*Dto` family documents these same fields at top level;
+  the two descriptions coexist until #369 reconciles the representations.)
 - **Cloud-parity (Gate 7):** add `docs/cloud-parity/criterion-stoppage-reason.md`
   — cyoda-go leads; the audit `data.reason` shape and the 400-body enrichment are
   the contract Cloud mirrors.
@@ -190,6 +207,7 @@ No new error code → no new `errors/<CODE>.md` topic.
 | Inline predicate rejects → default `"criterion did not match"` in `data.reason` | ✅ | ✅ | ✅ (register in `e2e/parity/registry.go`) | | |
 | Audit `data.reason` is backend-agnostic (memory/sqlite/postgres) | | | ✅ | | |
 | Peer-evaluated FUNCTION criterion returns reason to routing node via `DispatchCriteriaResponse` | | | | | ✅ `internal/cluster/dispatch` |
+| Cluster **local-branch** (`cluster_dispatcher.go:137`) returns the reason (same-node eval in cluster mode) | | | | | ✅ `internal/cluster/dispatch` |
 | Overlong reason truncated to cap before persist / 400 | ✅ | | | | |
 | Criterion-name derivation (FUNCTION name vs inline type) | ✅ | | | | |
 

--- a/docs/superpowers/specs/2026-07-14-criterion-response-reason-audit-design.md
+++ b/docs/superpowers/specs/2026-07-14-criterion-response-reason-audit-design.md
@@ -26,15 +26,40 @@ entity state-machine audit trail**, so clients can analyse a workflow and learn
 why a passage was blocked. Additionally, surface it synchronously in the
 manual-transition rejection response.
 
-No new endpoint. Two client surfaces:
+No new endpoint. Two client surfaces, each primary for a different rejection kind:
 
-1. **State-machine audit (durable record).** When a criterion returns
-   `matches=false`, the existing state-machine audit event gains a `data`
-   payload carrying the reason. Read via
-   `GET /audit/entity/{entityId}?eventTypes=StateMachine`.
-2. **Manual-transition 400 body (synchronous).** A manual transition rejected by
-   its criterion returns `400 WORKFLOW_FAILED` whose detail now includes the
-   reason, so interactive callers learn why without a second audit fetch.
+1. **State-machine audit (durable record) — for events whose transaction commits.**
+   When a criterion returns `matches=false`, the existing state-machine audit
+   event gains a `data` payload carrying the reason. Read via
+   `GET /audit/entity/{entityId}?eventTypes=StateMachine`. This is durable for
+   the **automated cascade** and **workflow-selection** paths, because those
+   commit their transaction (the entity settles at a stable state).
+2. **Manual-transition 400 body (synchronous) — the primary surface for a manual
+   rejection.** A manual transition rejected by its criterion returns
+   `400 WORKFLOW_FAILED` whose detail includes the reason. This is the
+   guaranteed delivery for manual rejections and does not depend on the
+   transaction or the audit store.
+
+### Transactional-audit invariant (design decision)
+
+State-machine audit events are recorded through a **transaction-bound** store
+(`factory.StateMachineAuditStore(ctx)`), so on a TX-bound backend (Postgres)
+they share the entity transaction's fate. A manual transition the engine
+**rejects** rolls the transaction back — so its `TRANSITION_NOT_MATCH_CRITERION`
+event is discarded on Postgres. **This is deliberate and left unchanged.** The
+established invariant (documented at the `TRANSITION_ABORTED`/`#228` sites,
+`entity/service.go:1505`) is: *the engine never commits — nor writes out of
+band — a transaction to preserve an audit event*; a rolled-back operation has
+empty audit, which is consistent. We do **not** flip the rollback to a commit,
+and we do **not** add a detached audit write, to satisfy the audit goal —
+transactional semantics must not bend to an audit-log requirement.
+
+Consequently the criterion reason for a **manual** rejection is delivered by
+surface (2), the direct 400 response — guaranteed on all backends and
+independent of the audit store. The manual `TRANSITION_NOT_MATCH_CRITERION`
+event is still populated with `data` (surface 1) for backends where audit is
+not TX-bound (e.g. memory), matching the `#228` pattern, but its durability is
+**not** asserted on TX-bound backends.
 
 ## Scope — two implemented contact points
 
@@ -166,12 +191,17 @@ exhaustive; `go build ./... && go vet ./...` surfaces the rest.
 
 ## Contract & documentation (Gate 4, Gate 7)
 
+- **OpenAPI — manual-transition 400 reason (REQUIRED, primary manual surface):**
+  the manual-transition endpoint's `400 WORKFLOW_FAILED` description must state
+  that when the rejection is a criterion no-match the `detail` carries the
+  criterion reason (`"transition \"X\" criterion not matched: <reason>"`). This
+  is the documented, guaranteed delivery of the reason for a manual explicit
+  transition. Apply to `api/openapi.yaml` and the mirror `docs/cyoda/openapi.yml`.
 - **OpenAPI (m3):** update `StateMachineAuditEventDto.data` description
   (`api/openapi.yaml:10893`) to document that `TRANSITION_NOT_MATCH_CRITERION`
   carries `{workflowName, transition, criterion, reason}` and `WORKFLOW_SKIP`
-  carries `{workflowName, reason}`. Also update the mirror
-  `docs/cyoda/openapi.yml`. The manual-transition endpoint's 400 description
-  already covers `WORKFLOW_FAILED`; note the reason is now appended to the detail.
+  carries `{workflowName, reason}` (durable for the automated + workflow-skip
+  paths). Also update the mirror `docs/cyoda/openapi.yml`.
   (The typed `StateMachine*Dto` family documents these same fields at top level;
   the two descriptions coexist until #369 reconciles the representations.)
 - **Cloud-parity (Gate 7):** add `docs/cloud-parity/criterion-stoppage-reason.md`
@@ -201,7 +231,7 @@ No new error code → no new `errors/<CODE>.md` topic.
 | Scenario | unit | running-backend e2e | cross-backend parity | gRPC | multi-node (isolated) |
 |---|---|---|---|---|---|
 | gRPC criteria response `reason` → `ProcessingResponse.Reason` | | | | ✅ `internal/grpc` | |
-| External FUNCTION criterion rejects **manual** transition → 400 body carries reason **and** audit `data.reason` | | ✅ | | | |
+| External FUNCTION criterion rejects **manual** transition → 400 body carries reason (audit durability NOT asserted — tx rolls back, see invariant above) | | ✅ | | | |
 | External FUNCTION criterion rejects **automated cascade** transition → audit `data.reason` (no error) | | ✅ | | | |
 | Workflow-selection FUNCTION criterion rejects → `WORKFLOW_SKIP` audit `data.reason` | | ✅ | | | |
 | Inline predicate rejects → default `"criterion did not match"` in `data.reason` | ✅ | ✅ | ✅ (register in `e2e/parity/registry.go`) | | |

--- a/docs/superpowers/specs/2026-07-14-criterion-response-reason-audit-design.md
+++ b/docs/superpowers/specs/2026-07-14-criterion-response-reason-audit-design.md
@@ -1,0 +1,209 @@
+# Criterion stoppage reason in the entity state-machine audit
+
+Issue: #413 (milestone v0.8.3). Follow-on: #414 (processor-criterion guarding, unmilestoned).
+
+## Problem
+
+`EntityCriteriaCalculationResponse.reason` — the field a gRPC criteria compute
+node returns to explain *why* a criterion returned `matches=false` — is dead
+data. It is declared on the CloudEvent payload schema
+(`docs/cyoda/schema/processing/EntityCriteriaCalculationResponse.json`) and the
+generated DTO (`api/grpc/events/types.go`, `Reason *string`), but:
+
+- The server never deserializes it — `handleCriteriaResponse`
+  (`internal/grpc/streaming.go`) unmarshals into a struct with no `reason` field.
+- `ProcessingResponse` (`internal/grpc/members.go`) has no `Reason`.
+- `DispatchCriteria` (`internal/contract/processing.go`) returns `(bool, error)`;
+  the criteria result collapses to a bare bool before it reaches the engine.
+
+Consequence: a client analysing a workflow can see *that* a passage was blocked
+(a criterion returned false) but not *why*.
+
+## Goal
+
+Make the criterion stoppage reason a live, client-observable value **on the
+entity state-machine audit trail**, so clients can analyse a workflow and learn
+why a passage was blocked. Additionally, surface it synchronously in the
+manual-transition rejection response.
+
+No new endpoint. Two client surfaces:
+
+1. **State-machine audit (durable record).** When a criterion returns
+   `matches=false`, the existing state-machine audit event gains a `data`
+   payload carrying the reason. Read via
+   `GET /audit/entity/{entityId}?eventTypes=StateMachine`.
+2. **Manual-transition 400 body (synchronous).** A manual transition rejected by
+   its criterion returns `400 WORKFLOW_FAILED` whose detail now includes the
+   reason, so interactive callers learn why without a second audit fetch.
+
+## Scope — two implemented contact points
+
+Both ride the shared `evaluateCriterion` chokepoint (`engine.go:623`), which has
+exactly three callers (verified): `selectWorkflow` (`:386`), the manual
+transition path (`:476`), and the automated cascade (`:553`).
+
+| Contact point | No-match event | `data` payload (in the audit event) |
+|---|---|---|
+| Transition criterion — manual (`engine.go:483`) | `TRANSITION_NOT_MATCH_CRITERION` | `{workflowName, transition, criterion, reason}` |
+| Transition criterion — automated cascade (`engine.go:560`) | `TRANSITION_NOT_MATCH_CRITERION` | `{workflowName, transition, criterion, reason}` |
+| Workflow-selection criterion (`engine.go:399`) | `WORKFLOW_SKIP` | `{workflowName, reason}` |
+
+All three sites currently call `recordEvent(..., nil)` — this change populates
+the `data` argument.
+
+### Data shapes — align to the existing typed DTOs
+
+The OpenAPI already defines per-event typed shapes (Java-parity family, presently
+unwired from the actual flat audit response — that reconciliation is #369, out of
+scope here). We adopt their field names so a future reconciliation is trivial:
+
+- `StateMachineTransitionCriterionNotMatchedDto` = `{workflowName, transition, criterion, reason}`
+  (`api/openapi.yaml:11019`; `reason` optional there).
+- `StateMachineWorkflowSkippedDto` = `{workflowName, reason}`
+  (`api/openapi.yaml:11084`; `reason` required there).
+
+We do **not** use `RejectedTransitionCriterionDto` — that schema belongs to
+`WorkflowStopReasonDto.rejectedTransitions`, a different feature, and its required
+`transitionName` is wrong for `WORKFLOW_SKIP`.
+
+The actual audit response emits a flat event map with a nested `data` bag
+(`internal/domain/audit/handler.go:110-119`, `:259`), so the fields above go
+**inside** `data`. `StateMachineEvent.Data` (`spi.types.go`,
+`map[string]any`) → HTTP DTO `data` is already wired end-to-end, and round-trips
+identically across memory (deep-copy), sqlite, and postgres
+(`json.Marshal` of the whole event) — no audit-layer or backend change needed.
+
+### Reason population rule (D3)
+
+`data.reason` is **always present** for a clean `matches=false`:
+
+- **FUNCTION (external) criterion:** the reason returned by the compute node.
+- **Inline predicate (simple/group/lifecycle/array):** no external source →
+  default `"criterion did not match"`.
+
+Always-present `reason` satisfies `StateMachineWorkflowSkippedDto`'s required
+`reason` and gives one consistent rule across both event types.
+
+### Criterion name (`data.criterion`)
+
+- **FUNCTION criterion:** the function name, parsed from the raw criterion JSON
+  `{"function":{"name":"..."}}` (same parse as `internal/grpc/dispatch.go:200`).
+- **Inline predicate:** the condition type string (`cond.Type()` —
+  `"simple"`/`"group"`/`"lifecycle"`/`"array"`).
+
+A small engine helper `criterionName(criterion []byte) string` derives this.
+`WORKFLOW_SKIP` omits `criterion` (its DTO has no criterion field).
+
+### Reason semantics (edge cases — verified)
+
+- `matches=true` with a reason present: no no-match event is recorded, so the
+  reason is naturally dropped. No code needed.
+- Criterion **errored** (`err != nil`): short-circuits before any
+  `TRANSITION_NOT_MATCH_CRITERION`/`WORKFLOW_SKIP` event. So `reason` strictly
+  means "clean `matches=false`" — correct semantics.
+- **Audit volume:** these no-match events already fire today (with `nil` data);
+  this change only enriches them. Zero new audit volume. Cascade re-visits are
+  already bounded by `maxStateVisits`.
+- **Reason length (security):** the reason is compute-node-influenceable and the
+  audit is durable storage. Truncate the reason to a bounded length
+  (`maxCriterionReasonLen`, proposed 2 KiB) before it is stored or reflected into
+  the 400 body. Never logged at any level beyond existing diagnostics.
+
+## Plumbing — all internal, no `cyoda-go-spi` change
+
+`ExternalProcessingService` is `internal/contract/processing.go:12` (verified: no
+such type in the SPI). No coordinated SPI release, no schema-version bump.
+
+1. **gRPC ingestion** — `internal/grpc/streaming.go handleCriteriaResponse`: add
+   `Reason string` to the deserialized struct (currently dropped).
+2. **`ProcessingResponse`** — `internal/grpc/members.go`: add `Reason string`.
+3. **Interface** — `contract.ExternalProcessingService.DispatchCriteria`:
+   `(bool, error)` → `(bool, string, error)` [D1]. The reason string is empty
+   when unavailable.
+4. **grpc dispatcher** — `internal/grpc/dispatch.go DispatchCriteria`: return
+   `resp.Reason` on the `matches=false` path (and generally alongside the bool).
+5. **Cluster cross-node** — `internal/cluster/dispatch/types.go`: add `Reason` to
+   `DispatchCriteriaResponse`. **Producer wiring (M2, multi-node-primary):**
+   `internal/cluster/dispatch/handler.go handleCriteria` (~`:96-109`) must copy
+   the local `DispatchCriteria` reason into the outbound response; the routing
+   node `cluster_dispatcher.go:171` returns it. Without this, peer-evaluated
+   criteria silently lose the reason in cluster mode.
+6. **Engine** — `evaluateCriterion` (`engine.go:623`): `(bool, error)` →
+   `(bool, string, error)`; propagate the reason (external reason for FUNCTION,
+   `""` for inline). Populate `data` at the three no-match sites, applying the D3
+   default and the length cap.
+7. **Manual-transition 400** — the manual path returns
+   `fmt.Errorf("transition %q criterion not matched", name)` (`engine.go:486`),
+   reflected verbatim into the 400 body via `classifyWorkflowError`
+   (`service.go:1950`, `ErrCodeWorkflowFailed`). Append the reason:
+   `"transition %q criterion not matched: %s"`. No new error code.
+
+### Test doubles to update (compilation-enforced, listed to prevent silent revert)
+
+`internal/cluster/dispatch/cluster_dispatcher_test.go:39`,
+`internal/cluster/dispatch/handler_test.go:40`,
+`internal/cluster/dispatch/integration_txtoken_test.go:41`,
+`internal/observability/dispatch_tracing_test.go:32`,
+`internal/domain/workflow/engine_test.go:871` and `:1600`. Plus the real
+implementors: `internal/skeleton/processing.go`,
+`internal/observability/dispatch_tracing.go`,
+`internal/testing/localproc/localproc.go`.
+
+## Contract & documentation (Gate 4, Gate 7)
+
+- **OpenAPI (m3):** update `StateMachineAuditEventDto.data` description
+  (`api/openapi.yaml:10893`) to document that `TRANSITION_NOT_MATCH_CRITERION`
+  carries `{workflowName, transition, criterion, reason}` and `WORKFLOW_SKIP`
+  carries `{workflowName, reason}`. Also update the mirror
+  `docs/cyoda/openapi.yml`. The manual-transition endpoint's 400 description
+  already covers `WORKFLOW_FAILED`; note the reason is now appended to the detail.
+- **Cloud-parity (Gate 7):** add `docs/cloud-parity/criterion-stoppage-reason.md`
+  — cyoda-go leads; the audit `data.reason` shape and the 400-body enrichment are
+  the contract Cloud mirrors.
+- **Help topic:** `cmd/cyoda/help/content/grpc.md` criteria-response section —
+  document that a compute node may return `reason` and where it surfaces
+  (audit + manual-transition 400). Keep compact.
+- **CHANGELOG.** No env-var, README, or COMPATIBILITY change (internal-only, no
+  SPI pin bump).
+
+## Error / status-code table
+
+| Endpoint | Status / code | Scenario | Change |
+|---|---|---|---|
+| `POST /entity/{format}/{entityId}/{transition}` | `400 WORKFLOW_FAILED` | manual transition criterion returns `matches=false` | detail now appends `: <reason>` |
+| `POST /entity/{format}/{entityId}/{transition}` | `400 BAD_REQUEST` | invalid payload/param | unchanged |
+| `POST /entity/{format}/{entityId}/{transition}` | `400 TRANSITION_NOT_FOUND` | named transition absent | unchanged |
+| `POST /entity/{format}/{entityId}/{transition}` | `2xx` | criterion matches | unchanged |
+| `GET /audit/entity/{entityId}` | `200` | SM events for entity | `TRANSITION_NOT_MATCH_CRITERION` / `WORKFLOW_SKIP` items now carry `data.reason` |
+| gRPC criteria response (compute-node → engine) | envelope | `reason` returned on `matches=false` | now reaches `ProcessingResponse.Reason` |
+
+No new error code → no new `errors/<CODE>.md` topic.
+
+## Coverage matrix (scenario × layer)
+
+| Scenario | unit | running-backend e2e | cross-backend parity | gRPC | multi-node (isolated) |
+|---|---|---|---|---|---|
+| gRPC criteria response `reason` → `ProcessingResponse.Reason` | | | | ✅ `internal/grpc` | |
+| External FUNCTION criterion rejects **manual** transition → 400 body carries reason **and** audit `data.reason` | | ✅ | | | |
+| External FUNCTION criterion rejects **automated cascade** transition → audit `data.reason` (no error) | | ✅ | | | |
+| Workflow-selection FUNCTION criterion rejects → `WORKFLOW_SKIP` audit `data.reason` | | ✅ | | | |
+| Inline predicate rejects → default `"criterion did not match"` in `data.reason` | ✅ | ✅ | ✅ (register in `e2e/parity/registry.go`) | | |
+| Audit `data.reason` is backend-agnostic (memory/sqlite/postgres) | | | ✅ | | |
+| Peer-evaluated FUNCTION criterion returns reason to routing node via `DispatchCriteriaResponse` | | | | | ✅ `internal/cluster/dispatch` |
+| Overlong reason truncated to cap before persist / 400 | ✅ | | | | |
+| Criterion-name derivation (FUNCTION name vs inline type) | ✅ | | | | |
+
+Concurrency: none required (no new shared-state contention). Multi-node reason
+propagation is an isolated single-backend cluster test, not in the parity suite.
+
+## Out of scope → #414
+
+Processor-selection criteria (`PROCESS_NOT_MATCH_CRITERION`,
+`StateMachineProcessCriterionNotMatchedDto` which already carries a `reason`
+field) require first building "guard a processor by a criterion" — an SPI
+`ProcessorConfig.Criterion` field (coordinated release + schema-version bump) plus
+guard semantics. Tracked in #414; the shared `evaluateCriterion` reason-plumbing
+from this change makes it a trivial drop-in.
+
+Full OpenAPI reconciliation of the typed `StateMachine*Dto` family vs the flat
+`StateMachineAuditEventDto`+`data` representation is #369, not this change.

--- a/e2e/parity/criterion_reason.go
+++ b/e2e/parity/criterion_reason.go
@@ -1,0 +1,76 @@
+package parity
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cyoda-platform/cyoda-go/e2e/parity/client"
+)
+
+// RunCriterionReasonInlineDefault verifies that an inline (non-FUNCTION)
+// transition criterion which evaluates false records the default stoppage
+// reason ("criterion did not match") on the TRANSITION_NOT_MATCH_CRITERION
+// state-machine audit event, identically across all backends.
+//
+// The transition is AUTOMATED (not manual): automated cascade commits its
+// transaction, so the audit event is durable. A manual-transition rejection
+// rolls back and its audit is intentionally not durable (see
+// TxBoundAuditFixture) — that shape is out of scope here. The criterion is
+// inline ("simple") rather than a FUNCTION criterion so this scenario needs
+// no compute node, and uses fixture.NewTenant rather than ComputeTenant.
+func RunCriterionReasonInlineDefault(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "critreason-inline-default"
+	const modelVersion = 1
+
+	wf := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "critreason-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {"transitions": [{"name": "auto-promote", "next": "PREMIUM", "manual": false,
+					"criterion": {"type":"simple","jsonPath":"$.amount","operatorType":"GREATER_THAN","value":100}}]},
+				"PREMIUM": {}
+			}
+		}]
+	}`
+	setupModelWithWorkflow(t, c, modelName, modelVersion, wf)
+
+	entityID, err := c.CreateEntity(t, modelName, modelVersion, `{"name":"X","amount":10}`)
+	if err != nil {
+		t.Fatalf("CreateEntity: %v", err)
+	}
+
+	auditResp, err := c.GetAuditEvents(t, entityID)
+	if err != nil {
+		t.Fatalf("GetAuditEvents: %v", err)
+	}
+
+	var found bool
+	for i := range auditResp.Items {
+		ev := &auditResp.Items[i]
+		if ev.AuditEventType != "StateMachine" {
+			continue
+		}
+		sm, err := ev.AsStateMachine()
+		if err != nil || sm.EventType != "TRANSITION_NOT_MATCH_CRITERION" {
+			continue
+		}
+		found = true
+
+		var data map[string]interface{}
+		if err := json.Unmarshal(sm.Data, &data); err != nil {
+			t.Fatalf("unmarshal StateMachine audit event data: %v", err)
+		}
+		reason, _ := data["reason"].(string)
+		if reason != "criterion did not match" {
+			t.Errorf("reason = %q, want %q", reason, "criterion did not match")
+		}
+	}
+	if !found {
+		t.Fatal("no TRANSITION_NOT_MATCH_CRITERION audit event found")
+	}
+}

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 197 (guarded by TestParityScenarioCount — bump
+// Total parity scenarios: 198 (guarded by TestParityScenarioCount — bump
 // wantParityScenarioCount in registry_count_test.go when adding/removing an
 // entry, or the test fails).
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
@@ -342,6 +342,10 @@ var allTests = []NamedTest{
 	// an unknown model before doing any query work. (The GET stats endpoint runs
 	// the model-existence check first; grouped-stats validates groupBy beforehand.)
 	{"UnknownModel404", RunUnknownModel404},
+
+	// Criterion rejection reason — inline (non-FUNCTION) criterion default
+	// audit reason is backend-agnostic (durable via the AUTOMATED cascade path).
+	{"CriterionReasonInlineDefault", RunCriterionReasonInlineDefault},
 }
 
 // Register appends additional NamedTests to the canonical list at init time.

--- a/e2e/parity/registry_count_test.go
+++ b/e2e/parity/registry_count_test.go
@@ -6,7 +6,7 @@ import "testing"
 // the registry.go header comment drifted silently for many PRs because nothing
 // asserted it; this test converts that drift into a failure. Bump this constant
 // (and the header comment) in the same change that adds or removes a scenario.
-const wantParityScenarioCount = 197
+const wantParityScenarioCount = 198
 
 // TestParityScenarioCount guards the documented scenario count against silent
 // drift.

--- a/internal/cluster/dispatch/cluster_dispatcher.go
+++ b/internal/cluster/dispatch/cluster_dispatcher.go
@@ -118,7 +118,7 @@ func (d *ClusterDispatcher) DispatchProcessor(ctx context.Context, entity *spi.E
 
 // DispatchCriteria tries the local node first. If the local node has no matching
 // calculation member, it looks up peers via gossip and forwards the request.
-func (d *ClusterDispatcher) DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (bool, error) {
+func (d *ClusterDispatcher) DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (bool, string, error) {
 	// Mint the owner token once before the local-vs-forward split so that
 	// a callback landing on a peer node routes back to this (owner) node.
 	tok := ""
@@ -132,12 +132,12 @@ func (d *ClusterDispatcher) DispatchCriteria(ctx context.Context, entity *spi.En
 	ctx = internalgrpc.WithTxToken(ctx, tok)
 
 	// Try local first.
-	matches, err := d.local.DispatchCriteria(ctx, entity, criterion, target, workflowName, transitionName, processorName, txID)
+	matches, reason, err := d.local.DispatchCriteria(ctx, entity, criterion, target, workflowName, transitionName, processorName, txID)
 	if err == nil {
-		return matches, nil
+		return matches, reason, nil
 	}
 	if !isNoMatchingMember(err) {
-		return false, err
+		return false, "", err
 	}
 
 	tags := extractCriteriaTags(criterion)
@@ -151,7 +151,7 @@ func (d *ClusterDispatcher) DispatchCriteria(ctx context.Context, entity *spi.En
 
 	peer, err := d.findPeerWithPolling(ctx, tenantID, tags)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	slog.Debug("forwarding criteria to peer",
@@ -159,16 +159,16 @@ func (d *ClusterDispatcher) DispatchCriteria(ctx context.Context, entity *spi.En
 
 	resp, err := d.forwarder.ForwardCriteria(ctx, peer.Addr, req)
 	if err != nil {
-		return false, fmt.Errorf("%s: forward to %s: %w", common.ErrCodeDispatchForwardFailed, peer.NodeID, err)
+		return false, "", fmt.Errorf("%s: forward to %s: %w", common.ErrCodeDispatchForwardFailed, peer.NodeID, err)
 	}
 	if !resp.Success {
-		return false, fmt.Errorf("peer %s criteria dispatch failed: %s", peer.NodeID, resp.Error)
+		return false, "", fmt.Errorf("peer %s criteria dispatch failed: %s", peer.NodeID, resp.Error)
 	}
 	for _, w := range resp.Warnings {
 		common.AddWarning(ctx, w)
 	}
 
-	return resp.Matches, nil
+	return resp.Matches, resp.Reason, nil
 }
 
 // findPeerWithPolling polls the gossip registry for a peer with matching tags,

--- a/internal/cluster/dispatch/cluster_dispatcher_test.go
+++ b/internal/cluster/dispatch/cluster_dispatcher_test.go
@@ -36,14 +36,14 @@ func (f *stubDispatcher) DispatchProcessor(_ context.Context, _ *spi.Entity, _ s
 	return f.processorResp, nil
 }
 
-func (f *stubDispatcher) DispatchCriteria(_ context.Context, _ *spi.Entity, _ json.RawMessage, _ string, _ string, _ string, _ string, _ string) (bool, error) {
+func (f *stubDispatcher) DispatchCriteria(_ context.Context, _ *spi.Entity, _ json.RawMessage, _ string, _ string, _ string, _ string, _ string) (bool, string, error) {
 	if f.otherErr != nil {
-		return false, f.otherErr
+		return false, "", f.otherErr
 	}
 	if f.noMember {
-		return false, fmt.Errorf("%w: tags %q", internalgrpc.ErrNoMatchingMember, "python")
+		return false, "", fmt.Errorf("%w: tags %q", internalgrpc.ErrNoMatchingMember, "python")
 	}
-	return f.criteriaResult, nil
+	return f.criteriaResult, "", nil
 }
 
 // stubNodeRegistry returns a fixed list of nodes.
@@ -132,7 +132,7 @@ func TestClusterDispatcher_LocalFirst(t *testing.T) {
 
 	t.Run("criteria_local_success", func(t *testing.T) {
 		ctx := testContext()
-		matches, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx1")
+		matches, _, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx1")
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -221,7 +221,7 @@ func TestClusterDispatcher_ForwardsToPeer(t *testing.T) {
 		d := NewClusterDispatcher(local, registry, "self-node", selector, forwarder, 1*time.Second, nil, 0)
 
 		ctx := testContext()
-		matches, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx1")
+		matches, _, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx1")
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -266,7 +266,7 @@ func TestClusterDispatcher_NoMemberAnywhere(t *testing.T) {
 
 	t.Run("criteria_no_member_anywhere", func(t *testing.T) {
 		ctx := testContext()
-		_, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx1")
+		_, _, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx1")
 		if err == nil {
 			t.Fatal("expected error")
 		}

--- a/internal/cluster/dispatch/cluster_dispatcher_test.go
+++ b/internal/cluster/dispatch/cluster_dispatcher_test.go
@@ -24,6 +24,7 @@ type stubDispatcher struct {
 	otherErr       error
 	processorResp  *spi.Entity
 	criteriaResult bool
+	criteriaReason string
 }
 
 func (f *stubDispatcher) DispatchProcessor(_ context.Context, _ *spi.Entity, _ spi.ProcessorDefinition, _ string, _ string, _ string) (*spi.Entity, error) {
@@ -43,7 +44,7 @@ func (f *stubDispatcher) DispatchCriteria(_ context.Context, _ *spi.Entity, _ js
 	if f.noMember {
 		return false, "", fmt.Errorf("%w: tags %q", internalgrpc.ErrNoMatchingMember, "python")
 	}
-	return f.criteriaResult, "", nil
+	return f.criteriaResult, f.criteriaReason, nil
 }
 
 // stubNodeRegistry returns a fixed list of nodes.
@@ -201,6 +202,7 @@ func TestClusterDispatcher_ForwardsToPeer(t *testing.T) {
 	t.Run("criteria_forwarded_to_peer", func(t *testing.T) {
 		peerLocal := &stubDispatcher{
 			criteriaResult: true,
+			criteriaReason: "peer-evaluated reason",
 		}
 		handler := NewDispatchHandler(peerLocal, auth)
 		mux := http.NewServeMux()
@@ -221,12 +223,17 @@ func TestClusterDispatcher_ForwardsToPeer(t *testing.T) {
 		d := NewClusterDispatcher(local, registry, "self-node", selector, forwarder, 1*time.Second, nil, 0)
 
 		ctx := testContext()
-		matches, _, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx1")
+		matches, reason, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx1")
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 		if !matches {
 			t.Fatal("expected matches=true from peer")
+		}
+		// The peer-evaluated reason must survive the full forward round-trip
+		// (producer -> DispatchCriteriaResponse.Reason -> peer-branch return).
+		if reason != "peer-evaluated reason" {
+			t.Fatalf("expected peer reason propagated, got %q", reason)
 		}
 	})
 }

--- a/internal/cluster/dispatch/handler.go
+++ b/internal/cluster/dispatch/handler.go
@@ -93,7 +93,7 @@ func (h *DispatchHandler) handleCriteria(w http.ResponseWriter, r *http.Request)
 		Data: []byte(req.Entity),
 	}
 
-	matches, err := h.local.DispatchCriteria(ctx, entity, req.Criterion, req.Target, req.WorkflowName, req.TransitionName, req.ProcessorName, req.TxID)
+	matches, reason, err := h.local.DispatchCriteria(ctx, entity, req.Criterion, req.Target, req.WorkflowName, req.TransitionName, req.ProcessorName, req.TxID)
 	if err != nil {
 		slog.Error("dispatch criteria failed", "pkg", "dispatch", "err", err)
 		writeJSON(w, http.StatusOK, DispatchCriteriaResponse{
@@ -106,6 +106,7 @@ func (h *DispatchHandler) handleCriteria(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, DispatchCriteriaResponse{
 		Success: true,
 		Matches: matches,
+		Reason:  reason,
 	})
 }
 

--- a/internal/cluster/dispatch/handler_test.go
+++ b/internal/cluster/dispatch/handler_test.go
@@ -23,6 +23,7 @@ type fakeLocalDispatcher struct {
 	processorResult *spi.Entity
 	processorErr    error
 	criteriaResult  bool
+	criteriaReason  string
 	criteriaErr     error
 	capturedCtx     context.Context
 }
@@ -42,9 +43,9 @@ func (f *fakeLocalDispatcher) DispatchCriteria(
 	_ *spi.Entity,
 	_ json.RawMessage,
 	_, _, _, _, _ string,
-) (bool, error) {
+) (bool, string, error) {
 	f.capturedCtx = ctx
-	return f.criteriaResult, f.criteriaErr
+	return f.criteriaResult, f.criteriaReason, f.criteriaErr
 }
 
 var testSecret32 = bytes.Repeat([]byte{0xAB}, 32)
@@ -317,6 +318,46 @@ func TestHandler_ProcessorError_SanitizedResponse(t *testing.T) {
 	}
 	if strings.Contains(resp.Error, "connection refused") {
 		t.Errorf("error response must not contain internal details, got %q", resp.Error)
+	}
+}
+
+func TestHandleCriteria_PropagatesReason(t *testing.T) {
+	auth := newAEAD(t)
+	fake := &fakeLocalDispatcher{criteriaResult: false, criteriaReason: "peer reason here"}
+
+	handler := NewDispatchHandler(fake, auth)
+	mux := http.NewServeMux()
+	handler.Register(mux)
+
+	req := DispatchCriteriaRequest{
+		Entity:         json.RawMessage(`{"foo":"bar"}`),
+		EntityMeta:     spi.EntityMeta{ID: "ent-2"},
+		Criterion:      json.RawMessage(`{"type":"eq","field":"x","value":1}`),
+		Target:         "target",
+		WorkflowName:   "wf",
+		TransitionName: "t1",
+		ProcessorName:  "proc1",
+		TxID:           "tx-2",
+		TenantID:       "tenant-a",
+		UserID:         "user-1",
+		Roles:          []string{"ROLE_USER"},
+	}
+	plain, _ := json.Marshal(req)
+	httpReq := signedRequest(t, auth, http.MethodPost, "/internal/dispatch/criteria", plain)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httpReq)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp DispatchCriteriaResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Reason != "peer reason here" {
+		t.Errorf("expected peer reason propagated, got %q", resp.Reason)
 	}
 }
 

--- a/internal/cluster/dispatch/integration_test.go
+++ b/internal/cluster/dispatch/integration_test.go
@@ -81,7 +81,7 @@ func TestIntegration_ClusterDispatch_FullFlow(t *testing.T) {
 		d := NewClusterDispatcher(nodeALocal, registry, "node-a", selector, forwarder, 2*time.Second, nil, 0)
 
 		ctx := testContext()
-		matches, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx-integration-2")
+		matches, _, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx-integration-2")
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -136,7 +136,7 @@ func TestIntegration_ClusterDispatch_NoMemberTimeout(t *testing.T) {
 	t.Run("criteria_timeout", func(t *testing.T) {
 		ctx := testContext()
 		start := time.Now()
-		_, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx-timeout-2")
+		_, _, err := d.DispatchCriteria(ctx, testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", "tx-timeout-2")
 		elapsed := time.Since(start)
 
 		if err == nil {

--- a/internal/cluster/dispatch/integration_txtoken_test.go
+++ b/internal/cluster/dispatch/integration_txtoken_test.go
@@ -43,11 +43,11 @@ func (d *capturingLocalDispatcher) DispatchCriteria(
 	_ *spi.Entity,
 	_ json.RawMessage,
 	_, _, _, _, _ string,
-) (bool, error) {
+) (bool, string, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.capturedCtx = ctx
-	return d.matches, nil
+	return d.matches, "", nil
 }
 
 func (d *capturingLocalDispatcher) captured() context.Context {
@@ -157,7 +157,7 @@ func TestIntegration_HandlerReinjectsTxToken_Criteria(t *testing.T) {
 	d := NewClusterDispatcher(nodeALocal, registry, "node-A", selector, forwarder, 2*time.Second, signer, time.Minute)
 
 	const txID = "tx-token-integration-crit"
-	matches, err := d.DispatchCriteria(testContext(), testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", txID)
+	matches, _, err := d.DispatchCriteria(testContext(), testEntity(), testCriterion(), "TRANSITION", "wf", "tr", "proc", txID)
 	if err != nil {
 		t.Fatalf("DispatchCriteria: %v", err)
 	}

--- a/internal/cluster/dispatch/types.go
+++ b/internal/cluster/dispatch/types.go
@@ -51,5 +51,6 @@ type DispatchCriteriaResponse struct {
 	Matches  bool     `json:"matches"`
 	Success  bool     `json:"success"`
 	Error    string   `json:"error,omitempty"`
+	Reason   string   `json:"reason,omitempty"`
 	Warnings []string `json:"warnings,omitempty"`
 }

--- a/internal/cluster/dispatch/types_test.go
+++ b/internal/cluster/dispatch/types_test.go
@@ -207,6 +207,21 @@ func TestDispatchCriteriaRequest_JSONRoundTrip(t *testing.T) {
 	}
 }
 
+func TestDispatchCriteriaResponse_ReasonRoundTrip(t *testing.T) {
+	in := dispatch.DispatchCriteriaResponse{Matches: false, Success: true, Reason: "amount 5 below minimum 10"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out dispatch.DispatchCriteriaResponse
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Reason != in.Reason {
+		t.Errorf("reason not round-tripped: got %q want %q", out.Reason, in.Reason)
+	}
+}
+
 func TestDispatchCriteriaResponse_JSONRoundTrip(t *testing.T) {
 	resp := dispatch.DispatchCriteriaResponse{
 		Matches:  true,

--- a/internal/contract/processing.go
+++ b/internal/contract/processing.go
@@ -11,5 +11,9 @@ import (
 // to external calculation nodes.
 type ExternalProcessingService interface {
 	DispatchProcessor(ctx context.Context, entity *spi.Entity, processor spi.ProcessorDefinition, workflowName string, transitionName string, txID string) (*spi.Entity, error)
+	// DispatchCriteria evaluates a FUNCTION criterion on an external node.
+	// reason carries the compute node's explanation for the result (empty
+	// when none was supplied); it is only consumed on a matches=false
+	// rejection.
 	DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (matches bool, reason string, err error)
 }

--- a/internal/contract/processing.go
+++ b/internal/contract/processing.go
@@ -11,5 +11,5 @@ import (
 // to external calculation nodes.
 type ExternalProcessingService interface {
 	DispatchProcessor(ctx context.Context, entity *spi.Entity, processor spi.ProcessorDefinition, workflowName string, transitionName string, txID string) (*spi.Entity, error)
-	DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (bool, error)
+	DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (matches bool, reason string, err error)
 }

--- a/internal/domain/workflow/capreason_test.go
+++ b/internal/domain/workflow/capreason_test.go
@@ -1,0 +1,57 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestCapReason covers the ASCII length-bounding behaviour of the criterion
+// reason cap — the security control that bounds compute-node-supplied text
+// before it is persisted to the audit trail or reflected into a 400 body.
+func TestCapReason(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantLen int
+	}{
+		{"empty", "", 0},
+		{"short ascii", "credit score too low", len("credit score too low")},
+		{"exactly at cap", strings.Repeat("a", maxCriterionReasonLen), maxCriterionReasonLen},
+		{"one over cap", strings.Repeat("a", maxCriterionReasonLen+1), maxCriterionReasonLen},
+		{"far over cap", strings.Repeat("a", maxCriterionReasonLen*4), maxCriterionReasonLen},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := capReason(tc.in)
+			if len(got) != tc.wantLen {
+				t.Errorf("len = %d, want %d", len(got), tc.wantLen)
+			}
+			if !strings.HasPrefix(tc.in, got) {
+				t.Errorf("result %q is not a prefix of the input", got)
+			}
+		})
+	}
+}
+
+// TestCapReason_NeverSplitsRune verifies that truncation backs off to a UTF-8
+// rune boundary rather than splitting a multibyte rune. '世' is 3 bytes and
+// maxCriterionReasonLen (2048) is not a multiple of 3, so a naive byte-slice
+// at 2048 would split a rune and produce invalid UTF-8.
+func TestCapReason_NeverSplitsRune(t *testing.T) {
+	in := strings.Repeat("世", (maxCriterionReasonLen/3)+10) // > 2048 bytes
+	got := capReason(in)
+
+	if len(got) > maxCriterionReasonLen {
+		t.Fatalf("result %d bytes exceeds cap %d", len(got), maxCriterionReasonLen)
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("result is not valid UTF-8 — truncation split a multibyte rune")
+	}
+	if len(got)%3 != 0 {
+		t.Errorf("expected only whole 3-byte runes, got %d bytes", len(got))
+	}
+	if !strings.HasPrefix(in, got) {
+		t.Errorf("result is not a prefix of the input")
+	}
+}

--- a/internal/domain/workflow/engine.go
+++ b/internal/domain/workflow/engine.go
@@ -49,6 +49,53 @@ const maxCascadeDepth = 100
 // defaultMaxStateVisits is the default per-state visit limit.
 const defaultMaxStateVisits = 10
 
+// maxCriterionReasonLen bounds the criterion reason stored in the audit and
+// reflected into the 400 body. The reason is compute-node-supplied and the
+// audit is durable storage, so it is capped defensively.
+const maxCriterionReasonLen = 2048
+
+// defaultCriterionReason is recorded when a criterion returns false without an
+// explanatory reason (inline predicates, or a FUNCTION criterion that supplies
+// none). Keeps the audit data.reason shape stable.
+const defaultCriterionReason = "criterion did not match"
+
+// capReason truncates a compute-node-supplied criterion reason to
+// maxCriterionReasonLen before it is persisted to the audit trail or
+// reflected into an error message.
+func capReason(s string) string {
+	if len(s) > maxCriterionReasonLen {
+		return s[:maxCriterionReasonLen]
+	}
+	return s
+}
+
+// criterionName derives the audit "criterion" field: the FUNCTION name for a
+// function criterion, else the parsed condition type (e.g. "simple", "group").
+// The canonical FUNCTION wire shape nests the name under "function" (see
+// internal/grpc/dispatch.go); a top-level "name" is kept as a fallback for
+// robustness.
+func criterionName(criterion []byte) string {
+	var envelope struct {
+		Type     string `json:"type"`
+		Name     string `json:"name"`
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if json.Unmarshal(criterion, &envelope) == nil && envelope.Type == "function" {
+		if envelope.Function.Name != "" {
+			return envelope.Function.Name
+		}
+		if envelope.Name != "" {
+			return envelope.Name
+		}
+	}
+	if cond, err := predicate.ParseCondition(criterion); err == nil {
+		return cond.Type()
+	}
+	return ""
+}
+
 // Engine orchestrates workflow execution for entities.
 type Engine struct {
 	factory          spi.StoreFactory
@@ -383,7 +430,7 @@ func (e *Engine) selectWorkflow(ctx context.Context, workflows []spi.WorkflowDef
 			return wf, nil
 		}
 
-		matched, err := e.evaluateCriterion(wf.Criterion, entity, &criterionContext{
+		matched, reason, err := e.evaluateCriterion(wf.Criterion, entity, &criterionContext{
 			ctx: ctx, txID: txID, workflowName: wf.Name, target: "WORKFLOW",
 		})
 		if err != nil {
@@ -395,8 +442,12 @@ func (e *Engine) selectWorkflow(ctx context.Context, workflows []spi.WorkflowDef
 			return wf, nil
 		}
 
+		if reason == "" {
+			reason = defaultCriterionReason
+		}
 		e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
-			spi.SMEventWorkflowSkipped, fmt.Sprintf("Workflow %q criterion not matched", wf.Name), nil)
+			spi.SMEventWorkflowSkipped, fmt.Sprintf("Workflow %q criterion not matched", wf.Name),
+			map[string]any{"workflowName": wf.Name, "reason": reason})
 	}
 
 	// No imported workflow matched the entity — fall back to the embedded
@@ -473,16 +524,29 @@ func (e *Engine) attemptTransition(ctx context.Context, entity *spi.Entity, wf *
 
 	// Evaluate transition criterion.
 	if len(transition.Criterion) > 0 && string(transition.Criterion) != "null" {
-		matched, err := e.evaluateCriterion(transition.Criterion, entity, &criterionContext{
+		matched, reason, err := e.evaluateCriterion(transition.Criterion, entity, &criterionContext{
 			ctx: ctx, txID: txID, workflowName: wf.Name, transitionName: transitionName, target: "TRANSITION",
 		})
 		if err != nil {
 			return ctx, txID, fmt.Errorf("failed to evaluate transition criterion: %w", err)
 		}
 		if !matched {
+			external := reason != ""
+			if reason == "" {
+				reason = defaultCriterionReason
+			}
 			e.recordEvent(auditStore, ctx, entity.Meta.ID, txID, entity.Meta.State,
 				spi.SMEventTransitionCriterionNoMatch,
-				fmt.Sprintf("Transition %q criterion not matched", transitionName), nil)
+				fmt.Sprintf("Transition %q criterion not matched", transitionName),
+				map[string]any{
+					"workflowName": wf.Name,
+					"transition":   transitionName,
+					"criterion":    criterionName(transition.Criterion),
+					"reason":       reason,
+				})
+			if external {
+				return ctx, txID, fmt.Errorf("transition %q criterion not matched: %s", transitionName, reason)
+			}
 			return ctx, txID, fmt.Errorf("transition %q criterion not matched", transitionName)
 		}
 	}
@@ -550,16 +614,25 @@ func (e *Engine) cascadeAutomated(ctx context.Context, entity *spi.Entity, wf *s
 
 			// Evaluate criterion.
 			if len(tr.Criterion) > 0 && string(tr.Criterion) != "null" {
-				matched, err := e.evaluateCriterion(tr.Criterion, entity, &criterionContext{
+				matched, reason, err := e.evaluateCriterion(tr.Criterion, entity, &criterionContext{
 					ctx: currentCtx, txID: txID, workflowName: wf.Name, transitionName: tr.Name, target: "TRANSITION",
 				})
 				if err != nil {
 					return currentCtx, currentTxID, fmt.Errorf("failed to evaluate transition criterion: %w", err)
 				}
 				if !matched {
+					if reason == "" {
+						reason = defaultCriterionReason
+					}
 					e.recordEvent(auditStore, currentCtx, entity.Meta.ID, txID, entity.Meta.State,
 						spi.SMEventTransitionCriterionNoMatch,
-						fmt.Sprintf("Automated transition %q criterion not matched", tr.Name), nil)
+						fmt.Sprintf("Automated transition %q criterion not matched", tr.Name),
+						map[string]any{
+							"workflowName": wf.Name,
+							"transition":   tr.Name,
+							"criterion":    criterionName(tr.Criterion),
+							"reason":       reason,
+						})
 					continue
 				}
 			}
@@ -619,16 +692,19 @@ type criterionContext struct {
 
 // evaluateCriterion parses and matches a JSON criterion against the entity.
 // If the criterion is a FUNCTION type, it delegates to the external processing
-// service using the provided criterionContext.
-func (e *Engine) evaluateCriterion(criterion []byte, entity *spi.Entity, cc *criterionContext) (bool, error) {
+// service using the provided criterionContext and returns the capped
+// compute-node-supplied reason for a clean matched=false. Inline predicates
+// have no such explanation and always return an empty reason (as does any
+// matched=true result).
+func (e *Engine) evaluateCriterion(criterion []byte, entity *spi.Entity, cc *criterionContext) (bool, string, error) {
 	cond, err := predicate.ParseCondition(criterion)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse criterion: %w", err)
+		return false, "", fmt.Errorf("failed to parse criterion: %w", err)
 	}
 
 	if _, ok := cond.(*predicate.FunctionCondition); ok {
 		if e.extProc == nil {
-			return false, fmt.Errorf("no external processing service configured for FUNCTION criteria")
+			return false, "", fmt.Errorf("no external processing service configured for FUNCTION criteria")
 		}
 		// Release any per-tx gate this call chain holds across the blocking
 		// FUNCTION-criterion dispatch — same H3 rationale as executeSyncProcessor:
@@ -636,11 +712,12 @@ func (e *Engine) evaluateCriterion(criterion []byte, entity *spi.Entity, cc *cri
 		// txID. No-op for the owner / non-joined calls.
 		resume := txgate.Suspend(cc.ctx)
 		defer resume()
-		matches, _, err := e.extProc.DispatchCriteria(cc.ctx, entity, criterion, cc.target, cc.workflowName, cc.transitionName, "", cc.txID)
-		return matches, err
+		matches, reason, err := e.extProc.DispatchCriteria(cc.ctx, entity, criterion, cc.target, cc.workflowName, cc.transitionName, "", cc.txID)
+		return matches, capReason(reason), err
 	}
 
-	return match.Match(cond, entity.Data, entity.Meta)
+	matched, err := match.Match(cond, entity.Data, entity.Meta)
+	return matched, "", err
 }
 
 // resolveAuditTxID returns the transaction ID to use for state-machine audit

--- a/internal/domain/workflow/engine.go
+++ b/internal/domain/workflow/engine.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -63,10 +64,16 @@ const defaultCriterionReason = "criterion did not match"
 // maxCriterionReasonLen before it is persisted to the audit trail or
 // reflected into an error message.
 func capReason(s string) string {
-	if len(s) > maxCriterionReasonLen {
-		return s[:maxCriterionReasonLen]
+	if len(s) <= maxCriterionReasonLen {
+		return s
 	}
-	return s
+	// Back off to a UTF-8 rune boundary so truncation never splits a
+	// multibyte rune.
+	cut := maxCriterionReasonLen
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut]
 }
 
 // criterionName derives the audit "criterion" field: the FUNCTION name for a
@@ -693,9 +700,9 @@ type criterionContext struct {
 // evaluateCriterion parses and matches a JSON criterion against the entity.
 // If the criterion is a FUNCTION type, it delegates to the external processing
 // service using the provided criterionContext and returns the capped
-// compute-node-supplied reason for a clean matched=false. Inline predicates
-// have no such explanation and always return an empty reason (as does any
-// matched=true result).
+// compute-node-supplied reason (passed through regardless of match result;
+// only consumed on a matched=false rejection). Inline predicates have no such
+// explanation and always return an empty reason.
 func (e *Engine) evaluateCriterion(criterion []byte, entity *spi.Entity, cc *criterionContext) (bool, string, error) {
 	cond, err := predicate.ParseCondition(criterion)
 	if err != nil {

--- a/internal/domain/workflow/engine.go
+++ b/internal/domain/workflow/engine.go
@@ -636,7 +636,8 @@ func (e *Engine) evaluateCriterion(criterion []byte, entity *spi.Entity, cc *cri
 		// txID. No-op for the owner / non-joined calls.
 		resume := txgate.Suspend(cc.ctx)
 		defer resume()
-		return e.extProc.DispatchCriteria(cc.ctx, entity, criterion, cc.target, cc.workflowName, cc.transitionName, "", cc.txID)
+		matches, _, err := e.extProc.DispatchCriteria(cc.ctx, entity, criterion, cc.target, cc.workflowName, cc.transitionName, "", cc.txID)
+		return matches, err
 	}
 
 	return match.Match(cond, entity.Data, entity.Meta)

--- a/internal/domain/workflow/engine_test.go
+++ b/internal/domain/workflow/engine_test.go
@@ -3406,6 +3406,34 @@ func TestEngine_ManualCriterionNoMatch_EnrichesError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), `criterion not matched: reason X`) {
 		t.Fatalf("expected enriched error, got %v", err)
 	}
+
+	// The rejection also populates the state-machine audit event data (durable
+	// on non-TX-bound backends like memory; rolled back on TX-bound backends).
+	// Assert the criterion name is the nested FUNCTION name, mirroring the
+	// automated sibling's data assertions.
+	auditStore, err := factory.StateMachineAuditStore(ctx)
+	if err != nil {
+		t.Fatalf("StateMachineAuditStore: %v", err)
+	}
+	events, err := auditStore.GetEvents(ctx, "manual-crit-reason-e1")
+	if err != nil {
+		t.Fatalf("GetEvents: %v", err)
+	}
+	var found bool
+	for _, ev := range events {
+		if ev.EventType == spi.SMEventTransitionCriterionNoMatch {
+			found = true
+			if ev.Data["criterion"] != "approval-check" {
+				t.Errorf("criterion: got %v, want approval-check", ev.Data["criterion"])
+			}
+			if ev.Data["reason"] != "reason X" {
+				t.Errorf("reason: got %v, want reason X", ev.Data["reason"])
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no TRANSITION_NOT_MATCH_CRITERION event recorded")
+	}
 }
 
 // TestEngine_ManualInlineCriterionNoMatch_NoRedundantSuffix verifies that a

--- a/internal/domain/workflow/engine_test.go
+++ b/internal/domain/workflow/engine_test.go
@@ -868,11 +868,11 @@ func (m *mockExtProc) DispatchProcessor(_ context.Context, _ *spi.Entity, _ spi.
 	return m.returnEntity, m.returnErr
 }
 
-func (m *mockExtProc) DispatchCriteria(_ context.Context, _ *spi.Entity, _ json.RawMessage, _, _, _, _, _ string) (bool, error) {
+func (m *mockExtProc) DispatchCriteria(_ context.Context, _ *spi.Entity, _ json.RawMessage, _, _, _, _, _ string) (bool, string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.dispatchCriteriaCalls++
-	return m.criteriaResult, m.criteriaErr
+	return m.criteriaResult, "", m.criteriaErr
 }
 
 func TestProcessorDispatchWithExtProc(t *testing.T) {
@@ -1597,8 +1597,8 @@ func (m *mockExternalProcessing) DispatchProcessor(ctx context.Context, entity *
 	return entity, nil
 }
 
-func (m *mockExternalProcessing) DispatchCriteria(_ context.Context, _ *spi.Entity, _ json.RawMessage, _, _, _, _, _ string) (bool, error) {
-	return true, nil
+func (m *mockExternalProcessing) DispatchCriteria(_ context.Context, _ *spi.Entity, _ json.RawMessage, _, _, _, _, _ string) (bool, string, error) {
+	return true, "", nil
 }
 
 func TestAsyncNewTxFailureDoesNotKillPipeline(t *testing.T) {

--- a/internal/domain/workflow/engine_test.go
+++ b/internal/domain/workflow/engine_test.go
@@ -858,6 +858,7 @@ type mockExtProc struct {
 	returnEntity           *spi.Entity
 	returnErr              error
 	criteriaResult         bool
+	criteriaReason         string
 	criteriaErr            error
 }
 
@@ -872,7 +873,7 @@ func (m *mockExtProc) DispatchCriteria(_ context.Context, _ *spi.Entity, _ json.
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.dispatchCriteriaCalls++
-	return m.criteriaResult, "", m.criteriaErr
+	return m.criteriaResult, m.criteriaReason, m.criteriaErr
 }
 
 func TestProcessorDispatchWithExtProc(t *testing.T) {
@@ -3231,5 +3232,278 @@ func TestEngine_AttemptTransition_Scheduled_ReturnsTransitionNotFound(t *testing
 	}
 	if entity.Meta.State != "S1" {
 		t.Errorf("expected entity to stay in source state S1; got %q", entity.Meta.State)
+	}
+}
+
+// --- Criterion reason propagation into audit data / manual-transition error ---
+
+// TestEngine_AutomatedCriterionNoMatch_RecordsReason verifies that when an
+// automated transition's FUNCTION criterion returns matched=false with a
+// compute-node-supplied reason, the TRANSITION_NOT_MATCH_CRITERION audit
+// event's Data carries that reason alongside workflowName/transition/criterion.
+func TestEngine_AutomatedCriterionNoMatch_RecordsReason(t *testing.T) {
+	factory := memory.NewStoreFactory()
+	t.Cleanup(func() { factory.Close() })
+	uuids := common.NewTestUUIDGenerator()
+	txMgr := factory.NewTransactionManager(uuids)
+
+	mock := &mockExtProc{criteriaResult: false, criteriaReason: "amount 5 below minimum 10"}
+	engine := NewEngine(factory, uuids, txMgr, WithExternalProcessing(mock))
+
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "auto-crit-reason", ModelVersion: "1.0"}
+
+	funcCriterion, _ := json.Marshal(map[string]any{"type": "function", "function": map[string]any{"name": "min-amount"}})
+
+	wf := spi.WorkflowDefinition{
+		Version: "1.1", Name: "AutoCritReasonWF", InitialState: "CREATED", Active: true,
+		States: map[string]spi.StateDefinition{
+			"CREATED": {Transitions: []spi.TransitionDefinition{
+				{Name: "upgrade", Next: "PREMIUM", Manual: false, Criterion: funcCriterion},
+			}},
+			"PREMIUM": {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+
+	txID, txCtx, err := txMgr.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+
+	entity := makeEntity("auto-crit-reason-e1", modelRef, map[string]any{"amount": 5})
+	entity.Meta.TransactionID = txID
+
+	_, err = engine.Execute(txCtx, entity, "")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if entity.Meta.State != "CREATED" {
+		t.Errorf("expected entity to stay in CREATED (criterion did not match), got %q", entity.Meta.State)
+	}
+
+	auditStore, err := factory.StateMachineAuditStore(ctx)
+	if err != nil {
+		t.Fatalf("StateMachineAuditStore: %v", err)
+	}
+	events, err := auditStore.GetEventsByTransaction(ctx, "auto-crit-reason-e1", txID)
+	if err != nil {
+		t.Fatalf("GetEventsByTransaction: %v", err)
+	}
+
+	var found bool
+	for _, ev := range events {
+		if ev.EventType == spi.SMEventTransitionCriterionNoMatch {
+			found = true
+			if ev.Data["reason"] != "amount 5 below minimum 10" {
+				t.Errorf("reason: got %v", ev.Data["reason"])
+			}
+			if ev.Data["transition"] != "upgrade" || ev.Data["workflowName"] != "AutoCritReasonWF" || ev.Data["criterion"] != "min-amount" {
+				t.Errorf("unexpected data keys: %v", ev.Data)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no TRANSITION_NOT_MATCH_CRITERION event recorded")
+	}
+}
+
+// TestEngine_InlineCriterionNoMatch_DefaultsReason verifies that an inline
+// (non-FUNCTION) criterion no-match records the default reason string since
+// inline predicates have no compute-node-supplied explanation.
+func TestEngine_InlineCriterionNoMatch_DefaultsReason(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "inline-crit-reason", ModelVersion: "1.0"}
+
+	wf := spi.WorkflowDefinition{
+		Version: "1.1", Name: "InlineCritReasonWF", InitialState: "CREATED", Active: true,
+		States: map[string]spi.StateDefinition{
+			"CREATED": {Transitions: []spi.TransitionDefinition{
+				{Name: "upgrade", Next: "PREMIUM", Manual: false,
+					Criterion: simpleCriterion("$.amount", "GREATER_THAN", 100)},
+			}},
+			"PREMIUM": {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+
+	txMgr, err := factory.TransactionManager(ctx)
+	if err != nil {
+		t.Fatalf("TransactionManager: %v", err)
+	}
+	txID, txCtx, err := txMgr.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+
+	entity := makeEntity("inline-crit-reason-e1", modelRef, map[string]any{"amount": 5})
+	entity.Meta.TransactionID = txID
+
+	_, err = engine.Execute(txCtx, entity, "")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	auditStore, err := factory.StateMachineAuditStore(ctx)
+	if err != nil {
+		t.Fatalf("StateMachineAuditStore: %v", err)
+	}
+	events, err := auditStore.GetEventsByTransaction(ctx, "inline-crit-reason-e1", txID)
+	if err != nil {
+		t.Fatalf("GetEventsByTransaction: %v", err)
+	}
+
+	var found bool
+	for _, ev := range events {
+		if ev.EventType == spi.SMEventTransitionCriterionNoMatch {
+			found = true
+			if ev.Data["reason"] != defaultCriterionReason {
+				t.Errorf("reason: got %v, want %q", ev.Data["reason"], defaultCriterionReason)
+			}
+			if ev.Data["criterion"] != "simple" {
+				t.Errorf("criterion: got %v, want %q", ev.Data["criterion"], "simple")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no TRANSITION_NOT_MATCH_CRITERION event recorded")
+	}
+}
+
+// TestEngine_ManualCriterionNoMatch_EnrichesError verifies that a manual
+// transition rejected by a FUNCTION criterion with an external reason returns
+// an error enriched with that reason.
+func TestEngine_ManualCriterionNoMatch_EnrichesError(t *testing.T) {
+	factory := memory.NewStoreFactory()
+	t.Cleanup(func() { factory.Close() })
+	uuids := common.NewTestUUIDGenerator()
+	txMgr := factory.NewTransactionManager(uuids)
+
+	mock := &mockExtProc{criteriaResult: false, criteriaReason: "reason X"}
+	engine := NewEngine(factory, uuids, txMgr, WithExternalProcessing(mock))
+
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "manual-crit-reason", ModelVersion: "1.0"}
+
+	funcCriterion, _ := json.Marshal(map[string]any{"type": "function", "function": map[string]any{"name": "approval-check"}})
+
+	wf := spi.WorkflowDefinition{
+		Version: "1.1", Name: "ManualCritReasonWF", InitialState: "PENDING", Active: true,
+		States: map[string]spi.StateDefinition{
+			"PENDING": {Transitions: []spi.TransitionDefinition{
+				{Name: "approve", Next: "APPROVED", Manual: true, Criterion: funcCriterion},
+			}},
+			"APPROVED": {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+
+	entity := makeEntity("manual-crit-reason-e1", modelRef, map[string]any{})
+	entity.Meta.State = "PENDING"
+
+	_, err := engine.ManualTransition(ctx, entity, "approve")
+	if err == nil || !strings.Contains(err.Error(), `criterion not matched: reason X`) {
+		t.Fatalf("expected enriched error, got %v", err)
+	}
+}
+
+// TestEngine_ManualInlineCriterionNoMatch_NoRedundantSuffix verifies that a
+// manual transition rejected by an inline criterion keeps the bare error
+// message — no redundant ": criterion did not match" suffix.
+func TestEngine_ManualInlineCriterionNoMatch_NoRedundantSuffix(t *testing.T) {
+	engine, factory := setupEngine(t)
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "manual-inline-crit-reason", ModelVersion: "1.0"}
+
+	wf := spi.WorkflowDefinition{
+		Version: "1.1", Name: "ManualInlineCritReasonWF", InitialState: "PENDING", Active: true,
+		States: map[string]spi.StateDefinition{
+			"PENDING": {Transitions: []spi.TransitionDefinition{
+				{Name: "approve", Next: "APPROVED", Manual: true,
+					Criterion: simpleCriterion("$.amount", "GREATER_THAN", 100)},
+			}},
+			"APPROVED": {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+
+	entity := makeEntity("manual-inline-crit-reason-e1", modelRef, map[string]any{"amount": 5})
+	entity.Meta.State = "PENDING"
+
+	_, err := engine.ManualTransition(ctx, entity, "approve")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != `transition "approve" criterion not matched` {
+		t.Errorf("unexpected error message: %v", err)
+	}
+	if strings.Contains(err.Error(), "criterion not matched: criterion did not match") {
+		t.Fatalf("unexpected redundant suffix: %v", err)
+	}
+}
+
+// TestEngine_WorkflowSkipped_RecordsReason verifies that a workflow-selection
+// FUNCTION criterion no-match records the reason on the WORKFLOW_SKIP audit
+// event.
+func TestEngine_WorkflowSkipped_RecordsReason(t *testing.T) {
+	factory := memory.NewStoreFactory()
+	t.Cleanup(func() { factory.Close() })
+	uuids := common.NewTestUUIDGenerator()
+	txMgr := factory.NewTransactionManager(uuids)
+
+	mock := &mockExtProc{criteriaResult: false, criteriaReason: "tenant not eligible"}
+	engine := NewEngine(factory, uuids, txMgr, WithExternalProcessing(mock))
+
+	ctx := ctxWithTenant(testTenant)
+	modelRef := spi.ModelRef{EntityName: "wf-skip-reason", ModelVersion: "1.0"}
+
+	funcCriterion, _ := json.Marshal(map[string]any{"type": "function", "function": map[string]any{"name": "eligibility"}})
+
+	wf := spi.WorkflowDefinition{
+		Version: "1.1", Name: "WFSkipReasonWF", InitialState: "SELECTED", Active: true,
+		Criterion: funcCriterion,
+		States: map[string]spi.StateDefinition{
+			"SELECTED": {},
+		},
+	}
+	saveWorkflow(t, factory, ctx, modelRef, []spi.WorkflowDefinition{wf})
+
+	txID, txCtx, err := txMgr.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+
+	entity := makeEntity("wf-skip-reason-e1", modelRef, map[string]any{})
+	entity.Meta.TransactionID = txID
+
+	_, err = engine.Execute(txCtx, entity, "")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	auditStore, err := factory.StateMachineAuditStore(ctx)
+	if err != nil {
+		t.Fatalf("StateMachineAuditStore: %v", err)
+	}
+	events, err := auditStore.GetEventsByTransaction(ctx, "wf-skip-reason-e1", txID)
+	if err != nil {
+		t.Fatalf("GetEventsByTransaction: %v", err)
+	}
+
+	var found bool
+	for _, ev := range events {
+		if ev.EventType == spi.SMEventWorkflowSkipped {
+			found = true
+			if ev.Data["reason"] != "tenant not eligible" {
+				t.Errorf("reason: got %v", ev.Data["reason"])
+			}
+			if ev.Data["workflowName"] != "WFSkipReasonWF" {
+				t.Errorf("workflowName: got %v", ev.Data["workflowName"])
+			}
+		}
+	}
+	if !found {
+		t.Fatal("no WORKFLOW_SKIP event recorded")
 	}
 }

--- a/internal/e2e/criterion_reason_test.go
+++ b/internal/e2e/criterion_reason_test.go
@@ -1,0 +1,140 @@
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// smEventReason returns the reason recorded on the first StateMachine audit
+// event of the given eventType for the entity, and whether such an event was
+// found. Used for the paths whose transaction commits (automated cascade,
+// workflow selection), where the event is durable.
+func smEventReason(t *testing.T, entityID, eventType string) (string, bool) {
+	t.Helper()
+	for _, ev := range getSMAuditEvents(t, entityID) {
+		if ev["eventType"] == eventType {
+			data, _ := ev["data"].(map[string]any)
+			if data == nil {
+				return "", true
+			}
+			r, _ := data["reason"].(string)
+			return r, true
+		}
+	}
+	return "", false
+}
+
+// TestCriterionReason_ManualReject_Reason400 verifies the primary surface for a
+// manual explicit transition rejected by its criterion: the reason is carried
+// in the direct 400 WORKFLOW_FAILED response. This is the guaranteed delivery
+// for manual rejections and does not depend on the audit store — the manual
+// path rolls its transaction back (the transactional-audit invariant is left
+// unchanged), so the audit copy is intentionally not asserted here.
+func TestCriterionReason_ManualReject_Reason400(t *testing.T) {
+	const model = "e2e-critreason-manual"
+	procSvc.RegisterCriteriaReason("credit-check",
+		func(ctx context.Context, e *spi.Entity, c json.RawMessage) (bool, string, error) {
+			return false, "credit score 540 below threshold 600", nil
+		})
+	defer procSvc.Reset()
+
+	wf := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "cr-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {"transitions": [{"name": "approve", "next": "APPROVED", "manual": true,
+					"criterion": {"type": "function", "function": {"name": "credit-check"}}}]},
+				"APPROVED": {}
+			}
+		}]
+	}`
+	setupModelWithWorkflow(t, model, wf)
+	entityID := createEntityE2E(t, model, 1, `{"name":"X","amount":10}`)
+
+	// Manual transition rejected by its criterion -> 400 WORKFLOW_FAILED whose
+	// detail carries the reason.
+	path := fmt.Sprintf("/api/entity/JSON/%s/approve", entityID)
+	resp := doAuth(t, http.MethodPut, path, `{"name":"X","amount":10}`)
+	body := readBody(t, resp)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, "credit score 540 below threshold 600") {
+		t.Errorf("400 body missing criterion reason: %s", body)
+	}
+}
+
+// TestCriterionReason_AutomatedReject_Audit verifies that an automated-cascade
+// transition rejected by an external FUNCTION criterion records the reason on
+// the durable TRANSITION_NOT_MATCH_CRITERION state-machine audit event. The
+// automated path commits (the entity settles at a stable state), so the event
+// is durable on a TX-bound backend.
+func TestCriterionReason_AutomatedReject_Audit(t *testing.T) {
+	const model = "e2e-critreason-auto"
+	procSvc.RegisterCriteriaReason("min-amount",
+		func(ctx context.Context, e *spi.Entity, c json.RawMessage) (bool, string, error) {
+			return false, "amount 10 below minimum 100", nil
+		})
+	defer procSvc.Reset()
+
+	wf := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "auto-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {"transitions": [{"name": "auto-promote", "next": "PREMIUM", "manual": false,
+					"criterion": {"type": "function", "function": {"name": "min-amount"}}}]},
+				"PREMIUM": {}
+			}
+		}]
+	}`
+	setupModelWithWorkflow(t, model, wf)
+	entityID := createEntityE2E(t, model, 1, `{"name":"X","amount":10}`)
+
+	reason, ok := smEventReason(t, entityID, "TRANSITION_NOT_MATCH_CRITERION")
+	if !ok {
+		t.Fatal("no TRANSITION_NOT_MATCH_CRITERION audit event")
+	}
+	if reason != "amount 10 below minimum 100" {
+		t.Errorf("audit reason: got %q, want %q", reason, "amount 10 below minimum 100")
+	}
+}
+
+// TestCriterionReason_InlineReject_DefaultReason verifies that an inline
+// (non-FUNCTION) predicate that evaluates false records the stable default
+// reason on the durable automated TRANSITION_NOT_MATCH_CRITERION audit event —
+// inline predicates have no external reason source.
+func TestCriterionReason_InlineReject_DefaultReason(t *testing.T) {
+	const model = "e2e-critreason-inline"
+	wf := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1", "name": "inline-wf", "initialState": "NONE", "active": true,
+			"states": {
+				"NONE": {"transitions": [{"name": "init", "next": "CREATED", "manual": false}]},
+				"CREATED": {"transitions": [{"name": "auto-promote", "next": "PREMIUM", "manual": false,
+					"criterion": {"type":"simple","jsonPath":"$.amount","operatorType":"GREATER_THAN","value":100}}]},
+				"PREMIUM": {}
+			}
+		}]
+	}`
+	setupModelWithWorkflow(t, model, wf)
+	entityID := createEntityE2E(t, model, 1, `{"name":"X","amount":10}`)
+
+	reason, ok := smEventReason(t, entityID, "TRANSITION_NOT_MATCH_CRITERION")
+	if !ok {
+		t.Fatal("no TRANSITION_NOT_MATCH_CRITERION audit event")
+	}
+	if reason != "criterion did not match" {
+		t.Errorf("expected default reason, got %q", reason)
+	}
+}

--- a/internal/grpc/dispatch.go
+++ b/internal/grpc/dispatch.go
@@ -192,7 +192,7 @@ func (d *ProcessorDispatcher) applyProcessorResponse(entity *spi.Entity, resp *P
 
 // DispatchCriteria sends an entity criteria calculation request to a matching
 // calculation member and waits for the boolean result.
-func (d *ProcessorDispatcher) DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (bool, error) {
+func (d *ProcessorDispatcher) DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (bool, string, error) {
 	uc := spi.MustGetUserContext(ctx)
 	tenantID := uc.Tenant.ID
 
@@ -211,7 +211,7 @@ func (d *ProcessorDispatcher) DispatchCriteria(ctx context.Context, entity *spi.
 		} `json:"function"`
 	}
 	if err := json.Unmarshal(criterion, &parsed); err != nil {
-		return false, fmt.Errorf("invalid criterion JSON: %w", err)
+		return false, "", fmt.Errorf("invalid criterion JSON: %w", err)
 	}
 
 	// attachEntity defaults to true when not explicitly set.
@@ -223,7 +223,7 @@ func (d *ProcessorDispatcher) DispatchCriteria(ctx context.Context, entity *spi.
 	member := d.registry.FindByTags(tenantID, parsed.Function.Config.CalculationNodesTags)
 	if member == nil {
 		slog.Warn("no matching calculation member", "pkg", "grpc", "tags", parsed.Function.Config.CalculationNodesTags, "entityId", entity.Meta.ID)
-		return false, fmt.Errorf("%w: tags %q", ErrNoMatchingMember, parsed.Function.Config.CalculationNodesTags)
+		return false, "", fmt.Errorf("%w: tags %q", ErrNoMatchingMember, parsed.Function.Config.CalculationNodesTags)
 	}
 
 	slog.Info("dispatching criteria", "pkg", "grpc", "memberId", member.ID, "criteria", parsed.Function.Name, "entityId", entity.Meta.ID)
@@ -270,7 +270,7 @@ func (d *ProcessorDispatcher) DispatchCriteria(ctx context.Context, entity *spi.
 
 	ce, err := NewCloudEvent(EntityCriteriaCalculationRequest, req)
 	if err != nil {
-		return false, fmt.Errorf("failed to build criteria cloud event: %w", err)
+		return false, "", fmt.Errorf("failed to build criteria cloud event: %w", err)
 	}
 	AttachAuthContext(ctx, ce)
 	AttachTxToken(ce, d.resolveTxToken(ctx, txID))
@@ -282,7 +282,7 @@ func (d *ProcessorDispatcher) DispatchCriteria(ctx context.Context, entity *spi.
 
 	if err := member.Send(ce); err != nil {
 		slog.Error("failed to send to member", "pkg", "grpc", "memberId", member.ID, "error", err)
-		return false, fmt.Errorf("failed to send criteria request: %w", err)
+		return false, "", fmt.Errorf("failed to send criteria request: %w", err)
 	}
 
 	timeoutMs := parsed.Function.Config.ResponseTimeoutMs
@@ -306,17 +306,17 @@ func (d *ProcessorDispatcher) DispatchCriteria(ctx context.Context, entity *spi.
 				errMsg = resp.Error
 				common.AddError(ctx, fmt.Sprintf("criteria %s: %s", parsed.Function.Name, errMsg))
 			}
-			return false, fmt.Errorf("criteria dispatch failed: %s", errMsg)
+			return false, "", fmt.Errorf("criteria dispatch failed: %s", errMsg)
 		}
 		slog.Info("criteria completed", "pkg", "grpc", "memberId", member.ID, "criteria", parsed.Function.Name, "requestId", requestID, "success", true)
 		if resp.Matches != nil {
-			return *resp.Matches, nil
+			return *resp.Matches, resp.Reason, nil
 		}
-		return false, nil
+		return false, resp.Reason, nil
 	case <-time.After(timeout):
 		slog.Error("dispatch timeout", "pkg", "grpc", "criteria", parsed.Function.Name, "requestId", requestID, "timeout", timeout)
-		return false, fmt.Errorf("criteria dispatch timed out after %dms", timeoutMs)
+		return false, "", fmt.Errorf("criteria dispatch timed out after %dms", timeoutMs)
 	case <-ctx.Done():
-		return false, ctx.Err()
+		return false, "", ctx.Err()
 	}
 }

--- a/internal/grpc/dispatch_test.go
+++ b/internal/grpc/dispatch_test.go
@@ -301,7 +301,7 @@ func TestDispatchCriteria_MatchesTrue(t *testing.T) {
 		})
 	}()
 
-	result, err := dispatcher.DispatchCriteria(ctx, entity, criterion, "transition", "wf1", "t1", "proc1", "tx-1")
+	result, _, err := dispatcher.DispatchCriteria(ctx, entity, criterion, "transition", "wf1", "t1", "proc1", "tx-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -336,15 +336,19 @@ func TestDispatchCriteria_MatchesFalse(t *testing.T) {
 		member.CompleteRequest(reqID, &ProcessingResponse{
 			Success: true,
 			Matches: &matchesFalse,
+			Reason:  "amount 5 below minimum 10",
 		})
 	}()
 
-	result, err := dispatcher.DispatchCriteria(ctx, entity, criterion, "transition", "wf1", "t1", "", "tx-1")
+	result, reason, err := dispatcher.DispatchCriteria(ctx, entity, criterion, "transition", "wf1", "t1", "", "tx-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result {
 		t.Error("expected matches=false")
+	}
+	if reason != "amount 5 below minimum 10" {
+		t.Errorf("expected reason returned, got %q", reason)
 	}
 }
 
@@ -522,7 +526,7 @@ func TestDispatchCriteria_ContextSurfacesAsParametersString(t *testing.T) {
 		member.CompleteRequest(reqID, &ProcessingResponse{Success: true, Matches: &matchesTrue})
 	}()
 
-	if _, err := dispatcher.DispatchCriteria(ctx, entity, criterion, "transition", "wf1", "t1", "proc1", "tx-1"); err != nil {
+	if _, _, err := dispatcher.DispatchCriteria(ctx, entity, criterion, "transition", "wf1", "t1", "proc1", "tx-1"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -563,7 +567,7 @@ func TestDispatchCriteria_EmptyContextOmitsParameters(t *testing.T) {
 		member.CompleteRequest(reqID, &ProcessingResponse{Success: true, Matches: &matchesTrue})
 	}()
 
-	if _, err := dispatcher.DispatchCriteria(ctx, entity, criterion, "transition", "wf1", "t1", "proc1", "tx-1"); err != nil {
+	if _, _, err := dispatcher.DispatchCriteria(ctx, entity, criterion, "transition", "wf1", "t1", "proc1", "tx-1"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/grpc/members.go
+++ b/internal/grpc/members.go
@@ -22,10 +22,14 @@ type SendFunc func(ce *cepb.CloudEvent) error
 
 // ProcessingResponse holds the response from a processor or criteria calculation.
 type ProcessingResponse struct {
-	Payload  json.RawMessage
-	Success  bool
-	Error    string
-	Matches  *bool    // for criteria responses (nil for processor responses)
+	Payload json.RawMessage
+	Success bool
+	Error   string
+	Matches *bool // for criteria responses (nil for processor responses)
+	// Reason is the criteria-response explanation for a matches=false result
+	// (EntityCriteriaCalculationResponse.reason). Empty for processor
+	// responses and for criteria that supply no reason.
+	Reason   string
 	Warnings []string // warnings from processor/criteria, propagated to client
 	// Retryable carries the member-supplied retryable flag from the inbound
 	// CloudEvent error shape (api/grpc/events/types.go: every *EventJsonError

--- a/internal/grpc/streaming.go
+++ b/internal/grpc/streaming.go
@@ -283,6 +283,7 @@ func (s *CloudEventsServiceImpl) handleCriteriaResponse(memberID string, payload
 		RequestID string `json:"requestId"`
 		Success   bool   `json:"success"`
 		Matches   bool   `json:"matches"`
+		Reason    string `json:"reason"`
 		Error     *struct {
 			Message   string `json:"message"`
 			Retryable *bool  `json:"retryable"`
@@ -310,6 +311,7 @@ func (s *CloudEventsServiceImpl) handleCriteriaResponse(memberID string, payload
 		Success:   resp.Success,
 		Error:     errMsg,
 		Matches:   &matches,
+		Reason:    resp.Reason,
 		Warnings:  resp.Warnings,
 		Retryable: retryable,
 	})

--- a/internal/grpc/streaming_test.go
+++ b/internal/grpc/streaming_test.go
@@ -487,6 +487,55 @@ func TestStreaming_CriteriaResponse(t *testing.T) {
 	<-done
 }
 
+func TestStreaming_CriteriaResponse_PropagatesReason(t *testing.T) {
+	svc := newServiceForTest()
+	ctx, cancel := context.WithCancel(m2mContext("tenant-1"))
+	defer cancel()
+
+	stream := newMockBidiStream(ctx)
+	stream.enqueue(makeJoinEvent(t, "tenant-1", []string{"python"}))
+
+	done := make(chan error, 1)
+	go func() { done <- svc.StartStreaming(stream) }()
+
+	greetCE := stream.waitForSent(t, 2*time.Second)
+	_, greetPayload, _ := ParseCloudEvent(greetCE)
+	memberID := ExtractStringField(greetPayload, "memberId")
+
+	member := svc.registry.Get(memberID)
+	if member == nil {
+		t.Fatal("member not found")
+	}
+	respCh := member.TrackRequest("req-reason-1")
+
+	respPayload := map[string]any{
+		"requestId": "req-reason-1",
+		"success":   true,
+		"matches":   false,
+		"reason":    "credit score 540 below threshold 600",
+	}
+	respCE, err := NewCloudEvent(EntityCriteriaCalculationResponse, respPayload)
+	if err != nil {
+		t.Fatalf("failed to create criteria response event: %v", err)
+	}
+	stream.enqueue(respCE)
+
+	select {
+	case resp := <-respCh:
+		if resp == nil {
+			t.Fatal("expected non-nil response")
+		}
+		if resp.Reason != "credit score 540 below threshold 600" {
+			t.Errorf("expected reason propagated, got %q", resp.Reason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for criteria response")
+	}
+
+	stream.closeRecv()
+	<-done
+}
+
 // --- Retryable flag plumbing (audit §M1) -----------------------------------
 //
 // These tests cover the wire tri-state: retryable=true / retryable=false /

--- a/internal/observability/dispatch_tracing.go
+++ b/internal/observability/dispatch_tracing.go
@@ -77,7 +77,7 @@ func (t *TracingExternalProcessingService) DispatchProcessor(
 func (t *TracingExternalProcessingService) DispatchCriteria(
 	ctx context.Context, entity *spi.Entity, criterion json.RawMessage,
 	target, workflowName, transitionName, processorName, txID string,
-) (bool, error) {
+) (bool, string, error) {
 	ctx, span := t.tracer.Start(ctx, "dispatch.criteria", trace.WithAttributes(
 		AttrCriterionTarget.String(target),
 		AttrWorkflowName.String(workflowName),
@@ -86,7 +86,7 @@ func (t *TracingExternalProcessingService) DispatchCriteria(
 	defer span.End()
 
 	start := time.Now()
-	matches, err := t.inner.DispatchCriteria(ctx, entity, criterion, target, workflowName, transitionName, processorName, txID)
+	matches, reason, err := t.inner.DispatchCriteria(ctx, entity, criterion, target, workflowName, transitionName, processorName, txID)
 	elapsed := time.Since(start).Seconds()
 
 	t.dispatchDuration.Record(ctx, elapsed, t.typeCriteria)
@@ -97,5 +97,5 @@ func (t *TracingExternalProcessingService) DispatchCriteria(
 		span.SetStatus(codes.Error, err.Error())
 	}
 	span.SetAttributes(AttrCriteriaMatches.Bool(matches))
-	return matches, err
+	return matches, reason, err
 }

--- a/internal/observability/dispatch_tracing_test.go
+++ b/internal/observability/dispatch_tracing_test.go
@@ -32,12 +32,12 @@ func (f *fakeDispatcher) DispatchProcessor(
 func (f *fakeDispatcher) DispatchCriteria(
 	ctx context.Context, entity *spi.Entity, criterion json.RawMessage,
 	target, workflowName, transitionName, processorName, txID string,
-) (bool, error) {
+) (bool, string, error) {
 	f.criteriaCalled = true
 	if f.returnErr != nil {
-		return false, f.returnErr
+		return false, "", f.returnErr
 	}
-	return true, nil
+	return true, "", nil
 }
 
 func TestTracingExternalProcessingService_DispatchProcessor_DelegatesToInner(t *testing.T) {
@@ -78,7 +78,7 @@ func TestTracingExternalProcessingService_DispatchCriteria_DelegatesToInner(t *t
 	entity := &spi.Entity{Meta: spi.EntityMeta{ID: "ent-2"}}
 	criterion := json.RawMessage(`{"op":"eq","field":"status","value":"active"}`)
 
-	matches, err := traced.DispatchCriteria(context.Background(), entity, criterion, "target1", "wf1", "t1", "proc1", "tx-1")
+	matches, _, err := traced.DispatchCriteria(context.Background(), entity, criterion, "target1", "wf1", "t1", "proc1", "tx-1")
 	if err != nil {
 		t.Fatalf("DispatchCriteria: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestTracingExternalProcessingService_DispatchCriteria_PropagatesError(t *te
 	entity := &spi.Entity{Meta: spi.EntityMeta{ID: "ent-4"}}
 	criterion := json.RawMessage(`{}`)
 
-	_, err := traced.DispatchCriteria(context.Background(), entity, criterion, "target1", "wf1", "t1", "proc1", "tx-1")
+	_, _, err := traced.DispatchCriteria(context.Background(), entity, criterion, "target1", "wf1", "t1", "proc1", "tx-1")
 	if !errors.Is(err, wantErr) {
 		t.Errorf("expected %v, got %v", wantErr, err)
 	}

--- a/internal/skeleton/processing.go
+++ b/internal/skeleton/processing.go
@@ -17,6 +17,6 @@ func (s *ExternalProcessingService) DispatchProcessor(_ context.Context, entity 
 	return entity, nil
 }
 
-func (s *ExternalProcessingService) DispatchCriteria(_ context.Context, _ *spi.Entity, _ json.RawMessage, _ string, _ string, _ string, _ string, _ string) (bool, error) {
-	return true, nil
+func (s *ExternalProcessingService) DispatchCriteria(_ context.Context, _ *spi.Entity, _ json.RawMessage, _ string, _ string, _ string, _ string, _ string) (bool, string, error) {
+	return true, "", nil
 }

--- a/internal/testing/localproc/localproc.go
+++ b/internal/testing/localproc/localproc.go
@@ -19,12 +19,15 @@ type ProcessorFunc func(ctx context.Context, entity *spi.Entity, proc spi.Proces
 // CriteriaFunc is a callback invoked when a function criterion is evaluated.
 type CriteriaFunc func(ctx context.Context, entity *spi.Entity, criterion json.RawMessage) (bool, error)
 
+// criteriaFuncR is the internal reason-returning criterion form.
+type criteriaFuncR func(ctx context.Context, entity *spi.Entity, criterion json.RawMessage) (bool, string, error)
+
 // LocalProcessingService dispatches processors and criteria to registered
 // Go function callbacks. It implements contract.ExternalProcessingService.
 type LocalProcessingService struct {
 	mu             sync.RWMutex
 	processors     map[string]ProcessorFunc
-	criteria       map[string]CriteriaFunc
+	criteria       map[string]criteriaFuncR
 	processorCalls map[string]*atomic.Int64
 	criteriaCalls  map[string]*atomic.Int64
 }
@@ -33,7 +36,7 @@ type LocalProcessingService struct {
 func New() *LocalProcessingService {
 	return &LocalProcessingService{
 		processors:     make(map[string]ProcessorFunc),
-		criteria:       make(map[string]CriteriaFunc),
+		criteria:       make(map[string]criteriaFuncR),
 		processorCalls: make(map[string]*atomic.Int64),
 		criteriaCalls:  make(map[string]*atomic.Int64),
 	}
@@ -49,8 +52,16 @@ func (s *LocalProcessingService) RegisterProcessor(name string, fn ProcessorFunc
 	}
 }
 
-// RegisterCriteria registers a criteria callback by function name.
+// RegisterCriteria registers a criteria callback by function name (no reason).
 func (s *LocalProcessingService) RegisterCriteria(name string, fn CriteriaFunc) {
+	s.RegisterCriteriaReason(name, func(ctx context.Context, e *spi.Entity, c json.RawMessage) (bool, string, error) {
+		m, err := fn(ctx, e, c)
+		return m, "", err
+	})
+}
+
+// RegisterCriteriaReason registers a criteria callback that also returns a reason.
+func (s *LocalProcessingService) RegisterCriteriaReason(name string, fn criteriaFuncR) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.criteria[name] = fn
@@ -82,14 +93,14 @@ func (s *LocalProcessingService) DispatchProcessor(ctx context.Context, entity *
 
 // DispatchCriteria dispatches to the registered criteria callback.
 // It parses the function name from the criterion JSON envelope.
-func (s *LocalProcessingService) DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (bool, error) {
+func (s *LocalProcessingService) DispatchCriteria(ctx context.Context, entity *spi.Entity, criterion json.RawMessage, target string, workflowName string, transitionName string, processorName string, txID string) (bool, string, error) {
 	var parsed struct {
 		Function struct {
 			Name string `json:"name"`
 		} `json:"function"`
 	}
 	if err := json.Unmarshal(criterion, &parsed); err != nil {
-		return false, fmt.Errorf("invalid criterion JSON: %w", err)
+		return false, "", fmt.Errorf("invalid criterion JSON: %w", err)
 	}
 	name := parsed.Function.Name
 
@@ -99,7 +110,7 @@ func (s *LocalProcessingService) DispatchCriteria(ctx context.Context, entity *s
 	s.mu.RUnlock()
 
 	if !ok {
-		return false, fmt.Errorf("no local criteria registered for %q", name)
+		return false, "", fmt.Errorf("no local criteria registered for %q", name)
 	}
 	counter.Add(1)
 	return fn(ctx, entity, criterion)

--- a/internal/testing/localproc/localproc_test.go
+++ b/internal/testing/localproc/localproc_test.go
@@ -82,7 +82,7 @@ func TestLocalProc_DispatchCriteria_Registered(t *testing.T) {
 
 	entity := testEntity()
 	criterion := json.RawMessage(`{"type":"function","function":{"name":"check-age"}}`)
-	matched, err := svc.DispatchCriteria(context.Background(), entity, criterion, "TRANSITION", "wf", "tr", "", "tx-1")
+	matched, _, err := svc.DispatchCriteria(context.Background(), entity, criterion, "TRANSITION", "wf", "tr", "", "tx-1")
 	if err != nil {
 		t.Fatalf("DispatchCriteria: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestLocalProc_DispatchCriteria_ReturnsFalse(t *testing.T) {
 
 	entity := testEntity()
 	criterion := json.RawMessage(`{"type":"function","function":{"name":"is-minor"}}`)
-	matched, err := svc.DispatchCriteria(context.Background(), entity, criterion, "TRANSITION", "wf", "tr", "", "tx-1")
+	matched, _, err := svc.DispatchCriteria(context.Background(), entity, criterion, "TRANSITION", "wf", "tr", "", "tx-1")
 	if err != nil {
 		t.Fatalf("DispatchCriteria: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestLocalProc_DispatchCriteria_Unregistered(t *testing.T) {
 	svc := localproc.New()
 	entity := testEntity()
 	criterion := json.RawMessage(`{"type":"function","function":{"name":"missing"}}`)
-	_, err := svc.DispatchCriteria(context.Background(), entity, criterion, "TRANSITION", "wf", "tr", "", "tx-1")
+	_, _, err := svc.DispatchCriteria(context.Background(), entity, criterion, "TRANSITION", "wf", "tr", "", "tx-1")
 	if err == nil {
 		t.Fatal("expected error for unregistered criteria")
 	}


### PR DESCRIPTION
## Summary

Surfaces a workflow criterion's **stoppage reason** — the free-text explanation a gRPC criteria compute node returns for a `matches=false` result — which was previously dead data (declared on `EntityCriteriaCalculationResponse.reason` but never deserialized, never surfaced). Clients can now learn *why* a passage was blocked, not just that a criterion said "no".

Closes #413.

## Two client surfaces (design decision: **Option B**)

State-machine audit events are **transaction-bound**, so a rejected manual transition's audit event rolls back with its transaction. Rather than change transaction commit/rollback semantics to force audit durability (an earlier attempt to do so was **rolled back** — it was unsound, persisting FUNCTION-criteria joined writes and missing a concurrency gate), the reason is delivered per path where it is durable:

- **Manual explicit transition rejected by its criterion → the reason is in the direct `400 WORKFLOW_FAILED` response** (`"transition \"X\" criterion not matched: <reason>"`). Guaranteed, backend-independent, and documented in OpenAPI + `cyoda help`. This is the primary surface for manual rejections.
- **Automated cascade + workflow-selection (`WORKFLOW_SKIP`) → durable state-machine audit `data.reason`** (these paths commit). Read via `GET /audit/entity/{id}?eventTypes=StateMachine`. Data shapes: `TRANSITION_NOT_MATCH_CRITERION` → `{workflowName, transition, criterion, reason}`; `WORKFLOW_SKIP` → `{workflowName, reason}`.

The entity transaction's commit/rollback semantics are **unchanged**.

## Implementation

- **Plumbing (all internal, no `cyoda-go-spi` change):** deserialize `reason` → `ProcessingResponse.Reason` → widened `DispatchCriteria (bool, string, error)` across all implementors/doubles → cross-node `DispatchCriteriaResponse.Reason` (peer producer + local/peer branches, multi-node-correct) → engine `evaluateCriterion`.
- **Engine:** capped (2 KiB, rune-safe) reason threaded to the three no-match sites; inline predicates default to `"criterion did not match"`; criterion name parsed from the nested `{"type":"function","function":{"name":...}}` shape.

## Testing & review

- Unit (`internal/grpc`, `internal/cluster/dispatch`, `internal/domain/workflow`) asserting exact reason strings; e2e on real Postgres (`internal/e2e/criterion_reason_test.go` — manual→400 body, automated/inline→durable audit); cross-backend parity (`e2e/parity`, registered + count bumped).
- `go test ./...` green (55 pkg); `make test-all` green (plugins, 58 pkg); `make race` green (0 races); `go vet` clean.
- Independent whole-branch review: **READY**, no Critical/Important. Security review: **PASS** (reason capped once covering the peer path, never logged, JSON-only 400 body, tenant binding intact, peer auth untouched).

## Docs (Gate 4 / Gate 7)

OpenAPI (`api/openapi.yaml` + `docs/cyoda/openapi.yml`), `cmd/cyoda/help/content/grpc.md`, `docs/cloud-parity/criterion-stoppage-reason.md`, CHANGELOG.

## Follow-on

Processor-selection criteria (`PROCESS_NOT_MATCH_CRITERION`) — guarding a processor by a criterion — is a separate unbuilt feature (needs an SPI `ProcessorConfig.Criterion` field + schema-version bump). Tracked in #414; the reason-plumbing here makes it a drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
