### PR TITLE
fix(grpc): stop echoing member keep-alives (unbounded CPU storm)

### DIFF
--- a/internal/grpc/streaming.go
+++ b/internal/grpc/streaming.go
@@ -156,22 +156,16 @@ func (s *CloudEventsServiceImpl) StartStreaming(stream googlegrpc.BidiStreamingS
 
 			switch evtType {
 			case CalculationMemberKeepAliveEvent:
+				// Liveness-only: an inbound keep-alive refreshes the member's
+				// LastSeen and nothing more. The server pings on its own ticker
+				// (keepAliveLoop); it must NOT echo a keep-alive back. Echoing
+				// against a client that also echoes inbound keep-alives produces
+				// a zero-delay, unbounded ping-pong storm pinning both processes
+				// at 100% CPU.
 				slog.Debug("keep-alive received", "pkg", "grpc", "memberId", memberID)
 				member := s.registry.Get(memberID)
 				if member != nil {
 					member.UpdateLastSeen()
-				}
-				// Send keep-alive response.
-				kaResp := events.CalculationMemberKeepAliveEventJson{
-					ID:       res.msg.Id,
-					MemberID: memberID,
-					Success:  true,
-				}
-				kaCE, err := NewCloudEvent(CalculationMemberKeepAliveEvent, kaResp)
-				if err == nil {
-					if err := stream.Send(kaCE); err != nil {
-						slog.Warn("failed to send keep-alive response", "pkg", "grpc", "memberId", memberID, "error", err)
-					}
 				}
 
 			case EntityProcessorCalculationResponse:

--- a/internal/grpc/streaming_test.go
+++ b/internal/grpc/streaming_test.go
@@ -243,8 +243,18 @@ func TestStreaming_MemberRegisteredAndUnregistered(t *testing.T) {
 	}
 }
 
-func TestStreaming_KeepAliveExchange(t *testing.T) {
+// TestStreaming_InboundKeepAliveUpdatesLivenessNoEcho asserts the keep-alive
+// protocol invariant: an inbound member keep-alive is liveness-only. The server
+// updates the member's LastSeen and does NOT echo a keep-alive back. Echoing
+// turns a client that also echoes inbound keep-alives into a zero-delay,
+// unbounded ping-pong storm that pins both processes at 100% CPU. Each side
+// must ping only on its own ticker (see TestStreaming_ServerSendsKeepAliveOnTicker).
+func TestStreaming_InboundKeepAliveUpdatesLivenessNoEcho(t *testing.T) {
 	svc := newServiceForTest()
+	// Long ticker interval so the server's own keep-alive ticker cannot fire
+	// during the test window and be mistaken for an echo.
+	svc.SetKeepAliveConfig(time.Hour, 2*time.Hour)
+
 	ctx, cancel := context.WithCancel(m2mContext("tenant-1"))
 	defer cancel()
 
@@ -256,35 +266,156 @@ func TestStreaming_KeepAliveExchange(t *testing.T) {
 		done <- svc.StartStreaming(stream)
 	}()
 
-	// Wait for greet.
-	_ = stream.waitForSent(t, 2*time.Second)
+	// Wait for greet, then grab the member so we can observe liveness.
+	greetCE := stream.waitForSent(t, 2*time.Second)
+	_, greetPayload, _ := ParseCloudEvent(greetCE)
+	memberID := ExtractStringField(greetPayload, "memberId")
+	member := svc.registry.Get(memberID)
+	if member == nil {
+		t.Fatal("member not found")
+	}
+	before := member.LastSeen()
 
-	// Send keep-alive.
+	// Send an inbound keep-alive from the "client".
 	stream.enqueue(makeKeepAliveEvent(t))
 
-	// Wait for keep-alive response.
-	kaCE := stream.waitForSent(t, 2*time.Second)
-	if kaCE.Type != CalculationMemberKeepAliveEvent {
-		t.Fatalf("expected keep-alive response type %s, got %s", CalculationMemberKeepAliveEvent, kaCE.Type)
+	// Liveness must be refreshed: poll until LastSeen advances past the
+	// registration timestamp (proves the keep-alive was processed).
+	deadline := time.Now().Add(2 * time.Second)
+	for member.LastSeen().Equal(before) {
+		if time.Now().After(deadline) {
+			t.Fatal("inbound keep-alive did not refresh member liveness")
+		}
+		time.Sleep(2 * time.Millisecond)
 	}
 
-	_, kaPayload, _ := ParseCloudEvent(kaCE)
-	var kaResp struct {
-		MemberID string `json:"memberId"`
-		Success  bool   `json:"success"`
-	}
-	if err := json.Unmarshal(kaPayload, &kaResp); err != nil {
-		t.Fatalf("failed to unmarshal keep-alive response: %v", err)
-	}
-	if !kaResp.Success {
-		t.Error("expected success=true in keep-alive response")
-	}
-	if kaResp.MemberID == "" {
-		t.Error("expected non-empty memberId in keep-alive response")
+	// The server must NOT echo a keep-alive back. Nothing (other than the
+	// already-consumed greet) should have been sent. Give any (buggy) echo a
+	// generous window to arrive on the send channel.
+	select {
+	case ce := <-stream.sentCh:
+		t.Fatalf("server echoed an event in response to an inbound keep-alive: type=%s", ce.Type)
+	case <-time.After(200 * time.Millisecond):
+		// No echo — correct.
 	}
 
 	// Close.
 	stream.closeRecv()
+	<-done
+}
+
+// TestStreaming_ServerSendsKeepAliveOnTicker guards the mechanism the server
+// now relies on solely: it pings the member on its own interval ticker,
+// independent of any inbound traffic. This is what keeps the member's liveness
+// fresh (via the client echoing on its own schedule) now that the server no
+// longer echoes inbound keep-alives.
+func TestStreaming_ServerSendsKeepAliveOnTicker(t *testing.T) {
+	svc := newServiceForTest()
+	// Short interval so the ticker fires quickly; large timeout so the member
+	// is never reaped during the test.
+	svc.SetKeepAliveConfig(30*time.Millisecond, time.Hour)
+
+	ctx, cancel := context.WithCancel(m2mContext("tenant-1"))
+	defer cancel()
+
+	stream := newMockBidiStream(ctx)
+	stream.enqueue(makeJoinEvent(t, "tenant-1", []string{}))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.StartStreaming(stream)
+	}()
+
+	// Consume the greet.
+	greetCE := stream.waitForSent(t, 2*time.Second)
+	if greetCE.Type != CalculationMemberGreetEvent {
+		t.Fatalf("expected greet first, got %s", greetCE.Type)
+	}
+
+	// Without sending any inbound message, the server's ticker must emit a
+	// keep-alive on its own.
+	kaCE := stream.waitForSent(t, 2*time.Second)
+	if kaCE.Type != CalculationMemberKeepAliveEvent {
+		t.Fatalf("expected server ticker to send a keep-alive, got %s", kaCE.Type)
+	}
+
+	stream.closeRecv()
+	<-done
+}
+
+// TestStreaming_EchoingClientDoesNotStorm reproduces the storm scenario from
+// the wild: a client that echoes every inbound keep-alive back to the server.
+// If the server also echoed inbound keep-alives, the two would ping-pong with
+// zero delay and the server's keep-alive output would grow without bound. With
+// the server treating inbound keep-alives as liveness-only, its output is
+// capped at roughly one keep-alive per ticker interval regardless of how
+// eagerly the client echoes.
+func TestStreaming_EchoingClientDoesNotStorm(t *testing.T) {
+	svc := newServiceForTest()
+	const interval = 20 * time.Millisecond
+	svc.SetKeepAliveConfig(interval, time.Hour)
+
+	ctx, cancel := context.WithCancel(m2mContext("tenant-1"))
+	defer cancel()
+
+	stream := newMockBidiStream(ctx)
+	stream.enqueue(makeJoinEvent(t, "tenant-1", []string{}))
+
+	done := make(chan error, 1)
+	go func() {
+		done <- svc.StartStreaming(stream)
+	}()
+
+	// Echoing client: for every keep-alive the server sends, immediately send
+	// one back — the exact behavior that ignited the storm in the field. The
+	// echoed event is read-only to the server, so one instance is reused (and
+	// built here, not in the goroutine, to keep t.* off a non-test goroutine).
+	echo := makeKeepAliveEvent(t)
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case ce := <-stream.sentCh:
+				if ce != nil && ce.Type == CalculationMemberKeepAliveEvent {
+					select {
+					case stream.recvCh <- echo:
+					case <-stop:
+						return
+					}
+				}
+			}
+		}
+	}()
+
+	// Let the loop run for a fixed number of ticker intervals.
+	const window = 10 * interval
+	start := time.Now()
+	time.Sleep(window)
+	elapsed := time.Since(start)
+
+	// Count keep-alives the server emitted. A correct server emits ~one per
+	// ticker interval of elapsed wall-time; a storming server emits orders of
+	// magnitude more (one per client echo, compounding with zero delay — the
+	// buggy code produced ~50k in this window). Scale the bound to actual
+	// elapsed time (not the nominal sleep) so a scheduling overrun on a loaded
+	// CI box can't false-fail, while still flagging any true storm.
+	expected := int(elapsed / interval)
+	limit := expected + 20
+	sent := stream.sentMessages()
+	kaCount := 0
+	for _, ce := range sent {
+		if ce.Type == CalculationMemberKeepAliveEvent {
+			kaCount++
+		}
+	}
+	if kaCount > limit {
+		t.Fatalf("server emitted %d keep-alives in %v with an echoing client — storm not contained (expected ~%d ticker sends, limit %d)", kaCount, elapsed, expected, limit)
+	}
+
+	close(stop)
+	cancel()
 	<-done
 }
 


