### PR TITLE
fix(workflow): reject malformed regex in criteria at import (fail-loud)

### DIFF
--- a/docs/workflow-schema-versioning.md
+++ b/docs/workflow-schema-versioning.md
@@ -46,6 +46,18 @@ Document the choice (dual-shape vs retirement, with rationale) in the per-versio
 - Bug-fixing a validator that was already supposed to reject something — i.e., the rejection was always documented and the validator was the bug. Add a test, ship the fix; no schema bump. (Borderline cases: if a validator was widely-relied-upon-via-its-absence, treat as a tightening release per §above.)
 - Internal refactoring of the engine, store, or audit shape. The wire contract is unchanged.
 
+### Malformed-regex criteria rejected at import (v0.8.3)
+
+A workflow-level or transition-level criterion whose `MATCHES_PATTERN`
+operator carries a regex that fails to compile is now rejected at import
+(`400 VALIDATION_FAILED`), instead of importing successfully and only
+erroring the first time the transition is evaluated. This is the §"When NOT
+to bump" "bug-fixing a validator that was already supposed to reject
+something" case: a malformed regex never worked — every evaluation attempt
+already failed — so no *working* config is newly rejected, only the failure
+moves from eval time to import time. No `CurrentSchemaVersion` or
+`SupportedSchemaRanges` change.
+
 ### Model export surface — `uniqueKeys` field (v0.8.2)
 
 `GET /model/export/…` responses carry a top-level `uniqueKeys` array listing the model's declared composite unique keys. The field uses **omitempty** semantics — it is present only when the model declares at least one key; a model with no keys exports byte-identically to a pre-feature model (matching the descriptor storage DTOs, which also omit the empty case). This is a purely additive change to the **model export DTO** (`ExportModel`) — it is separate from `WorkflowConfigurationDto` and therefore does **not** trigger a workflow schema version bump per the rule above. No `CurrentSchemaVersion` change is required.

