### PR TITLE
fix(workflow): default processor config.attachEntity to true at import (#421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,16 @@ All notable changes to Cyoda-Go are documented here. The project follows [Keep a
 
 ### Changed
 
+- **Processor `config.attachEntity` now defaults to `true`.** A processor whose
+  `config` omits `attachEntity` is imported with `attachEntity: true`, so the
+  full entity payload is attached to its calculation request — matching
+  `schedule.function` and the criterion `function` callout, which already
+  default to `true`. Set `attachEntity: false` explicitly to opt out. Existing
+  workflows that omit the field and re-import (e.g. export → import) will start
+  attaching the entity payload; compute nodes that ignore the payload are
+  unaffected.
+  ([#421](https://github.com/Cyoda-platform/cyoda-go/issues/421))
+
 - **`DELETE /model/{entityName}/{modelVersion}` now enforces the documented
   UNLOCKED precondition** — deleting a `LOCKED` model returns `409
   MODEL_ALREADY_LOCKED` (previously the lock state was ignored). Unlock the model

--- a/api/generated.go
+++ b/api/generated.go
@@ -2092,7 +2092,7 @@ type ErrorResponseDtoError string
 
 // ExternalizedFunctionConfigDto defines model for ExternalizedFunctionConfigDto.
 type ExternalizedFunctionConfigDto struct {
-	// AttachEntity Whether to attach entity data to the function call
+	// AttachEntity Whether to attach the full entity payload to the criterion function calculation request. Defaults to true.
 	AttachEntity *bool `json:"attachEntity,omitempty"`
 
 	// CalculationNodesTags Comma-separated list of calculation node tags
@@ -2148,7 +2148,7 @@ type ExternalizedProcessorConfigDto struct {
 	// false case.
 	AsyncResult *bool `json:"asyncResult,omitempty"`
 
-	// AttachEntity Whether to attach entity data to the function call
+	// AttachEntity Whether to attach the full entity payload to the processor calculation request. Defaults to true.
 	AttachEntity *bool `json:"attachEntity,omitempty"`
 
 	// CalculationNodesTags Comma-separated list of calculation node tags

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -9078,7 +9078,9 @@ components:
       properties:
         attachEntity:
           type: boolean
-          description: Whether to attach entity data to the function call
+          default: true
+          description: Whether to attach the full entity payload to the
+            criterion function calculation request. Defaults to true.
         calculationNodesTags:
           type: string
           description: Comma-separated list of calculation node tags
@@ -9788,7 +9790,9 @@ components:
       properties:
         attachEntity:
           type: boolean
-          description: Whether to attach entity data to the function call
+          default: true
+          description: Whether to attach the full entity payload to the
+            processor calculation request. Defaults to true.
         calculationNodesTags:
           type: string
           description: Comma-separated list of calculation node tags

--- a/cmd/cyoda/help/content/workflows.md
+++ b/cmd/cyoda/help/content/workflows.md
@@ -183,7 +183,7 @@ Import-time validation rejects any `executionMode` value not in the list above (
 
 **ProcessorConfig fields:**
 
-- `attachEntity` — boolean — when `true`, the full entity payload is sent to the processor
+- `attachEntity` — boolean, optional, default `true` — when `true`, the full entity payload is sent to the processor; set `false` to omit it
 - `calculationNodesTags` — string — comma-separated tags for routing to registered calculation nodes; the engine selects a node that declares all required tags; returns `errors.NO_COMPUTE_MEMBER_FOR_TAG` if no node matches
 - `responseTimeoutMs` — int64 — timeout in milliseconds for `SYNC` processor response; `0` means use node default
 - `retryPolicy` — string — selects the server-resolved retry strategy.

--- a/docs/cloud-parity/README.md
+++ b/docs/cloud-parity/README.md
@@ -23,6 +23,7 @@ Cloud needs to adopt.
 | `openapi-conformance.md` | OpenAPI operation status, live common ground, tolerant-reader obligation, deferred open questions (E6, D2) |
 | `search-sort.md` | Search result sorting — HTTP `sort` grammar, gRPC `orderBy`, canonical ordering semantics |
 | `processor-criteria-annotations.md` | Processor `annotations` + workflow/transition `criterionAnnotations`, well-known renderer keys, schema 1.1 → 1.2 |
+| `processor-attach-entity-default.md` | Processor `config.attachEntity` defaults to `true` on import, aligning with the function callouts |
 | `nested-join-tx-serialisation.md` | Per-tx gate must release across external dispatch so depth-2+ nested joined cascades commit atomically instead of deadlocking |
 | `criterion-stoppage-reason.md` | Criteria `reason` field: 400-response delivery + durable audit `data.reason` on automated/skip paths |
 | `scheduled-transitions.md` | Scheduled-transition runtime: arm/cancel atomicity, one-shot criterion, grace-band expiry, explicit-fire reject, audit events, settled-interval reset |

--- a/docs/cloud-parity/processor-attach-entity-default.md
+++ b/docs/cloud-parity/processor-attach-entity-default.md
@@ -1,0 +1,24 @@
+# Processor `config.attachEntity` default
+
+## Contract
+
+On workflow import, a processor whose `config` omits `attachEntity` resolves to
+`attachEntity: true` — the full entity payload is attached to its
+`EntityProcessorCalculationRequest`. An explicit `false` or `true` is preserved
+verbatim. The default is applied at the import boundary, so a re-export stamps
+the resolved value explicitly.
+
+This makes all three compute-node callout shapes agree on an omitted
+`attachEntity`:
+
+| Callout | Config shape | Omitted `attachEntity` |
+|---|---|---|
+| Processor | `processors[].config` | **true** |
+| Scheduled-transition function | `schedule.function` | **true** |
+| Criterion function | `{"type":"function"}.config` | **true** |
+
+## Cloud obligation
+
+Resolve an omitted processor `config.attachEntity` to `true` at import,
+identically to the function callouts. A payload that already sets the field
+explicitly is unaffected.

--- a/e2e/parity/registry.go
+++ b/e2e/parity/registry.go
@@ -2,7 +2,7 @@ package parity
 
 import "testing"
 
-// Total parity scenarios: 198 (guarded by TestParityScenarioCount — bump
+// Total parity scenarios: 199 (guarded by TestParityScenarioCount — bump
 // wantParityScenarioCount in registry_count_test.go when adding/removing an
 // entry, or the test fails).
 // (Phase 1 smoke + Phase 4a CRUD/persistence + Phase 4b workflow/compute +
@@ -49,6 +49,7 @@ var allTests = []NamedTest{
 	{"WorkflowImportExport", RunWorkflowImportExport},
 	{"WorkflowAnnotationsRoundTrip", RunWorkflowAnnotationsRoundTrip},
 	{"WorkflowProcCriterionAnnotationsRoundTrip", RunWorkflowProcCriterionAnnotationsRoundTrip},
+	{"WorkflowProcAttachEntityDefaultRoundTrip", RunWorkflowProcAttachEntityDefaultRoundTrip},
 
 	// Phase 4a — entity CRUD (Task 4a.2)
 	{"EntityCreateAndGet", RunEntityCreateAndGet},

--- a/e2e/parity/registry_count_test.go
+++ b/e2e/parity/registry_count_test.go
@@ -6,7 +6,7 @@ import "testing"
 // the registry.go header comment drifted silently for many PRs because nothing
 // asserted it; this test converts that drift into a failure. Bump this constant
 // (and the header comment) in the same change that adds or removes a scenario.
-const wantParityScenarioCount = 198
+const wantParityScenarioCount = 199
 
 // TestParityScenarioCount guards the documented scenario count against silent
 // drift.

--- a/e2e/parity/workflow.go
+++ b/e2e/parity/workflow.go
@@ -207,3 +207,73 @@ func RunWorkflowProcCriterionAnnotationsRoundTrip(t *testing.T, fixture BackendF
 		t.Errorf("processor annotations: got %#v, want %#v", got, want)
 	}
 }
+
+const workflowProcAttachEntityPayload = `{
+  "importMode": "REPLACE",
+  "workflows": [{
+    "version": "1.3", "name": "proc-attach-wf", "initialState": "NONE", "active": true,
+    "states": { "NONE": { "transitions": [
+      { "name": "t", "next": "NONE", "manual": true, "processors": [
+        { "name": "p_omitted", "type": "externalized", "config": { "calculationNodesTags": "billing" } },
+        { "name": "p_false", "type": "externalized", "config": { "calculationNodesTags": "billing", "attachEntity": false } },
+        { "name": "p_true", "type": "externalized", "config": { "calculationNodesTags": "billing", "attachEntity": true } }
+      ] }
+    ] } }
+  }]
+}`
+
+// RunWorkflowProcAttachEntityDefaultRoundTrip verifies that an omitted
+// processor config.attachEntity defaults to true on import, while an explicit
+// false/true is preserved, consistently on every backend.
+func RunWorkflowProcAttachEntityDefaultRoundTrip(t *testing.T, fixture BackendFixture) {
+	tenant := fixture.NewTenant(t)
+	c := client.NewClient(fixture.BaseURL(), tenant.Token)
+
+	const modelName = "wf-proc-attach-test"
+	const modelVersion = 1
+
+	if err := c.ImportModel(t, modelName, modelVersion, `{"name":"Test Order","status":"draft"}`); err != nil {
+		t.Fatalf("ImportModel: %v", err)
+	}
+	if err := c.LockModel(t, modelName, modelVersion); err != nil {
+		t.Fatalf("LockModel: %v", err)
+	}
+	if err := c.ImportWorkflow(t, modelName, modelVersion, workflowProcAttachEntityPayload); err != nil {
+		t.Fatalf("ImportWorkflow: %v", err)
+	}
+	raw, err := c.ExportWorkflow(t, modelName, modelVersion)
+	if err != nil {
+		t.Fatalf("ExportWorkflow: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("ExportWorkflow: parse: %v", err)
+	}
+	wf := body["workflows"].([]any)[0].(map[string]any)
+	tr := wf["states"].(map[string]any)["NONE"].(map[string]any)["transitions"].([]any)[0].(map[string]any)
+	procs := tr["processors"].([]any)
+	if len(procs) != 3 {
+		t.Fatalf("expected 3 processors, got %d", len(procs))
+	}
+
+	// attach reads config.attachEntity, treating an absent key (omitempty on
+	// an explicit/defaulted false) as false.
+	attach := func(i int) bool {
+		p := procs[i].(map[string]any)
+		cfg, _ := p["config"].(map[string]any)
+		if cfg == nil {
+			return false
+		}
+		b, _ := cfg["attachEntity"].(bool)
+		return b
+	}
+	if !attach(0) {
+		t.Errorf("p_omitted: attachEntity = false, want true (defaulted)")
+	}
+	if attach(1) {
+		t.Errorf("p_false: attachEntity = true, want false (preserved)")
+	}
+	if !attach(2) {
+		t.Errorf("p_true: attachEntity = false, want true (preserved)")
+	}
+}

--- a/internal/domain/workflow/attach_entity_default_test.go
+++ b/internal/domain/workflow/attach_entity_default_test.go
@@ -5,11 +5,10 @@ import (
 	"testing"
 )
 
-// TestApplyScheduleFunctionAttachEntityDefault_HeterogeneousTransitions is a
-// direct unit test (C1, final review) guarding
-// applyScheduleFunctionAttachEntityDefault's raw-JSON re-decode/index-align
-// probe. The logic itself is unchanged — this only adds coverage the
-// existing single-transition, full-HTTP-import tests
+// TestApplyAttachEntityDefaults_HeterogeneousTransitions is a direct unit
+// test guarding applyAttachEntityDefaults' raw-JSON re-decode/index-align
+// probe for schedule.function.attachEntity. It covers a case the existing
+// single-transition, full-HTTP-import tests
 // (TestImport_ScheduleFunction_AttachEntityOmitted_DefaultsToTrue /
 // ...ExplicitFalse_Preserved in handler_test.go) don't reach: a
 // multi-workflow request with a heterogeneous transition mix in one state
@@ -21,10 +20,10 @@ import (
 //
 // Mirrors ImportEntityModelWorkflow's own mechanism (handler.go): decode
 // the SAME raw JSON bytes twice — once strictly into []workflowImportDef,
-// once loosely into scheduleFunctionAttachEntityProbe — rather than
-// hand-building the probe's unexported anonymous-struct literals, so the
-// test input is guaranteed aligned the same way production input is.
-func TestApplyScheduleFunctionAttachEntityDefault_HeterogeneousTransitions(t *testing.T) {
+// once loosely into attachEntityProbe — rather than hand-building the
+// probe's unexported anonymous-struct literals, so the test input is
+// guaranteed aligned the same way production input is.
+func TestApplyAttachEntityDefaults_HeterogeneousTransitions(t *testing.T) {
 	raw := []byte(`{
 		"importMode": "REPLACE",
 		"workflows": [
@@ -123,12 +122,12 @@ func TestApplyScheduleFunctionAttachEntityDefault_HeterogeneousTransitions(t *te
 	if err := json.Unmarshal(raw, &req); err != nil {
 		t.Fatalf("decode importRequest: %v", err)
 	}
-	var probe scheduleFunctionAttachEntityProbe
+	var probe attachEntityProbe
 	if err := json.Unmarshal(raw, &probe); err != nil {
 		t.Fatalf("decode probe: %v", err)
 	}
 
-	applyScheduleFunctionAttachEntityDefault(req.Workflows, probe)
+	applyAttachEntityDefaults(req.Workflows, probe)
 
 	wf1Trs := req.Workflows[0].States["S"].Transitions
 	if len(wf1Trs) != 5 {
@@ -159,5 +158,77 @@ func TestApplyScheduleFunctionAttachEntityDefault_HeterogeneousTransitions(t *te
 	}
 	if got := wf2Trs[1].Schedule.Function.AttachEntity; !got {
 		t.Errorf("T2_FN_OMITTED: AttachEntity = %v, want true (defaulted) — workflow-index alignment broken", got)
+	}
+}
+
+// TestApplyAttachEntityDefaults_Processors is the processor companion to the
+// schedule.function test above: it exercises the processor-index alignment of
+// applyAttachEntityDefaults. One transition carries three processors whose
+// config.attachEntity is omitted / explicit-false / explicit-true; a second
+// transition carries none. Decodes the same raw bytes twice, mirroring the
+// handler, so the probe indices line up the same way production input does.
+func TestApplyAttachEntityDefaults_Processors(t *testing.T) {
+	raw := []byte(`{
+		"importMode": "REPLACE",
+		"workflows": [
+			{
+				"version": "1.3",
+				"name": "wf",
+				"initialState": "S",
+				"states": {
+					"S": {
+						"transitions": [
+							{
+								"name": "T_NO_PROC",
+								"next": "S",
+								"manual": false
+							},
+							{
+								"name": "T_PROCS",
+								"next": "S",
+								"manual": false,
+								"processors": [
+									{"name": "p_omitted", "type": "externalized", "config": {"calculationNodesTags": "billing"}},
+									{"name": "p_false", "type": "externalized", "config": {"attachEntity": false}},
+									{"name": "p_true", "type": "externalized", "config": {"attachEntity": true}}
+								]
+							}
+						]
+					}
+				}
+			}
+		]
+	}`)
+
+	var req importRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		t.Fatalf("decode importRequest: %v", err)
+	}
+	var probe attachEntityProbe
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("decode probe: %v", err)
+	}
+
+	applyAttachEntityDefaults(req.Workflows, probe)
+
+	trs := req.Workflows[0].States["S"].Transitions
+	if len(trs) != 2 {
+		t.Fatalf("expected 2 transitions, got %d", len(trs))
+	}
+	if len(trs[0].Processors) != 0 {
+		t.Errorf("T_NO_PROC: expected no processors, got %d", len(trs[0].Processors))
+	}
+	procs := trs[1].Processors
+	if len(procs) != 3 {
+		t.Fatalf("T_PROCS: expected 3 processors, got %d", len(procs))
+	}
+	if got := procs[0].Config.AttachEntity; !got {
+		t.Errorf("p_omitted: AttachEntity = %v, want true (defaulted)", got)
+	}
+	if got := procs[1].Config.AttachEntity; got {
+		t.Errorf("p_false: AttachEntity = %v, want false (preserved)", got)
+	}
+	if got := procs[2].Config.AttachEntity; !got {
+		t.Errorf("p_true: AttachEntity = %v, want true (preserved)", got)
 	}
 }

--- a/internal/domain/workflow/handler.go
+++ b/internal/domain/workflow/handler.go
@@ -90,19 +90,16 @@ type importRequest struct {
 	Workflows   []workflowImportDef `json:"workflows"`
 }
 
-// scheduleFunctionAttachEntityProbe captures the raw-JSON presence of
-// schedule.function.attachEntity per transition. ScheduleFunctionDto
-// documents "Defaults to true" for an omitted attachEntity, but the SPI's
-// ScheduleFunction.AttachEntity is a plain bool (matching the wire shape
-// ProcessorConfig.AttachEntity already uses) — decoding straight into it,
-// as workflowImportDef.States does for the whole state graph, collapses
+// attachEntityProbe captures the raw-JSON presence of an omitted attachEntity
+// per transition, for both callout shapes that carry one:
+// schedule.function.attachEntity and each processors[].config.attachEntity.
+// The OpenAPI DTOs document these as "Defaults to true", but the SPI decodes
+// them into plain bool fields, which — decoded straight from the request body
+// as workflowImportDef.States does for the whole state graph — collapse
 // "omitted" and "explicit false" to the same zero value. This probe is a
-// second, non-strict decode of the same request body that declares only
-// the field path needed to recover the distinction; every other field is
-// ignored. Applied only to schedule.function — ProcessorConfig.AttachEntity
-// has the identical gap but is a separate, already-shipped feature and out
-// of scope here.
-type scheduleFunctionAttachEntityProbe struct {
+// second, non-strict decode of the same request body that declares only the
+// field paths needed to recover the distinction; every other field is ignored.
+type attachEntityProbe struct {
 	Workflows []struct {
 		States map[string]struct {
 			Transitions []struct {
@@ -111,19 +108,25 @@ type scheduleFunctionAttachEntityProbe struct {
 						AttachEntity *bool `json:"attachEntity"`
 					} `json:"function"`
 				} `json:"schedule"`
+				Processors []struct {
+					Config struct {
+						AttachEntity *bool `json:"attachEntity"`
+					} `json:"config"`
+				} `json:"processors"`
 			} `json:"transitions"`
 		} `json:"states"`
 	} `json:"workflows"`
 }
 
-// applyScheduleFunctionAttachEntityDefault defaults
-// schedule.function.attachEntity to true for every transition where the
-// client omitted it, using probe (decoded from the same raw request body)
-// to distinguish omission from an explicit false. workflows and probe.
-// Workflows are index-aligned (both decoded from the same top-level JSON
-// array in the same order); states are matched by map key; transitions
-// within a state are index-aligned (both decoded from the same JSON array).
-func applyScheduleFunctionAttachEntityDefault(workflows []workflowImportDef, probe scheduleFunctionAttachEntityProbe) {
+// applyAttachEntityDefaults defaults an omitted attachEntity to true for every
+// callout in every transition — schedule.function.attachEntity and each
+// processors[].config.attachEntity — using probe (decoded from the same raw
+// request body) to distinguish omission from an explicit false. workflows and
+// probe.Workflows are index-aligned (both decoded from the same top-level JSON
+// array in the same order); states are matched by map key; transitions and
+// processors within a state are index-aligned (both decoded from the same JSON
+// arrays).
+func applyAttachEntityDefaults(workflows []workflowImportDef, probe attachEntityProbe) {
 	for i, w := range workflows {
 		if i >= len(probe.Workflows) {
 			continue
@@ -138,13 +141,23 @@ func applyScheduleFunctionAttachEntityDefault(workflows []workflowImportDef, pro
 				if j >= len(pState.Transitions) {
 					continue
 				}
-				sched := state.Transitions[j].Schedule
-				pSched := pState.Transitions[j].Schedule
-				if sched == nil || sched.Function == nil || pSched == nil || pSched.Function == nil {
-					continue
+				// state.Transitions shares its backing array with the stored
+				// StateDefinition, so mutations via tr propagate to the value
+				// the handler goes on to persist.
+				tr := &state.Transitions[j]
+				pTr := pState.Transitions[j]
+				if tr.Schedule != nil && tr.Schedule.Function != nil &&
+					pTr.Schedule != nil && pTr.Schedule.Function != nil &&
+					pTr.Schedule.Function.AttachEntity == nil {
+					tr.Schedule.Function.AttachEntity = true
 				}
-				if pSched.Function.AttachEntity == nil {
-					sched.Function.AttachEntity = true
+				for k := range tr.Processors {
+					if k >= len(pTr.Processors) {
+						continue
+					}
+					if pTr.Processors[k].Config.AttachEntity == nil {
+						tr.Processors[k].Config.AttachEntity = true
+					}
 				}
 			}
 		}
@@ -187,14 +200,15 @@ func (h *Handler) ImportEntityModelWorkflow(w http.ResponseWriter, r *http.Reque
 
 	// Second, non-strict decode of the same bytes to recover the
 	// "attachEntity omitted" signal the strict decode above collapsed into
-	// spi.ScheduleFunction.AttachEntity's zero value. data was already
-	// proven valid JSON matching this shape by the strict decode, so this
-	// unmarshal cannot fail on a well-formed request; ignoring a defensive
-	// error here just leaves every attachEntity un-defaulted, which is the
-	// pre-existing (safe) behaviour.
-	var probe scheduleFunctionAttachEntityProbe
+	// the SPI's plain-bool AttachEntity zero value (both on
+	// ScheduleFunction and ProcessorConfig). data was already proven valid
+	// JSON matching this shape by the strict decode, so this unmarshal
+	// cannot fail on a well-formed request; ignoring a defensive error here
+	// just leaves every attachEntity un-defaulted, which is the safe
+	// fallback.
+	var probe attachEntityProbe
 	_ = json.Unmarshal(data, &probe)
-	applyScheduleFunctionAttachEntityDefault(req.Workflows, probe)
+	applyAttachEntityDefaults(req.Workflows, probe)
 
 	mode := strings.ToUpper(req.ImportMode)
 	if mode == "" {

--- a/internal/domain/workflow/handler_test.go
+++ b/internal/domain/workflow/handler_test.go
@@ -1059,6 +1059,164 @@ func TestImport_ScheduleFunction_AttachEntityExplicitFalse_Preserved(t *testing.
 	}
 }
 
+// TestImport_Processor_AttachEntityOmitted_DefaultsToTrue asserts the
+// import→export round trip for a processor's config.attachEntity: an omitted
+// attachEntity defaults to true, matching schedule.function.attachEntity so
+// the two callout shapes agree on what an omitted attachEntity means.
+func TestImport_Processor_AttachEntityOmitted_DefaultsToTrue(t *testing.T) {
+	srv := newTestServer(t)
+	importModel(t, srv.URL, "Order", 1)
+
+	body := `{
+		"importMode": "REPLACE",
+		"workflows": [
+			{
+				"version": "1.3",
+				"name": "proc-flow",
+				"initialState": "NEW",
+				"states": {
+					"NEW": {
+						"transitions": [
+							{
+								"name": "PROCESS",
+								"next": "DONE",
+								"manual": false,
+								"processors": [
+									{"name": "enrich", "type": "externalized", "config": {"calculationNodesTags": "billing"}}
+								]
+							}
+						]
+					},
+					"DONE": {
+						"transitions": []
+					}
+				}
+			}
+		]
+	}`
+	resp := doWorkflowImport(t, srv.URL, "Order", 1, body)
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("import expected 200, got %d: %s", resp.StatusCode, b)
+	}
+	resp.Body.Close()
+
+	wfs := readWorkflows(t, doWorkflowExport(t, srv.URL, "Order", 1))
+	if len(wfs) != 1 {
+		t.Fatalf("expected 1 workflow, got %d", len(wfs))
+	}
+	tr := wfs[0].States["NEW"].Transitions[0]
+	if len(tr.Processors) != 1 {
+		t.Fatalf("expected processor to round-trip, got %+v", tr)
+	}
+	if !tr.Processors[0].Config.AttachEntity {
+		t.Errorf("expected omitted processor attachEntity to default to true, got AttachEntity=false")
+	}
+}
+
+// TestImport_Processor_AttachEntityExplicitFalse_Preserved is the companion
+// regression guard: an explicit `false` must NOT be overridden by the default.
+func TestImport_Processor_AttachEntityExplicitFalse_Preserved(t *testing.T) {
+	srv := newTestServer(t)
+	importModel(t, srv.URL, "Order", 1)
+
+	body := `{
+		"importMode": "REPLACE",
+		"workflows": [
+			{
+				"version": "1.3",
+				"name": "proc-flow",
+				"initialState": "NEW",
+				"states": {
+					"NEW": {
+						"transitions": [
+							{
+								"name": "PROCESS",
+								"next": "DONE",
+								"manual": false,
+								"processors": [
+									{"name": "enrich", "type": "externalized", "config": {"calculationNodesTags": "billing", "attachEntity": false}}
+								]
+							}
+						]
+					},
+					"DONE": {
+						"transitions": []
+					}
+				}
+			}
+		]
+	}`
+	resp := doWorkflowImport(t, srv.URL, "Order", 1, body)
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("import expected 200, got %d: %s", resp.StatusCode, b)
+	}
+	resp.Body.Close()
+
+	wfs := readWorkflows(t, doWorkflowExport(t, srv.URL, "Order", 1))
+	tr := wfs[0].States["NEW"].Transitions[0]
+	if len(tr.Processors) != 1 {
+		t.Fatalf("expected processor to round-trip, got %+v", tr)
+	}
+	if tr.Processors[0].Config.AttachEntity {
+		t.Errorf("expected explicit processor attachEntity=false to be preserved, got AttachEntity=true")
+	}
+}
+
+// TestImport_Processor_AttachEntityExplicitTrue_Preserved guards that an
+// explicit `true` round-trips unchanged.
+func TestImport_Processor_AttachEntityExplicitTrue_Preserved(t *testing.T) {
+	srv := newTestServer(t)
+	importModel(t, srv.URL, "Order", 1)
+
+	body := `{
+		"importMode": "REPLACE",
+		"workflows": [
+			{
+				"version": "1.3",
+				"name": "proc-flow",
+				"initialState": "NEW",
+				"states": {
+					"NEW": {
+						"transitions": [
+							{
+								"name": "PROCESS",
+								"next": "DONE",
+								"manual": false,
+								"processors": [
+									{"name": "enrich", "type": "externalized", "config": {"calculationNodesTags": "billing", "attachEntity": true}}
+								]
+							}
+						]
+					},
+					"DONE": {
+						"transitions": []
+					}
+				}
+			}
+		]
+	}`
+	resp := doWorkflowImport(t, srv.URL, "Order", 1, body)
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("import expected 200, got %d: %s", resp.StatusCode, b)
+	}
+	resp.Body.Close()
+
+	wfs := readWorkflows(t, doWorkflowExport(t, srv.URL, "Order", 1))
+	tr := wfs[0].States["NEW"].Transitions[0]
+	if len(tr.Processors) != 1 {
+		t.Fatalf("expected processor to round-trip, got %+v", tr)
+	}
+	if !tr.Processors[0].Config.AttachEntity {
+		t.Errorf("expected explicit processor attachEntity=true to be preserved, got AttachEntity=false")
+	}
+}
+
 func TestImport_EmptyArrayReplace_Rejected(t *testing.T) {
 	srv := newTestServer(t)
 	importModel(t, srv.URL, "Order", 1)


### PR DESCRIPTION
## What

Default an omitted processor `config.attachEntity` to **`true`** at workflow
import, attaching the full entity payload to the processor's calculation
request. This aligns the three compute-node callout shapes — all now default an
omitted `attachEntity` to `true`:

| Callout | Config | Omitted `attachEntity` |
|---|---|---|
| Processor | `processors[].config` | **true** (this change) |
| Scheduled-transition function | `schedule.function` | true |
| Criterion function | `{"type":"function"}.config` | true |

Explicit `true`/`false` are preserved verbatim.

## How

The existing import-time default probe (previously schedule-function-only) is
generalised to `attachEntityProbe` / `applyAttachEntityDefaults`, extended to
also walk `processors[].config.attachEntity` via the same raw-JSON
re-decode/index-align mechanism that distinguishes an omitted field from an
explicit `false` (the SPI decodes both into a plain-bool zero value).

## Compatibility

Semantic change to released behaviour: an existing workflow whose processor
**omits** `attachEntity` will start receiving the full entity payload when
re-imported (e.g. export → import). Compute nodes that ignore the payload are
unaffected. Called out in the CHANGELOG. No workflow schema-version bump — the
wire shape is unchanged and no previously-valid payload is newly rejected.

## Docs

- `cyoda help workflows` — processor `attachEntity` now documents the default.
- OpenAPI `ExternalizedProcessorConfigDto` — states `default: true`; sibling
  `ExternalizedFunctionConfigDto` doc aligned (its true-default was already
  applied at dispatch but undocumented).
- New cloud-parity contract `docs/cloud-parity/processor-attach-entity-default.md`.

## Tests

- Unit: `applyAttachEntityDefaults` processor index-alignment (omitted /
  explicit-false / explicit-true / no-processor).
- HTTP import→export round trip: omitted→true, explicit-false→preserved,
  explicit-true→preserved.
- Cross-backend parity scenario `WorkflowProcAttachEntityDefaultRoundTrip`
  (memory / sqlite / postgres).
- `go test ./...` green (packages serial), full `internal/e2e` green,
  `make race` green.

Closes #421