### PR DESCRIPTION
## Summary

The gRPC streaming receive loop treated an inbound member keep-alive as both a liveness signal **and** a trigger to echo a keep-alive back (`internal/grpc/streaming.go`). The server already pings independently on its interval ticker (`keepAliveLoop`), so the echo broke the protocol invariant: against any client that also echoes inbound keep-alives, one ticker tick ignited a **zero-delay, unbounded ping-pong** that pinned both the cyoda-go process and the compute node at ~100% CPU indefinitely — with no INFO-level log output, making it hard to spot in the field.

This is latent because the reference client (`cmd/compute-test-client`) doesn't echo, but nothing in the protocol or server prevented a conforming-looking client from doing so.

## Fix

Treat an inbound keep-alive as **liveness-only** — `UpdateLastSeen()` and nothing more; drop the echo. Each side now pings solely on its own ticker, making the server robust to any client behavior and removing the whole storm class.

## Tests (`internal/grpc/streaming_test.go`)

- **`InboundKeepAliveUpdatesLivenessNoEcho`** — the core invariant (liveness refreshed, no echo). Replaces `TestStreaming_KeepAliveExchange`, which codified the buggy echo.
- **`ServerSendsKeepAliveOnTicker`** — guards the ticker, now the sole keep-alive source.
- **`EchoingClientDoesNotStorm`** — reproduces the field scenario. Verified it catches the bug: with the echo temporarily restored it recorded **50,719** keep-alives in 200ms vs. the ~10 ticker sends it asserts.

The E2E `callback_harness_test.go` client itself echoes keep-alives, so the passing E2E suite is living proof the server is now hardened against echoing clients.

## Verification

- `go vet ./...` clean
- Streaming tests green under `-race`
- Short unit suite green; E2E callback/dispatch subset green

## Gates

No new error/status codes, no env-var or public-interface change (the `grpc.md` help topic already documents the correct protocol: server pings on its ticker, client echoes for liveness). The change removes an outbound send, eliminating a CPU-DoS vector.

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)