--- a/internal/domain/workflow/criterion_regex_test.go
+++ b/internal/domain/workflow/criterion_regex_test.go
@@ -1,0 +1,155 @@
+package workflow
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	spi "github.com/cyoda-platform/cyoda-go-spi"
+)
+
+// Tests for import-time rejection of malformed MATCHES_PATTERN regexes in
+// workflow/transition criteria. Before this validator, a malformed regex
+// (e.g. "[") imported successfully and only surfaced as an error on every
+// subsequent transition evaluation (engine.go's predicate.ParseCondition ->
+// match.Match path) — a fail-open gap at import time. These tests pin the
+// fail-closed behaviour: reject at import instead.
+
+const malformedPattern = "["
+const validPattern = "^ORD-[0-9]+$"
+
+func simpleMatchesPatternCriterion(pattern string) json.RawMessage {
+	return json.RawMessage(`{"type":"simple","jsonPath":"$.orderId","operatorType":"MATCHES_PATTERN","value":"` + pattern + `"}`)
+}
+
+func groupWithNestedMatchesPattern(pattern string) json.RawMessage {
+	return json.RawMessage(`{
+		"type": "group",
+		"operator": "AND",
+		"conditions": [
+			{"type":"simple","jsonPath":"$.status","operatorType":"EQUALS","value":"OPEN"},
+			{
+				"type": "group",
+				"operator": "OR",
+				"conditions": [
+					{"type":"simple","jsonPath":"$.orderId","operatorType":"MATCHES_PATTERN","value":"` + pattern + `"}
+				]
+			}
+		]
+	}`)
+}
+
+func functionCriterion() json.RawMessage {
+	return json.RawMessage(`{"type":"function","function":{"name":"myFn","calculationNodesTags":"tag"}}`)
+}
+
+func wfWithTransitionCriterion(criterion json.RawMessage) spi.WorkflowDefinition {
+	return spi.WorkflowDefinition{
+		Version: "1.1", Name: "wf-regex", InitialState: "S1", Active: true,
+		States: map[string]spi.StateDefinition{
+			"S1": {
+				Transitions: []spi.TransitionDefinition{
+					{Name: "go", Next: "S2", Manual: true, Criterion: criterion},
+				},
+			},
+			"S2": {},
+		},
+	}
+}
+
+func wfWithWorkflowCriterion(criterion json.RawMessage) spi.WorkflowDefinition {
+	return spi.WorkflowDefinition{
+		Version: "1.1", Name: "wf-regex", InitialState: "S1", Active: true,
+		Criterion: criterion,
+		States: map[string]spi.StateDefinition{
+			"S1": {
+				Transitions: []spi.TransitionDefinition{
+					{Name: "go", Next: "S2", Manual: true},
+				},
+			},
+			"S2": {},
+		},
+	}
+}
+
+// (a) transition-level malformed regex is rejected.
+func TestValidateWorkflowStructure_RejectsMalformedRegexInTransitionCriterion(t *testing.T) {
+	wf := wfWithTransitionCriterion(simpleMatchesPatternCriterion(malformedPattern))
+	err := validateWorkflowStructure(wf)
+	if err == nil {
+		t.Fatalf("expected error for malformed MATCHES_PATTERN regex, got nil")
+	}
+	if !strings.Contains(err.Error(), "wf-regex") || !strings.Contains(err.Error(), "go") {
+		t.Errorf("error must name the offending workflow/transition, got: %v", err)
+	}
+}
+
+// (b) workflow-level malformed regex is rejected.
+func TestValidateWorkflowStructure_RejectsMalformedRegexInWorkflowCriterion(t *testing.T) {
+	wf := wfWithWorkflowCriterion(simpleMatchesPatternCriterion(malformedPattern))
+	err := validateWorkflowStructure(wf)
+	if err == nil {
+		t.Fatalf("expected error for malformed MATCHES_PATTERN regex, got nil")
+	}
+	if !strings.Contains(err.Error(), "wf-regex") {
+		t.Errorf("error must name the offending workflow, got: %v", err)
+	}
+}
+
+// (c) malformed regex nested inside a GROUP (AND/OR) condition is rejected.
+func TestValidateWorkflowStructure_RejectsMalformedRegexNestedInGroup(t *testing.T) {
+	wf := wfWithTransitionCriterion(groupWithNestedMatchesPattern(malformedPattern))
+	err := validateWorkflowStructure(wf)
+	if err == nil {
+		t.Fatalf("expected error for malformed regex nested in a group condition, got nil")
+	}
+}
+
+// (d) a FUNCTION criterion is skipped, not rejected.
+func TestValidateWorkflowStructure_FunctionCriterionSkipped(t *testing.T) {
+	wf := wfWithTransitionCriterion(functionCriterion())
+	if err := validateWorkflowStructure(wf); err != nil {
+		t.Fatalf("FUNCTION criterion must not be rejected by regex validation: %v", err)
+	}
+}
+
+// (e) a valid, non-malformed regex (and a valid non-regex criterion) is accepted.
+func TestValidateWorkflowStructure_ValidRegexAccepted(t *testing.T) {
+	wf := wfWithTransitionCriterion(simpleMatchesPatternCriterion(validPattern))
+	if err := validateWorkflowStructure(wf); err != nil {
+		t.Fatalf("valid MATCHES_PATTERN regex must be accepted: %v", err)
+	}
+}
+
+func TestValidateWorkflowStructure_ValidNonRegexCriterionAccepted(t *testing.T) {
+	criterion := json.RawMessage(`{"type":"simple","jsonPath":"$.status","operatorType":"EQUALS","value":"OPEN"}`)
+	wf := wfWithTransitionCriterion(criterion)
+	if err := validateWorkflowStructure(wf); err != nil {
+		t.Fatalf("valid non-regex criterion must be accepted: %v", err)
+	}
+}
+
+// (f) a criterion that does not parse as a condition at all is left alone
+// (not newly rejected by this change) — pre-existing behaviour preserved.
+func TestValidateWorkflowStructure_UnparseableCriterionNotNewlyRejected(t *testing.T) {
+	criterion := json.RawMessage(`{"type":"totally-unknown-shape"}`)
+	wf := wfWithTransitionCriterion(criterion)
+	if err := validateWorkflowStructure(wf); err != nil {
+		t.Fatalf("unparseable criterion must not be newly rejected by regex validation: %v", err)
+	}
+}
+
+// Empty / null criteria are not touched by this validator either.
+func TestValidateWorkflowStructure_EmptyAndNullCriteriaAccepted(t *testing.T) {
+	for name, criterion := range map[string]json.RawMessage{
+		"nil":  nil,
+		"null": json.RawMessage("null"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			wf := wfWithTransitionCriterion(criterion)
+			if err := validateWorkflowStructure(wf); err != nil {
+				t.Fatalf("empty/null criterion must be accepted: %v", err)
+			}
+		})
+	}
+}

