### PR TITLE
feat(help): let plugins contribute help topics via an overlay registry (#439)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,19 @@ The `cyoda help` topic tree is a stable interface. Topic paths (e.g. `config.dat
 
 New topics may be added freely at any point under existing parent paths. Adding a top-level topic is also permitted but update the hardcoded list in `cmd/cyoda/help/help_test.go` (`topLevelTopicsV061`) at the same time.
 
+### Plugin-contributed topics (overlays)
+
+External storage plugins can add their own help topics without editing the OSS content tree. A plugin embeds a `content/` directory (same layout and front-matter contract as the OSS base) and registers it from `init()`:
+
+```go
+//go:embed content
+var helpContent embed.FS
+
+func init() { help.RegisterOverlay(helpContent) }
+```
+
+The runtime tree (`help.BuildTree()`, used by both `cyoda help` and the HTTP help routes) merges the OSS base with every registered overlay: topics at fresh paths are added; a topic whose path collides with an OSS topic overrides it ("later wins", `see_also` unions unless `see_also_replace: true`). Overlay content is held to the same front-matter validation as the base — a malformed overlay fails binary startup. Prefer a dedicated path namespace for plugin topics to avoid unintended overrides. `help.DefaultTree` remains the OSS-only base (used by tests and OSS-only consumers).
+
 ### Renames / removals
 
 A rename or removal requires:

--- a/app/app.go
+++ b/app/app.go
@@ -726,7 +726,8 @@ func New(cfg Config) *App {
 		// Discovery routes at root (no auth, no context path)
 		internalapi.RegisterDiscoveryRoutes(outerMux, contextPath)
 		// Help routes — unauthenticated, public content embedded in the binary
-		internalapi.RegisterHelpRoutes(outerMux, help.DefaultTree, contextPath, cfg.Version)
+		// (OSS base merged with any plugin-registered overlays).
+		internalapi.RegisterHelpRoutes(outerMux, help.BuildTree(), contextPath, cfg.Version)
 		// Internal dispatch routes at root (AEAD-authenticated, not under context path)
 		if cfg.Cluster.Enabled {
 			dispatchHandler := clusterdispatch.NewDispatchHandler(localDispatcher, peerAuth)
@@ -738,7 +739,8 @@ func New(cfg Config) *App {
 		// No context path — discovery routes on the main mux
 		internalapi.RegisterDiscoveryRoutes(mux, "")
 		// Help routes — unauthenticated, public content embedded in the binary
-		internalapi.RegisterHelpRoutes(mux, help.DefaultTree, "", cfg.Version)
+		// (OSS base merged with any plugin-registered overlays).
+		internalapi.RegisterHelpRoutes(mux, help.BuildTree(), "", cfg.Version)
 		// Internal dispatch routes (AEAD-authenticated)
 		if cfg.Cluster.Enabled {
 			dispatchHandler := clusterdispatch.NewDispatchHandler(localDispatcher, peerAuth)

--- a/cmd/cyoda/help/export_test.go
+++ b/cmd/cyoda/help/export_test.go
@@ -1,0 +1,41 @@
+package help
+
+import (
+	"io/fs"
+	"sync"
+)
+
+// snapshotOverlaysForTest returns a copy of the current overlay registry so a
+// test can restore it afterwards.
+func snapshotOverlaysForTest() []fs.FS {
+	overlayMu.Lock()
+	defer overlayMu.Unlock()
+	return append([]fs.FS(nil), overlays...)
+}
+
+// resetOverlaysForTest clears the overlay registry so a test starts from the
+// OSS-only base.
+func resetOverlaysForTest() {
+	overlayMu.Lock()
+	defer overlayMu.Unlock()
+	overlays = nil
+}
+
+// restoreOverlaysForTest restores a registry snapshot taken by
+// snapshotOverlaysForTest.
+func restoreOverlaysForTest(saved []fs.FS) {
+	overlayMu.Lock()
+	defer overlayMu.Unlock()
+	overlays = saved
+}
+
+// resetBuildTreeForTest clears BuildTree's memoisation so the next call
+// rebuilds from the current overlay registry. Without this, a BuildTree call in
+// one test would memoise a tree for the whole test binary and leak into later
+// tests (e.g. one that registers an overlay and then asserts on BuildTree).
+func resetBuildTreeForTest() {
+	overlayMu.Lock()
+	defer overlayMu.Unlock()
+	buildOnce = sync.Once{}
+	builtTree = nil
+}

--- a/cmd/cyoda/help/help.go
+++ b/cmd/cyoda/help/help.go
@@ -21,6 +21,12 @@ var embeddedContent embed.FS
 // at package init; panics if content is malformed (a compile-time
 // guarantee would be preferable, but go:embed can't enforce topic
 // structure).
+//
+// This is the OSS-only base. Runtime consumers (the CLI and the HTTP help
+// routes) build from BuildTree (see overlay.go), which merges this base with
+// any plugin-registered overlays. DefaultTree is retained for tests and
+// OSS-only consumers; its eager init also keeps process-start fail-fast for
+// malformed OSS content, independent of when BuildTree is first called.
 var DefaultTree = func() *Tree {
 	t, err := Load(embeddedContent)
 	if err != nil {

--- a/cmd/cyoda/help/overlay.go
+++ b/cmd/cyoda/help/overlay.go
@@ -1,0 +1,61 @@
+package help
+
+import (
+	"fmt"
+	"io/fs"
+	"sync"
+)
+
+// Overlay registry. Plugins register additional help content from their
+// init(); the runtime tree (BuildTree) merges the embedded OSS base with every
+// registered overlay. The eager DefaultTree remains the OSS-only base, because
+// it is computed at package-init time — before any plugin init() has run — and
+// is still used by OSS-only consumers and tests.
+var (
+	overlayMu sync.Mutex
+	overlays  []fs.FS
+
+	buildOnce sync.Once
+	builtTree *Tree
+)
+
+// RegisterOverlay registers an additional help-content source to be merged over
+// the embedded OSS base when the runtime tree is built. root must contain a
+// top-level "content/" directory of markdown topic files, exactly like the OSS
+// embed. Intended to be called from a plugin's init(): overlays merge in
+// registration order, after the base, with the documented "later wins"
+// collision semantics (see Load). A plugin adding a topic at a fresh path
+// simply contributes a new node; overriding an OSS topic requires colliding on
+// its path deliberately.
+func RegisterOverlay(root fs.FS) {
+	overlayMu.Lock()
+	defer overlayMu.Unlock()
+	overlays = append(overlays, root)
+}
+
+// buildMergedTree merges the embedded OSS content with every registered overlay
+// into a single tree. It is the un-memoised builder behind BuildTree.
+func buildMergedTree() (*Tree, error) {
+	overlayMu.Lock()
+	roots := make([]fs.FS, 0, len(overlays)+1)
+	roots = append(roots, embeddedContent)
+	roots = append(roots, overlays...)
+	overlayMu.Unlock()
+	return Load(roots...)
+}
+
+// BuildTree returns the runtime help tree: the embedded OSS content merged with
+// every overlay registered via RegisterOverlay. It builds once, on first call —
+// by which point all plugin init() registrations have run — and memoises the
+// result. It panics if the merged content is malformed, matching DefaultTree's
+// fail-fast contract.
+func BuildTree() *Tree {
+	buildOnce.Do(func() {
+		t, err := buildMergedTree()
+		if err != nil {
+			panic(fmt.Sprintf("help: failed to build merged tree: %v", err))
+		}
+		builtTree = t
+	})
+	return builtTree
+}

--- a/cmd/cyoda/help/overlay_test.go
+++ b/cmd/cyoda/help/overlay_test.go
@@ -1,0 +1,152 @@
+package help
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// overlayFixture is a minimal, valid single-topic content overlay a plugin
+// would embed and register.
+func overlayFixture() fstest.MapFS {
+	return fstest.MapFS{
+		"content/storagenote.md": &fstest.MapFile{Data: []byte(`---
+topic: storagenote
+title: Storage Note
+stability: experimental
+---
+
+Cassandra plain reads are a latest-committed dirty read.
+`)},
+	}
+}
+
+// withOverlays saves the global overlay registry, resets it (and BuildTree's
+// memoisation), runs fn, and restores the registry — so overlay-registration
+// tests neither see nor leak state through the global registry or the memoised
+// runtime tree.
+func withOverlays(t *testing.T, fn func()) {
+	t.Helper()
+	saved := snapshotOverlaysForTest()
+	resetOverlaysForTest()
+	resetBuildTreeForTest()
+	defer func() {
+		restoreOverlaysForTest(saved)
+		resetBuildTreeForTest()
+	}()
+	fn()
+}
+
+// TestRegisterOverlay_TopicAppearsInMergedTree is the core of the bridge: a
+// topic registered by a plugin overlay is merged over the OSS base, and the
+// OSS topics remain present.
+func TestRegisterOverlay_TopicAppearsInMergedTree(t *testing.T) {
+	withOverlays(t, func() {
+		RegisterOverlay(overlayFixture())
+
+		tree, err := buildMergedTree()
+		if err != nil {
+			t.Fatalf("buildMergedTree: %v", err)
+		}
+		if tree.Find([]string{"storagenote"}) == nil {
+			t.Error("overlay topic 'storagenote' missing from merged tree")
+		}
+		if tree.Find([]string{"cli"}) == nil {
+			t.Error("OSS topic 'cli' missing from merged tree — base was dropped")
+		}
+	})
+}
+
+// TestRegisterOverlay_RendersViaRunHelp exercises the full CLI render path on
+// an overlay topic, proving the bridge surfaces plugin content through the
+// same command users invoke.
+func TestRegisterOverlay_RendersViaRunHelp(t *testing.T) {
+	withOverlays(t, func() {
+		RegisterOverlay(overlayFixture())
+
+		tree, err := buildMergedTree()
+		if err != nil {
+			t.Fatalf("buildMergedTree: %v", err)
+		}
+		var buf bytes.Buffer
+		if rc := RunHelp(tree, []string{"storagenote"}, &buf, "v0.0.0", false, ""); rc != 0 {
+			t.Fatalf("RunHelp rc = %d, want 0; output:\n%s", rc, buf.String())
+		}
+		if !strings.Contains(buf.String(), "dirty read") {
+			t.Errorf("rendered overlay topic missing body text; got:\n%s", buf.String())
+		}
+	})
+}
+
+// TestRegisterOverlay_AppearsInJSONOutput exercises the machine-readable
+// surfaces named in the acceptance criteria: the overlay topic must appear both
+// in the topic-JSON for the topic itself and in the full tree-summary JSON.
+func TestRegisterOverlay_AppearsInJSONOutput(t *testing.T) {
+	withOverlays(t, func() {
+		RegisterOverlay(overlayFixture())
+
+		tree, err := buildMergedTree()
+		if err != nil {
+			t.Fatalf("buildMergedTree: %v", err)
+		}
+
+		var topicJSON bytes.Buffer
+		if rc := RunHelp(tree, []string{"storagenote", "--format=json"}, &topicJSON, "v0.0.0", false, ""); rc != 0 {
+			t.Fatalf("topic JSON rc = %d, want 0; output:\n%s", rc, topicJSON.String())
+		}
+		if !strings.Contains(topicJSON.String(), `"storagenote"`) {
+			t.Errorf("topic JSON missing overlay topic; got:\n%s", topicJSON.String())
+		}
+
+		var treeJSON bytes.Buffer
+		if rc := RunHelp(tree, []string{"--format=json"}, &treeJSON, "v0.0.0", false, ""); rc != 0 {
+			t.Fatalf("tree-summary JSON rc = %d, want 0; output:\n%s", rc, treeJSON.String())
+		}
+		if !strings.Contains(treeJSON.String(), "storagenote") {
+			t.Errorf("tree-summary JSON missing overlay topic; got:\n%s", treeJSON.String())
+		}
+	})
+}
+
+// TestBuildTree_NoOverlays_HasOSSTopics confirms the merged runtime tree equals
+// the OSS base when no plugin registers an overlay (the default binary).
+func TestBuildTree_NoOverlays_HasOSSTopics(t *testing.T) {
+	withOverlays(t, func() {
+		tree, err := buildMergedTree()
+		if err != nil {
+			t.Fatalf("buildMergedTree: %v", err)
+		}
+		if tree.Find([]string{"cli"}) == nil {
+			t.Error("OSS topic 'cli' missing from no-overlay merged tree")
+		}
+		if tree.Find([]string{"storagenote"}) != nil {
+			t.Error("unexpected overlay topic present with no overlay registered")
+		}
+	})
+}
+
+// TestRegisterOverlay_MalformedContentErrors confirms overlay content is held
+// to the same front-matter contract as the OSS base: a malformed overlay fails
+// tree construction rather than being silently skipped (BuildTree turns this
+// error into a fail-fast panic).
+func TestRegisterOverlay_MalformedContentErrors(t *testing.T) {
+	withOverlays(t, func() {
+		RegisterOverlay(fstest.MapFS{
+			"content/bad.md": &fstest.MapFile{Data: []byte("no front-matter here\n")},
+		})
+		if _, err := buildMergedTree(); err == nil {
+			t.Error("buildMergedTree accepted an overlay with missing front-matter; want error")
+		}
+	})
+}
+
+// TestBuildTree_Memoized verifies the runtime accessor builds the tree once and
+// returns the same instance on subsequent calls.
+func TestBuildTree_Memoized(t *testing.T) {
+	resetBuildTreeForTest()
+	defer resetBuildTreeForTest()
+	if a, b := BuildTree(), BuildTree(); a != b {
+		t.Errorf("BuildTree returned distinct instances %p vs %p; expected memoized", a, b)
+	}
+}

--- a/cmd/cyoda/main.go
+++ b/cmd/cyoda/main.go
@@ -52,7 +52,8 @@ func runHelpCmd(args []string) int {
 	// takes version as a parameter for the topic-JSON flow; the setter
 	// feeds the action dispatch path.
 	help.SetBinaryVersion(func() string { return version })
-	return help.RunHelp(help.DefaultTree, args, os.Stdout, version, isTTY, style)
+	// BuildTree merges the OSS base with any plugin-registered help overlays.
+	return help.RunHelp(help.BuildTree(), args, os.Stdout, version, isTTY, style)
 }
 
 func main() {


### PR DESCRIPTION
Closes #439.

## Summary

The help tree-loader already supported merging multiple `fs.FS` roots (`Load(base, overlays...)`), but nothing let an external storage plugin reach that capability: the binary built help from the OSS-only `DefaultTree`, and plugins had no help-content registration hook to match the spi storage-factory registry.

This PR adds the bridge so a plugin (e.g. `cyoda-go-cassandra`) can contribute its own `cyoda help` topics.

## Changes

- **`help.RegisterOverlay(fs.FS)`** — a plugin calls this from `init()` with its embedded `content/` FS. Registration is mutex-guarded.
- **`help.BuildTree()`** — the runtime tree: OSS embed merged with every registered overlay, built once (`sync.Once`) on first call (after all plugin `init()`s have run) and memoised. Panics on malformed merged content, matching `DefaultTree`'s fail-fast contract.
- **Runtime wiring** — the CLI (`cmd/cyoda/main.go`) and the HTTP help routes (`app/app.go`, both context-path branches) now build from `BuildTree()`. `DefaultTree` stays the OSS-only base for tests and OSS-only consumers.
- **Docs** — `CONTRIBUTING.md` (Help topic tree → Plugin-contributed topics).

Overlay content goes through the same front-matter validation as the base (a malformed overlay fails startup), and merges with the existing documented "later wins" + `see_also`-union collision semantics — so a plugin topic at a fresh path just adds a node.

## Testing

`cmd/cyoda/help/overlay_test.go` (TDD, red-first) covers: registration → merge over the real OSS base, the `RunHelp` render path on an overlay topic, the no-overlay base, malformed-overlay error, and memoisation. `go build ./...`, `go vet`, the help/cmd/api package tests, and `-race` on the registry are all green.

## Motivating consumer

`cyoda-go-cassandra` will register a read-consistency / PIT topic documenting the plain-read dirty-read-by-contract semantic once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