--- a/internal/domain/workflow/validate.go
+++ b/internal/domain/workflow/validate.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
 	spi "github.com/cyoda-platform/cyoda-go-spi"
+	"github.com/cyoda-platform/cyoda-go-spi/predicate"
 )
 
 // Processor execution-mode tokens. Sourced from the OpenAPI enum in
@@ -195,6 +197,70 @@ func validateAndNormalizeAnnotations(workflows []spi.WorkflowDefinition) error {
 	return nil
 }
 
+// validateCriterionRegex rejects a criterion whose MATCHES_PATTERN operator
+// carries a regex that fails to compile. Criteria are stored opaquely
+// (json.RawMessage) and previously were only parsed at transition-evaluation
+// time (engine.go's evaluateCriterion -> match.Match -> operators.go's
+// opMatchesPattern), so a malformed regex imported successfully and then
+// errored on every subsequent evaluation of that transition. This closes
+// that fail-open gap by compiling MATCHES_PATTERN regexes at import time.
+//
+// location names the workflow/state/transition the criterion belongs to, for
+// the error message. Empty/null criteria are skipped. A criterion that does
+// not parse as a predicate.Condition at all is left alone — this validator
+// only tightens already-parseable conditions, it does not newly reject
+// shapes ParseCondition already rejects (that is out of scope for this
+// check; those criteria fail at evaluation time exactly as before).
+func validateCriterionRegex(criterion json.RawMessage, location string) error {
+	trimmed := bytes.TrimSpace(criterion)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	cond, err := predicate.ParseCondition(trimmed)
+	if err != nil {
+		return nil
+	}
+	return walkCriterionForRegex(cond, location)
+}
+
+// walkCriterionForRegex recurses into GroupCondition.Conditions and checks
+// every SimpleCondition / LifecycleCondition leaf whose OperatorType is
+// MATCHES_PATTERN. Other condition kinds (FunctionCondition, ArrayCondition)
+// carry no OperatorType to check and are silently skipped — in particular
+// this is how a FUNCTION criterion is exempted from regex validation.
+func walkCriterionForRegex(cond predicate.Condition, location string) error {
+	switch c := cond.(type) {
+	case *predicate.SimpleCondition:
+		return compileMatchesPattern(c.OperatorType, c.Value, location)
+	case *predicate.LifecycleCondition:
+		return compileMatchesPattern(c.OperatorType, c.Value, location)
+	case *predicate.GroupCondition:
+		for _, sub := range c.Conditions {
+			if err := walkCriterionForRegex(sub, location); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// compileMatchesPattern compiles value as a regex exactly the way
+// the evaluator does — internal/match/operators.go's opMatchesPattern calls
+// regexp.MatchString(fmt.Sprintf("%v", expected), actual.String()), which
+// itself compiles via regexp.Compile. Mirroring the %v stringification
+// and Compile call here means a pattern accepted here is guaranteed
+// compilable at evaluation time, and vice versa — no accept/reject skew.
+func compileMatchesPattern(operatorType string, value any, location string) error {
+	if operatorType != "MATCHES_PATTERN" {
+		return nil
+	}
+	pattern := fmt.Sprintf("%v", value)
+	if _, err := regexp.Compile(pattern); err != nil {
+		return fmt.Errorf("%s: invalid MATCHES_PATTERN regex %q: %v", location, pattern, err)
+	}
+	return nil
+}
+
 // validateImportRequest enforces the per-incoming-workflow structural
 // rules (audit §H4, §H6.a–e, §M4). Violations are returned as plain
 // errors that the caller wraps in a 400 with ErrCodeValidationFailed.
@@ -267,11 +333,13 @@ func validateWorkflows(workflows []spi.WorkflowDefinition, allowCycles bool) err
 // validateWorkflowStructure enforces the per-workflow structural rules
 // (H6.a–e, H4) plus the security-audit follow-ups M-1 (empty state-map
 // keys), L-1 (empty transition / processor names) and L-2 (identifier
-// length cap). Any violation is a 4xx at import time —
-// the engine would otherwise silently degrade at runtime (park entity
-// in an undefined state, shadow duplicate transitions, coerce typo'd
-// ExecutionMode to SYNC) or accept arbitrarily long identifiers into
-// operational logs and audit events.
+// length cap), plus criterion regex validation. Any violation is a 4xx at
+// import time — the engine would otherwise silently degrade at runtime
+// (park entity in an undefined state, shadow duplicate transitions, coerce
+// typo'd ExecutionMode to SYNC) or accept arbitrarily long identifiers into
+// operational logs and audit events. A malformed MATCHES_PATTERN regex in a
+// workflow-level or transition-level criterion is rejected here rather than
+// at every subsequent transition-evaluation attempt.
 func validateWorkflowStructure(wf spi.WorkflowDefinition) error {
 	// H6.c — Name non-empty.
 	if wf.Name == "" {
@@ -291,6 +359,12 @@ func validateWorkflowStructure(wf spi.WorkflowDefinition) error {
 		return fmt.Errorf("workflow %q: initialState %q is not declared in states", wf.Name, wf.InitialState)
 	}
 
+	// Workflow-level criterion — reject a malformed MATCHES_PATTERN regex
+	// at import instead of failing every evaluation.
+	if err := validateCriterionRegex(wf.Criterion, fmt.Sprintf("workflow %q", wf.Name)); err != nil {
+		return err
+	}
+
 	// Iterate states once and enforce:
 	//   M-1 — state-map keys must be non-empty.
 	//   L-2 — state-map keys length cap.
@@ -302,6 +376,7 @@ func validateWorkflowStructure(wf spi.WorkflowDefinition) error {
 	//   L-2 — Processor Name length cap.
 	//   H4  — ExecutionMode ∈ {SYNC, ASYNC_SAME_TX, ASYNC_NEW_TX, COMMIT_BEFORE_DISPATCH, ""}.
 	//   M1  — RetryPolicy ∈ {NONE, FIXED, ""}.
+	//   Transition.Criterion — a MATCHES_PATTERN regex, if present, must compile.
 	for stateName, stateDef := range wf.States {
 		if stateName == "" {
 			return fmt.Errorf("workflow %q: empty state name is not allowed in the states map",
@@ -331,6 +406,11 @@ func validateWorkflowStructure(wf spi.WorkflowDefinition) error {
 			if _, ok := wf.States[tr.Next]; !ok {
 				return fmt.Errorf("workflow %q state %q transition %q: next state %q is not declared in states",
 					wf.Name, stateName, tr.Name, tr.Next)
+			}
+
+			if err := validateCriterionRegex(tr.Criterion,
+				fmt.Sprintf("workflow %q state %q transition %q", wf.Name, stateName, tr.Name)); err != nil {
+				return err
 			}
 
 			if tr.Manual && tr.Schedule != nil {

--- a/internal/e2e/workflow_test.go
+++ b/internal/e2e/workflow_test.go
@@ -299,6 +299,61 @@ func TestWorkflow_Import_ValidationFailed(t *testing.T) {
 	}
 }
 
+// TestWorkflow_Import_MalformedCriterionRegex_ValidationFailed verifies that
+// a transition criterion whose MATCHES_PATTERN regex fails to compile is
+// rejected at import with 400 VALIDATION_FAILED, instead of importing
+// successfully and only surfacing the error the first time the transition is
+// evaluated.
+func TestWorkflow_Import_MalformedCriterionRegex_ValidationFailed(t *testing.T) {
+	const entityName = "e2e-wf-badregex"
+	importModelE2E(t, entityName, 1)
+
+	body := `{
+		"importMode": "REPLACE",
+		"workflows": [{
+			"version": "1.1",
+			"name": "wf-badregex",
+			"initialState": "S1",
+			"active": true,
+			"states": {
+				"S1": {
+					"transitions": [{
+						"name": "go",
+						"next": "S2",
+						"manual": false,
+						"criterion": {
+							"type": "simple",
+							"jsonPath": "$.orderId",
+							"operatorType": "MATCHES_PATTERN",
+							"value": "["
+						}
+					}]
+				},
+				"S2": {}
+			}
+		}]
+	}`
+	status, respBody := importWorkflowE2E(t, entityName, 1, body)
+	if status != http.StatusBadRequest {
+		t.Fatalf("expected 400 VALIDATION_FAILED; got %d: %s", status, respBody)
+	}
+	var errBody struct {
+		Detail     string `json:"detail"`
+		Properties struct {
+			ErrorCode string `json:"errorCode"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(respBody), &errBody); err != nil {
+		t.Fatalf("decode error body: %v; raw: %s", err, respBody)
+	}
+	if errBody.Properties.ErrorCode != "VALIDATION_FAILED" {
+		t.Fatalf("errorCode = %q; want VALIDATION_FAILED; body: %s", errBody.Properties.ErrorCode, respBody)
+	}
+	if !strings.Contains(errBody.Detail, "go") {
+		t.Errorf("detail %q does not name the offending transition", errBody.Detail)
+	}
+}
+
 // TestWorkflow_ExportEmpty verifies that exporting a workflow for a model
 // that has no imported workflows returns 404 WORKFLOW_NOT_FOUND. A properly
 // structured GET on a non-existent resource should return NOT FOUND, not


### PR DESCRIPTION
## Summary

Reject a malformed `MATCHES_PATTERN` regex in a workflow criterion **at import time** instead of letting it through and erupting at transition-evaluation time.

Workflow criteria are stored as opaque JSON and only parsed (`predicate.ParseCondition` → `match.Match`) when a transition is evaluated. Import validation did no regex checking, so a criterion like `{"operatorType":"MATCHES_PATTERN","value":"["}` imported successfully and then errored on every evaluation of that transition — a validation-*timing* gap (fail-closed, but late). This validates and rejects it at registration, consistent with the request-boundary regex validation the search path already does.

Surfaced by the code review on #424 (tx-aware search pushdown), which closed the same class for the *search*/*grouped-stats* paths; this closes it for the *workflow-criteria* path. Independent — does not depend on #424.

## Change

`validateWorkflowStructure` now, for the workflow-level criterion and each transition criterion: skips empty/`null` and FUNCTION criteria; parses the condition; walks it (SimpleCondition, LifecycleCondition, recursing GroupCondition — ArrayCondition/FunctionCondition can't carry `MATCHES_PATTERN` and are skipped); and compiles each `MATCHES_PATTERN` pattern with the **exact** call the evaluator uses (`regexp.Compile(fmt.Sprintf("%v", value))`, mirroring `opMatchesPattern`) — no accept/reject skew. A compile failure returns the existing import validation error (400 `VALIDATION_FAILED`); a criterion that doesn't parse as a condition is **not** newly rejected (behavior preserved). Eval-time code is untouched.

## Schema versioning

**No `CurrentSchemaVersion` bump** (stays `1.3`). Per `docs/workflow-schema-versioning.md` §"When NOT to bump": a non-compiling regex was never a *working* criterion (it always errored at eval, since `regexp.MatchString` compiles internally), so no working config is newly rejected — the failure only moves earlier (import vs runtime). This is a validator bugfix for always-broken input, not a restriction on valid configs. A dated changelog entry documenting this rationale is added to the doc.

## Tests

Unit (`internal/domain/workflow`): reject malformed regex at transition-level, workflow-level, and nested in an AND/OR group; accept a valid regex, a FUNCTION criterion, and a non-regex criterion; preserve acceptance of unparseable criteria. E2E: import with a malformed-regex criterion → HTTP 400 `VALIDATION_FAILED`. `go vet` clean; scoped `-race` on the package clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
